### PR TITLE
Update version of OpenSplice referenced in docs.

### DIFF
--- a/Linux-Development-Setup.rst
+++ b/Linux-Development-Setup.rst
@@ -100,7 +100,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 rti-connext-dds-5.3.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
 
 .. _linux-development-setup-install-more-dds-implementations-optional:
 

--- a/Linux-Development-Setup.rst
+++ b/Linux-Development-Setup.rst
@@ -100,7 +100,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
 
 .. _linux-development-setup-install-more-dds-implementations-optional:
 
@@ -120,6 +120,10 @@ PrismTech OpenSplice Debian Packages built by OSRF
 
 .. code-block:: bash
 
+   # For Bouncy Bolson
+   sudo apt install libopensplice67  # from repo.ros2.org
+
+   # For Crystal Clemmys
    sudo apt install libopensplice69  # from repo.ros2.org
 
 Add this to your ``~/.bashrc``

--- a/Linux-Install-Binary.rst
+++ b/Linux-Install-Binary.rst
@@ -51,7 +51,7 @@ Installing the missing dependencies
 
 .. code-block:: bash
 
-       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice69 osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
 
 
 
@@ -93,7 +93,7 @@ Bouncy and earlier:
 .. code-block:: bash
 
        sudo apt update && sudo apt install -q -y \
-           libopensplice67
+           libopensplice69
 
 
 RTI Connext

--- a/OSX-Development-Setup.rst
+++ b/OSX-Development-Setup.rst
@@ -168,7 +168,7 @@ When you run the build make sure that your chosen DDS vendor(s) are exposed in y
 When multiple vendors are present, you can choose the used RMW implementation by setting the the environment variable ``RMW_IMPLEMENTATION`` to the package providing the RMW implementation.
 See `Working with multiple RMW implementations <Working-with-multiple-RMW-implementations>` for more details.
 
-Adlink OpenSplice (6.7)
+Adlink OpenSplice (6.9)
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 To install OpenSplice, download the latest release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.

--- a/OSX-Development-Setup.rst
+++ b/OSX-Development-Setup.rst
@@ -171,8 +171,8 @@ See `Working with multiple RMW implementations <Working-with-multiple-RMW-implem
 Adlink OpenSplice
 ^^^^^^^^^^^^^^^^^
 
-ROS 2 Bouncy Bolson supports OpenSplice 6.7.
 ROS 2 Crystal Clemmys supports OpenSplice 6.9.
+ROS 2 Bouncy Bolson supports OpenSplice 6.7.
 
 To install OpenSplice, download the latest supported release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.
 

--- a/OSX-Development-Setup.rst
+++ b/OSX-Development-Setup.rst
@@ -168,10 +168,13 @@ When you run the build make sure that your chosen DDS vendor(s) are exposed in y
 When multiple vendors are present, you can choose the used RMW implementation by setting the the environment variable ``RMW_IMPLEMENTATION`` to the package providing the RMW implementation.
 See `Working with multiple RMW implementations <Working-with-multiple-RMW-implementations>` for more details.
 
-Adlink OpenSplice (6.9)
-^^^^^^^^^^^^^^^^^^^^^^^
+Adlink OpenSplice
+^^^^^^^^^^^^^^^^^
 
-To install OpenSplice, download the latest release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.
+ROS 2 Bouncy Bolson supports OpenSplice 6.7.
+ROS 2 Crystal Clemmys supports OpenSplice 6.9.
+
+To install OpenSplice, download the latest supported release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.
 
 Source the ``release.com`` file provided to set up the environment before building your ROS 2 workspace, e.g.:
 

--- a/Windows-Development-Setup.rst
+++ b/Windows-Development-Setup.rst
@@ -186,7 +186,7 @@ Then run something like the following command before building ROS 2, to set up t
 
 .. code-block:: bash
 
-   call "C:\opensplice67\HDE\x86_64.win64\release.bat"
+   call "C:\opensplice69\HDE\x86_64.win64\release.bat"
 
 where the exact paths may need to be slightly altered depending on where you selected to install OpenSplice.
 

--- a/Windows-Install-Binary.rst
+++ b/Windows-Install-Binary.rst
@@ -224,7 +224,7 @@ Only do this step **after** you have sourced the ROS 2 setup file:
 
 .. code-block:: bash
 
-   > call "C:\opensplice67\HDE\x86_64.win64\release.bat"
+   > call "C:\opensplice69\HDE\x86_64.win64\release.bat"
 
 Try some examples
 -----------------

--- a/Windows-Install-Binary.rst
+++ b/Windows-Install-Binary.rst
@@ -107,7 +107,11 @@ If you would like to use one of the other vendors you will need to install their
 Adlink OpenSplice
 ~~~~~~~~~~~~~~~~~
 
-If you want to use OpenSplice, you will need to `download the latest version <https://github.com/ADLINK-IST/opensplice/releases>`__ (for ROS 2 Bouncy we require at least version 6.7.180404OSS-HDE-x86_64.win-vs2017).
+If you want to use OpenSplice, you will need to download the latest supported version.
+* For ROS 2 Bouncy version 6.7.180404OSS-HDE-x86_64.win-vs2017 or later is required.
+* For ROS 2 Crystal version 6.9.181126OSS-HDE-x86_64.win-vs2017 or later is required.
+
+Download the `latest supported version <https://github.com/ADLINK-IST/opensplice/releases>`__
 For ROS 2 releases up to and including Ardent, extract it but do not do anything else at this point.
 For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable to the unpacked directory that contains the ``release.bat`` script.
 

--- a/Windows-Install-Binary.rst
+++ b/Windows-Install-Binary.rst
@@ -108,8 +108,8 @@ Adlink OpenSplice
 ~~~~~~~~~~~~~~~~~
 
 If you want to use OpenSplice, you will need to download the latest supported version.
-* For ROS 2 Bouncy version 6.7.180404OSS-HDE-x86_64.win-vs2017 or later is required.
 * For ROS 2 Crystal version 6.9.181126OSS-HDE-x86_64.win-vs2017 or later is required.
+* For ROS 2 Bouncy version 6.7.180404OSS-HDE-x86_64.win-vs2017 or later is required.
 
 Download the `latest supported version <https://github.com/ADLINK-IST/opensplice/releases>`__
 For ROS 2 releases up to and including Ardent, extract it but do not do anything else at this point.


### PR DESCRIPTION
Do separate clauses for opensplice67 on Bouncy and earlier need to be added or should these articles support only Crystal+?