### PR TITLE
RTI connext packages provided only for amd64 architecture

### DIFF
--- a/source/Installation/Linux-Development-Setup.rst
+++ b/source/Installation/Linux-Development-Setup.rst
@@ -163,8 +163,8 @@ PrismTech OpenSplice Debian Packages built by OSRF
 
 
 
-RTI Connext (version 5.3.1)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+RTI Connext (version 5.3.1, amd64 only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Debian packages provided in the ROS 2 apt repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Installation/Linux-Install-Binary.rst
+++ b/source/Installation/Linux-Install-Binary.rst
@@ -104,8 +104,8 @@ Bouncy and earlier:
            libopensplice69
 
 
-RTI Connext
-^^^^^^^^^^^
+RTI Connext (version 5.3.1, amd64 only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To use RTI Connext you will need to have obtained a license from RTI.
 Add the following line to your ``.bashrc`` file pointing to your copy of the license (and source it).


### PR DESCRIPTION
As it's possible to install the placeholder package for arm64 it can get confusing on the user-side