### PR TITLE
Yield content for all redirects.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -169,7 +169,7 @@ class RedirectFrom(Directive):
                         )
                     )
                 }
-            yield (redirect_url, context, cls.template_name)
+                yield (redirect_url, context, cls.template_name)
 
     def run(self):
         document_path = self.state.document.current_source


### PR DESCRIPTION
This was likely an indentation bug.

With this change content is yielded once per redirect_url rather than only once per canonical_url. A side effect of the previous revision is that if a source file redirects from multiple paths only one of those redirects (specifically the last one to be iterated) will be placed.