### PR TITLE
generate redirect pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # sys.path.insert(0, os.path.abspath('.'))
 
 # The suffix(es) of source filenames.
@@ -99,3 +99,37 @@ html_theme = 'alabaster'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ros2_docsdoc'
+
+
+redirect_snippet = """\
+<html>
+  <head>
+    <link rel="canonical" href="{rel}.html" />
+    <meta http-equiv="refresh" content="1; url={rel}.html:" />
+    <script>
+      window.location.href = "{rel}.html"
+    </script>
+  </head>
+</html>
+"""
+
+
+def generate_redirects(app, docname):
+    if app.builder.name != 'html':
+        return
+    print('generating html redirects:')
+    redirects = {
+        'About-Quality-of-Service-Settings':
+        'Concepts/About-Quality-of-Service-Settings',
+    }
+    for src, dst in redirects.items():
+        print(' ', src, '->', dst)
+        abs_dst = os.path.join(app.outdir, src + '.html')
+        os.makedirs(os.path.dirname(abs_dst), exist_ok=True)
+        with open(abs_dst, 'w') as h:
+            rel = os.path.relpath(dst, os.path.dirname(src))
+            h.write(redirect_snippet.format_map(locals()))
+
+
+def setup(app):
+    app.connect('build-finished', generate_redirects)

--- a/source/About-Quality-of-Service-Settings.rst
+++ b/source/About-Quality-of-Service-Settings.rst
@@ -1,5 +1,0 @@
-
-About Quality of Service Settings
-=================================
-
-This page now lives `here <Concepts/About-Quality-of-Service-Settings>`.

--- a/source/index.rst
+++ b/source/index.rst
@@ -130,7 +130,6 @@ The following `ROSCon <http://roscon.ros.org>`__ talks have been given on ROS 2 
 .. toctree::
    :hidden:
 
-   About-Quality-of-Service-Settings
    About-ROS-Interfaces
    Allocator-Template-Tutorial
    Alpha-Overview


### PR DESCRIPTION
In #79 a lot of pages where moved/renamed. In order to keep existing links working dummy pages have been created which only contain a link to the new location of the content.

First this manual link following is neither very convenient for the user nor do search engines pick up the changes quickly. Second all these the `.rst` files for these redirect pages make it more difficult to spot files with actual content.

This patch is a proof of concept removing these redirect `.rst` files and instead generating the `.html` files directly during `make html` and not only offer a manual link to the new location but also an automatic redirect as well as a canonical URL for crawlers.

This patch works when building the repo locally with `make html`. The remaining question is if this also works when embedded into index.ros.org.

If this is working the patch should be updated to replace all manual redirect pages with this new approach.