### PR TITLE
Add actions tutorial page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ install:
 script:
   - make html 2> stderr.log
   - cat stderr.log
-  - doc8 --ignore D001 --ignore-path build
+  - doc8 --ignore D001 --ignore-path build --ignore-path source/Tutorials/Actions
+  # ignore D000 in action tutorials to allow for :linenos:
+  - doc8 --ignore D000 --ignore D001 --ignore-path build source/Tutorials/Actions
   # fail the build for any stderr output
   - if [ -s "stderr.log" ]; then false; fi
 notifications:

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -24,6 +24,7 @@ Basic
    Tutorials/Rosidl-Tutorial.rst
    Tutorials/New-features-in-ROS-2-interfaces-(msg-srv)
    Tutorials/Defining-custom-interfaces-(msg-srv)
+   Tutorials/Actions
    Tutorials/Eclipse-Oxygen-with-ROS-2-and-rviz2
    Tutorials/Building-ROS-2-on-Linux-with-Eclipse-Oxygen
    Tutorials/Building-Realtime-rt_preempt-kernel-for-ROS-2

--- a/source/Tutorials/Actions.rst
+++ b/source/Tutorials/Actions.rst
@@ -10,260 +10,34 @@ About
 
 Actions are a form of asynchronous communication in ROS.
 *Action clients* send goal requests to *action servers*.
-Upon receiving a goal, an action server provides feedback messages and, ultimately, a result message when the goal is done.
-After a goal request has been accepted by an action server, the action client has the option to cancel the goal before it completes.
+*Action servers* send goal feedback and results to *action clients*.
 For more detailed information about ROS actions, please refer to the `design article <http://design.ros2.org/articles/actions.html>`__.
 
-This document contains tutorials on how to create action servers and action clients as well as using the CLI tool for interaction/introspection.
+This document contains a list of tutorials related to actions.
+Each tutorial builds on the previous, and so it is recommended that they are completed in order.
+By the end of all the tutorials, you should expect to have a ROS package that looks the package `action_tutorials <https://github.com/ros2/demos/tree/master/action_tutorials>`__.
 
-Creating a new Action
----------------------
+Prequisites
+-----------
 
-In this tutorial we look how to define an action in a ROS package.
-
-Identical to ROS 1, actions are be defined with ``.action`` files of the form:
-
-.. code-block:: bash
-
-    # Request
-    ---
-    # Result
-    ---
-    # Feedback
-
-This defines the request, result, and feedback messages for action goals that we intend to send between our action servers and clients.
-
-Say we want to define a new action "Fibonacci" for computing the `Fibonacci sequence <https://en.wikipedia.org/wiki/Fibonacci_number>`__.
-Let's start by creating a new package ``actions_tutorial`` in a colcon workspace:
+- `Install ROS <../Installation>
+- `Install colcon <https://colcon.readthedocs.org>`__
+- Setup a workspace create a package named ``action_tutorials``:
 
 .. code-block:: bash
 
     mkdir -p action_ws/src
     cd action_ws/src
-    ros2 pkg create action_tutorial
-
-Next we add the file ``action/Fibonacci.action`` with the following content:
-
-.. code-block:: bash
-
-    int32 order
-    ---
-    int32[] sequence
-    ---
-    int32[] sequence
-
-The goal request is the order of the Fibonacci sequence we want to compute, the result is the final sequence, and the feedback is the sequence computed so far.
-
-Similar to ROS messages and services, we need to generate language specific types for this action by passing our Fibonacci action defintition to the rosidl pipeline.
-This is accomplished by adding the following to our ``CMakeLists.txt``:
-
-.. code-block:: cmake
-
-    find_package(action_msgs REQUIRED)
-    find_package(rosidl_default_generators REQUIRED)
-
-    rosidl_generate_interfaces(${PROJECT_NAME}
-      "action/Fibonacci.action"
-      DEPENDENCIES action_msgs
-    )
-
-We should also add the required dependencies to our ``package.xml``:
-
-.. code-block:: xml
-
-    <buildtool_depend>rosidl_default_generators</buildtool_depend>
-
-    <depend>action_msgs</depend>
-
-    <!-- We need to use package format 3 for this tag -->
-    <member_of_group>rosidl_interface_packages</member_of_group>
-
-Note, we need to depend on ``action_msgs`` since action definitions include additional metadata (e.g. goal IDs).
-
-We're done! We should now be able to build the package containing the "Fibonacci" action definition.
-
-.. code-block:: bash
-
-    # Change to the root of the workspace
-    cd ..
-    # Build
-    colcon build
-
-Writing an Action Server (C++)
-------------------------------
-
-Coming soon.
-
-
-Writing an Action Client (C++)
-------------------------------
-
-Coming soon.
-
-Writing an Action Server (Python)
----------------------------------
-
-Here we look at implementing an action server in Python.
-Let's walk through the following action server implementation (``fibonacci_action_server.py``):
-
-.. code-block:: python
-    :linenos:
-
-    import time
-
-    from action_tutorial.action import Fibonacci
-
-    import rclpy
-    from rclpy.action import ActionServer
-    from rclpy.node import Node
-
-
-    class FibonacciActionServer(Node):
-
-        def __init__(self):
-            super().__init__('fibonacci_action_server')
-
-            self._action_server = ActionServer(
-                self,
-                Fibonacci,
-                'fibonacci',
-                execute_callback=self.execute_callback)
-
-        def destroy(self):
-            self._action_server.destroy()
-            super().destroy_node()
-
-        def execute_callback(self, goal_handle):
-            self.get_logger().info('Executing goal...')
-
-            feedback_msg = Fibonacci.Feedback()
-            feedback_msg.sequence = [0, 1]
-
-            for i in range(1, goal_handle.request.order):
-                feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
-                self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
-                goal_handle.publish_feedback(feedback_msg)
-                time.sleep(1)
-
-            goal_handle.succeed()
-
-            result = Fibonacci.Result()
-            result.sequence = feedback_msg.sequence
-            self.get_logger().info('Returning result: {0}'.format(result.sequence))
-            return result
-
-
-    def main(args=None):
-        rclpy.init(args=args)
-
-        fibonacci_action_server = FibonacciActionServer()
-
-        rclpy.spin(fibonacci_action_server)
-
-        fibonacci_action_server.destroy()
-        rclpy.shutdown()
-
-
-    if __name__ == '__main__':
-        main()
-
-At line 3 we import our custom action definition from the previous tutorial on `Creating a new Action`_.
-Lines 5-7 are importing types from the client library that we need.
-
-Starting at line 10 we define a new class to encapsulate our action server implementation.
-It is a subclass of ``Node``.
-
-We initialize the class by calling the ``Node`` constructor, naming our node "fibonacci_action_server":
-
-.. code-block:: python
-
-    super().__init__('fibonacci_action_server')
-
-Also during initialization, we instantiate an ``ActionServer`` with four arguments:
-
-.. code-block:: python
-
-    self._action_server = ActionServer(
-        self,
-        Fibonacci,
-        'fibonacci',
-        execute_callback=self.execute_callback)
-
-The first argument is the node to add the action server to (ie. self).
-The second argument is the type of the action.
-The third argument is the action name.
-And the final argument is the function we want called when a new goal is accepted.
-Note, all goals are accepted by default.
-
-Line 21-23 defines a ``destroy`` method that is useful for freeing resources used by the node and action server.
-
-Lines 25-42 is the method called whenever we get a new goal request.
-It takes one argument that is a handle to the goal.
-After logging a message, we create a feedback message:
-
-.. code-block:: python
-
-    feedback_msg = Fibonacci.Feedback()
-    feedback_msg.sequence = [0, 1]
-
-Then, we loop up to the requested Fibonacci order (accessed from the goal handle):
-
-.. code-block:: python
-
-    for i in range(1, goal_handle.request.order):
-
-And update the feedback message, publish it, and sleep for dramatic effect:
-
-.. code-block:: python
-
-    feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
-    self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
-    goal_handle.publish_feedback(feedback_msg)
-    time.sleep(1)
-
-After computing the sequence, we mark the goal as successful:
-
-.. code-block:: python
-
-    goal_handle.succeed()
-
-Finally, we populate the result message and return it:
-
-.. code-block:: python
-
-    result = Fibonacci.Result()
-    result.sequence = feedback_msg.sequence
-    self.get_logger().info('Returning result: {0}'.format(result.sequence))
-    return result
-
-On lines 45-57 We define a main function and call to create an executable.
-Because ``FibonacciActionServer`` is a subclass of ``Node`` we can spin on it, which will process our callbacks for any action requests.
-
-Let's run the action server:
-
-.. code-block:: bash
-
-    python3 fibonacci_action_server.py
-
-In another terminal, try sending a goal with the command line tool:
-
-.. code-block:: bash
-
-    ros2 action send_goal -f fibonacci action_tutorial/Fibonacci "{order: 5}"
-
-You should see feedback and the final result sequence printed to both terminals.
-
-Rejecting goals
-^^^^^^^^^^^^^^^
-
-Coming soon.
-
-Allowing goals to be canceled
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Coming soon.
-
-Writing an Action Client (Python)
----------------------------------
-
-Coming soon.
+    ros2 pkg create action_tutorials
+
+Tutorials
+---------
+
+.. toctree::
+   :maxdepth: 1
+
+   Actions/Creating-an-Action
+   Actions/Create-an-Action-Server-CPP
+   Actions/Create-an-Action-Client-CPP
+   Actions/Create-an-Action-Server-Python
+   Actions/Create-an-Action-Client-Python

