### PR TITLE
Added inter sphinx example

### DIFF
--- a/About.rst
+++ b/About.rst
@@ -2,9 +2,6 @@
 About this documentation
 ========================
 
-This documentation lives in http://github.com/ros2/ros2_documentation. Purely
-written in ReST markup format, it is processed using Sphinx during ROSIndex
-builds. `Intersphinx support <Inter-Sphinx-Support>` is readily available for
-cross-linking package specific entities.
+This documentation lives in http://github.com/ros2/ros2_documentation. Purely written in `ReST markup format <http://docutils.sourceforge.net/rst.html>`, it is processed using Sphinx during ROSIndex builds. `Intersphinx support <Inter-Sphinx-Support>` is readily available for cross-linking package specific entities.
 
 Updates submission is currently handled through pull requests.

--- a/About.rst
+++ b/About.rst
@@ -1,0 +1,10 @@
+
+About this documentation
+========================
+
+This documentation lives in http://github.com/ros2/ros2_documentation. Purely
+written in ReST markup format, it is processed using Sphinx during ROSIndex
+builds. `Intersphinx support <Inter-Sphinx-Support>` is readily available for
+cross-linking package specific entities.
+
+Updates submission is currently handled through pull requests.

--- a/Inter-Sphinx-Example.rst
+++ b/Inter-Sphinx-Example.rst
@@ -1,0 +1,47 @@
+Using Sphinx for cross-referencing packages
+===========================================
+
+This is an example of how you can cross-reference documentation between different packages with rosindex using Sphinx.
+
+Inventory files must be added to Sphinx's `conf.py` file found `here <https://github.com/ros2/rosindex/blob/ros2/_sphinx/conf.py>`__.
+
+Small caveat: the `URI` added to the configuration file must point to the directory where the `.inv` file is rather than to the file itself (i.e: `http://docs.ros.org/independent/api/catkin_pkg` instead of `http://docs.ros.org/independent/api/catkin_pkg/objects.inv`).
+
+
+Showing all links of an Intersphinx mapping file
+================================================
+
+(Partially borrowed from `here <http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`__).
+
+To show all Intersphinx links and their targets of an Intersphinx mapping file, run:
+
+.. code-block:: bash
+
+    python -msphinx.ext.intersphinx url-or-path
+
+This is helpful when searching for the root cause of a broken Intersphinx link in a documentation project.
+
+
+Linking to Other Sites Using Intersphinx
+========================================
+
+(Partially borrowed from `here <https://my-favorite-documentation-test.readthedocs.io/en/latest/using_intersphinx.html>`__).
+
+* You may supply an explicit title and reference target: `\:role\:\`title \<target\>\`` will refer to target, but the link text will be title.
+* If you prefix the content with !, no reference/hyperlink will be created.
+* If you prefix the content with ~, the link text will only be the last component of the target. For example, `\`\:py\:meth\:\`~Queue.Queue.get\`` will refer to `Queue.Queue.get` but only display get as the link text.
+
+
+Examples of intersphinx in action
+=================================
+
+Linking to source code
+----------------------
+
+* I really like the class :class:`vcstools.VcsClient` because it have the method :meth:`vcstools.VcsClient.checkout`.
+
+
+Linking to specific documentation parts
+---------------------------------------
+
+* You can refer to rosinstall's developer guide by visiting the :doc:`Developer's Guide <developers_guide>`.

--- a/Inter-Sphinx-Support.rst
+++ b/Inter-Sphinx-Support.rst
@@ -1,13 +1,9 @@
 Using Sphinx for cross-referencing packages
 ===========================================
 
-This is an example of how you can cross-reference documentation between different packages with rosindex using Sphinx.
+This is an example of how you can cross-reference packages documentation within rosindex using Sphinx.
 
-Inventory files must be added to ROSIndex Sphinx's `conf.py` file found `here <https://github.com/ros2/rosindex/blob/ros2/_sphinx/conf.py>`__.
-
-.. note::
-
-   The `URI` added to the configuration file must point to the directory where the `.inv` file is rather than to the file itself (i.e: `http://docs.ros.org/independent/api/catkin_pkg` instead of `http://docs.ros.org/independent/api/catkin_pkg/objects.inv`).
+Inventory files must be added to ROSIndex Sphinx's `conf.py` file found `here <https://github.com/ros2/rosindex/blob/ros2/_sphinx/conf.py>`__. Note that the `URI` added to the configuration file must point to the directory where the `.inv` file is rather than to the file itself (i.e: `http://docs.ros.org/independent/api/catkin_pkg` instead of `http://docs.ros.org/independent/api/catkin_pkg/objects.inv`).
 
 
 Showing all links of an Intersphinx mapping file
@@ -15,11 +11,11 @@ Showing all links of an Intersphinx mapping file
 
 (Partially borrowed from `here <http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`__).
 
