### PR TITLE
remove .0 from ROS 2

### DIFF
--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -212,7 +212,7 @@ If you are using gtest:
 Linters
 ~~~~~~~
 
-In ROS 2.0 we are working to maintain clean code using linters.
+In ROS 2 we are working to maintain clean code using linters.
 The styles for different languages are defined in our `Developer Guide <Developer-Guide>`.
 
 If you are starting a project from scratch it is recommended to follow the style guide and turn on the automatic linter unittests by adding these lines just below ``if(BUILD_TESTING)`` (until alpha 5 this was ``AMENT_ENABLE_TESTING``).

--- a/source/Installation/Linux-Development-Setup.rst
+++ b/source/Installation/Linux-Development-Setup.rst
@@ -87,8 +87,8 @@ Install development tools and ROS tools
 
 .. _linux-dev-get-ros2-code:
 
-Get ROS 2.0 code
-----------------
+Get ROS 2 code
+--------------
 
 Create a workspace and clone all repos:
 
@@ -121,11 +121,11 @@ Install dependencies using rosdep
 Install more DDS implementations (Optional)
 -------------------------------------------
 
-ROS 2.0 builds on top of DDS.
+ROS 2 builds on top of DDS.
 It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
-The repositories you downloaded for ROS 2.0 includes eProsima's Fast RTPS, which is the only bundled vendor.
+The repositories you downloaded for ROS 2 includes eProsima's Fast RTPS, which is the only bundled vendor.
 If you would like to use one of the other vendors you will need to install their software separately before building.
-The ROS 2.0 build will automatically build support for vendors that have been installed and sourced correctly.
+The ROS 2 build will automatically build support for vendors that have been installed and sourced correctly.
 
 By default we include eProsima's FastRTPS in the workspace and it is the default middleware. Detailed instructions for installing other DDS vendors are provided below.
 

--- a/source/Installation/OSX-Development-Setup.rst
+++ b/source/Installation/OSX-Development-Setup.rst
@@ -124,11 +124,11 @@ Create a workspace and clone all repos:
 Install additional DDS vendors (optional)
 -----------------------------------------
 
-ROS 2.0 builds on top of DDS.
+ROS 2 builds on top of DDS.
 It is compatible with `multiple DDS or RTPS (the DDS wire protocol) vendors <../Concepts/DDS-and-ROS-middleware-implementations>`.
-The repositories you downloaded for ROS 2.0 includes eProsima's Fast RTPS, which is the only bundled vendor.
+The repositories you downloaded for ROS 2 includes eProsima's Fast RTPS, which is the only bundled vendor.
 If you would like to use one of the other vendors you will need to install their software separately before building.
-The ROS 2.0 build will automatically build support for vendors that have been installed and sourced correctly.
+The ROS 2 build will automatically build support for vendors that have been installed and sourced correctly.
 
 By default we include eProsima's FastRTPS in the workspace and it is the default middleware.
 Detailed instructions for installing other DDS vendors are provided in the "Alternative DDS sources" section below.
@@ -172,7 +172,7 @@ Alternative DDS sources
 -----------------------
 
 The demos will attempt to build against any detected DDS vendor.
-The only bundled vendor is eProsima's Fast RTPS, which is included in the default set of sources for ROS 2.0.
+The only bundled vendor is eProsima's Fast RTPS, which is included in the default set of sources for ROS 2.
 If you would like to switch out the vendor below are the instructions.
 When you run the build make sure that your chosen DDS vendor(s) are exposed in your environment.
 

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -274,7 +274,7 @@ Alternative DDS Sources
 -----------------------
 
 The demos will attempt to build against any detected DDS vendor.
-The only bundled vendor is eProsima's Fast RTPS, which is included in the default set of sources for ROS 2.0.
+The only bundled vendor is eProsima's Fast RTPS, which is included in the default set of sources for ROS 2.
 To build for other vendors, make sure that your chosen DDS vendor(s) are exposed in your environment when you run the build.
 If you would like to change which vendor is being used see: `Working with Multiple RMW Implementations <../Tutorials/Working-with-multiple-RMW-implementations>`
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -79,7 +79,7 @@ There's a full article on the motivation of ROS 2 `here <http://design.ros2.org/
 Where to find more information
 ------------------------------
 
-There are various articles on the design of ROS 2 at `design.ros2.org <http://design.ros2.org>`__\ , such as: `\ *Why ROS 2.0?* <http://design.ros2.org/articles/why_ros2.html>`__\ , `\ *ROS on DDS* <http://design.ros2.org/articles/ros_on_dds.html>`__\ , and `\ *Changes between ROS 1 and ROS 2* <http://design.ros2.org/articles/changes.html>`__.
+There are various articles on the design of ROS 2 at `design.ros2.org <http://design.ros2.org>`__\ , such as: `\ *Why ROS 2?* <http://design.ros2.org/articles/why_ros2.html>`__\ , `\ *ROS on DDS* <http://design.ros2.org/articles/ros_on_dds.html>`__\ , and `\ *Changes between ROS 1 and ROS 2* <http://design.ros2.org/articles/changes.html>`__.
 
 The code for ROS 2 is open source and broken into various repositories.
 You can find the code for most of the repositories on the `ros2 github organization <https://github.com/ros2>`__.
@@ -117,7 +117,7 @@ The following `ROSCon <http://roscon.ros.org>`__ talks have been given on ROS 2 
    * - ROS 2 on "small" embedded systems
      - ROSCon 2015 presentation
      - `slides <http://roscon.ros.org/2015/presentations/ros2_on_small_embedded_systems.pdf>`__ / `video <https://vimeo.com/142150576>`__
-   * - Real-time control in ROS and ROS 2.0
+   * - Real-time control in ROS and ROS 2
      - ROSCon 2015 presentation
      - `slides <http://roscon.ros.org/2015/presentations/RealtimeROS2.pdf>`__ / `video <https://vimeo.com/142621778>`__
    * - Why you want to use ROS 2


### PR DESCRIPTION
Instead of using `ROS 2.0` we commonly refer to "it" as ROS 2. This patch removes the `.0` from the remaining locations where it is still being used.