--- a/source/Tutorials/Actions.rst
+++ b/source/Tutorials/Actions.rst
@@ -1,0 +1,269 @@
+Actions
+=======
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+About
+-----
+
+Actions are a form of asynchronous communication in ROS.
+*Action clients* send goal requests to *action servers*.
+Upon receiving a goal, an action server provides feedback messages and, ultimately, a result message when the goal is done.
+After a goal request has been accepted by an action server, the action client has the option to cancel the goal before it completes.
+For more detailed information about ROS actions, please refer to the `design article <http://design.ros2.org/articles/actions.html>`__.
+
+This document contains tutorials on how to create action servers and action clients as well as using the CLI tool for interaction/introspection.
+
+Creating a new Action
+---------------------
+
+In this tutorial we look how to define an action in a ROS package.
+
+Identical to ROS 1, actions are be defined with ``.action`` files of the form:
+
+.. code-block:: bash
+
+    # Request
+    ---
+    # Result
+    ---
+    # Feedback
+
+This defines the request, result, and feedback messages for action goals that we intend to send between our action servers and clients.
+
+Say we want to define a new action "Fibonacci" for computing the `Fibonacci sequence <https://en.wikipedia.org/wiki/Fibonacci_number>`__.
+Let's start by creating a new package ``actions_tutorial`` in a colcon workspace:
+
+.. code-block:: bash
+
+    mkdir -p action_ws/src
+    cd action_ws/src
+    ros2 pkg create action_tutorial
+
+Next we add the file ``action/Fibonacci.action`` with the following content:
+
+.. code-block:: bash
+
+    int32 order
+    ---
+    int32[] sequence
+    ---
+    int32[] sequence
+
+The goal request is the order of the Fibonacci sequence we want to compute, the result is the final sequence, and the feedback is the sequence computed so far.
+
+Similar to ROS messages and services, we need to generate language specific types for this action by passing our Fibonacci action defintition to the rosidl pipeline.
+This is accomplished by adding the following to our ``CMakeLists.txt``:
+
+.. code-block:: cmake
+
+    find_package(action_msgs REQUIRED)
+    find_package(rosidl_default_generators REQUIRED)
+
+    rosidl_generate_interfaces(${PROJECT_NAME}
+      "action/Fibonacci.action"
+      DEPENDENCIES action_msgs
+    )
+
+We should also add the required dependencies to our ``package.xml``:
+
+.. code-block:: xml
+
+    <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+    <depend>action_msgs</depend>
+
+    <!-- We need to use package format 3 for this tag -->
+    <member_of_group>rosidl_interface_packages</member_of_group>
+
+Note, we need to depend on ``action_msgs`` since action definitions include additional metadata (e.g. goal IDs).
+
+We're done! We should now be able to build the package containing the "Fibonacci" action definition.
+
+.. code-block:: bash
+
+    # Change to the root of the workspace
+    cd ..
+    # Build
+    colcon build
+
+Writing an Action Server (C++)
+------------------------------
+
+Coming soon.
+
+
+Writing an Action Client (C++)
+------------------------------
+
+Coming soon.
+
+Writing an Action Server (Python)
+---------------------------------
+
+Here we look at implementing an action server in Python.
+Let's walk through the following action server implementation (``fibonacci_action_server.py``):
+
+.. code-block:: python
+    :linenos:
+
+    import time
+
+    from action_tutorial.action import Fibonacci
+
+    import rclpy
+    from rclpy.action import ActionServer
+    from rclpy.node import Node
+
+
+    class FibonacciActionServer(Node):
+
+        def __init__(self):
+            super().__init__('fibonacci_action_server')
+
+            self._action_server = ActionServer(
+                self,
+                Fibonacci,
+                'fibonacci',
+                execute_callback=self.execute_callback)
+
+        def destroy(self):
+            self._action_server.destroy()
+            super().destroy_node()
+
+        def execute_callback(self, goal_handle):
+            self.get_logger().info('Executing goal...')
+
+            feedback_msg = Fibonacci.Feedback()
+            feedback_msg.sequence = [0, 1]
+
+            for i in range(1, goal_handle.request.order):
+                feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
+                self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
+                goal_handle.publish_feedback(feedback_msg)
+                time.sleep(1)
+
+            goal_handle.succeed()
+
+            result = Fibonacci.Result()
+            result.sequence = feedback_msg.sequence
+            self.get_logger().info('Returning result: {0}'.format(result.sequence))
+            return result
+
+
+    def main(args=None):
+        rclpy.init(args=args)
+
+        fibonacci_action_server = FibonacciActionServer()
+
+        rclpy.spin(fibonacci_action_server)
+
+        fibonacci_action_server.destroy()
+        rclpy.shutdown()
+
+
+    if __name__ == '__main__':
+        main()
+
+At line 3 we import our custom action definition from the previous tutorial on `Creating a new Action`_.
+Lines 5-7 are importing types from the client library that we need.
+
+Starting at line 10 we define a new class to encapsulate our action server implementation.
+It is a subclass of ``Node``.
+
+We initialize the class by calling the ``Node`` constructor, naming our node "fibonacci_action_server":
+
+.. code-block:: python
+
+    super().__init__('fibonacci_action_server')
+
+Also during initialization, we instantiate an ``ActionServer`` with four arguments:
+
+.. code-block:: python
+
+    self._action_server = ActionServer(
+        self,
+        Fibonacci,
+        'fibonacci',
+        execute_callback=self.execute_callback)
+
+The first argument is the node to add the action server to (ie. self).
+The second argument is the type of the action.
+The third argument is the action name.
+And the final argument is the function we want called when a new goal is accepted.
+Note, all goals are accepted by default.
+
+Line 21-23 defines a ``destroy`` method that is useful for freeing resources used by the node and action server.
+
+Lines 25-42 is the method called whenever we get a new goal request.
+It takes one argument that is a handle to the goal.
+After logging a message, we create a feedback message:
+
+.. code-block:: python
+
+    feedback_msg = Fibonacci.Feedback()
+    feedback_msg.sequence = [0, 1]
+
+Then, we loop up to the requested Fibonacci order (accessed from the goal handle):
+
+.. code-block:: python
+
+    for i in range(1, goal_handle.request.order):
+
+And update the feedback message, publish it, and sleep for dramatic effect:
+
+.. code-block:: python
+
+    feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
+    self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
+    goal_handle.publish_feedback(feedback_msg)
+    time.sleep(1)
+
+After computing the sequence, we mark the goal as successful:
+
+.. code-block:: python
+
+    goal_handle.succeed()
+
+Finally, we populate the result message and return it:
+
+.. code-block:: python
+
+    result = Fibonacci.Result()
+    result.sequence = feedback_msg.sequence
+    self.get_logger().info('Returning result: {0}'.format(result.sequence))
+    return result
+
+On lines 45-57 We define a main function and call to create an executable.
+Because ``FibonacciActionServer`` is a subclass of ``Node`` we can spin on it, which will process our callbacks for any action requests.
+
+Let's run the action server:
+
+.. code-block:: bash
+
+    python3 fibonacci_action_server.py
+
+In another terminal, try sending a goal with the command line tool:
+
+.. code-block:: bash
+
+    ros2 action send_goal -f fibonacci action_tutorial/Fibonacci "{order: 5}"
+
+You should see feedback and the final result sequence printed to both terminals.
+
+Rejecting goals
+^^^^^^^^^^^^^^^
+
+Coming soon.
+
+Allowing goals to be canceled
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Coming soon.
+
+Writing an Action Client (Python)
+---------------------------------
+
+Coming soon.