-To show all Intersphinx links and their targets of an Intersphinx mapping file, run:
+To show all Intersphinx links and their targets of an Intersphinx mapping file, either local or remote, run:
 
 .. code-block:: bash
 
-    python -msphinx.ext.intersphinx url-or-path
+    python -msphinx.ext.intersphinx url-or-path-to-inv-file
 
 This is helpful when searching for the root cause of a broken Intersphinx link in a documentation project.
 
@@ -42,7 +38,9 @@ Linking to source code
 
 * Class :class:`vcstools.VcsClient` implements the :meth:`vcstools.VcsClient.checkout` method.
 
-Linking to specific documentation parts
----------------------------------------
+Linking to documentation pages
+------------------------------
 
-* Refer to vcstools :doc:`Developer's Guide <developers_guide>` document.
+* Refer to :doc:`vcstools Developer's Guide document<developers_guide>`.
+
+* See `the installation page <Installation>`.

--- a/Inter-Sphinx-Support.rst
+++ b/Inter-Sphinx-Support.rst
@@ -3,9 +3,11 @@ Using Sphinx for cross-referencing packages
 
 This is an example of how you can cross-reference documentation between different packages with rosindex using Sphinx.
 
-Inventory files must be added to Sphinx's `conf.py` file found `here <https://github.com/ros2/rosindex/blob/ros2/_sphinx/conf.py>`__.
+Inventory files must be added to ROSIndex Sphinx's `conf.py` file found `here <https://github.com/ros2/rosindex/blob/ros2/_sphinx/conf.py>`__.
 
-Small caveat: the `URI` added to the configuration file must point to the directory where the `.inv` file is rather than to the file itself (i.e: `http://docs.ros.org/independent/api/catkin_pkg` instead of `http://docs.ros.org/independent/api/catkin_pkg/objects.inv`).
+.. note::
+
+   The `URI` added to the configuration file must point to the directory where the `.inv` file is rather than to the file itself (i.e: `http://docs.ros.org/independent/api/catkin_pkg` instead of `http://docs.ros.org/independent/api/catkin_pkg/objects.inv`).
 
 
 Showing all links of an Intersphinx mapping file
@@ -22,7 +24,7 @@ To show all Intersphinx links and their targets of an Intersphinx mapping file, 
 This is helpful when searching for the root cause of a broken Intersphinx link in a documentation project.
 
 
-Linking to Other Sites Using Intersphinx
+Linking to other sites using Intersphinx
 ========================================
 
 (Partially borrowed from `here <https://my-favorite-documentation-test.readthedocs.io/en/latest/using_intersphinx.html>`__).
@@ -38,10 +40,9 @@ Examples of intersphinx in action
 Linking to source code
 ----------------------
 
-* I really like the class :class:`vcstools.VcsClient` because it have the method :meth:`vcstools.VcsClient.checkout`.
-
+* Class :class:`vcstools.VcsClient` implements the :meth:`vcstools.VcsClient.checkout` method.
 
 Linking to specific documentation parts
 ---------------------------------------
 
-* You can refer to rosinstall's developer guide by visiting the :doc:`Developer's Guide <developers_guide>`.
+* Refer to vcstools :doc:`Developer's Guide <developers_guide>` document.

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,20 @@
 ROS 2
 =====
 
+Overview
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   Roadmap
+   Releases
+   Features
+   Tutorials
+   Installation
+   Migration-guide
+   About
+
 The Robot Operating System (ROS) is a set of software libraries and tools that help you build robot applications.
 From drivers to state-of-the-art algorithms, and with powerful developer tools, ROS has what you need for your next robotics project.
 And it's all open source.

--- a/Releases.rst
+++ b/Releases.rst
@@ -1,4 +1,7 @@
 
+ROS 2 Releases
+==============
+
 A summary of releases of ROS 2 software is listed below.
 For more details about each release, see the corresponding release overview.
 

--- a/Tutorials.rst
+++ b/Tutorials.rst
@@ -1,4 +1,7 @@
 
+Tutorials
+=========
+
 About ROS 2
 -----------
 

--- a/Tutorials.rst
+++ b/Tutorials.rst
@@ -9,7 +9,7 @@ About ROS 2
 * `Overview of ROS 2 concepts <Overview-of-ROS-2-concepts>`
 * `DDS and ROS middleware implementations <DDS-and-ROS-middleware-implementations>`
 * `ROS 2 Client Libraries <ROS-2-Client-Libraries>`
-* `About ROS interfaces <About-ROS-interfaces>`
+* `About ROS interfaces <About-ROS-Interfaces>`
 * `About Quality of Service Settings <About-Quality-of-Service-Settings>`
 
 ROS 2 Tutorials


### PR DESCRIPTION
This PR goes hand-by-hand with [rosindex#85](https://github.com/ros2/rosindex/pull/85).
- Adds an example document that shows how to use the inter-sphinx feature to cross-reference documentation.