### PR TITLE
Fix broken link to intra process communication

### DIFF
--- a/Composition.rst
+++ b/Composition.rst
@@ -25,7 +25,7 @@ By making the process layout a deploy-time decision the user can choose between:
 
 
 * running multiple nodes in separate processes with the benefits of process/fault isolation as well as easier debugging of individual nodes and
-* running multiple nodes in a single process with the lower overhead and optionally more efficient communication (see `Intra Process Communication <./Intra-Process-Communication/>`_).
+* running multiple nodes in a single process with the lower overhead and optionally more efficient communication (see `Intra Process Communication <../Intra-Process-Communication/>`_).
 
 The vision is that a future version of ``ros2 launch`` will support making these different deployments easily configurable.
 


### PR DESCRIPTION
#48 made the resulting URL `https://index.ros.org/doc/ros2/Composition/Intra-Process-Communication/`. Changing `./` to `../` should result in `https://index.ros.org/doc/ros2/Composition/../Intra-Process-Communication/` which is the correct page.