--- a/source/Tutorials/Actions.rst
+++ b/source/Tutorials/Actions.rst
@@ -19,7 +19,7 @@ For reference, after completing all of the tutorials you should expect to have a
 Prequisites
 -----------
 
-- `Install ROS (Dashing) <../Installation>`
+- `Install ROS (Dashing or later) <../Installation>`
 
 - `Install colcon <https://colcon.readthedocs.org>`__
 

--- a/source/Tutorials/Actions.rst
+++ b/source/Tutorials/Actions.rst
@@ -14,21 +14,32 @@ Actions are a form of asynchronous communication in ROS.
 For more detailed information about ROS actions, please refer to the `design article <http://design.ros2.org/articles/actions.html>`__.
 
 This document contains a list of tutorials related to actions.
-Each tutorial builds on the previous, and so it is recommended that they are completed in order.
-By the end of all the tutorials, you should expect to have a ROS package that looks the package `action_tutorials <https://github.com/ros2/demos/tree/master/action_tutorials>`__.
+For reference, after completing all of the tutorials you should expect to have a ROS package that looks like the package `action_tutorials <https://github.com/ros2/demos/tree/master/action_tutorials>`__.
 
 Prequisites
 -----------
 
-- `Install ROS <../Installation>
+- `Install ROS (Dashing) <../Installation>`
+
 - `Install colcon <https://colcon.readthedocs.org>`__
-- Setup a workspace create a package named ``action_tutorials``:
 
-.. code-block:: bash
+- Setup a workspace and create a package named ``action_tutorials``:
 
-    mkdir -p action_ws/src
-    cd action_ws/src
-    ros2 pkg create action_tutorials
+  Linux / OSX:
+
+  .. code-block:: bash
+
+      mkdir -p action_ws/src
+      cd action_ws/src
+      ros2 pkg create action_tutorials
+
+  Windows:
+
+  .. code-block:: bash
+
+      mkdir -p action_ws\src
+      cd action_ws\src
+      ros2 pkg create action_tutorials
 
 Tutorials
 ---------
@@ -37,7 +48,7 @@ Tutorials
    :maxdepth: 1
 
    Actions/Creating-an-Action
-   Actions/Create-an-Action-Server-CPP
-   Actions/Create-an-Action-Client-CPP
-   Actions/Create-an-Action-Server-Python
-   Actions/Create-an-Action-Client-Python
+   Actions/Writing-an-Action-Server-CPP
+   Actions/Writing-an-Action-Client-CPP
+   Actions/Writing-an-Action-Server-Python
+   Actions/Writing-an-Action-Client-Python

--- a/source/Tutorials/Actions/Creating-an-Action.rst
+++ b/source/Tutorials/Actions/Creating-an-Action.rst
@@ -89,6 +89,6 @@ We can check that our action built successfully with the command line tool:
     # On Windows: call install/setup.bat
     . install/setup.bash
     # Check that our action definition exists
-    ros2 action show action_tutorials/action/Fibonacci
+    ros2 action show action_tutorials/Fibonacci
 
 You should see the Fibonacci action definition printed to the screen.

--- a/source/Tutorials/Actions/Creating-an-Action.rst
+++ b/source/Tutorials/Actions/Creating-an-Action.rst
@@ -3,12 +3,12 @@ Creating an Action
 
 In this tutorial we look how to define an action in a ROS package.
 
-Make sure you have the `prequisites <../Actions>`.
+Make sure you have satisfied all `prequisites <../Actions>`.
 
 Defining an Action
 ------------------
 
-Identical to ROS 1, actions are be defined with ``.action`` files of the form:
+Just like in ROS 1, actions are defined in ``.action`` files of the form:
 
 .. code-block:: bash
 
