### PR TITLE
remove trailing /

### DIFF
--- a/OSX-Install-Binary.rst
+++ b/OSX-Install-Binary.rst
@@ -121,7 +121,7 @@ Set the ``NDDSHOME`` environment variable:
 
 .. code-block:: bash
 
-   export NDDSHOME=/Applications/rti_connext_dds-5.3.1/
+   export NDDSHOME=/Applications/rti_connext_dds-5.3.1
 
 You may need to increase shared memory resources following https://community.rti.com/kb/osx510.
 


### PR DESCRIPTION
To avoid this warning when sourcing setup.bash:

```
[connext_cmake_module] Warning: NDDSHOME environment variable is set to [[/Applications/rti_connext_dds-5.3.1/]]. When the workspace was built, Connext was found at [[/Applications/rti_connext_dds-5.3.1]], which is what will actually be used. Manually modify the environment now if this is not the configuration you want.
```