### PR TITLE
Use the same title underline as other sections.

### DIFF
--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -388,7 +388,8 @@ Changes since the `Crystal Clemmys <Release-Crystal-Clemmys>` release:
  * `rmw_take <https://github.com/ros2/rmw/blob/dc7b2f49f1f961d6cf2c173adc54736451be8938/rmw/include/rmw/rmw.h#L556>`_
 
 actions
-~~~~~~~
+^^^^^^^
+
 
 * Changes to ``rclcpp_action::Client`` signatures:
 


### PR DESCRIPTION
Fixes build errors on master. @jacobperron is putting actions on a peer level with the other headers a reasonable thing to do.


Fixes the warning
```
/home/travis/build/ros2/ros2_documentation/source/Releases/Release-Dashing-Diademata.rst:390: WARNING: Title level inconsistent:
```