@@ -18,11 +18,11 @@ Identical to ROS 1, actions are be defined with ``.action`` files of the form:
     ---
     # Feedback
 
-An action defintion is made up of three message definitions separated by ``---``.
+An action definition is made up of three message definitions separated by ``---``.
 An instance of an action is typically referred to as a *goal*.
 A *request* message is sent from an action client to an action server initiating a new goal.
 A *result* message is sent from an action server to an action client when a goal is done.
-*Feedback* messages are periodically sent from an action server to an action client to updates about a goal.
+*Feedback* messages are periodically sent from an action server to an action client with updates about a goal.
 
 Say we want to define a new action "Fibonacci" for computing the `Fibonacci sequence <https://en.wikipedia.org/wiki/Fibonacci_number>`__.
 

--- a/source/Tutorials/Actions/Creating-an-Action.rst
+++ b/source/Tutorials/Actions/Creating-an-Action.rst
@@ -1,0 +1,81 @@
+Creating an Action
+==================
+
+In this tutorial we look how to define an action in a ROS package.
+
+
+Defining an Action
+------------------
+
+Identical to ROS 1, actions are be defined with ``.action`` files of the form:
+
+.. code-block:: bash
+
+    # Request
+    ---
+    # Result
+    ---
+    # Feedback
+
+An action defintion is made up of three message definitions separated by ``---``.
+An instance of an action is typically referred to as a *goal*.
+A *request* message is sent from an action client to an action server initiating a new goal.
+A *result* message is sent from an action server to an action client when a goal is done.
+*Feedback* messages are periodically sent from an action server to an action client to updates about a goal.
+
+Say we want to define a new action "Fibonacci" for computing the `Fibonacci sequence <https://en.wikipedia.org/wiki/Fibonacci_number>`__.
+Let's start by creating a new package ``actions_tutorial`` in a colcon workspace:
+
+.. code-block:: bash
+
+    mkdir -p action_ws/src
+    cd action_ws/src
+    ros2 pkg create action_tutorial
+
+Next we add the file ``action/Fibonacci.action`` with the following content:
+
+.. code-block:: bash
+
+    int32 order
+    ---
+    int32[] sequence
+    ---
+    int32[] sequence
+
+The goal request is the order of the Fibonacci sequence we want to compute, the result is the final sequence, and the feedback is the sequence computed so far.
+
+Similar to ROS messages and services, we need to generate language specific types for this action by passing our Fibonacci action defintition to the rosidl pipeline.
+This is accomplished by adding the following to our ``CMakeLists.txt``:
+
+.. code-block:: cmake
+
+    find_package(action_msgs REQUIRED)
+    find_package(rosidl_default_generators REQUIRED)
+
+    rosidl_generate_interfaces(${PROJECT_NAME}
+      "action/Fibonacci.action"
+      DEPENDENCIES action_msgs
+    )
+
+We should also add the required dependencies to our ``package.xml``:
+
+.. code-block:: xml
+
+    <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+    <depend>action_msgs</depend>
+
+    <!-- We need to use package format 3 for this tag -->
+    <member_of_group>rosidl_interface_packages</member_of_group>
+
+Note, we need to depend on ``action_msgs`` since action definitions include additional metadata (e.g. goal IDs).
+
+We're done! We should now be able to build the package containing the "Fibonacci" action definition.
+
+.. code-block:: bash
+
+    # Change to the root of the workspace
+    cd ..
+    # Build
+    colcon build
+

--- a/source/Tutorials/Actions/Creating-an-Action.rst
+++ b/source/Tutorials/Actions/Creating-an-Action.rst
@@ -3,6 +3,7 @@ Creating an Action
 
 In this tutorial we look how to define an action in a ROS package.
 
+Make sure you have the `prequisites <../Actions>`.
 
 Defining an Action
 ------------------
@@ -24,15 +25,9 @@ A *result* message is sent from an action server to an action client when a goal
 *Feedback* messages are periodically sent from an action server to an action client to updates about a goal.
 
 Say we want to define a new action "Fibonacci" for computing the `Fibonacci sequence <https://en.wikipedia.org/wiki/Fibonacci_number>`__.
-Let's start by creating a new package ``actions_tutorial`` in a colcon workspace:
 
-.. code-block:: bash
-
-    mkdir -p action_ws/src
-    cd action_ws/src
-    ros2 pkg create action_tutorial
-
-Next we add the file ``action/Fibonacci.action`` with the following content:
+First, create a directory ``action`` in our ROS package.
+With your favorite editor, add the file ``action/Fibonacci.action`` with the following content:
 
 .. code-block:: bash
 
@@ -40,12 +35,15 @@ Next we add the file ``action/Fibonacci.action`` with the following content:
     ---
     int32[] sequence
     ---
-    int32[] sequence
+    int32[] partial_sequence
 
-The goal request is the order of the Fibonacci sequence we want to compute, the result is the final sequence, and the feedback is the sequence computed so far.
+The goal request is the ``order`` of the Fibonacci sequence we want to compute, the result is the final ``sequence``, and the feedback is the ``partial_sequence`` computed so far.
 
-Similar to ROS messages and services, we need to generate language specific types for this action by passing our Fibonacci action defintition to the rosidl pipeline.
-This is accomplished by adding the following to our ``CMakeLists.txt``:
+Building an Action
+------------------
+
+Before we can use the new Fibonacci action type in our code, we must pass the definition to the rosidl code generation pipeline.
+This is accomplished by adding the following lines to our ``CMakeLists.txt``:
 
 .. code-block:: cmake
 
@@ -65,17 +63,32 @@ We should also add the required dependencies to our ``package.xml``:
 
     <depend>action_msgs</depend>
 
-    <!-- We need to use package format 3 for this tag -->
     <member_of_group>rosidl_interface_packages</member_of_group>
 
 Note, we need to depend on ``action_msgs`` since action definitions include additional metadata (e.g. goal IDs).
 
-We're done! We should now be able to build the package containing the "Fibonacci" action definition.
+We should now be able to build the package containing the "Fibonacci" action definition:
 
 .. code-block:: bash
 
-    # Change to the root of the workspace
-    cd ..
+    # Change to the root of the workspace (ie. action_ws)
+    cd ../..
     # Build
     colcon build
 
+We're done!
+
+By convention, action types will be prefixed by their package name and the word ``action``.
+So when we want to refer to our new action, it will have the full name ``action_tutorials/action/Fibonacci``.
+
+We can check that our action built successfully with the command line tool:
+
+.. code-block:: bash
+
+    # Source our workspace
+    # On Windows: call install/setup.bat
+    . install/setup.bash
+    # Check that our action definition exists
+    ros2 action show action_tutorials/action/Fibonacci
+
+You should see the Fibonacci action definition printed to the screen.

