### PR TITLE
Don't tell the user to override OSPL_URI

### DIFF
--- a/source/Installation/Linux-Development-Setup.rst
+++ b/source/Installation/Linux-Development-Setup.rst
@@ -132,13 +132,6 @@ PrismTech OpenSplice Debian Packages built by OSRF
    # For Bouncy Bolson
    sudo apt install libopensplice67  # from packages.ros.org/ros2/ubuntu
 
-Add this to your ``~/.bashrc``
-
-.. code-block:: bash
-
-   export OSPL_URI=file:///usr/etc/opensplice/config/ospl.xml
-
-
 .. raw:: html
 
    <!--


### PR DESCRIPTION
We now ship our own ros_ospl.xml, which also gets properly exported into the environment by setup.bash, so just let that mechanism work.