### PR TITLE
refer to building from source for Windows users

### DIFF
--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -218,6 +218,8 @@ If you don't install any additional DDS vendors, ROS 2 will default to using ePr
 Building the ROS 2 Code
 -----------------------
 
+.. _windows-dev-build-ros2:
+
 To build ROS 2 you will need a Visual Studio Command Prompt (usually titled "x64 Native Tools Command Prompt for VS 2017" for bouncy and later or "x64 Native Tools Command Prompt for VS 2015" for ardent and earlier) running as Administrator.
 
 FastRTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.

--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -145,6 +145,8 @@ In general, it is recommended to use an overlay when you plan to iterate on a sm
 Build the workspace
 ^^^^^^^^^^^^^^^^^^^
 
+.. attention:: To build packages on Windows you need to be in a Visual Studio environment, see `Building the ROS 2 Code <../Installation/Windows-Development-Setup/#building-the-ros-2-code>`__ for more details.
+
 In the root of the workspace, run ``colcon build``.
 Since build types such as ``ament_cmake`` do not support the concept of the ``devel`` space and require the package to be installed, colcon supports the option ``--symlink-install``.
 This allows the installed files to be changed by changing the files in the ``source`` space (e.g. Python files or other not compiled resourced) for faster iteration.

--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -145,7 +145,9 @@ In general, it is recommended to use an overlay when you plan to iterate on a sm
 Build the workspace
 ^^^^^^^^^^^^^^^^^^^
 
-.. attention:: To build packages on Windows you need to be in a Visual Studio environment, see `Building the ROS 2 Code <../Installation/Windows-Development-Setup/#building-the-ros-2-code>`__ for more details.
+.. attention::
+
+   To build packages on Windows you need to be in a Visual Studio environment, see `Building the ROS 2 Code <windows-dev-build-ros2>` for more details.
 
 In the root of the workspace, run ``colcon build``.
 Since build types such as ``ament_cmake`` do not support the concept of the ``devel`` space and require the package to be installed, colcon supports the option ``--symlink-install``.


### PR DESCRIPTION
in response to https://answers.ros.org/question/317475/ros2-windows10-colcon-build-fails-on-ros2_example_ws-tutorial/

Question: Is that the right way to reference a different page's section?