### PR TITLE
RQt install by source for Windows and Mac

### DIFF
--- a/RQt-Port-Plugin-Windows.rst
+++ b/RQt-Port-Plugin-Windows.rst
@@ -5,64 +5,70 @@ RQt has not been historically supported on Windows, but compatibility is happeni
 
 RQt Porting examples
 --------------------
+
 Microsoft pushed an effort to port much of ROS to Windows, their repos are a good resource for necessary changes.
 They live at the ms-iot organization with branches called init-windows.
 For example: https://github.com/ms-iot/qt_gui_core/tree/init_windows
 
-Here is the ROS2 port of `qt_gui_core <https://github.com/ros-visualization/qt_gui_core/pull/146/commits/c3a9630de6fed3c46684925e7688b6d4c7b8baf8>`_.
+Here is the ROS 2 port of `qt_gui_core <https://github.com/ros-visualization/qt_gui_core/pull/146/commits/c3a9630de6fed3c46684925e7688b6d4c7b8baf8>`_.
 
-Here is the ROS2 port of `python_qt_binding <https://github.com/ros-visualization/python_qt_binding/pull/56>`_.
+Here is the ROS 2 port of `python_qt_binding <https://github.com/ros-visualization/python_qt_binding/pull/56>`_.
 
 Considerations for Windows 10
 -----------------------------
 
-Troubles with Tinyxml
-~~~~~~~~~~~~~~~~~~~~~
+Troubles with TinyXML version 1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-I could not successfully use Tinyxml.
-I upgraded to TinyXml2 where needed.
+I could not successfully use TinyXML.
+I upgraded to TinyXML-2 where needed.
 It’s a pretty straight forward change.
 
-Checkout `this PR <https://github.com/ros-visualization/qt_gui_core/pull/147>`_ for an example of porting to TinyXML2.
+Checkout `this PR <https://github.com/ros-visualization/qt_gui_core/pull/147>`_ for an example of porting to TinyXML-2.
 
 Code that uses ``__cplusplus`` and code that requires pluginlib
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In some places, notably in the ROS2 port of pluginlib, there is use of the ``__cplusplus`` flag.
-Unfortunately on Windows Visual Studio does not set this flag correctly regardless of the c++ standard that is actually being used.
+
+In some places, notably in the ROS 2 port of pluginlib, there is use of the ``__cplusplus`` flag.
+Unfortunately on Windows Visual Studio does not set this flag correctly regardless of the C++ standard that is actually being used.
 See `this page <https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=vs-2017>`_ for more information.
 
-To set it, you need to add the compile option  ``/Zc:__cplusplus``
+To set it, you need to add the compile option ``/Zc:__cplusplus``.
 
-For example, in cmake you could do something like this:
+For example, in CMake you could do something like this:
+
 ::
+
    target_compile_options(${PROJECT_NAME} PUBLIC "/Zc:__cplusplus")
 
 Locations of build artifacts (before install)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 This only came up during when building ``qt_gui_cpp``.
 In that package, a custom command depends on a target library in another part of the package.
 However, that library isn’t installed until build is complete. Windows builds in a ${configuration} directory.
 For example:
 
-On linux, ``qt_gui_cpp.a`` would be built in:
-/home/brawner/ros2_ws/build/qt_gui_cpp/src/qt_gui_cpp/
+On Linux, ``qt_gui_cpp.a`` would be built in:
+<ros2_ws>/build/qt_gui_cpp/src/qt_gui_cpp/
 
 But on Windows ``qt_gui_cpp.lib`` is built in
-/home/brawner/ros2_ws/build/qt_gui_cpp/src/qt_gui_cpp/Release
+<ros2_ws>/build/qt_gui_cpp/src/qt_gui_cpp/Release
 
-For compatibility across platforms in this situation, use `cmake generator expressions. <https://cmake.org/cmake/help/v3.5/manual/cmake-generator-expressions.7.html>`_
+For compatibility across platforms in this situation, use `CMake generator expressions <https://cmake.org/cmake/help/v3.5/manual/cmake-generator-expressions.7.html>`_.
 However, when you need a library to link against be sure to use ``$<TARGET_LINKER_FILE:_target>`` instead of ``$<TARGET_FILE:_target>``.
 The latter will find ``.dll`` files, which cannot be linked against on Windows.
