### PR TITLE
Add opencv-python to Windows pip-installed packages

### DIFF
--- a/Windows-Install-Binary.rst
+++ b/Windows-Install-Binary.rst
@@ -177,7 +177,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg empy git+https://github.com/lark-parser/lark.git@0.7b pyparsing pyyaml setuptools
+   python -m pip install -U catkin_pkg empy git+https://github.com/lark-parser/lark.git@0.7b opencv-python pyparsing pyyaml setuptools
 
 rqt dependencies
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is going to be necessary for the demos that use opencv python for images.

connects to ros2/demos#85