### PR TITLE
Added git checkout step to tutorials

### DIFF
--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -117,6 +117,12 @@ Let's clone the `examples <https://github.com/ros2/examples>`__ repository into 
 
 .. attention:: It is recommended to checkout a branch that is compatible with the version of ROS that was installed (e.g. ``crystal``).
 
+CD into the directory 
+.. code-block:: bash
+    cd ~/ros2_example_ws/src/examples/
+    git checkout ROSDISTRO
+    cd ~/ros2_example_ws
+
 Now the workspace should have the source code to the ROS 2 examples:
 
 .. code-block:: bash

--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -117,8 +117,9 @@ Let's clone the `examples <https://github.com/ros2/examples>`__ repository into 
 
 .. attention:: It is recommended to checkout a branch that is compatible with the version of ROS that was installed (e.g. ``crystal``).
 
-CD into the directory 
+
 .. code-block:: bash
+
     cd ~/ros2_example_ws/src/examples/
     git checkout ROSDISTRO
     cd ~/ros2_example_ws


### PR DESCRIPTION
A few people have run into issues running colcon because they are pulling the wrong branch (master). This adds a more explicit step in the tutorial to checkout the correct branch. 