-See an `example here. <https://github.com/ros-visualization/qt_gui_core/pull/162/files>`_
+See an `example here <https://github.com/ros-visualization/qt_gui_core/pull/162/files>`_.
 
 Compiler and linker flags
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-In general when porting to Windows, many packages might make use of additional compiler flags.
-You can find the Windows compiler flags on `Microsoft's documentation. <https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-by-category?view=vs-2017>`_
-The c++ compiler is called ``cl.exe``.
 
-For linker flags see `Microsoft's documentation <https://docs.microsoft.com/en-us/cpp/build/reference/linker-options?view=vs-2017>`_
+In general when porting to Windows, many packages might make use of additional compiler flags.
+You can find the Windows compiler flags on `Microsoft's documentation <https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-by-category?view=vs-2017>`_.
+The C++ compiler is called ``cl.exe``.
+
+For linker flags see `Microsoft's documentation <https://docs.microsoft.com/en-us/cpp/build/reference/linker-options?view=vs-2017>`_.
 The linker program is called ``link.exe``.
 
-However, Cmake actually provides many of these options in variables.
-This `StackOverflow page <https://stackoverflow.com/questions/9298278/cmake-print-out-all-accessible-variables-in-a-script>`_ contains a good example of how to see all the cmake variables available in a script.
+However, CMake actually provides many of these options in variables.
+This `StackOverflow page <https://stackoverflow.com/questions/9298278/cmake-print-out-all-accessible-variables-in-a-script>`_ contains a good example of how to see all the CMake variables available in a script.

--- a/RQt-Port-Plugin-Windows.rst
+++ b/RQt-Port-Plugin-Windows.rst
@@ -1,0 +1,68 @@
+Porting RQt plugins to Windows
+==============================
+
+RQt has not been historically supported on Windows, but compatibility is happening, slowly.
+
+RQt Porting examples
+--------------------
+Microsoft pushed an effort to port much of ROS to Windows, their repos are a good resource for necessary changes.
+They live at the ms-iot organization with branches called init-windows.
+For example: https://github.com/ms-iot/qt_gui_core/tree/init_windows
+
+Here is the ROS2 port of `qt_gui_core <https://github.com/ros-visualization/qt_gui_core/pull/146/commits/c3a9630de6fed3c46684925e7688b6d4c7b8baf8>`_.
+
+Here is the ROS2 port of `python_qt_binding <https://github.com/ros-visualization/python_qt_binding/pull/56>`_.
+
+Considerations for Windows 10
+-----------------------------
+
+Troubles with Tinyxml
+~~~~~~~~~~~~~~~~~~~~~
+
+I could not successfully use Tinyxml.
+I upgraded to TinyXml2 where needed.
+It’s a pretty straight forward change.
+
+Checkout `this PR <https://github.com/ros-visualization/qt_gui_core/pull/147>`_ for an example of porting to TinyXML2.
+
+Code that uses ``__cplusplus`` and code that requires pluginlib
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In some places, notably in the ROS2 port of pluginlib, there is use of the ``__cplusplus`` flag.
+Unfortunately on Windows Visual Studio does not set this flag correctly regardless of the c++ standard that is actually being used.
+See `this page <https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=vs-2017>`_ for more information.
+
+To set it, you need to add the compile option  ``/Zc:__cplusplus``
+
+For example, in cmake you could do something like this:
+::
+   target_compile_options(${PROJECT_NAME} PUBLIC "/Zc:__cplusplus")
+
+Locations of build artifacts (before install)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This only came up during when building ``qt_gui_cpp``.
+In that package, a custom command depends on a target library in another part of the package.
+However, that library isn’t installed until build is complete. Windows builds in a ${configuration} directory.
+For example:
+
+On linux, ``qt_gui_cpp.a`` would be built in:
+/home/brawner/ros2_ws/build/qt_gui_cpp/src/qt_gui_cpp/
+
+But on Windows ``qt_gui_cpp.lib`` is built in
+/home/brawner/ros2_ws/build/qt_gui_cpp/src/qt_gui_cpp/Release
+
+For compatibility across platforms in this situation, use `cmake generator expressions. <https://cmake.org/cmake/help/v3.5/manual/cmake-generator-expressions.7.html>`_
+However, when you need a library to link against be sure to use ``$<TARGET_LINKER_FILE:_target>`` instead of ``$<TARGET_FILE:_target>``.
+The latter will find ``.dll`` files, which cannot be linked against on Windows.
+See an `example here. <https://github.com/ros-visualization/qt_gui_core/pull/162/files>`_
+
+Compiler and linker flags
+~~~~~~~~~~~~~~~~~~~~~~~~~
+In general when porting to Windows, many packages might make use of additional compiler flags.
+You can find the Windows compiler flags on `Microsoft's documentation. <https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-by-category?view=vs-2017>`_
+The c++ compiler is called ``cl.exe``.
+
+For linker flags see `Microsoft's documentation <https://docs.microsoft.com/en-us/cpp/build/reference/linker-options?view=vs-2017>`_
+The linker program is called ``link.exe``.
+
+However, Cmake actually provides many of these options in variables.
+This `StackOverflow page <https://stackoverflow.com/questions/9298278/cmake-print-out-all-accessible-variables-in-a-script>`_ contains a good example of how to see all the cmake variables available in a script.

