### PR TITLE
ROS 2 Crystal can now use the latest tinyxml2 formula.

### DIFF
--- a/source/Installation/OSX-Install-Binary.rst
+++ b/source/Installation/OSX-Install-Binary.rst
@@ -46,16 +46,8 @@ You need the following things installed before installing ROS 2.
 
        brew install python3
 
-       # install asio for Fast-RTPS
-       brew install asio
-
-       # install tinyxml2 for Fast-RTPS
-       # currently, the binary installation only supports v6.2
-       # make sure remove an existing newer version
-       brew remove tinyxml2
-       brew tap osrf/simulation
-       brew install osrf/simulation/tinyxml2@6.2.0
-       brew link --force tinyxml2@6.2.0
+       # install asio and tinyxml2 for Fast-RTPS
+       brew install asio tinyxml2
 
        # install dependencies for robot state publisher
        brew install tinyxml eigen pcre poco


### PR DESCRIPTION
The change which necessitated this restriction was fixed upstream and
released in Fast-RTPS 1.7.1. Fast-RTPS 1.7.2 was released into Crystal
on 2019-04-08.

This reverts commit 99bd6bf7b13a7d690b934e23edece1eb85d9c39a from #68.