### PR TITLE
Update instructions for installing tinyxml2 for OSX binary

### DIFF
--- a/OSX-Install-Binary.rst
+++ b/OSX-Install-Binary.rst
@@ -39,8 +39,14 @@ You need the following things installed before installing ROS 2.
 
        brew install python3
 
-       # install asio and tinyxml2 for Fast-RTPS
-       brew install asio tinyxml2
+       # install asio for Fast-RTPS
+       brew install asio
+
+       # install tinyxml2 for Fast-RTPS
+       # currently, the binary installation only supports v6.2
+       # make sure to unlink (or remove) a newer version
+       brew unlink tinyxml2
+       brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/da9a96f093a57eb8ac7c9470c1ec04fd1823a37a/Formula/tinyxml2.rb
 
        # install dependencies for robot state publisher
        brew install tinyxml eigen pcre poco


### PR DESCRIPTION
Currently, the binary only supports 6.2.
Users installing from source should be okay with the latest version.

Resolves ros2/ros2#625