### PR TITLE
Use $CHOOSE_ROS_DISTRO uniformly

### DIFF
--- a/source/Installation/Linux-Install-Debians.rst
+++ b/source/Installation/Linux-Install-Debians.rst
@@ -116,7 +116,7 @@ You may want to add this to your ``.bashrc``.
 
 .. code-block:: bash
 
-   echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" >> ~/.bashrc
 
 Install additional RMW implementations
 --------------------------------------
@@ -129,8 +129,8 @@ To install support for OpenSplice or RTI Connext on Bouncy:
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install ros-$ROS_DISTRO-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-$ROS_DISTRO-rmw-connext-cpp # for RTI Connext (requires license agreement)
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-opensplice-cpp # for OpenSplice
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-connext-cpp # for RTI Connext (requires license agreement)
 
 By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice instead.
 For ROS 2 releases Bouncy and newer, ``RMW_IMPLEMENTATION=rmw_connext_cpp`` can also be selected to use RTI Connext.
@@ -151,13 +151,13 @@ Now you can install the remaining packages:
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install ros-$ROS_DISTRO-ros1-bridge
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros1-bridge
 
 The turtlebot2 packages are available in Bouncy but not Crystal.
 
 .. code-block:: bash
 
-   sudo apt install ros-$ROS_DISTRO-turtlebot2-*
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-turtlebot2-*
 
 Build your own packages
 -----------------------


### PR DESCRIPTION
Change uses of `$ROS_DISTRO` (the old variable name in previous documentation, if I recall correctly) to `$CHOOSE_ROS_DISTRO`.

Going the other way and unifying on `$ROS_DISTRO` would also work, but I am not aware of why `$CHOOSE_ROS_DISTRO` was chosen so maybe that was to avoid confusion with a ROS-provided environment variable.