### PR TITLE
rqt specific dependencies for macOS

### DIFF
--- a/Set-up-a-new-macOS-CI-node.rst
+++ b/Set-up-a-new-macOS-CI-node.rst
@@ -92,6 +92,15 @@ Including:
 * the optional RTI Connext and OpenSplice packages
 * everything but downloading the source and building ROS 2 (unless you want to do so for testing the setup)
 
+rqt dependencies
+~~~~~~~~~~~~~~~~
+
+* `brew install sip pyqt5`
+* `ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5`
+* `brew install graphviz`
+* `python3 -m pip install pygraphviz pydot`
+* `brew link --force qt`
+
 RTI Connext Specific Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Set-up-a-new-macOS-CI-node.rst
+++ b/Set-up-a-new-macOS-CI-node.rst
@@ -95,11 +95,14 @@ Including:
 rqt dependencies
 ~~~~~~~~~~~~~~~~
 
-* `brew install sip pyqt5`
-* `ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5`
-* `brew install graphviz`
-* `python3 -m pip install pygraphviz pydot`
-* `brew link --force qt`
+* ``brew install sip pyqt5``
+* Fix some path names when looking for sip stuff during install (see `ROS 1 wiki <http://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source#Qt_naming_issue>`_):
+
+  ``ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5``
+
+* ``brew install graphviz``
+* ``python3 -m pip install pygraphviz pydot``
+* ``brew link --force qt``
 
 RTI Connext Specific Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Set-up-a-new-macOS-CI-node.rst
+++ b/Set-up-a-new-macOS-CI-node.rst
@@ -102,11 +102,15 @@ rqt dependencies
 
 * ``brew install graphviz``
 * ``python3 -m pip install pygraphviz pydot``
-* ``brew link --force qt`` This is the quickest solution but may cause issues when upgrading qt or if other packages are expecting qt4. Another option is to update your PATH and CMAKE_PREFIX_PATH to include the qt install location.
-``
-export PATH="$(brew --prefix qt)/bin:$PATH"
-export CMAKE_PREFIX_PATH="$(brew --prefix qt):$CMAKE_PREFIX_PATH"
-``
+* ``brew link --force qt``
+
+  This is the quickest solution but may cause issues when upgrading Qt or if other packages are expecting Qt 4.
+  Another option is to update your ``PATH`` and ``CMAKE_PREFIX_PATH`` to include the Qt install location:
+
+  .. code-block:: bash
+
+     $ export PATH="$(brew --prefix qt)/bin:$PATH"
+     $ export CMAKE_PREFIX_PATH="$(brew --prefix qt):$CMAKE_PREFIX_PATH"
 
 RTI Connext Specific Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Set-up-a-new-macOS-CI-node.rst
+++ b/Set-up-a-new-macOS-CI-node.rst
@@ -102,7 +102,11 @@ rqt dependencies
 
 * ``brew install graphviz``
 * ``python3 -m pip install pygraphviz pydot``
-* ``brew link --force qt``
+* ``brew link --force qt`` This is the quickest solution but may cause issues when upgrading qt or if other packages are expecting qt4. Another option is to update your PATH and CMAKE_PREFIX_PATH to include the qt install location.
+``
+export PATH="$(brew --prefix qt)/bin:$PATH"
+export CMAKE_PREFIX_PATH="$(brew --prefix qt):$CMAKE_PREFIX_PATH"
+``
 
 RTI Connext Specific Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`rqt` needs `PyQt5` and `sip` and uses `graphviz`, `pygraphviz` and `pydot`.