### PR TITLE
Fix broken link to image_transport

### DIFF
--- a/source/Features.rst
+++ b/source/Features.rst
@@ -74,7 +74,7 @@ Beside features of the platform the most impact of ROS comes from its available 
 The following are a few high profile packages which are available in the latest release:
 
 * `gazebo_ros_pkgs <https://index.ros.org/r/gazebo_ros_pkgs/>`__
-* `image_transport <https://index.ros.org/r/image_transport>`__
+* `image_transport <https://index.ros.org/r/image_common>`__
 * `navigation2 <https://index.ros.org/r/navigation2/>`__
 * `rosbag2 <https://index.ros.org/r/rosbag2/>`__
 * `RQt <https://index.ros.org/r/rqt/>`__


### PR DESCRIPTION
Fixes ros-infrastructure/rosindex#137

The package `image_transport` is in a repo called `image_common`.