--- a/source/Tutorials/Actions/Writing-an-Action-Client-CPP.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Client-CPP.rst
@@ -1,0 +1,4 @@
+Writing an Action Client (C++)
+==============================
+
+Coming soon.

--- a/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
@@ -1,4 +1,174 @@
 Writing an Action Client (Python)
 ---------------------------------
 
-Coming soon.
+In this tutorial, we look at implementing an action client in Python.
+
+We assume you have the `prequisites <../Actions>`.
+
+Sending a Goal
+^^^^^^^^^^^^^^
+
+Let's get started!
+
+To keep things simple, we'll scope this tutorial to a single file.
+Open a new file, let's call it ``fibonacci_action_client.py``, and add the following boilerplate code:
+
+.. literalinclude:: client_0.py
+    :language: python
+    :linenos:
+    :lines: 1,3,6-11,13-22
+
+Right now, we define a class ``FibonacciActionClient`` that is a subclass of ``Node``.
+The class is initialized by calling the ``Node`` constructor, naming our node "fibonacci_action_client":
+
+.. code-block:: python
+
+    super().__init__('fibonacci_action_server')
+
+
+After the class defintion, we define a function ``main`` that initializes ROS and creates an instance of our ``FibonacciActionClient`` node.
+
+Finally, we call ``main()`` in the entry point of our Python program.
+
+You can try running the program:
+
+.. code-block:: bash
+
+    python3 fibonacci_action_client.py
+
+It doesn't do anything interesting...yet.
+
+Let's import and create an action client using the custom action definition from the previous tutorial on `Creating an Action <Creating-an-Action>`.
+
+.. literalinclude:: client_0.py
+    :language: python
+    :linenos:
+    :lines: 1-12
+    :emphasize-lines: 2,5,12
+
+At line 12 we create an ``ActionClient`` by passing it three arguments:
+
+1. the node to add the action client to: ``self``.
+2. the type of the action: ``Fibonacci``.
+3. the action name: ``'fibonacci'``.
+
+Our action client will be able to communicate with action servers of the same action name and type.
+
+Now let's tell the action client to send a goal.
+Add a new method ``send_goal()``:
+
+.. literalinclude:: client_1.py
+    :language: python
+    :linenos:
+    :lines: 8-20
+    :emphasize-lines: 7-13
+
+We create a new Fibonacci goal message and assign a sequence order.
+Before sending the goal message, we must wait for an action server to become available.
+Otherwise, a potential action server may miss the goal we're sending.
+
+Finally, call the ``send_goal`` method with a value:
+
+.. literalinclude:: client_1.py
+    :language: python
+    :linenos:
+    :lines: 27-32
+    :emphasize-lines: 6
+
+Let's test our action client by first running an action server built in the tutorial on `Writing an Action Server (Python) <Writing-an-Action-Server-Python>`:
+
+.. code-block:: bash
+
+    ros2 run action_tutorials fibonacci_action_server.py
+
+In another terminal, run the action client:
+
+.. code-block:: bash
+
+    python3 fibonacci_action_client.py
+
+Tada! You should see messages printed by the action server as it successfully executes the goal.
+
+Getting Feedback
+^^^^^^^^^^^^^^^^
+
+Our action client can send goals.
+Nice!
+But it would be great if we could get some feedback about the goals we send from the action server.
+Easy, let's write a callback function for feedback messsages:
+
+.. literalinclude:: client_1.py
+    :language: python
+    :linenos:
+    :lines: 8-24
+    :emphasize-lines: 15-17
+
+In the callback we get the feedback portion of the message and print the ``partial_sequence`` field to the screen.
+
+We need to register the callback with the action client.
+This is achieved by passing the callback to the action client when we send a goal:
+
+.. literalinclude:: client_2.py
+    :language: python
+    :linenos:
+    :lines: 14-21
+    :emphasize-lines: 7
+
+You'll notice at this point that our action client is not printing any feedback.
+This is because we're missing a call to `rclpy.spin() <http://docs.ros2.org/latest/api/rclpy/api/init_shutdown.html#rclpy.spin>`_ in order to process callbacks on our node.
+Let's add it:
+
+.. literalinclude:: client_2.py
+    :language: python
+    :linenos:
+    :lines: 27-34
+    :emphasize-lines: 8
+
+We're all set. If we run our action client, you should see feedback being printed to the screen.
+
+Getting a Result
+^^^^^^^^^^^^^^^^
+
+So we can send a goal, but how do we know when it is completed?
+We can get the result information with a couple steps.
+First, we need to get a goal handle for the goal we sent.
+Then, we can use the goal handle to request the result.
+
+The `ActionClient.send_goal_async() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.client.ActionClient.send_goal_async>`_ method returns a future to a goal handle.
+Let's register a callback for when the future is complete:
+
+.. literalinclude:: client_3.py
+    :language: python
+    :linenos:
+    :lines: 8-27
+    :emphasize-lines: 13-20
+
+
+Note, the future is completed when an action server accepts or rejects the goal request.
+We can actually check to see if the goal was rejected and return early since we know there will be no result:
+
+.. literalinclude:: client_3.py
+    :language: python
+    :linenos:
+    :lines: 26-33
+    :emphasize-lines: 4-8
+
+Now that we've got a goal handle, we can use it to request the result with the method `get_result_async() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.client.ClientGoalHandle.get_result_async>`_.
+Similar to sending the goal, we will get a future that will complete when the result is ready.
+Let's register a callback just like we did for the goal response:
+
+.. literalinclude:: client_3.py
+    :language: python
+    :linenos:
+    :lines: 26-42
+    :emphasize-lines: 10-17
+
+In the callback, we log the result sequence and shutdown ROS for a clean exit.
+
+With an action server running in a separate terminal, go ahead and try running our Fibonacci action client!
+
+.. code-block:: bash
+
+    python3 fibonacci_action_client.py
+
+You should see logged messages for the goal being accepted, feedback, and the final result.

--- a/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
@@ -18,7 +18,7 @@ Open a new file, let's call it ``fibonacci_action_client.py``, and add the follo
     :linenos:
     :lines: 1,3,6-11,13-22
 
-Right now, we define a class ``FibonacciActionClient`` that is a subclass of ``Node``.
+We've define a class ``FibonacciActionClient`` that is a subclass of ``Node``.
 The class is initialized by calling the ``Node`` constructor, naming our node "fibonacci_action_client":
 
 .. code-block:: python
@@ -26,8 +26,7 @@ The class is initialized by calling the ``Node`` constructor, naming our node "f
     super().__init__('fibonacci_action_server')
 
 
-After the class defintion, we define a function ``main`` that initializes ROS and creates an instance of our ``FibonacciActionClient`` node.
-
+After the class defintion, we define a function ``main()`` that initializes ROS and creates an instance of our ``FibonacciActionClient`` node.
 Finally, we call ``main()`` in the entry point of our Python program.
 
 You can try running the program:
@@ -48,7 +47,7 @@ Let's import and create an action client using the custom action definition from
 
 At line 12 we create an ``ActionClient`` by passing it three arguments:
 
