### PR TITLE
[Node Arguments] Python nodes support parameters

### DIFF
--- a/Node-arguments.rst
+++ b/Node-arguments.rst
@@ -72,15 +72,9 @@ Other nodes will be able to retrieve the parameter values, e.g.:
 
 .. code-block:: bash
 
-   $ ros2 param list /talker
+   $ ros2 param list talker
      a_string
      some_int
      some_lists.some_doubles
      some_lists.some_integers
-
-If you are using the bouncy release then the node name must not be fully qualified.
-
-.. code-block:: bash
-
-   ros2 param list talker
 

--- a/Node-arguments.rst
+++ b/Node-arguments.rst
@@ -70,7 +70,7 @@ Other nodes will be able to retrieve the parameter values, e.g.:
 
 .. code-block:: bash
 
-   $ ros2 param list /talker
+   $ ros2 param list talker
      a_string
      some_int
      some_lists.some_doubles

--- a/Node-arguments.rst
+++ b/Node-arguments.rst
@@ -77,4 +77,3 @@ Other nodes will be able to retrieve the parameter values, e.g.:
      some_int
      some_lists.some_doubles
      some_lists.some_integers
-

--- a/Node-arguments.rst
+++ b/Node-arguments.rst
@@ -46,8 +46,6 @@ See `the logging page <logging-command-line-configuration-of-the-default-severit
 Parameters
 ----------
 
-*Parameters are currently only supported for C++ nodes.*
-
 Setting parameters from the command-line is currently supported in the form of yaml files.
 
 `See here <https://github.com/ros2/rcl/tree/master/rcl_yaml_param_parser>`__ for examples of the yaml file syntax. As an example, save the following as ``demo_params.yaml``
@@ -72,7 +70,7 @@ Other nodes will be able to retrieve the parameter values, e.g.:
 
 .. code-block:: bash
 
-   $ ros2 param list talker
+   $ ros2 param list /talker
      a_string
      some_int
      some_lists.some_doubles

--- a/Node-arguments.rst
+++ b/Node-arguments.rst
@@ -46,6 +46,8 @@ See `the logging page <logging-command-line-configuration-of-the-default-severit
 Parameters
 ----------
 
+*Parameters support for Python nodes was added in Crystal. In Bouncy only C++ nodes are supported.*
+
 Setting parameters from the command-line is currently supported in the form of yaml files.
 
 `See here <https://github.com/ros2/rcl/tree/master/rcl_yaml_param_parser>`__ for examples of the yaml file syntax. As an example, save the following as ``demo_params.yaml``

--- a/Node-arguments.rst
+++ b/Node-arguments.rst
@@ -70,8 +70,15 @@ Other nodes will be able to retrieve the parameter values, e.g.:
 
 .. code-block:: bash
 
-   $ ros2 param list talker
+   $ ros2 param list /talker
      a_string
      some_int
      some_lists.some_doubles
      some_lists.some_integers
+
+If you are using the bouncy release then the node name must not be fully qualified.
+
+.. code-block:: bash
+
+   ros2 param list talker
+


### PR DESCRIPTION
Python nodes in Crystal support parameters
`ros2 param list` requires fully qualified node name (ros2/ros2cli#178)