### PR TITLE
Use pytest, setuptools from pip on Bionic

### DIFF
--- a/Linux-Development-Setup.rst
+++ b/Linux-Development-Setup.rst
@@ -62,9 +62,7 @@ Install development tools and ROS tools
      flake8-quotes \
      git+https://github.com/lark-parser/lark.git@0.7b \
      pytest-repeat \
-     pytest-rerunfailures
-   # [Ubuntu 16.04] install extra packages not available or recent enough on Xenial
-   python3 -m pip install -U \
+     pytest-rerunfailures \
      pytest \
      pytest-cov \
      pytest-runner \


### PR DESCRIPTION
Resolves ros2/ros2_documentation#67

The comment suggests these dependencies are new enough to install from deb's on Bionic, but CI is installing them using pip. This makes the documentation say to install these dependencies from pip.

@alsora fyi