### PR TITLE
Link to bloom and intersphinx examples

### DIFF
--- a/Inter-Sphinx-Support.rst
+++ b/Inter-Sphinx-Support.rst
@@ -33,14 +33,30 @@ Linking to other sites using Intersphinx
 Examples of intersphinx in action
 =================================
 
-Linking to source code
-----------------------
+Links to **source code** can be created as follows:
 
-* Class :class:`vcstools.VcsClient` implements the :meth:`vcstools.VcsClient.checkout` method.
+.. code-block:: bash
 
-Linking to documentation pages
-------------------------------
+    Class :class:`vcstools.VcsClient` implements the :meth:`vcstools.VcsClient.checkout` method.
 
-* Refer to :doc:`vcstools Developer's Guide document<developers_guide>`.
+Class :class:`vcstools.VcsClient` implements the :meth:`vcstools.VcsClient.checkout` method.
 
-* See `the installation page <Installation>`.
+------------
+
+Links to documentation pages:
+
+.. code-block:: bash
+
+    Refer to :doc:`vcstools Developer's Guide document<developers_guide>`.
+
+Refer to :doc:`vcstools Developer's Guide document<developers_guide>`.
+
+------------
+
+Links to other pages in this documentation:
+
+.. code-block:: bash
+
+    See `the installation page <Installation>`.
+
+See `the installation page <Installation>`.

--- a/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/Releasing-a-ROS-2-package-with-bloom.rst
@@ -60,6 +60,8 @@ Procedure
 
 Same as in ROS 1: `Following this tutorial <http://wiki.ros.org/bloom/Tutorials/FirstTimeRelease>`__
 
+If porting a ROS 1 package to ROS 2, it's recommended to create a new `-release` repository.
+
 Build Status
 ------------
 

--- a/Tutorials.rst
+++ b/Tutorials.rst
@@ -34,6 +34,7 @@ Advanced
 
 
 * `Implement a custom memory allocator <Allocator-Template-Tutorial>`
+* `Releasing a ROS 2 package with bloom <Releasing-a-ROS-2-package-with-bloom>`
 
 Docker
 ^^^^^^

--- a/Tutorials.rst
+++ b/Tutorials.rst
@@ -11,6 +11,7 @@ About ROS 2
 * `ROS 2 Client Libraries <ROS-2-Client-Libraries>`
 * `About ROS interfaces <About-ROS-Interfaces>`
 * `About Quality of Service Settings <About-Quality-of-Service-Settings>`
+* `Releasing a ROS 2 package with bloom <Releasing-a-ROS-2-package-with-bloom>`
 
 ROS 2 Tutorials
 ---------------
@@ -34,7 +35,6 @@ Advanced
 
 
 * `Implement a custom memory allocator <Allocator-Template-Tutorial>`
-* `Releasing a ROS 2 package with bloom <Releasing-a-ROS-2-package-with-bloom>`
 
 Docker
 ^^^^^^


### PR DESCRIPTION
The bloom instructions weren't linked from anywhere, so added it to the tutorials list.

Also tweaked the intersphinx support page so the source code is shown for the examples.