-1. the node to add the action client to: ``self``.
+1. a ROS node to add the action client to: ``self``.
 2. the type of the action: ``Fibonacci``.
 3. the action name: ``'fibonacci'``.
 

--- a/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
@@ -1,0 +1,4 @@
+Writing an Action Client (Python)
+---------------------------------
+
+Coming soon.

--- a/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
@@ -1,12 +1,12 @@
 Writing an Action Client (Python)
----------------------------------
+=================================
 
 In this tutorial, we look at implementing an action client in Python.
 
-We assume you have the `prequisites <../Actions>`.
+Make sure you have satisfied all `prequisites <../Actions>`.
 
 Sending a Goal
-^^^^^^^^^^^^^^
+--------------
 
 Let's get started!
 
@@ -18,13 +18,12 @@ Open a new file, let's call it ``fibonacci_action_client.py``, and add the follo
     :linenos:
     :lines: 1,3,6-11,13-22
 
-We've define a class ``FibonacciActionClient`` that is a subclass of ``Node``.
+We've defined a class ``FibonacciActionClient`` that is a subclass of ``Node``.
 The class is initialized by calling the ``Node`` constructor, naming our node "fibonacci_action_client":
 
-.. code-block:: python
-
-    super().__init__('fibonacci_action_server')
-
+.. literalinclude:: client_0.py
+    :language: python
+    :lines: 11
 
 After the class defintion, we define a function ``main()`` that initializes ROS and creates an instance of our ``FibonacciActionClient`` node.
 Finally, we call ``main()`` in the entry point of our Python program.
@@ -89,7 +88,7 @@ In another terminal, run the action client:
 Tada! You should see messages printed by the action server as it successfully executes the goal.
 
 Getting Feedback
-^^^^^^^^^^^^^^^^
+----------------
 
 Our action client can send goals.
 Nice!
@@ -126,7 +125,7 @@ Let's add it:
 We're all set. If we run our action client, you should see feedback being printed to the screen.
 
 Getting a Result
-^^^^^^^^^^^^^^^^
+----------------
 
 So we can send a goal, but how do we know when it is completed?
 We can get the result information with a couple steps.

--- a/source/Tutorials/Actions/Writing-an-Action-Server-CPP.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Server-CPP.rst
@@ -1,0 +1,4 @@
+Writing an Action Server (C++)
+==============================
+
+Coming soon.

--- a/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
@@ -1,7 +1,10 @@
 Writing an Action Server (Python)
 ---------------------------------
 
-Here we look at implementing an action server in Python.
+In this tutorial, we look at implementing an action server in Python.
+
+We assume you have the `prequisites <../Actions>` and have completed the `Creating an Action tutorial <Creating-an-Action>`.
+
 Let's walk through the following action server implementation (``fibonacci_action_server.py``):
 
 .. code-block:: python
@@ -9,7 +12,7 @@ Let's walk through the following action server implementation (``fibonacci_actio
 
     import time
 
-    from action_tutorial.action import Fibonacci
+    from action_tutorials.action import Fibonacci
 
     import rclpy
     from rclpy.action import ActionServer
@@ -35,18 +38,19 @@ Let's walk through the following action server implementation (``fibonacci_actio
             self.get_logger().info('Executing goal...')
 
             feedback_msg = Fibonacci.Feedback()
-            feedback_msg.sequence = [0, 1]
+            feedback_msg.partial_sequence = [0, 1]
 
             for i in range(1, goal_handle.request.order):
-                feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
-                self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
+                feedback_msg.partial_sequence.append(
+                    feedback_msg.partial_sequence[i] + feedback_msg.partial_sequence[i-1])
+                self.get_logger().info('Feedback: {0}'.format(feedback_msg.partial_sequence))
                 goal_handle.publish_feedback(feedback_msg)
                 time.sleep(1)
 
             goal_handle.succeed()
 
             result = Fibonacci.Result()
-            result.sequence = feedback_msg.sequence
+            result.sequence = feedback_msg.partial_sequence
             self.get_logger().info('Returning result: {0}'.format(result.sequence))
             return result
 
@@ -65,7 +69,7 @@ Let's walk through the following action server implementation (``fibonacci_actio
     if __name__ == '__main__':
         main()
 
-At line 3 we import our custom action definition from the previous tutorial on `Creating a new Action`_.
+At line 3 we import our custom action definition from the previous tutorial on `Creating an Action <Creating-an-Action>`.
 Lines 5-7 are importing types from the client library that we need.
 
 Starting at line 10 we define a new class to encapsulate our action server implementation.
@@ -95,14 +99,14 @@ Note, all goals are accepted by default.
 
 Line 21-23 defines a ``destroy`` method that is useful for freeing resources used by the node and action server.
 
-Lines 25-42 is the method called whenever we get a new goal request.
+Lines 25-43 is the method called whenever we get a new goal request.
 It takes one argument that is a handle to the goal.
 After logging a message, we create a feedback message:
 
 .. code-block:: python
 
     feedback_msg = Fibonacci.Feedback()
-    feedback_msg.sequence = [0, 1]
+    feedback_msg.partial_sequence = [0, 1]
 
 Then, we loop up to the requested Fibonacci order (accessed from the goal handle):
 
@@ -114,18 +118,20 @@ And update the feedback message, publish it, and sleep for dramatic effect:
 
 .. code-block:: python
 
-    feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
-    self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
+    feedback_msg.partial_sequence.append(
+        feedback_msg.partial_sequence[i] + feedback_msg.partial_sequence[i-1])
+    self.get_logger().info('Feedback: {0}'.format(feedback_msg.partial_sequence))
     goal_handle.publish_feedback(feedback_msg)
     time.sleep(1)
 
-After computing the sequence, we mark the goal as successful:
+Now that the goal is done, we need to tell the client the result.
+We'll use a method on the ``goal_handle`` to tell the client the goal was successfully reached:
 
 .. code-block:: python
 
     goal_handle.succeed()
 
-Finally, we populate the result message and return it:
+Finally, populate the result message and return it:
 
 .. code-block:: python
 
@@ -134,7 +140,7 @@ Finally, we populate the result message and return it:
     self.get_logger().info('Returning result: {0}'.format(result.sequence))
     return result
 
-On lines 45-57 We define a main function and call to create an executable.
+On lines 46-58 We define a main function and call to create an executable.
 Because ``FibonacciActionServer`` is a subclass of ``Node`` we can spin on it, which will process our callbacks for any action requests.
 
 Let's run the action server:
@@ -150,13 +156,3 @@ In another terminal, try sending a goal with the command line tool:
     ros2 action send_goal -f fibonacci action_tutorial/Fibonacci "{order: 5}"
 
 You should see feedback and the final result sequence printed to both terminals.
-
-Rejecting goals
-^^^^^^^^^^^^^^^
-
-Coming soon.
-
-Allowing goals to be canceled
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Coming soon.

