### PR TITLE
Update OSX-Install-Binary.rst

### DIFF
--- a/source/Installation/OSX-Install-Binary.rst
+++ b/source/Installation/OSX-Install-Binary.rst
@@ -107,7 +107,7 @@ Downloading ROS 2
 
 
 * Go to the releases page: https://github.com/ros2/ros2/releases
-* Download the latest package for OS X; let's assume that it ends up at ``~/Downloads/ros2-package-osx-x86_64.tar.bz2``.
+* Download the latest package for OS X; let's assume that it ends up at ``~/Downloads/ros2-distro-date-macos-amd64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
 

--- a/source/Installation/OSX-Install-Binary.rst
+++ b/source/Installation/OSX-Install-Binary.rst
@@ -107,7 +107,7 @@ Downloading ROS 2
 
 
 * Go to the releases page: https://github.com/ros2/ros2/releases
-* Download the latest package for OS X; let's assume that it ends up at ``~/Downloads/ros2-distro-date-macos-amd64.tar.bz2``.
+* Download the latest package for OS X; let's assume that it ends up at ``~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
 
@@ -118,7 +118,7 @@ Downloading ROS 2
 
        mkdir -p ~/ros2_install
        cd ~/ros2_install
-       tar xf ~/Downloads/ros2-package-osx-x86_64.tar.bz2
+       tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
 
 Install additional DDS implementations (optional)
 -------------------------------------------------


### PR DESCRIPTION
Edited typo. The file name which called `ros2-package-osx-x86_64.tar.bz2` was changed.

Thanks.