### PR TITLE
Standardizing use of pip

### DIFF
--- a/source/Installation/Linux-Development-Setup.rst
+++ b/source/Installation/Linux-Development-Setup.rst
@@ -54,7 +54,7 @@ Install development tools and ROS tools
      python3-vcstool \
      wget
    # install some pip packages needed for testing
-   sudo -H python3 -m pip install -U \
+   python3 -m pip install -U \
      argcomplete \
      flake8 \
      flake8-blind-except \


### PR DESCRIPTION
Using `pip` with `sudo` is generally a bad idea. `pip install --user` is a cleaner better way to install `pip` packages.