### PR TITLE
add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+sudo: false
+install:
+  - pip install sphinx
+script:
+  - make html 2> stderr.log
+  - cat stderr.log
+  # fail the build for any stderr output
+  - if [ -s "stderr.log" ]; then false; fi
+notifications:
+  email: false


### PR DESCRIPTION
The CI build invokes `make html` and ensures that there is no `stderr` output.