### PR TITLE
Add gnupg2 to the required packages for apt-key

### DIFF
--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -24,7 +24,7 @@ First you will need to authorize our gpg key with apt like this:
 
 .. code-block:: bash
 
-   sudo apt update && sudo apt install curl
+   sudo apt update && sudo apt install curl gnupg2
    curl http://repo.ros2.org/repos.key | sudo apt-key add -
 
 And then add the repository to your sources list:


### PR DESCRIPTION
When using a really minimal container (like the one that LXC uses), gnupg2 is not installed, so calls to `apt-key` fail.  Add `gnupg2` to the list of needed packages to ensure that it exists.