--- a/RQt-Source-Install-MacOS.rst
+++ b/RQt-Source-Install-MacOS.rst
@@ -1,0 +1,35 @@
+Building RQt from Source on MacOS
+=================================
+This page provides specific information to building RQt from source on MacOS.
+Follow these instructions before proceeding with `RQt Source Install <RQt-Source-Install>`_ page.
+
+System Requirements
+-------------------
+RQt is supported on MacOS 10.12, but 10.13 also seems to work.
+
+Dependencies
+------------
+The primary dependencies of the RQt package are sip and PyQt5.
+PySide2 may be supported in the future.
+
+Install dependencies
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+     $ brew install sip pyqt5
+     $ brew install graphviz
+     $ python3 -m pip install pygraphviz pydot
+     $ brew link --force qt
+
+This is the quickest solution but may cause issues when upgrading Qt or if other packages are expecting Qt 4.
+Another option is to update your ``PATH`` and ``CMAKE_PREFIX_PATH`` to include the Qt install location:
+
+  .. code-block:: bash
+
+     $ export PATH="$(brew --prefix qt)/bin:$PATH"
+     $ export CMAKE_PREFIX_PATH="$(brew --prefix qt):$CMAKE_PREFIX_PATH"
+
+Install RQt by source
+---------------------
+Continue with the `RQt source install page <RQt-Source-Install>`_

--- a/RQt-Source-Install-MacOS.rst
+++ b/RQt-Source-Install-MacOS.rst
@@ -1,11 +1,11 @@
-Building RQt from Source on MacOS
+Building RQt from Source on macOS
 =================================
-This page provides specific information to building RQt from source on MacOS.
+This page provides specific information to building RQt from source on macOS.
 Follow these instructions before proceeding with `RQt Source Install <RQt-Source-Install>`_ page.
 
 System Requirements
 -------------------
-RQt is supported on MacOS 10.12, but 10.13 also seems to work.
+RQt is supported on macOS 10.12, but 10.13 also seems to work.
 
 Dependencies
 ------------

