### PR TITLE
Add `lsb-release` to Setup Sources

### DIFF
--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -37,7 +37,7 @@ First you will need to authorize our gpg key with apt like this:
 
 .. code-block:: bash
 
-   sudo apt update && sudo apt install curl gnupg2
+   sudo apt update && sudo apt install curl gnupg2 lsb-release
    curl http://repo.ros2.org/repos.key | sudo apt-key add -
 
 And then add the repository to your sources list:


### PR DESCRIPTION
https://discourse.ros.org/t/ros-2-crystal-clemmys-call-for-testing-and-package-releases/7072/2

`lsb_release -cs` is used in the code block below this one.