### PR TITLE
added instructions to install additional dependencies

### DIFF
--- a/source/Installation/Linux-Install-Debians.rst
+++ b/source/Installation/Linux-Install-Debians.rst
@@ -81,6 +81,15 @@ See specific sections below for how to also install the `ros1_bridge <Install ad
 Environment setup
 -----------------
 
+Install additional dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    python3 -m pip install -U \
+        vcstool \
+        colcon-common-extensions
+
 (optional) Install argcomplete
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I was running through the tutorials on a new computer but it never had me install colcon or vcs.  Adding instructions to do so here (I assume this is the right place?  I believe bouncy is where things went from ament to colcon?)  Could also put it under the colcon tutorial.  It's a bit weird to have ros2 crystal installed via debian without these packages.  A better solution is probably to have the debians depend on these instead of having to install separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ros2/ros2_documentation/120)
<!-- Reviewable:end -->
