### PR TITLE
fix warning and trailing spaces

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -34,7 +34,7 @@ A summary of releases of ROS 2 software is listed below.
      - 31 August 2015 - 4 October 2016
 
 For more details about each release, see the corresponding release overview.
-       
+
 Release practices
 -----------------
 

--- a/source/Roadmap.rst
+++ b/source/Roadmap.rst
@@ -33,7 +33,7 @@ Design / Concept
 
   * Support for non-ASCII strings in messages / services
   * Leverage new features like grouping and various annotations (comments, units)
-  * Extend usage to `.idl` files with just constants and/or declare parameters with ranges
+  * Extend usage to ``.idl`` files with just constants and/or declare parameters with ranges
 
 * Progress on migration plan
 * Reconsider 1-to-1 mapping of ROS nodes to DDS participants


### PR DESCRIPTION
Fixes the following warning when invoking `make html`:

> ros2_documentation/source/Roadmap.rst:36: WARNING: 'any' reference target not found: .idl