### PR TITLE
Comments out bad CMake syntax

### DIFF
--- a/Migration-Guide.md
+++ b/Migration-Guide.md
@@ -101,7 +101,7 @@ Apply the following changes to use `ament_cmake` instead of `catkin`:
   ``` cmake
   find_package(ament_cmake REQUIRED)
   find_package(component1 REQUIRED)
-  ...
+  # ...
   find_package(componentN REQUIRED)
   ```
 


### PR DESCRIPTION
Tiny pull request to fix the syntax of a CMake code block Sphinx was complaining about.