### PR TITLE
install PyQt5 on Windows for rqt

### DIFF
--- a/Windows-Development-Setup.rst
+++ b/Windows-Development-Setup.rst
@@ -127,6 +127,13 @@ Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` where you i
 
 Note, this path might change based on which MSVC version you're using or if you installed it to a different directory.
 
+rqt dependencies
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   > pip install -U PyQt5
+
 Getting the Source Code
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Windows-Development-Setup.rst
+++ b/Windows-Development-Setup.rst
@@ -132,7 +132,7 @@ rqt dependencies
 
 .. code-block:: bash
 
-   > pip install -U PyQt5
+   > pip install -U pydot PyQt5
 
 Getting the Source Code
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/Windows-Install-Binary.rst
+++ b/Windows-Install-Binary.rst
@@ -186,6 +186,13 @@ You must also install some python dependencies for command-line tools:
 
    python -m pip install -U catkin_pkg empy git+https://github.com/lark-parser/lark.git@0.7b pyparsing pyyaml setuptools
 
+rqt dependencies
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   python -m pip install -U PyQt5
+
 Downloading ROS 2
 -----------------
 

--- a/Windows-Install-Binary.rst
+++ b/Windows-Install-Binary.rst
@@ -191,7 +191,7 @@ rqt dependencies
 
 .. code-block:: bash
 
-   python -m pip install -U PyQt5
+   python -m pip install -U pydot PyQt5
 
 Downloading ROS 2
 -----------------


### PR DESCRIPTION
Add install instructions for `PyQt5` needed for `rqt` on Windows, see ros2/ros2#619.