--- a/RQt-Source-Install-Windows10.rst
+++ b/RQt-Source-Install-Windows10.rst
@@ -1,0 +1,80 @@
+Building RQt from Source on Windows 10
+======================================
+This page provides specific information to building RQt from source on Windows.
+Follow these instructions before proceeding with the `RQt Source Install <RQt-Source-Install>`_ page.
+
+If you have not done so, follow the `ROS2 Windows Development Setup guide <Windows-Development-Setup>`_ before continuing.
+
+System Requirements
+-------------------
+* Windows 10
+* Visual Studio 15.7.6
+
+Currently Visual Studio 15.8 fails to build ROS2 (`see issue <https://github.com/osrf/osrf_testing_tools_cpp/issues/15>`_).
+Older versions of VS can be found `here <https://docs.microsoft.com/en-us/visualstudio/productinfo/installing-an-earlier-release-of-vs2017>`_
+
+
+Dependencies
+------------
+The primary dependencies of the RQt package are sip and PyQt5.
+PySide2 may be supported in the future.
+Even though they are provided through PyPi and chocolatey, you must install them by source to get compatible versions.
+
+Install sip by source
+~~~~~~~~~~~~~~~~~~~~~
+
+Download from https://www.riverbankcomputing.com/software/sip/download
+
+Run the x64 Native Tools Command Prompt as Administrator, and ``cd`` to the uncompressed source directory.
+
+Run:
+::
+
+   python3 configure.py
+   nmake
+   nmake install
+
+If ``python3`` is installed on your system as ``python``, be sure to use that program name instead.
+
+Install PyQt5 by source
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Download from https://www.riverbankcomputing.com/software/pyqt/download5
+
+Run the x64 Native Tools Command Prompt as Administrator, and ``cd`` to the uncompressed source directory.
+I ran into trouble with Qt 5.11.3 and PyQt5 compiling QtNfc, but it can be easily disabled.
+::
+
+   python3 --disable QtNfc
+   nmake
+   nmake install
+
+Test that it works
+~~~~~~~~~~~~~~~~~~
+If install occurred without failure, try the commands below.
+They should run without issue and you should see 4.19.13 as your sip.exe version.
+::
+
+   sip -V
+   python3 -c “from PyQt5 import QtCore”
+
+
+Other dependencies
+~~~~~~~~~~~~~~~~~~
+Install GraphViz https://graphviz.gitlab.io/_pages/Download/Download_windows.html
+
+Install pydot, pyparsing
+::
+
+   pip3 install pydot pyparsing
+
+
+
+PyGraphViz is a test dependency of ``qt_dotgraph``, but it is currently unsupported on Windows and building by source is not straight forward.
+Manually merging this patch is the currently recommended solution, but I could not get it to work.
+(see `pygraphviz patch <https://github.com/Kagami/pygraphviz/commit/fe442dc16accb629c3feaf157af75f67ccabbd6e>`_)
+
+
+Install RQt by source
+---------------------
+Continue with the `RQt source install page <RQt-Source-Install>`_

--- a/RQt-Source-Install-Windows10.rst
+++ b/RQt-Source-Install-Windows10.rst
@@ -1,16 +1,17 @@
 Building RQt from Source on Windows 10
 ======================================
+
 This page provides specific information to building RQt from source on Windows.
 Follow these instructions before proceeding with the `RQt Source Install <RQt-Source-Install>`_ page.
 
-If you have not done so, follow the `ROS2 Windows Development Setup guide <Windows-Development-Setup>`_ before continuing.
+If you have not done so, follow the `ROS 2 Windows Development Setup guide <Windows-Development-Setup>`_ before continuing.
 
 System Requirements
 -------------------
 * Windows 10
 * Visual Studio 15.7.6
 
-Currently Visual Studio 15.8 fails to build ROS2 (`see issue <https://github.com/osrf/osrf_testing_tools_cpp/issues/15>`_).
+Currently Visual Studio 15.8 fails to build ROS 2 (`see issue <https://github.com/osrf/osrf_testing_tools_cpp/issues/15>`_).
 Older versions of VS can be found `here <https://docs.microsoft.com/en-us/visualstudio/productinfo/installing-an-earlier-release-of-vs2017>`_
 
 
@@ -28,6 +29,7 @@ Download from https://www.riverbankcomputing.com/software/sip/download
 Run the x64 Native Tools Command Prompt as Administrator, and ``cd`` to the uncompressed source directory.
 
 Run:
+
 ::
 
    python3 configure.py
