### PR TITLE
Update Linux-Development-Setup, Ubuntu 16.04

### DIFF
--- a/Linux-Development-Setup.rst
+++ b/Linux-Development-Setup.rst
@@ -221,7 +221,7 @@ More info on working with a ROS workspace can be found in `this tutorial <Colcon
    # On Ubuntu Linux Bionic Beaver 18.04
    colcon build --symlink-install
    # On Ubuntu Linux Xenial Xerus 16.04
-   colcon build --symlink-install --packages-ignore qt_gui_cpp rqt_gui_cpp
+   colcon build --symlink-install --packages-ignore qt_gui_cpp rqt_gui_cpp opensplice_cmake_module rmw_opensplice_cpp rosidl_typesupport_opensplice_c rosidl_typesupport_opensplice_cpp
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
 Take for instance: you would like to avoid installing the large OpenCV library.


### PR DESCRIPTION
Ignore the compilation of packages related to `opensplice`, which is not the default DDS implementation. Those packages fail if to compile if the instructions are followed, so it is simpler to avoid compiling them IMO.

I have tested this only in Ubuntu 16.04. I guess this has been already tested in 18.04 and causes no trouble.