### PR TITLE
Set locale when installing from debian packages

### DIFF
--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -16,6 +16,19 @@ Resources:
 
 .. _linux-install-debians-setup-sources:
 
+Setup Locale
+------------
+Make sure you have a locale which supports ``UTF-8``.
+If you are in a minimal environment, such as a docker container, the locale may be something minimal like POSIX.
+We test with the following settings.
+It should be fine if you're using a different UTF-8 supported locale.
+
+.. code-block:: bash
+
+   sudo locale-gen en_US en_US.UTF-8
+   sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+   export LANG=en_US.UTF-8
+
 Setup Sources
 -------------
 


### PR DESCRIPTION
Resolves https://github.com/ros2/launch/issues/157

Without a locale set `ros2 launch --print <path to launch file>` raises `ValueError`.