### PR TITLE
Update Dashing Diademata changelist after legacy launch deprecation.

### DIFF
--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -77,6 +77,10 @@ launch
 The ``launch_testing`` package caught up with the ``launch`` package redesign done in Bouncy Bolson.
 The legacy Python API, already moved into the ``launch.legacy`` submodule, has thus been deprecated and removed.
 
+See ``launch`` `examples <https://github.com/ros2/launch/tree/master/launch/examples>`__ and `documentation <https://github.com/ros2/launch/tree/master/launch/doc>`__ for reference on how to use its new API.
+
+See `demos tests <https://github.com/ros2/demos>`__ for reference on how to use the new ``launch_testing`` API.
+
 rmw
 ~~~
 

--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -71,6 +71,12 @@ you need to update the condition to ensure it considers a string value as ``TRUE
 
    if(var)
 
+launch
+~~~~~~
+
+The ``launch_testing`` package caught up with the ``launch`` package redesign done in Bouncy Bolson.
+The legacy Python API, already moved into the ``launch.legacy`` submodule, has thus been deprecated and removed.
+
 rmw
 ~~~
 


### PR DESCRIPTION
Precisely what the title says. Connected to ros2/launch#191.