### PR TITLE
Added missing export of ROS_DISTRO to .bashrc to documentation

### DIFF
--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -54,20 +54,20 @@ First set an environment variable for the ROS 2 release you want to install so i
 
 .. code-block:: bash
 
-   export ROS_DISTRO=crystal  # or bouncy or ardent
+   export CHOOSE_ROS_DISTRO=crystal  # or bouncy or ardent
    sudo apt update
 
 Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash
 
-   sudo apt install ros-$ROS_DISTRO-desktop
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-desktop
 
 ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools. No GUI tools.
 
 .. code-block:: bash
 
-   sudo apt install ros-$ROS_DISTRO-ros-base
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros-base
 
 See specific sections below for how to also install the ros1_bridge, TurtleBot packages, or alternative RMW packages.
 
@@ -103,7 +103,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   source /opt/ros/$ROS_DISTRO/setup.bash
+   source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash
 
 You may want to add this to your ``.bashrc``.
 

--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -103,6 +103,7 @@ Set up your environment by sourcing the following file (you may want to add this
 
 .. code-block:: bash
 
+   export ROS_DISTRO=crystal  # or bouncy or ardent
    source /opt/ros/$ROS_DISTRO/setup.bash
 
 Installing additional RMW implementations

--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -99,12 +99,17 @@ To install ``argcomplete`` on Ubuntu 16.04 (Xenial), you'll need to use pip, bec
 Sourcing the setup script
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Set up your environment by sourcing the following file (you may want to add this to your ``.bashrc``\ ).
+Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   export ROS_DISTRO=crystal  # or bouncy or ardent
    source /opt/ros/$ROS_DISTRO/setup.bash
+
+You may want to add this to your ``.bashrc``.
+
+ .. code-block:: bash
+
+   echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 
 Installing additional RMW implementations
 -----------------------------------------

--- a/Linux-Install-Debians.rst
+++ b/Linux-Install-Debians.rst
@@ -107,7 +107,7 @@ Set up your environment by sourcing the following file.
 
 You may want to add this to your ``.bashrc``.
 
- .. code-block:: bash
+.. code-block:: bash
 
    echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 


### PR DESCRIPTION
In the description ROS_DISTRO is only set temporarily. It is required to add it to the ~/.bashrc to source correctly.