### PR TITLE
Add notes about lxml dependency where required.

### DIFF
--- a/source/Installation/Fedora-Development-Setup.rst
+++ b/source/Installation/Fedora-Development-Setup.rst
@@ -12,7 +12,7 @@ First install a bunch of dependencies:
 
 .. code-block:: bash
 
-   $ sudo dnf install cppcheck cmake libXaw-devel opencv-devel poco-devel poco-foundation python3-empy python3-devel python3-nose python3-pip python3-pyparsing python3-pytest python3-pytest-cov python3-pytest-runner python3-setuptools python3-yaml tinyxml-devel eigen3-devel python3-pydocstyle python3-pyflakes python3-coverage python3-mock python3-pep8 uncrustify python3-argcomplete python3-flake8 python3-flake8-import-order asio-devel tinyxml2-devel libyaml-devel
+   $ sudo dnf install cppcheck cmake libXaw-devel opencv-devel poco-devel poco-foundation python3-empy python3-devel python3-nose python3-pip python3-pyparsing python3-pytest python3-pytest-cov python3-pytest-runner python3-setuptools python3-yaml tinyxml-devel eigen3-devel python3-pydocstyle python3-pyflakes python3-coverage python3-mock python3-pep8 uncrustify python3-argcomplete python3-flake8 python3-flake8-import-order asio-devel tinyxml2-devel libyaml-devel python3-lxml
 
 Then install vcstool from pip:
 

--- a/source/Installation/OSX-Install-Binary.rst
+++ b/source/Installation/OSX-Install-Binary.rst
@@ -85,6 +85,11 @@ You need the following things installed before installing ROS 2.
   ``python3 -m pip install pygraphviz pydot``
 
 *
+  Install SROS2 dependencies
+
+  ``python3 -m pip install lxml``
+
+*
   Install additional runtime dependencies for command-line tools:
 
   .. code-block:: bash

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -378,5 +378,30 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
    > python_d path\to\colcon_executable build
 
-
 * Hooray, you're done!
+
+SROS2 Debug Mode
+^^^^^^^^^^^^^^^^
+
+In order to use SROS2 in Debug mode on Windows, a corresponding debug build for ``lxml`` must be installed.
+
+* A pre-built Python wheel binary for ``lxml`` debug is provided, to install:
+
+.. code-block:: bash
+
+   > pip install https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl
+
+* To verify installation
+
+.. code-block:: bash
+
+   > python_d
+   > from lxml import etree
+
+* No import errors should appear.
+
+* Note, in order to switch back to release, reinstall the release wheel of lxml via pip:
+
+.. code-block:: bash
+
+   > pip install lxml

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -194,6 +194,13 @@ RQt dependencies
 
    python -m pip install -U pydot PyQt5
 
+SROS2 dependencies
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   python -m pip install -U lxml
+
 Downloading ROS 2
 -----------------
 


### PR DESCRIPTION
This adds notes about the `lxml` dependency for the corresponding binary installs.

Places where `rosdep` are used (Ubuntu) should not need this, because it's already specified in the `package.xml` for SROS2 (https://github.com/ros2/sros2/blob/crystal/sros2/package.xml#L16) and has a corresponding rosdep key (https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L4777)