### PR TITLE
update known issues for Crystal

### DIFF
--- a/source/Releases/Release-Crystal-Clemmys.rst
+++ b/source/Releases/Release-Crystal-Clemmys.rst
@@ -153,7 +153,6 @@ Known Issues
 ------------
 
 * Cross-vendor communication between rmw_fastrtps_cpp and other implementations is not functioning on Windows (`Issue <https://github.com/ros2/rmw_fastrtps/issues/246>`__).
-* 100% CPU usage in Action Server when cancelling a goal from the client. (`Issue <https://github.com/ros2/examples/issues/221>`__).
-* Action Server can crash when a goal expires. (`Pull Request <https://github.com/ros2/rcl/pull/360>`__).
-* Segfault in ``ros2 param get`` when a string parameter value contains non-ASCII characters. (`Issue <https://github.com/ros2/ros2cli/issues/176>`__).
-* The latest version of OpenSplice on Windows is not compatible with the available binaries. (`Issue <https://github.com/ros2/build_cop/issues/157>`__).
+* When using OpenSplice (version < 6.9.190227) on macOS and Windows you might experience naming conflicts when referecing field types with names from other packages if the same name also exist in the same package (`Issue <https://github.com/ros2/rmw_opensplice/issues/259>`__).
+  By updating the a newer OpenSplice version as well as at least the third patch release of Crystal the problem should be resolved.
+  On Linux updating to the latest Debian packages will include the newest OpenSplice version.

--- a/source/Releases/Release-Crystal-Clemmys.rst
+++ b/source/Releases/Release-Crystal-Clemmys.rst
@@ -153,6 +153,6 @@ Known Issues
 ------------
 
 * Cross-vendor communication between rmw_fastrtps_cpp and other implementations is not functioning on Windows (`Issue <https://github.com/ros2/rmw_fastrtps/issues/246>`__).
-* When using OpenSplice (version < 6.9.190227) on macOS and Windows you might experience naming conflicts when referecing field types with names from other packages if the same name also exist in the same package (`Issue <https://github.com/ros2/rmw_opensplice/issues/259>`__).
-  By updating the a newer OpenSplice version as well as at least the third patch release of Crystal the problem should be resolved.
+* When using OpenSplice (version < 6.9.190227) on macOS and Windows you might experience naming conflicts when when referencing field types with names from other packages if the same name also exist in the current package (`Issue <https://github.com/ros2/rmw_opensplice/issues/259>`__).
+  By updating to a newer OpenSplice version as well as at least the third patch release of Crystal the problem should be resolved.
   On Linux updating to the latest Debian packages will include the newest OpenSplice version.


### PR DESCRIPTION
The four removed items have already been addressed and released in previous patch releases.

The newly added OpenSplice problem will be addressed in the next patch release but for macOS and Windows the user will need to update the isntalled OpenSplice version.