### PR TITLE
Adds installation instructions for log4cxx.

### DIFF
--- a/source/Installation/OSX-Development-Setup.rst
+++ b/source/Installation/OSX-Development-Setup.rst
@@ -59,6 +59,9 @@ You need the following things installed to build ROS 2:
 
        brew install opencv
 
+       # install dependencies for rcl_logging_log4cxx
+       brew install log4cxx
+
 #.
    Install rviz dependencies
 

--- a/source/Installation/OSX-Install-Binary.rst
+++ b/source/Installation/OSX-Install-Binary.rst
@@ -69,6 +69,9 @@ You need the following things installed before installing ROS 2.
        # install Qt for RViz
        brew install qt freetype assimp
 
+       # install dependencies for rcl_logging_log4cxx
+       brew install log4cxx
+
 *
   Install rqt dependencies
 

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -303,7 +303,7 @@ Hit the windows key and type ``Edit Group Policy``. Navigate to Local Computer P
 Close and open your terminal to reset the environment and try building again.
 
 CMake Packages Unable to Find asio, tinyxml2, tinyxml, eigen, or log4cxx
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We've seen, but been unable to identify the root cause, that sometimes the chocolatey packages for ``asio``, ``tinyxml2``, etc. do not add important registry entries and that will cause CMake to be unable to find them when building ROS 2.
 

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -302,7 +302,7 @@ Hit the windows key and type ``Edit Group Policy``. Navigate to Local Computer P
 
 Close and open your terminal to reset the environment and try building again.
 
-CMake Packages Unable to Find asio, tinyxml2, tinyxml, or eigen
+CMake Packages Unable to Find asio, tinyxml2, tinyxml, eigen, or log4cxx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We've seen, but been unable to identify the root cause, that sometimes the chocolatey packages for ``asio``, ``tinyxml2``, etc. do not add important registry entries and that will cause CMake to be unable to find them when building ROS 2.

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -171,12 +171,13 @@ Please download these packages from `this <https://github.com/ros2/choco-package
 * eigen-3.3.4.nupkg
 * tinyxml-usestl.2.6.2.nupkg
 * tinyxml2.6.0.0.nupkg
+* log4cxx.0.10.0.nupkg
 
 Once these packages are downloaded, open an administrative shell and execute the following command:
 
 .. code-block:: bash
 
-   > choco install -y -s <PATH\TO\DOWNLOADS\> asio eigen tinyxml-usestl tinyxml2
+   > choco install -y -s <PATH\TO\DOWNLOADS\> asio eigen tinyxml-usestl tinyxml2 log4cxx
 
 Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 


### PR DESCRIPTION
Windows and Mac require log4cxx to be installed via choco and brew,
respectively. This change updates the build and install instructions
to include information about installing log4cxx.

Connected to [ros2/rcl_logging#3](https://github.com/ros2/rcl_logging/pull/3)