### PR TITLE
use relative link to RQt-Overview-Usage

### DIFF
--- a/Release-Crystal-Clemmys.rst
+++ b/Release-Crystal-Clemmys.rst
@@ -28,7 +28,7 @@ New features in this ROS 2 release
 * `image_transport <https://github.com/ros-perception/image_common/wiki/ROS2-Migration>`__
 * `navigation2 <https://github.com/ros-planning/navigation2/blob/master/README.md>`__
 * `rosbag2 <https://index.ros.org/r/rosbag2/github-ros2-rosbag2/#crystal>`__
-* `rqt <https://index.ros.org/doc/ros2/RQt-Overview-Usage/>`__
+* `rqt <RQt-Overview-Usage>`
 * Improvement in memory management
 * Introspection information about nodes
 * Launch system improvements


### PR DESCRIPTION
Follow up of #78.

While this doesn't change anything it uses a relative link over an absolute one.