### PR TITLE
Support Ubuntu 18.04 (Tier 1 Distro)

### DIFF
--- a/Linux-Development-Setup.rst
+++ b/Linux-Development-Setup.rst
@@ -5,7 +5,14 @@ Building ROS 2 on Linux
 System Requirements
 -------------------
 
-We support Ubuntu Linux Xenial Xerus 16.04 on 64-bit (until alpha 6 we supported Trusty Tahr 14.04).  These instructions should also work for later Ubuntu as well as Debian Stretch, though these are not actively tested or supported.  Fedora 26 also works if you follow `alternate <Fedora-Development-Setup>` instructions, though it is not actively tested or supported. The same goes for `Arch Linux <https://wiki.archlinux.org/index.php/Ros#Ros_2>`__.
+Tier 1
+- Ubuntu Linux Xenial Xerus 16.04 64-bit
+- Ubuntu Linux Bionic Beaver 18.04 64-bit
+
+Tier 2 (not actively tested or supported)
+- Debian Stretch
+- Fedora 26, see `alternate instructions <Fedora-Development-Setup>`
+- Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/Ros#Ros_2>`__.
 
 Make sure that you have a locale set which supports ``UTF-8`` We test with the following settings.
 If you are in a minimal environment such as a docker containers the locale may be set to something minimal like POSIX.

--- a/Linux-Development-Setup.rst
+++ b/Linux-Development-Setup.rst
@@ -5,11 +5,11 @@ Building ROS 2 on Linux
 System Requirements
 -------------------
 
-Tier 1
+Target platforms for Bouncy Bolson (see [REP](http://www.ros.org/reps/rep-2000.html)).
 - Ubuntu Linux Xenial Xerus 16.04 64-bit
 - Ubuntu Linux Bionic Beaver 18.04 64-bit
 
-Tier 2 (not actively tested or supported)
+Recommended Support (not actively tested or supported)
 - Debian Stretch
 - Fedora 26, see `alternate instructions <Fedora-Development-Setup>`
 - Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/Ros#Ros_2>`__.


### PR DESCRIPTION
My understanding is that the main target for ROS building from source right now is actually 18.04, based on a REP from @dirk-thomas