--- a/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
@@ -1,12 +1,12 @@
 Writing an Action Server (Python)
----------------------------------
+=================================
 
 In this tutorial, we look at implementing an action server in Python.
 
-We assume you have the `prequisites <../Actions>`.
+Make sure you have satisfied all `prequisites <../Actions>`.
 
 Executing Goals
-^^^^^^^^^^^^^^^
+---------------
 
 Let's focus on writing an action server that computes the Fibonacci sequence using the action we created in the `Creating an Action <Creating-an-Action>` tutorial.
 
@@ -21,9 +21,9 @@ Open a new file, let's call it ``fibonacci_action_server.py``, and add the follo
 We've defined a class ``FibonacciActionServer`` that is a subclass of ``Node``.
 The class is initialized by calling the ``Node`` constructor, naming our node "fibonacci_action_server":
 
-.. code-block:: python
-
-    super().__init__('fibonacci_action_server')
+.. literalinclude:: server_0.py
+    :language: python
+    :lines: 11
 
 After the class defintion, we define a function ``main()`` that initializes ROS, creates an instance of our ``FibonacciActionServer`` node, and calls `rclpy.spin() <http://docs.ros2.org/latest/api/rclpy/api/init_shutdown.html#rclpy.spin>`_ on our node.
 The spin will keep our action sever alive and responsive to incoming goals.
@@ -59,7 +59,7 @@ In another terminal, we can use the command line interface to send a goal:
 
     ros2 action  send_goal fibonacci action_tutorials/Fibonacci "{order: 5}"
 
-You should see our logged message "Executing goal..." folowed by a warning that the goal state was not set.
+You should see our logged message "Executing goal..." followed by a warning that the goal state was not set.
 By default, if the goal handle state is not set in the execute callback it assumes the *aborted* state.
 
 We can use the method `succeed() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.server.ServerGoalHandle.succeeded>`_ on the goal handle to indicate that the goal was successful:
@@ -85,7 +85,7 @@ After computing the sequence, we assign it to the result message field before re
 Again restarting the action server and send another goal, you should see the goal finished, this time with the proper result sequence.
 
 Publishing Feedback
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 One of the nice things about actions is the ability to provide feedback to an action client during goal execution.
 We can make our action server publish feedback for action clients by calling the goal handle's `publish_feedback() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.server.ServerGoalHandle.publish_feedback>`_ method.

--- a/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
@@ -1,0 +1,162 @@
+Writing an Action Server (Python)
+---------------------------------
+
+Here we look at implementing an action server in Python.
+Let's walk through the following action server implementation (``fibonacci_action_server.py``):
+
+.. code-block:: python
+    :linenos:
+
+    import time
+
+    from action_tutorial.action import Fibonacci
+
+    import rclpy
+    from rclpy.action import ActionServer
+    from rclpy.node import Node
+
+
+    class FibonacciActionServer(Node):
+
+        def __init__(self):
+            super().__init__('fibonacci_action_server')
+
+            self._action_server = ActionServer(
+                self,
+                Fibonacci,
+                'fibonacci',
+                execute_callback=self.execute_callback)
+
+        def destroy(self):
+            self._action_server.destroy()
+            super().destroy_node()
+
+        def execute_callback(self, goal_handle):
+            self.get_logger().info('Executing goal...')
+
+            feedback_msg = Fibonacci.Feedback()
+            feedback_msg.sequence = [0, 1]
+
+            for i in range(1, goal_handle.request.order):
+                feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
+                self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
+                goal_handle.publish_feedback(feedback_msg)
+                time.sleep(1)
+
+            goal_handle.succeed()
+
+            result = Fibonacci.Result()
+            result.sequence = feedback_msg.sequence
+            self.get_logger().info('Returning result: {0}'.format(result.sequence))
+            return result
+
+
+    def main(args=None):
+        rclpy.init(args=args)
+
+        fibonacci_action_server = FibonacciActionServer()
+
+        rclpy.spin(fibonacci_action_server)
+
+        fibonacci_action_server.destroy()
+        rclpy.shutdown()
+
+
+    if __name__ == '__main__':
+        main()
+
+At line 3 we import our custom action definition from the previous tutorial on `Creating a new Action`_.
+Lines 5-7 are importing types from the client library that we need.
+
+Starting at line 10 we define a new class to encapsulate our action server implementation.
+It is a subclass of ``Node``.
+
+We initialize the class by calling the ``Node`` constructor, naming our node "fibonacci_action_server":
+
+.. code-block:: python
+
+    super().__init__('fibonacci_action_server')
+
+Also during initialization, we instantiate an ``ActionServer`` with four arguments:
+
+.. code-block:: python
+
+    self._action_server = ActionServer(
+        self,
+        Fibonacci,
+        'fibonacci',
+        execute_callback=self.execute_callback)
+
+The first argument is the node to add the action server to (ie. self).
+The second argument is the type of the action.
+The third argument is the action name.
+And the final argument is the function we want called when a new goal is accepted.
+Note, all goals are accepted by default.
+
+Line 21-23 defines a ``destroy`` method that is useful for freeing resources used by the node and action server.
+
+Lines 25-42 is the method called whenever we get a new goal request.
+It takes one argument that is a handle to the goal.
+After logging a message, we create a feedback message:
+
+.. code-block:: python
+
+    feedback_msg = Fibonacci.Feedback()
+    feedback_msg.sequence = [0, 1]
+
+Then, we loop up to the requested Fibonacci order (accessed from the goal handle):
+
+.. code-block:: python
+
+    for i in range(1, goal_handle.request.order):
+
+And update the feedback message, publish it, and sleep for dramatic effect:
+
+.. code-block:: python
+
+    feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
+    self.get_logger().info('Publishing feedback: {0}'.format(feedback_msg.sequence))
+    goal_handle.publish_feedback(feedback_msg)
+    time.sleep(1)
+
+After computing the sequence, we mark the goal as successful:
+
+.. code-block:: python
+
+    goal_handle.succeed()
+
+Finally, we populate the result message and return it:
+
+.. code-block:: python
+
+    result = Fibonacci.Result()
+    result.sequence = feedback_msg.sequence
+    self.get_logger().info('Returning result: {0}'.format(result.sequence))
+    return result
+
+On lines 45-57 We define a main function and call to create an executable.
+Because ``FibonacciActionServer`` is a subclass of ``Node`` we can spin on it, which will process our callbacks for any action requests.
+
+Let's run the action server:
+
+.. code-block:: bash
+
+    python3 fibonacci_action_server.py
+
+In another terminal, try sending a goal with the command line tool:
+
+.. code-block:: bash
+
+    ros2 action send_goal -f fibonacci action_tutorial/Fibonacci "{order: 5}"
+
+You should see feedback and the final result sequence printed to both terminals.
+
+Rejecting goals
+^^^^^^^^^^^^^^^
+
+Coming soon.
+
+Allowing goals to be canceled
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Coming soon.