@@ -43,6 +45,7 @@ Download from https://www.riverbankcomputing.com/software/pyqt/download5
 
 Run the x64 Native Tools Command Prompt as Administrator, and ``cd`` to the uncompressed source directory.
 I ran into trouble with Qt 5.11.3 and PyQt5 compiling QtNfc, but it can be easily disabled.
+
 ::
 
    python3 --disable QtNfc
@@ -51,19 +54,23 @@ I ran into trouble with Qt 5.11.3 and PyQt5 compiling QtNfc, but it can be easil
 
 Test that it works
 ~~~~~~~~~~~~~~~~~~
+
 If install occurred without failure, try the commands below.
-They should run without issue and you should see 4.19.13 as your sip.exe version.
+They should run without issue and you should see 4.19.13 as your ``sip.exe`` version.
+
 ::
 
    sip -V
-   python3 -c “from PyQt5 import QtCore”
+   python3 -c "from PyQt5 import QtCore"
 
 
 Other dependencies
 ~~~~~~~~~~~~~~~~~~
+
 Install GraphViz https://graphviz.gitlab.io/_pages/Download/Download_windows.html
 
-Install pydot, pyparsing
+Install ``pydot`` and ``pyparsing``:
+
 ::
 
    pip3 install pydot pyparsing

--- a/RQt-Source-Install.rst
+++ b/RQt-Source-Install.rst
@@ -39,7 +39,7 @@ As an alternative to the hosted ``.repos`` file you can use ``rosinstall_generat
 
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
-For non-linux platforms, see the `MacOS RQT source install page <RQt-Source-Install-MacOS>`_ or the `Windows 10 RQT source install page <RQt-Source-Install-Windows10>`_ before continuing here.
+For non-Linux platforms, see the `macOS RQt source install page <RQt-Source-Install-MacOS>`_ or the `Windows 10 RQt source install page <RQt-Source-Install-Windows10>`_ before continuing here.
 
 ::
 
@@ -74,7 +74,7 @@ Advanced Colcon usages:
 Source your environment
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Linux or MacOS
+Linux or macOS
 ::
 
    . install/local_setup.bash

--- a/RQt-Source-Install.rst
+++ b/RQt-Source-Install.rst
@@ -23,7 +23,7 @@ In order to build RQt from source, first create a ROS2 workspace at ``~/ros2_ws/
 This is step is already covered in `building ROS 2 from source <https://index.ros.org/doc/ros2/Installation/>`_. instructions, so we skip it here.
 
 Download RQt Repositories
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -39,6 +39,7 @@ As an alternative to the hosted ``.repos`` file you can use ``rosinstall_generat
 
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
+For non-linux platforms, see the `MacOS RQT source install page <RQt-Source-Install-MacOS>`_ or the `Windows 10 RQT source install page <RQt-Source-Install-Windows10>`_ before continuing here.
 
 ::
 
@@ -46,14 +47,19 @@ Install Dependencies
 
 Build The Workspace
 ~~~~~~~~~~~~~~~~~~~
-
+Generally building a workspace is as simple as:
 ::
 
    colcon build
 
+For Windows, it is recommended to use the ``--merge-install`` option.
+::
+
+   colcon build --merge-install
+
 Advanced Colcon usages:
 
--  Show verbose output:
+-  Show verbose output on the console:
 
    ::
 
@@ -68,12 +74,18 @@ Advanced Colcon usages:
 Source your environment
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+Linux or MacOS
 ::
 
    . install/local_setup.bash
+
+Windows
+::
+
+   call install/local_setup.bat
 
 
 Using RQt
 ----------
 
-See `Overview of RQt<RQt-Overview-Usage>`.
+See `Overview of RQt <RQt-Overview-Usage>`_.


### PR DESCRIPTION
This adds more information to the RQt wiki pages that is mostly specific to building and using on Mac and Windows.

Depends on #28 
New commit: https://github.com/ros2/ros2_documentation/pull/56/commits/a06f04648e385f9ed423e5ca0861a356f6dc7f03
