### PR TITLE
Remove unsupported `emphasize-lines` directives.

### DIFF
--- a/source/Contributing/Quality-Guide.rst
+++ b/source/Contributing/Quality-Guide.rst
@@ -183,7 +183,6 @@ The code migration suggestions here are by no means complete - when writing (or 
     * Add the ``RCPPUTILS_TSA_GUARDED_BY(mutex_name)`` annotation to the data that is protected by the mutex
 
     .. code-block:: cpp
-      :emphasize-lines: 14
 
       class Foo {
       public:
@@ -206,7 +205,6 @@ The code migration suggestions here are by no means complete - when writing (or 
     * In the above example - ``Foo::get`` will produce a compiler warning! To fix it, lock before returning bar
 
     .. code-block:: cpp
-      :emphasize-lines: 2
 
       void get() const {
         std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
This issue was introduced in #140. I didn't explicitly override CI to include these changes. I'm not sure why the GitHub UI let this through but this should resolve the issue.

FYI @emersonknapp I've had to remove the line emphasis from your contribution. If there are any further edits that you'd like to make as a result of this change please tag me directly for review.