--- a/source/Tutorials/Actions/client_0.py
+++ b/source/Tutorials/Actions/client_0.py
@@ -1,0 +1,22 @@
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionClient(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_client')
+        self._action_client = ActionClient(self, Fibonacci, 'fibonacci')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    action_client = FibonacciActionClient()
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/client_1.py
+++ b/source/Tutorials/Actions/client_1.py
@@ -1,0 +1,36 @@
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionClient(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_client')
+        self._action_client = ActionClient(self, Fibonacci, 'fibonacci')
+
+    def send_goal(self, order):
+        goal_msg = Fibonacci.Goal()
+        goal_msg.order = order
+
+        self._action_client.wait_for_server()
+
+        self._action_client.send_goal_async(goal_msg)
+
+    def feedback_callback(self, feedback_msg):
+        feedback = feedback_msg.feedback
+        self.get_logger().info('Received feedback: {0}'.format(feedback.partial_sequence))
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    action_client = FibonacciActionClient()
+
+    action_client.send_goal(10)
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/client_2.py
+++ b/source/Tutorials/Actions/client_2.py
@@ -1,0 +1,38 @@
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionClient(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_client')
+        self._action_client = ActionClient(self, Fibonacci, 'fibonacci')
+
+    def send_goal(self, order):
+        goal_msg = Fibonacci.Goal()
+        goal_msg.order = order
+
+        self._action_client.wait_for_server()
+
+        self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
+
+    def feedback_callback(self, feedback_msg):
+        feedback = feedback_msg.feedback
+        self.get_logger().info('Received feedback: {0}'.format(feedback.partial_sequence))
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    action_client = FibonacciActionClient()
+
+    action_client.send_goal(10)
+
+    rclpy.spin(action_client)
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/client_3.py
+++ b/source/Tutorials/Actions/client_3.py
@@ -1,0 +1,60 @@
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionClient(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_client')
+        self._action_client = ActionClient(self, Fibonacci, 'fibonacci')
+
+    def send_goal(self, order):
+        goal_msg = Fibonacci.Goal()
+        goal_msg.order = order
+
+        self._action_client.wait_for_server()
+
+        self._send_goal_future = self._action_client.send_goal_async(
+            goal_msg,
+            feedback_callback=self.feedback_callback)
+
+        self._send_goal_future.add_done_callback(self.goal_response_callback)
+
+    def goal_response_callback(self, future):
+        goal_handle = future.result()
+
+        if not goal_handle.accepted:
+            self.get_logger().info('Goal rejected :(')
+            return
+
+        self.get_logger().info('Goal accepted :)')
+
+        self._get_result_future = goal_handle.get_result_async()
+
+        self._get_result_future.add_done_callback(self.get_result_callback)
+
+    def get_result_callback(self, future):
+        result = future.result().result
+        self.get_logger().info('Result: {0}'.format(result.sequence))
+        rclpy.shutdown()
+
+    def feedback_callback(self, feedback_msg):
+        feedback = feedback_msg.feedback
+        self.get_logger().info('Received feedback: {0}'.format(feedback.partial_sequence))
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    action_client = FibonacciActionClient()
+
+    action_client.send_goal(10)
+
+    rclpy.spin(action_client)
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/server_0.py
+++ b/source/Tutorials/Actions/server_0.py
@@ -1,0 +1,32 @@
+import rclpy
+from rclpy.action import ActionServer
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionServer(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_server')
+        self._action_server = ActionServer(
+            self,
+            Fibonacci,
+            'fibonacci',
+            self.execute_callback)
+
+    def execute_callback(self, goal_handle):
+        self.get_logger().info('Executing goal...')
+        return Fibonacci.Result()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    fibonacci_action_server = FibonacciActionServer()
+
+    rclpy.spin(fibonacci_action_server)
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/server_1.py
+++ b/source/Tutorials/Actions/server_1.py
@@ -1,0 +1,33 @@
+import rclpy
+from rclpy.action import ActionServer
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionServer(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_server')
+        self._action_server = ActionServer(
+            self,
+            Fibonacci,
+            'fibonacci',
+            self.execute_callback)
+
+    def execute_callback(self, goal_handle):
+        self.get_logger().info('Executing goal...')
+        goal_handle.succeed()
+        return Fibonacci.Result()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    fibonacci_action_server = FibonacciActionServer()
+
+    rclpy.spin(fibonacci_action_server)
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/server_2.py
+++ b/source/Tutorials/Actions/server_2.py
@@ -1,0 +1,42 @@
+import rclpy
+from rclpy.action import ActionServer
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionServer(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_server')
+        self._action_server = ActionServer(
+            self,
+            Fibonacci,
+            'fibonacci',
+            self.execute_callback)
+
+    def execute_callback(self, goal_handle):
+        self.get_logger().info('Executing goal...')
+
+        sequence = [0, 1]
+
+        for i in range(1, goal_handle.request.order):
+            sequence.append(sequence[i] + sequence[i-1])
+
+        goal_handle.succeed()
+
+        result = Fibonacci.Result()
+        result.sequence = sequence
+        return result
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    fibonacci_action_server = FibonacciActionServer()
+
+    rclpy.spin(fibonacci_action_server)
+
+
+if __name__ == '__main__':
+    main()

--- a/source/Tutorials/Actions/server_3.py
+++ b/source/Tutorials/Actions/server_3.py
@@ -1,0 +1,49 @@
+import time
+
+import rclpy
+from rclpy.action import ActionServer
+from rclpy.node import Node
+
+from action_tutorials.action import Fibonacci
+
+
+class FibonacciActionServer(Node):
+
+    def __init__(self):
+        super().__init__('fibonacci_action_server')
+        self._action_server = ActionServer(
+            self,
+            Fibonacci,
+            'fibonacci',
+            self.execute_callback)
+
+    def execute_callback(self, goal_handle):
+        self.get_logger().info('Executing goal...')
+
+        feedback_msg = Fibonacci.Feedback()
+        feedback_msg.partial_sequence = [0, 1]
+
+        for i in range(1, goal_handle.request.order):
+            feedback_msg.partial_sequence.append(
+                feedback_msg.partial_sequence[i] + feedback_msg.partial_sequence[i-1])
+            self.get_logger().info('Feedback: {0}'.format(feedback_msg.partial_sequence))
+            goal_handle.publish_feedback(feedback_msg)
+            time.sleep(1)
+
+        goal_handle.succeed()
+
+        result = Fibonacci.Result()
+        result.sequence = feedback_msg.partial_sequence
+        return result
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    fibonacci_action_server = FibonacciActionServer()
+
+    rclpy.spin(fibonacci_action_server)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Contains action server tutorial in Python and placeholders for other tutorials.

Looking for early feedback before I continue with the other sections. Perhaps this is too verbose?
Also, I'm considering adding a separate tutorial package to go along with this tutorial (ideally this tutorial would live with that package).

Resolves #166