### PR TITLE
Add installation docs for Dashing.

### DIFF
--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -19,7 +19,7 @@ Select your ROS distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 +-----------------------------------------------+-------------------------------------------------+---------------------------------------------------+
-| `ROS 2 Bouncy Bolson <Installation/Crystal>`  | `ROS 2 Crystal Clemmys <Installation/Crystal>`  | `ROS 2 Dashing Diademata <Installation/Crystal>`  |
+| `ROS 2 Bouncy Bolson <Installation/Crystal>`  | `ROS 2 Crystal Clemmys <Installation/Crystal>`  | `ROS 2 Dashing Diademata <Installation/Dashing>`  |
 +-----------------------------------------------+-------------------------------------------------+---------------------------------------------------+
 | Released July 2018                            | Released December 2018                          | To be released May 2019 (In progress)             |
 +-----------------------------------------------+-------------------------------------------------+---------------------------------------------------+

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -7,6 +7,7 @@ Installation
    :glob:
 
    Installation/Crystal
+   Installation/Dashing
 
 ROS 2 Installation Options
 --------------------------

--- a/source/Installation/Dashing.rst
+++ b/source/Installation/Dashing.rst
@@ -21,7 +21,7 @@ We provide ROS 2 binary packages for the following platforms:
 * `Windows <Dashing/Windows-Install-Binary>`
 
 
-.. _building-from-source:
+.. _Dashing_building-from-source:
 
 Building from source
 --------------------

--- a/source/Installation/Dashing.rst
+++ b/source/Installation/Dashing.rst
@@ -1,24 +1,24 @@
-Installing ROS 2 Crystal and earlier
-====================================
+Installing ROS 2 Dashing Diademata
+==================================
 
 .. toctree::
    :hidden:
    :glob:
 
-   Crystal/*
+   Dashing/*
 
 Binary packages
 ---------------
 
 We provide ROS 2 binary packages for the following platforms:
 
-* Linux (Ubuntu Xenial(16.04) and Ubuntu Bionic(18.04))
+* Linux (Ubuntu Bionic(18.04))
 
-  * `Debian packages <Crystal/Linux-Install-Debians>`
-  * `"fat" archive <Crystal/Linux-Install-Binary>`
+  * `Debian packages <Dashing/Linux-Install-Debians>`
+  * `"fat" archive <Dashing/Linux-Install-Binary>`
 
-* `OS X <Crystal/OSX-Install-Binary>`
-* `Windows <Crystal/Windows-Install-Binary>`
+* `OS X <Dashing/OSX-Install-Binary>`
+* `Windows <Dashing/Windows-Install-Binary>`
 
 
 .. _building-from-source:
@@ -29,7 +29,7 @@ Building from source
 We support building ROS 2 from source on the following platforms:
 
 
-* `Linux <Crystal/Linux-Development-Setup>`
-* `OS X <Crystal/OSX-Development-Setup>`
-* `Windows <Crystal/Windows-Development-Setup>`
+* `Linux <Dashing/Linux-Development-Setup>`
+* `OS X <Dashing/OSX-Development-Setup>`
+* `Windows <Dashing/Windows-Development-Setup>`
 

--- a/source/Installation/Dashing.rst
+++ b/source/Installation/Dashing.rst
@@ -1,0 +1,35 @@
+Installing ROS 2 Crystal and earlier
+====================================
+
+.. toctree::
+   :hidden:
+   :glob:
+
+   Crystal/*
+
+Binary packages
+---------------
+
+We provide ROS 2 binary packages for the following platforms:
+
+* Linux (Ubuntu Xenial(16.04) and Ubuntu Bionic(18.04))
+
+  * `Debian packages <Crystal/Linux-Install-Debians>`
+  * `"fat" archive <Crystal/Linux-Install-Binary>`
+
+* `OS X <Crystal/OSX-Install-Binary>`
+* `Windows <Crystal/Windows-Install-Binary>`
+
+
+.. _building-from-source:
+
+Building from source
+--------------------
+
+We support building ROS 2 from source on the following platforms:
+
+
+* `Linux <Crystal/Linux-Development-Setup>`
+* `OS X <Crystal/OSX-Development-Setup>`
+* `Windows <Crystal/Windows-Development-Setup>`
+

--- a/source/Installation/Dashing/Fedora-Development-Setup.rst
+++ b/source/Installation/Dashing/Fedora-Development-Setup.rst
@@ -1,0 +1,24 @@
+.. redirect-from::
+
+    Fedora-Development-Setup
+    Installation/Fedora-Development-Setup
+
+Building ROS 2 on Fedora Linux
+==============================
+
+How to setup the development environment?
+-----------------------------------------
+
+First install a bunch of dependencies:
+
+.. code-block:: bash
+
+   $ sudo dnf install cppcheck cmake libXaw-devel opencv-devel poco-devel poco-foundation python3-empy python3-devel python3-nose python3-pip python3-pyparsing python3-pytest python3-pytest-cov python3-pytest-runner python3-setuptools python3-yaml tinyxml-devel eigen3-devel python3-pydocstyle python3-pyflakes python3-coverage python3-mock python3-pep8 uncrustify python3-argcomplete python3-flake8 python3-flake8-import-order asio-devel tinyxml2-devel libyaml-devel python3-lxml
+
+Then install vcstool from pip:
+
+.. code-block:: bash
+
+   $ pip3 install vcstool
+
+With this done, you can follow the rest of the `instructions <linux-dev-get-ros2-code>` to fetch and build ROS2.

--- a/source/Installation/Dashing/Fedora-Development-Setup.rst
+++ b/source/Installation/Dashing/Fedora-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Fedora-Development-Setup
-    Installation/Fedora-Development-Setup
-
 Building ROS 2 on Fedora Linux
 ==============================
 

--- a/source/Installation/Dashing/Install-Connext-Security-Plugins.rst
+++ b/source/Installation/Dashing/Install-Connext-Security-Plugins.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-   Install-Connext-Security-Plugins
-   Installation/Install-Connext-Security-Plugins
-
 Installing Connext security plugins
 ===================================
 

--- a/source/Installation/Dashing/Install-Connext-Security-Plugins.rst
+++ b/source/Installation/Dashing/Install-Connext-Security-Plugins.rst
@@ -1,0 +1,52 @@
+.. redirect-from::
+
+   Install-Connext-Security-Plugins
+   Installation/Install-Connext-Security-Plugins
+
+Installing Connext security plugins
+===================================
+
+The Connext DDS Libraries are included with ROS2 under a `non-commercial
+license <https://www.rti.com/ncl>`__ and do not include the security
+plug-in libraries. These libraries are available in the commercial,
+university and research license versions of RTI Connext DDS Pro, which
+is bundled with tools for system debugging, monitoring, record/replay,
+etc.
+
+A video walk-thru of this installation (tools and security plug-ins) is
+available
+`here <https://www.rti.com/gettingstarted/installwindows_secure>`__ at
+the RTI website. The steps are:
+
+**Install Connext DDS Pro (Host)**
+This is a host-specific installer application (for Windows, Linux, MacOS) to install a 'Host' bundle which includes the Launcher, tools, and other software services.
+At the end of the installation, the RTI 'Launcher' program will be started.
+The Launcher is used to install target libraries, security plugins, and other layered services.
+
+**Use the Package Installer in Launcher**
+
+.. figure:: https://cdn2.hubspot.net/hub/1754418/file-3649043118-png/blog-files/launchermacos.png
+   :alt: Launcher Image
+
+   Launcher Image
+
+The 'RTI Package Installer' is used to install '.rtipkg' files -- target
+libraries, security plug-ins, etc. Open the Package Installer and select
+all of the .rtipkg files that were included in the Connext DDS Secure
+bundle for installation:
+
+ * Target Libraries - such as: rti\_connext\_dds-[version]-pro-target-[toolchain].rtipkg
+ * Security Plugin Host - such as: rti\_security\_plugins-[version]-host-[toolchain].rtipkg
+ * Security Plugin Target - such as: rti\_security\_plugins-[version]-target-[toolchain].rtipkg
+ * OpenSSL Host - such as: openssl-1.0.2x-[version]-host-[toolchain].rtipkg
+
+**Extract and Install OpenSSL**
+This is included as an archive (.zip or
+otherwise) and can be simply extracted and copied to a convenient
+location on your host computer. As a suggestion, this could also be
+installed into the 'rti\_connext\_dds-[version]' directory in your home
+directory space (this was created during installation of the RTI host
+tools). Note: this directory location may need to be placed in your PATH
+environment variable.
+
+Installation complete.

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Linux-Development-Setup
-    Installation/Linux-Development-Setup
-
 Building ROS 2 on Linux
 =======================
 

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -53,6 +53,8 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-lark-parser \
+     python3-lxml \
+     python3-numpy \
      python3-pip \
      python-rosdep \
      python3-vcstool \

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -13,15 +13,14 @@ Building ROS 2 on Linux
 
 System Requirements
 -------------------
-Target platforms for Crystal Clemmys are (see `REP 2000 <http://www.ros.org/reps/rep-2000.html>`__):
+Target platforms for Dashing Diademata are (see `REP 2000 <http://www.ros.org/reps/rep-2000.html>`__):
 
 - Tier 1: Ubuntu Linux - Bionic Beaver (18.04) 64-bit
-- Tier 2: Ubuntu Linux - Xenial Xerus (16.04) 64-bit
 
 Tier 3 platforms (not actively tested or supported) include:
 
 - Debian Linux - Stretch (9)
-- Fedora 26, see `alternate instructions <Fedora-Development-Setup>`
+- Fedora 30, see `alternate instructions <Fedora-Development-Setup>`
 - Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/Ros#Ros_2>`__
 
 System setup
@@ -112,11 +111,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   # [Ubuntu 18.04]
-   rosdep install --from-paths src --ignore-src --rosdistro crystal -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
-   # [Ubuntu 16.04]
-   rosdep install --from-paths src --ignore-src --rosdistro crystal -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 python3-lark-parser rti-connext-dds-5.3.1 urdfdom_headers"
-   python3 -m pip install -U lark-parser
+   rosdep install --from-paths src --ignore-src --rosdistro dashing -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
 
 .. _linux-development-setup-install-more-dds-implementations-optional:
 
@@ -136,11 +131,7 @@ PrismTech OpenSplice Debian Packages built by OSRF
 
 .. code-block:: bash
 
-   # For Crystal Clemmys
    sudo apt install libopensplice69  # from packages.ros.org/ros2/ubuntu
-
-   # For Bouncy Bolson
-   sudo apt install libopensplice67  # from packages.ros.org/ros2/ubuntu
 
 .. raw:: html
 
@@ -226,10 +217,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 .. code-block:: bash
 
    cd ~/ros2_ws/
-   # On Ubuntu Linux Bionic Beaver 18.04
    colcon build --symlink-install
-   # On Ubuntu Linux Xenial Xerus 16.04
-   colcon build --symlink-install --packages-ignore qt_gui_cpp rqt_gui_cpp
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
 Take for instance: you would like to avoid installing the large OpenCV library.

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -21,7 +21,7 @@ Tier 3 platforms (not actively tested or supported) include:
 System setup
 ------------
 
-.. _linux-dev-add-ros2-repo:
+.. _Dashing_linux-dev-add-ros2-repo:
 
 Set Locale
 ^^^^^^^^^^
@@ -80,7 +80,7 @@ Install development tools and ROS tools
      libasio-dev \
      libtinyxml2-dev
 
-.. _linux-dev-get-ros2-code:
+.. _Dashing_linux-dev-get-ros2-code:
 
 Get ROS 2 code
 --------------
@@ -108,7 +108,7 @@ Install dependencies using rosdep
    rosdep update
    rosdep install --from-paths src --ignore-src --rosdistro dashing -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
 
-.. _linux-development-setup-install-more-dds-implementations-optional:
+.. _Dashing_linux-development-setup-install-more-dds-implementations-optional:
 
 Install more DDS implementations (Optional)
 -------------------------------------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -1,0 +1,311 @@
+.. redirect-from::
+
+    Linux-Development-Setup
+    Installation/Linux-Development-Setup
+
+Building ROS 2 on Linux
+=======================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+
+System Requirements
+-------------------
+Target platforms for Crystal Clemmys are (see `REP 2000 <http://www.ros.org/reps/rep-2000.html>`__):
+
+- Tier 1: Ubuntu Linux - Bionic Beaver (18.04) 64-bit
+- Tier 2: Ubuntu Linux - Xenial Xerus (16.04) 64-bit
+
+Tier 3 platforms (not actively tested or supported) include:
+
+- Debian Linux - Stretch (9)
+- Fedora 26, see `alternate instructions <Fedora-Development-Setup>`
+- Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/Ros#Ros_2>`__
+
+System setup
+------------
+
+.. _linux-dev-add-ros2-repo:
+
+Set Locale
+^^^^^^^^^^
+Make sure to set a locale that supports UTF-8.
+If you are in a minimal environment such as a Docker container, the locale may be set to something minimal like POSIX.
+
+The following is an example for setting locale.
+However, it should be fine if you're using a different UTF-8 supported locale.
+
+.. code-block:: bash
+
+   sudo locale-gen en_US en_US.UTF-8
+   sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+   export LANG=en_US.UTF-8
+
+Add the ROS 2 apt repository
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+First make sure you have the ROS 2 apt repositories added to your system, if not refer to `the following section <linux-install-debians-setup-sources>`.
+
+Install development tools and ROS tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   sudo apt update && sudo apt install -y \
+     build-essential \
+     cmake \
+     git \
+     python3-colcon-common-extensions \
+     python3-lark-parser \
+     python3-pip \
+     python-rosdep \
+     python3-vcstool \
+     wget
+   # install some pip packages needed for testing
+   python3 -m pip install -U \
+     argcomplete \
+     flake8 \
+     flake8-blind-except \
+     flake8-builtins \
+     flake8-class-newline \
+     flake8-comprehensions \
+     flake8-deprecated \
+     flake8-docstrings \
+     flake8-import-order \
+     flake8-quotes \
+     pytest-repeat \
+     pytest-rerunfailures \
+     pytest \
+     pytest-cov \
+     pytest-runner \
+     setuptools
+   # install Fast-RTPS dependencies
+   sudo apt install --no-install-recommends -y \
+     libasio-dev \
+     libtinyxml2-dev
+
+.. _linux-dev-get-ros2-code:
+
+Get ROS 2 code
+--------------
+
+Create a workspace and clone all repos:
+
+.. code-block:: bash
+
+   mkdir -p ~/ros2_ws/src
+   cd ~/ros2_ws
+   wget https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos
+   vcs import src < ros2.repos
+
+..
+
+   Note: if you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the URL above with ``master``. The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+
+
+Install dependencies using rosdep
+---------------------------------
+
+.. code-block:: bash
+
+   sudo rosdep init
+   rosdep update
+   # [Ubuntu 18.04]
+   rosdep install --from-paths src --ignore-src --rosdistro crystal -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers"
+   # [Ubuntu 16.04]
+   rosdep install --from-paths src --ignore-src --rosdistro crystal -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 python3-lark-parser rti-connext-dds-5.3.1 urdfdom_headers"
+   python3 -m pip install -U lark-parser
+
+.. _linux-development-setup-install-more-dds-implementations-optional:
+
+Install more DDS implementations (Optional)
+-------------------------------------------
+
+ROS 2 builds on top of DDS.
+It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
+The repositories you downloaded for ROS 2 includes eProsima's Fast RTPS, which is the only bundled vendor.
+If you would like to use one of the other vendors you will need to install their software separately before building.
+The ROS 2 build will automatically build support for vendors that have been installed and sourced correctly.
+
+By default we include eProsima's FastRTPS in the workspace and it is the default middleware. Detailed instructions for installing other DDS vendors are provided below.
+
+PrismTech OpenSplice Debian Packages built by OSRF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   # For Crystal Clemmys
+   sudo apt install libopensplice69  # from packages.ros.org/ros2/ubuntu
+
+   # For Bouncy Bolson
+   sudo apt install libopensplice67  # from packages.ros.org/ros2/ubuntu
+
+.. raw:: html
+
+   <!--
+   ##### Official binary packages from PrismTech
+
+   Install the packages provided by [OpenSplice](https://github.com/ADLINK-IST/opensplice/releases/tag/OSPL_V6_7_180404OSS_RELEASE%2BVS2017%2Bubuntu1804).
+   Remember to replace `@@INSTALLDIR@@` with the path where you unpacked the OpenSplice distribution.
+   Then, source the ROS `setup.bash` file, and finally, source the `release.com` file in the root of the OpenSplice distribution to set the `OSPL_HOME` environment variable appropriately.
+   After that, your shell is ready to run ROS2 binaries with the official OpenSplice distribution.
+
+   You may also need to add the following line to your `.bashrc` file:
+
+   ```
+   export PTECH_LICENSE_FILE=path/to/prismtech.lic
+   ```
+
+   ##### Building OpenSplice from source
+
+   If you build OpenSplice from source, be sure to remember to following the INSTALL.txt instructions and manually replace the @@INSTALLDIR@@ placeholder in the OpenSplice install/HDE/x86_64.linux/release.com
+   -->
+
+
+
+RTI Connext (version 5.3.1, amd64 only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Debian packages provided in the ROS 2 apt repositories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can install a Debian package of RTI Connext available on the ROS 2 apt repositories.
+You will need to accept a license from RTI.
+
+.. code-block:: bash
+
+   sudo apt install -q -y \
+       rti-connext-dds-5.3.1  # from packages.ros.org/ros2/ubuntu
+
+Source the setup file to set the ``NDDSHOME`` environment variable.
+
+.. code-block:: bash
+
+   cd /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts && source ./rtisetenv_x64Linux3gcc5.4.0.bash; cd -
+
+Note: when using ``zsh`` you need to be in the directory of the script when sourcing it to have it work properly
+
+Now you can build as normal and support for RTI will be built as well.
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`
+
+Official binary packages from RTI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can install the Connext 5.3.1 package for Linux provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+
+To use RTI Connext you will need to have obtained a license from RTI.
+Add the following line to your ``.bashrc`` file pointing to your copy of the license.
+
+.. code-block:: bash
+
+   export RTI_LICENSE_FILE=path/to/rti_license.dat
+
+After downloading, use ``chmod +x`` on the ``.run`` executable and then execute it.
+Note that if you're installing to a system directory use ``sudo`` as well.
+
+The default location is ``~/rti_connext_dds-5.3.1``
+
+Source the setup file to set the ``NDDSHOME`` environment variable.
+
+.. code-block:: bash
+
+   source ~/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Linux3gcc5.4.0.bash
+
+Now you can build as normal and support for RTI will be built as well.
+
+Build the code in the workspace
+-------------------------------
+
+Note: to build the ROS 1 bridge, read the `ros1_bridge instructions <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__.
+
+More info on working with a ROS workspace can be found in `this tutorial </Tutorials/Colcon-Tutorial>`.
+
+.. code-block:: bash
+
+   cd ~/ros2_ws/
+   # On Ubuntu Linux Bionic Beaver 18.04
+   colcon build --symlink-install
+   # On Ubuntu Linux Xenial Xerus 16.04
+   colcon build --symlink-install --packages-ignore qt_gui_cpp rqt_gui_cpp
+
+Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
+Take for instance: you would like to avoid installing the large OpenCV library.
+Well then simply ``$ touch AMENT_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
+
+Optionally install all packages into a combined directory (rather than each package in a separate subdirectory).
+On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
+
+Also, if you have already installed ROS2 from Debian make sure that you run the ``build`` command in a fresh environment. You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
+
+
+.. code-block:: bash
+
+   colcon build --symlink-install --merge-install
+
+Afterwards source the ``local_setup.*`` from the ``install`` folder.
+
+Try some examples
+-----------------
+
+In one terminal, source the setup file and then run a ``talker``\ :
+
+.. code-block:: bash
+
+   . ~/ros2_ws/install/local_setup.bash
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a ``listener``\ :
+
+.. code-block:: bash
+
+   . ~/ros2_ws/install/local_setup.bash
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+Hooray!
+
+See the `demos </Tutorials>` for other things to try.
+
+Alternate compilers
+-------------------
+
+Using a different compiler besides gcc to compile ROS 2 is easy. If you set the environment variables ``CC`` and ``CXX`` to executables for a working C and C++ compiler, respectively, and retrigger CMake configuration (by using ``--force-cmake-config`` or by deleting the packages you want to be affected), CMake will reconfigure and use the different compiler.
+
+Clang
+^^^^^
+
+To configure CMake to detect and use Clang:
+
+.. code-block:: bash
+
+   sudo apt install clang
+   export CC=clang
+   export CXX=clang++
+   colcon build --cmake-force-configure
+
+TODO: using ThreadSanitizer, MemorySanitizer
+
+Troubleshooting
+---------------
+
+Internal compiler error
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If you experience an ICE when trying to compile on a memory constrained platform like a Raspberry PI you might want to build single threaded (prefix the build invocation with ``MAKEFLAGS=-j1``).
+
+Out of memory
+^^^^^^^^^^^^^
+
+The ``ros1_bridge`` in its current form requires 4Gb of free RAM to compile.
+If you don't have that amount of RAM available it's suggested to use ``AMENT_IGNORE`` in that folder and skip its compilation.
+
+Multiple Host Interference
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you're running multiple instances on the same network you may get interference.
+To avoid this you can set the environment variable ``ROS_DOMAIN_ID`` to a different integer, the default is zero.
+This will define the DDS domain id for your system.
+Note that if you are using the OpenSplice DDS implementation you will also need to update the OpenSplice configuration file accordingly. The location of the configuration file is referenced in the ``OSPL_URI`` environment variable.

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -1,0 +1,180 @@
+.. redirect-from::
+
+    Linux-Install-Binary
+    Installation/Linux-Install-Binary
+
+Installing ROS 2 on Linux
+=========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This page explains how to install ROS 2 on Linux from a pre-built binary package.
+
+As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+
+System Requirements
+-------------------
+
+We support Ubuntu Linux Bionic Beaver (18.04) and Ubuntu Xenial Xerus (16.04) on 64-bit x86 and 64-bit ARM.
+
+Note: Ardent and beta versions supported Ubuntu Xenial Xerus 16.04.
+
+Add the ROS 2 apt repository
+----------------------------
+
+See the `development instructions <linux-dev-add-ros2-repo>`.
+
+Downloading ROS 2
+-----------------
+
+
+* Go `the releases page <https://github.com/ros2/ros2/releases>`_
+* Download the latest package for Linux; let's assume that it ends up at ``~/Downloads/ros2-crystal-linux-x86_64.tar.bz2``.
+
+  * Note: there may be more than one binary download option which might cause the file name to differ.
+
+*
+  Unpack it:
+
+  .. code-block:: bash
+
+       mkdir -p ~/ros2_install
+       cd ~/ros2_install
+       tar xf ~/Downloads/ros2-crystal-linux-x86_64.tar.bz2
+
+Installing and initializing rosdep
+----------------------------------
+
+.. code-block:: bash
+
+       sudo apt install -y python-rosdep
+       rosdep init
+       rosdep update
+
+
+Installing the missing dependencies
+-----------------------------------
+
+Set your rosdistro according to the release you downloaded.
+
+.. code-block:: bash
+
+       CHOOSE_ROS_DISTRO=crystal # or bouncy
+       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro $CHOOSE_ROS_DISTRO -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+
+#. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
+   Follow the normal install instructions: http://wiki.ros.org/kinetic/Installation/Ubuntu
+
+Installing the python3 libraries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+       sudo apt install -y libpython3-dev
+
+
+Install additional DDS implementations (optional)
+-------------------------------------------------
+
+ROS 2 builds on top of DDS.
+It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
+
+The package you downloaded has been built with optional support for multiple vendors: eProsima FastRTPS, Adlink OpenSplice, and (as of ROS 2 Bouncy) RTI Connext as the middleware options.
+Run-time support for eProsima's Fast RTPS is included bundled by default.
+If you would like to use one of the other vendors you will need to install their software separately.
+
+Adlink OpenSplice
+^^^^^^^^^^^^^^^^^
+
+To use OpenSplice you can install a Debian package built by OSRF.
+
+Crystal and above:
+
+.. code-block:: bash
+
+       sudo apt update && sudo apt install -q -y \
+           libopensplice69
+
+Bouncy and earlier:
+
+.. code-block:: bash
+
+       sudo apt update && sudo apt install -q -y \
+           libopensplice69
+
+
+RTI Connext (version 5.3.1, amd64 only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To use RTI Connext you will need to have obtained a license from RTI.
+Add the following line to your ``.bashrc`` file pointing to your copy of the license (and source it).
+
+.. code-block:: bash
+
+   export RTI_LICENSE_FILE=path/to/rti_license.dat
+
+You can install a Debian package of RTI Connext built by OSRF.
+You will need to accept a license from RTI.
+
+.. code-block:: bash
+
+       sudo apt update && sudo apt install -q -y \
+           rti-connext-dds-5.3.1
+
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
+
+Try some examples
+-----------------
+
+In one terminal, source the setup file and then run a ``talker``:
+
+.. code-block:: bash
+
+   . ~/ros2_install/ros2-linux/setup.bash
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a ``listener``:
+
+.. code-block:: bash
+
+   . ~/ros2_install/ros2-linux/setup.bash
+   ros2 run demo_nodes_cpp listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+Hooray!
+
+If you have installed support for an optional vendor, see `this page </Tutorials/Working-with-multiple-RMW-implementations>` for details on how to use that vendor.
+
+See the `demos </Tutorials>` for other things to try, including how to `run the talker-listener example in Python </Tutorials/Python-Programming>`.
+
+Using the ROS 1 bridge
+^^^^^^^^^^^^^^^^^^^^^^
+
+If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
+We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
+
+If you haven't already, start a roscore:
+
+.. code-block:: bash
+
+   . /opt/ros/melodic/setup.bash
+   roscore
+
+
+In another terminal, start the bridge:
+
+.. code-block:: bash
+
+   . /opt/ros/melodic/setup.bash
+   . ~/ros2_install/ros2-linux/setup.bash
+   ros2 run ros1_bridge dynamic_bridge
+
+For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -31,7 +31,7 @@ Downloading ROS 2
 
 
 * Go `the releases page <https://github.com/ros2/ros2/releases>`_
-* Download the latest package for Linux; let's assume that it ends up at ``~/Downloads/ros2-crystal-linux-x86_64.tar.bz2``.
+* Download the latest package for Linux; let's assume that it ends up at ``~/Downloads/ros2-dashing-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
 
@@ -42,7 +42,7 @@ Downloading ROS 2
 
        mkdir -p ~/ros2_install
        cd ~/ros2_install
-       tar xf ~/Downloads/ros2-crystal-linux-x86_64.tar.bz2
+       tar xf ~/Downloads/ros2-dashing-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
 ----------------------------------
@@ -61,11 +61,10 @@ Set your rosdistro according to the release you downloaded.
 
 .. code-block:: bash
 
-       CHOOSE_ROS_DISTRO=crystal # or bouncy
-       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro $CHOOSE_ROS_DISTRO -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro dashing -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 libopensplice69 osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
 
 #. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
-   Follow the normal install instructions: http://wiki.ros.org/kinetic/Installation/Ubuntu
+   Follow the normal install instructions: http://wiki.ros.org/melodic/Installation/Ubuntu
 
 Installing the python3 libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,15 +88,6 @@ Adlink OpenSplice
 ^^^^^^^^^^^^^^^^^
 
 To use OpenSplice you can install a Debian package built by OSRF.
-
-Crystal and above:
-
-.. code-block:: bash
-
-       sudo apt update && sudo apt install -q -y \
-           libopensplice69
-
-Bouncy and earlier:
 
 .. code-block:: bash
 

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Linux-Install-Binary
-    Installation/Linux-Install-Binary
-
 Installing ROS 2 on Linux
 =========================
 

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -1,0 +1,170 @@
+.. redirect-from::
+
+    Linux-Install-Debians
+    Installation/Linux-Install-Debians
+
+Installing ROS2 via Debian Packages
+===================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Debian packages for ROS 2 Crystal (the latest release) and ROS 2 Bouncy are available for Ubuntu Bionic; packages for ROS 2 Ardent are available for Ubuntu Xenial.
+
+Resources
+---------
+
+* Status Pages:
+
+  * ROS 2 Crystal (Ubuntu Bionic): `amd64 <http://repo.ros2.org/status_page/ros_crystal_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_crystal_ubv8.html>`__
+  * ROS 2 Bouncy (Ubuntu Bionic): `amd64 <http://repo.ros2.org/status_page/ros_bouncy_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_bouncy_ubv8.html>`__
+  * ROS 2 Ardent (Ubuntu Xenial): `amd64 <http://repo.ros2.org/status_page/ros_ardent_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_ardent_uxv8.html>`__
+* `Jenkins Instance <http://build.ros2.org/>`__
+* `Repositories <http://repo.ros2.org>`__
+
+.. _linux-install-debians-setup-sources:
+
+Setup Locale
+------------
+Make sure you have a locale which supports ``UTF-8``.
+If you are in a minimal environment, such as a docker container, the locale may be something minimal like POSIX.
+We test with the following settings.
+It should be fine if you're using a different UTF-8 supported locale.
+
+.. code-block:: bash
+
+   sudo locale-gen en_US en_US.UTF-8
+   sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+   export LANG=en_US.UTF-8
+
+Setup Sources
+-------------
+
+To install the Debian packages you will need to add our Debian repository to your apt sources.
+First you will need to authorize our gpg key with apt like this:
+
+.. code-block:: bash
+
+   sudo apt update && sudo apt install curl gnupg2 lsb-release
+   curl http://repo.ros2.org/repos.key | sudo apt-key add -
+
+And then add the repository to your sources list:
+
+.. code-block:: bash
+
+   sudo sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+
+Install ROS 2 packages
+----------------------
+
+First set an environment variable for the ROS 2 release you want to install so it can be used in other commands.
+
+.. code-block:: bash
+
+   export CHOOSE_ROS_DISTRO=crystal  # or bouncy or ardent
+   sudo apt update
+
+Desktop Install (Recommended): ROS, RViz, demos, tutorials.
+
+.. code-block:: bash
+
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-desktop
+
+ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools. No GUI tools.
+
+.. code-block:: bash
+
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros-base
+
+See specific sections below for how to also install the :ref:`ros1_bridge <linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <linux-install-additional-rmw-implementations>`.
+
+Environment setup
+-----------------
+
+(optional) Install argcomplete
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete to autocompletion. So if you want autocompletion, installing argcomplete is necessary.
+
+Ubuntu 18.04
+~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
+Ubuntu 16.04 (argcomplete >= 0.8.5)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install ``argcomplete`` on Ubuntu 16.04 (Xenial), you'll need to use pip, because the version available through ``apt`` will not work due to a bug in that version of ``argcomplete``:
+
+.. code-block:: bash
+
+   sudo apt install python3-pip
+   sudo pip3 install argcomplete
+
+Sourcing the setup script
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+   source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash
+
+You may want to add this to your ``.bashrc``.
+
+.. code-block:: bash
+
+   echo "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" >> ~/.bashrc
+
+.. _linux-install-additional-rmw-implementations:
+
+Install additional RMW implementations
+--------------------------------------
+
+By default the RMW implementation ``FastRTPS`` is used.
+If using Ardent OpenSplice is also installed.
+
+To install support for OpenSplice or RTI Connext on Bouncy:
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-opensplice-cpp # for OpenSplice
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-connext-cpp # for RTI Connext (requires license agreement)
+
+By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice instead.
+For ROS 2 releases Bouncy and newer, ``RMW_IMPLEMENTATION=rmw_connext_cpp`` can also be selected to use RTI Connext.
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
+
+.. _linux-ros1-add-pkgs:
+
+Install additional packages using ROS 1 packages
+------------------------------------------------
+
+The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
+To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
+
+If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
+This will also avoid the need to setup the ROS sources as they will already be integrated.
+
+Now you can install the remaining packages:
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros1-bridge
+
+The turtlebot2 packages are available in Bouncy but not Crystal.
+
+.. code-block:: bash
+
+   sudo apt install ros-$CHOOSE_ROS_DISTRO-turtlebot2-*
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -10,16 +10,14 @@ Installing ROS2 via Debian Packages
    :depth: 2
    :local:
 
-Debian packages for ROS 2 Crystal (the latest release) and ROS 2 Bouncy are available for Ubuntu Bionic; packages for ROS 2 Ardent are available for Ubuntu Xenial.
+Debian packages for ROS 2 Dashing Diademata are available for Ubuntu Bionic.
 
 Resources
 ---------
 
-* Status Pages:
+* Status Page:
 
-  * ROS 2 Crystal (Ubuntu Bionic): `amd64 <http://repo.ros2.org/status_page/ros_crystal_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_crystal_ubv8.html>`__
-  * ROS 2 Bouncy (Ubuntu Bionic): `amd64 <http://repo.ros2.org/status_page/ros_bouncy_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_bouncy_ubv8.html>`__
-  * ROS 2 Ardent (Ubuntu Xenial): `amd64 <http://repo.ros2.org/status_page/ros_ardent_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_ardent_uxv8.html>`__
+  * ROS 2 Dashing (Ubuntu Bionic): `amd64 <http://repo.ros2.org/status_page/ros_dashing_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_dashing_ubv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
@@ -58,24 +56,23 @@ And then add the repository to your sources list:
 Install ROS 2 packages
 ----------------------
 
-First set an environment variable for the ROS 2 release you want to install so it can be used in other commands.
+Update your apt repository caches after setting up the repositories.
 
 .. code-block:: bash
 
-   export CHOOSE_ROS_DISTRO=crystal  # or bouncy or ardent
    sudo apt update
 
 Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash
 
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-desktop
+   sudo apt install ros-dashing-desktop
 
 ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools. No GUI tools.
 
 .. code-block:: bash
 
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros-base
+   sudo apt install ros-dashing-ros-base
 
 See specific sections below for how to also install the :ref:`ros1_bridge <linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <linux-install-additional-rmw-implementations>`.
 
@@ -87,22 +84,10 @@ Environment setup
 
 ROS 2 command line tools use argcomplete to autocompletion. So if you want autocompletion, installing argcomplete is necessary.
 
-Ubuntu 18.04
-~~~~~~~~~~~~
-
 .. code-block:: bash
 
    sudo apt install python3-argcomplete
 
-Ubuntu 16.04 (argcomplete >= 0.8.5)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To install ``argcomplete`` on Ubuntu 16.04 (Xenial), you'll need to use pip, because the version available through ``apt`` will not work due to a bug in that version of ``argcomplete``:
-
-.. code-block:: bash
-
-   sudo apt install python3-pip
-   sudo pip3 install argcomplete
 
 Sourcing the setup script
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,13 +96,13 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash
+   source /opt/ros/dashing/setup.bash
 
 You may want to add this to your ``.bashrc``.
 
 .. code-block:: bash
 
-   echo "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/dashing/setup.bash" >> ~/.bashrc
 
 .. _linux-install-additional-rmw-implementations:
 
@@ -132,8 +117,8 @@ To install support for OpenSplice or RTI Connext on Bouncy:
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-connext-cpp # for RTI Connext (requires license agreement)
+   sudo apt install ros-dashing-rmw-opensplice-cpp # for OpenSplice
+   sudo apt install ros-dashing-rmw-connext-cpp # for RTI Connext (requires license agreement)
 
 By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice instead.
 For ROS 2 releases Bouncy and newer, ``RMW_IMPLEMENTATION=rmw_connext_cpp`` can also be selected to use RTI Connext.
@@ -153,16 +138,12 @@ This will also avoid the need to setup the ROS sources as they will already be i
 
 Now you can install the remaining packages:
 
-.. code-block:: bash
+. code-block:: bash
 
    sudo apt update
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros1-bridge
+   sudo apt install ros-dashing-ros1-bridge
 
-The turtlebot2 packages are available in Bouncy but not Crystal.
-
-.. code-block:: bash
-
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-turtlebot2-*
+The turtlebot2 packages are not currently available in Dashing.
 
 Build your own packages
 -----------------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -16,7 +16,7 @@ Resources
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
-.. _linux-install-debians-setup-sources:
+.. _Dashing_linux-install-debians-setup-sources:
 
 Setup Locale
 ------------
@@ -99,7 +99,7 @@ You may want to add this to your ``.bashrc``.
 
    echo "source /opt/ros/dashing/setup.bash" >> ~/.bashrc
 
-.. _linux-install-additional-rmw-implementations:
+.. _Dashing_linux-install-additional-rmw-implementations:
 
 Install additional RMW implementations
 --------------------------------------
@@ -120,7 +120,7 @@ For ROS 2 releases Bouncy and newer, ``RMW_IMPLEMENTATION=rmw_connext_cpp`` can 
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
 
-.. _linux-ros1-add-pkgs:
+.. _Dashing_linux-ros1-add-pkgs:
 
 Install additional packages using ROS 1 packages
 ------------------------------------------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Linux-Install-Debians
-    Installation/Linux-Install-Debians
-
 Installing ROS2 via Debian Packages
 ===================================
 

--- a/source/Installation/Dashing/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Dashing/Maintaining-a-Source-Checkout.rst
@@ -1,0 +1,162 @@
+.. redirect-from::
+
+    Maintaining-a-Source-Checkout
+    Installation/Maintaining-a-Source-Checkout
+
+Maintaining a Source Checkout of ROS 2
+======================================
+
+.. contents::
+   :depth: 2
+   :local:
+
+If you have installed ROS 2 from source, there may have been changes made to the source code since the time that you checked it out.
+To keep your source checkout up to date, you will have to periodically update your ``ros2.repos`` file, download the latest sources, and rebuild your workspace.
+
+Update your repository list
+---------------------------
+
+Each ROS 2 release includes a ``ros2.repos`` file that contains the list of repositories and their version for that release.
+
+Latest release
+^^^^^^^^^^^^^^
+
+To download the repository list from the latest ROS 2 release, run:
+
+**Linux/OS X**
+
+.. code-block:: bash
+
+   cd ~/ros2_ws
+   mv -i ros2.repos ros2.repos.old
+   wget https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos
+
+**Windows**
+
+.. code-block:: bash
+
+   # CMD
+   > cd \dev\ros2
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos -o ros2.repos
+
+   # PowerShell
+   > cd \dev\ros2
+   > curl https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos -o ros2.repos
+
+Particular release
+^^^^^^^^^^^^^^^^^^
+
+If you wish to checkout a particular release, you can get its repository list by specifying the name of the release in the url of the following step, e.g. for alpha 7:
+
+**Linux/OS X**
+
+.. code-block:: bash
+
+   cd ~/ros2_ws
+   mv -i ros2.repos ros2.repos.old
+   wget https://raw.githubusercontent.com/ros2/ros2/release-alpha8/ros2.repos
+
+**Windows**
+
+.. code-block:: bash
+
+   # CMD
+   > cd \dev\ros2
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-alpha8/ros2.repos -o ros2.repos
+
+   # PowerShell
+   > cd \dev\ros2
+   > curl https://raw.githubusercontent.com/ros2/ros2/release-alpha8/ros2.repos -o ros2.repos
+
+The format of the name of the release comes from the tag associated with the release `here <https://github.com/ros2/ros2/tags>`__.
+
+Development branches
+^^^^^^^^^^^^^^^^^^^^
+
+If you wish to checkout the bleeding-edge development code, you can get the relevant repository list by running:
+
+**Linux/OS X**
+
+.. code-block:: bash
+
+   cd ~/ros2_ws
+   mv -i ros2.repos ros2.repos.old
+   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+
+**Windows**
+
+.. code-block:: bash
+
+   # CMD
+   > cd \dev\ros2
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+
+   # PowerShell
+   > cd \dev\ros2
+   > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+
+Update your repositories
+------------------------
+
+You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
+It is possible that these versions refer to new tags/branches that your local copy of the repositories will not recognize as they are out-of-date.
+Because of this, you should update the repositories that you have already checked out with the following command:
+
+.. code-block:: bash
+
+   vcs custom --args remote update
+
+Download the new source code
+----------------------------
+
+You should now be able to download the sources associated with the new repository list with:
+
+**Linux/OS X**
+
+.. code-block:: bash
+
+   vcs import src < ros2.repos
+   vcs pull src
+
+**Windows**
+
+.. code-block:: bash
+
+   # CMD
+   > vcs import src < ros2.repos
+   > vcs pull src
+
+   # PowerShell
+   > vcs import --input ros2.repos src
+   > vcs pull src
+
+Rebuild your workspace
+----------------------
+
+Now that the workspace is up to date with the latest sources, remove your previous install and rebuild your workspace with, for example:
+
+.. code-block:: bash
+
+   colcon build --symlink-install
+
+Inspecting your source checkout
+-------------------------------
+
+During your development you may have deviated from the original state of your workspace from when you imported the repository list.
+If you wish to know the versions of the set of repositories in your workspace, you can export the information using the following command:
+
+**Linux/OS X**
+
+.. code-block:: bash
+
+   cd ~/ros2_ws
+   vcs export src > my_ros2.repos
+
+**Windows**
+
+.. code-block:: bash
+
+   > cd \dev\ros2
+   > vcs export src > my_ros2.repos
+
+This ``my_ros2.repos`` file can then be shared with others so that they can reproduce the state of the repositories in your workspace.

--- a/source/Installation/Dashing/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Dashing/Maintaining-a-Source-Checkout.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Maintaining-a-Source-Checkout
-    Installation/Maintaining-a-Source-Checkout
-
 Maintaining a Source Checkout of ROS 2
 ======================================
 

--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-   OSX-Development-Setup
-   Installation/OSX-Development-Setup
-
 Building ROS 2 on OS X
 ======================
 

--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -1,0 +1,293 @@
+.. redirect-from::
+
+   OSX-Development-Setup
+   Installation/OSX-Development-Setup
+
+Building ROS 2 on OS X
+======================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+System requirements
+-------------------
+
+We support OS X 10.12.x.
+
+However, some new versions like 10.13.x and some older versions like 10.11.x and 10.10.x are known to work as well.
+
+Install prerequisites
+---------------------
+
+You need the following things installed to build ROS 2:
+
+
+#.
+   **Xcode**
+
+
+   *
+     If you don't already have it installed, install Xcode and the Command Line Tools:
+
+     .. code-block:: bash
+
+        xcode-select --install
+
+#.
+   **brew** *(needed to install more stuff; you probably already have this)*:
+
+
+   * Follow installation instructions at http://brew.sh/
+   *
+     *Optional*: Check that ``brew`` is happy with your system configuration by running:
+
+     .. code-block:: bash
+
+        brew doctor
+
+     Fix any problems that it identifies.
+
+#.
+   Use ``brew`` to install more stuff:
+
+   .. code-block:: bash
+
+       brew install cmake cppcheck eigen pcre poco python3 tinyxml wget
+
+       # install dependencies for Fast-RTPS if you are using it
+       brew install asio tinyxml2
+
+       brew install opencv
+
+       # install dependencies for rcl_logging_log4cxx
+       brew install log4cxx
+
+#.
+   Install rviz dependencies
+
+   .. code-block:: bash
+
+       # install dependencies for Rviz
+       brew install qt freetype assimp
+
+       # Add the Qt directory to the PATH and CMAKE_PREFIX_PATH
+       export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/usr/local/opt/qt
+       export PATH=$PATH:/usr/local/opt/qt/bin
+
+#.
+   Use ``python3 -m pip`` (just ``pip`` may install Python3 or Python2) to install more stuff:
+
+   .. code-block:: bash
+
+       python3 -m pip install argcomplete catkin_pkg colcon-common-extensions coverage empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes lark-parser mock nose pep8 pydocstyle pyparsing setuptools vcstool
+
+#.
+   *Optional*: if you want to build the ROS 1<->2 bridge, then you must also install ROS 1:
+
+
+   * Start with the normal install instructions: http://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source
+   *
+     When you get to the step where you call ``rosinstall_generator`` to get the source code, here's an alternate invocation that brings in just the minimum required to produce a useful bridge:
+
+     .. code-block:: bash
+
+          rosinstall_generator catkin common_msgs roscpp rosmsg --rosdistro kinetic --deps --wet-only --tar > kinetic-ros2-bridge-deps.rosinstall
+          wstool init -j8 src kinetic-ros2-bridge-deps.rosinstall
+
+
+     Otherwise, just follow the normal instructions, then source the resulting ``install_isolated/setup.bash`` before proceeding here to build ROS 2.
+
+Disable System Integrity Protection (SIP)
+-----------------------------------------
+
+OS X versions >=10.11 have System Integrity Protection enabled by default.
+So that SIP doesn't prevent processes from inheriting dynamic linker environment variables, such as ``DYLD_LIBRARY_PATH``, you'll need to disable it `following these instructions <https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html>`__.
+
+Get the ROS 2 code
+------------------
+
+Create a workspace and clone all repos:
+
+.. code-block:: bash
+
+   mkdir -p ~/ros2_ws/src
+   cd ~/ros2_ws
+   wget https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos
+   vcs import src < ros2.repos
+
+
+.. note::
+
+   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the url above with ``master``. The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+
+
+Install additional DDS vendors (optional)
+-----------------------------------------
+
+ROS 2 builds on top of DDS.
+It is compatible with `multiple DDS or RTPS (the DDS wire protocol) vendors </Concepts/DDS-and-ROS-middleware-implementations>`.
+The repositories you downloaded for ROS 2 includes eProsima's Fast RTPS, which is the only bundled vendor.
+If you would like to use one of the other vendors you will need to install their software separately before building.
+The ROS 2 build will automatically build support for vendors that have been installed and sourced correctly.
+
+By default we include eProsima's FastRTPS in the workspace and it is the default middleware.
+Detailed instructions for installing other DDS vendors are provided in the "Alternative DDS sources" section below.
+
+Build the ROS 2 code
+--------------------
+
+**Note**\ : if you are trying to build the ROS 1 <-> ROS 2 bridge, follow instead these `modified instructions <https://github.com/ros2/ros1_bridge/blob/master/README#build-the-bridge-from-source>`__.
+
+Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this tutorial </Tutorials/Colcon-Tutorial>`):
+
+.. code-block:: bash
+
+   cd ~/ros2_ws/
+   colcon build --symlink-install
+
+
+Try some examples
+-----------------
+
+In a clean new terminal, source the setup file (this will automatically set up the environment for any DDS vendors that support was built for) and then run a ``talker``:
+
+.. code-block:: bash
+
+   . ~/ros2_ws/install/setup.bash
+   ros2 run demo_nodes_cpp talker
+
+
+In another terminal source the setup file and then run a ``listener``:
+
+.. code-block:: bash
+
+   . ~/ros2_ws/install/setup.bash
+   ros2 run demo_nodes_cpp listener
+
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+Hooray!
+
+Alternative DDS sources
+-----------------------
+
+The demos will attempt to build against any detected DDS vendor.
+The only bundled vendor is eProsima's Fast RTPS, which is included in the default set of sources for ROS 2.
+If you would like to switch out the vendor below are the instructions.
+When you run the build make sure that your chosen DDS vendor(s) are exposed in your environment.
+
+When multiple vendors are present, you can choose the used RMW implementation by setting the the environment variable ``RMW_IMPLEMENTATION`` to the package providing the RMW implementation.
+See `Working with multiple RMW implementations </Tutorials/Working-with-multiple-RMW-implementations>` for more details.
+
+Adlink OpenSplice
+^^^^^^^^^^^^^^^^^
+
+ROS 2 Crystal Clemmys supports OpenSplice 6.9.
+ROS 2 Bouncy Bolson supports OpenSplice 6.7.
+
+To install OpenSplice, download the latest supported release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.
+
+Source the ``release.com`` file provided to set up the environment before building your ROS 2 workspace, e.g.:
+
+.. code-block:: bash
+
+   source <path_to_opensplice>/x86_64.darwin10_clang/release.com
+
+RTI Connext (5.3)
+^^^^^^^^^^^^^^^^^
+
+To use RTI Connext you will need to have obtained a license from RTI.
+
+You can install the OS X package of Connext version 5.3 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+
+You also need a Java runtime installed to run the RTI code generator, which you can get `here <https://support.apple.com/kb/DL1572?locale=en_US>`__.
+
+After installing, run RTI launcher and point it to your license file.
+
+Source the setup file to set the ``NDDSHOME`` environment variable before building your workspace.
+
+The setup file and path will depend on your macOS version.
+
+.. code-block:: bash
+
+   # macOS 10.12 Sierra
+   source /Applications/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Darwin16clang8.0.bash
+   # macOS 10.13 High Sierra
+   source /Applications/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Darwin17clang9.0.bash
+
+You may need to increase shared memory resources following https://community.rti.com/kb/osx510.
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
+
+.. _osx-development-setup-troubleshooting:
+
+Troubleshooting
+---------------
+
+Segmentation Fault when using ``pyenv``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``pyenv`` seems to default to building Python with ``.a`` files, but that causes issues with ``rclpy``, so it's recommended to build Python with Frameworks enabled on macOS when using ``pyenv``:
+
+https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with-framework-support-on-os-x
+
+Library not loaded; image not found
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are seeing library loading issues at runtime (either running tests or running nodes), such as the following:
+
+.. code-block:: bash
+
+   ImportError: dlopen(.../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
+     Referenced from: .../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
+     Reason: image not found
+
+then you probably have System Integrity Protection enabled.
+See "Disable System Integrity Protection (SIP)" above for how instructions on how to disable it.
+
+Qt build errors e.g. ``unknown type name 'Q_ENUM'``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you see build errors related to Qt, e.g.:
+
+.. code-block:: bash
+
+   In file included from /usr/local/opt/qt/lib/QtGui.framework/Headers/qguiapplication.h:46:
+   /usr/local/opt/qt/lib/QtGui.framework/Headers/qinputmethod.h:87:5: error:
+         unknown type name 'Q_ENUM'
+       Q_ENUM(Action)
+       ^
+
+you may be using qt4 instead of qt5: see https://github.com/ros2/ros2/issues/441
+
+Missing symbol when opencv (and therefore libjpeg, libtiff, and libpng) are installed with Homebrew
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have opencv installed you might get this:
+
+.. code-block:: bash
+
+   dyld: Symbol not found: __cg_jpeg_resync_to_restart
+     Referenced from: /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+     Expected in: /usr/local/lib/libJPEG.dylib
+    in /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+   /bin/sh: line 1: 25274 Trace/BPT trap: 5       /usr/local/bin/cmake
+
+If so, to build you'll have to do this:
+
+.. code-block:: bash
+
+   $ brew unlink libpng libtiff libjpeg
+
+But this will break opencv, so you'll also need to update it to continue working:
+
+.. code-block:: bash
+
+   $ sudo install_name_tool -change /usr/local/lib/libjpeg.8.dylib /usr/local/opt/jpeg/lib/libjpeg.8.dylib /usr/local/lib/libopencv_highgui.2.4.dylib
+   $ sudo install_name_tool -change /usr/local/lib/libpng16.16.dylib /usr/local/opt/libpng/lib/libpng16.16.dylib /usr/local/lib/libopencv_highgui.2.4.dylib
+   $ sudo install_name_tool -change /usr/local/lib/libtiff.5.dylib /usr/local/opt/libtiff/lib/libtiff.5.dylib /usr/local/lib/libopencv_highgui.2.4.dylib
+   $ sudo install_name_tool -change /usr/local/lib/libjpeg.8.dylib /usr/local/opt/jpeg/lib/libjpeg.8.dylib /usr/local/Cellar/libtiff/4.0.4/lib/libtiff.5.dylib
+
+The first command is necessary to avoid things built against the system libjpeg (etc.) from getting the version in /usr/local/lib.
+The others are updating things built by Homebrew so that they can find the version of libjpeg (etc.) without having them in /usr/local/lib.

--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -214,7 +214,7 @@ You may need to increase shared memory resources following https://community.rti
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
 
-.. _osx-development-setup-troubleshooting:
+.. _Dashing_osx-development-setup-troubleshooting:
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -183,8 +183,7 @@ See `Working with multiple RMW implementations </Tutorials/Working-with-multiple
 Adlink OpenSplice
 ^^^^^^^^^^^^^^^^^
 
-ROS 2 Crystal Clemmys supports OpenSplice 6.9.
-ROS 2 Bouncy Bolson supports OpenSplice 6.7.
+ROS 2 Dashing Diademata supports OpenSplice 6.9.
 
 To install OpenSplice, download the latest supported release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.
 

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -82,7 +82,7 @@ You need the following things installed before installing ROS 2.
 
   .. code-block:: bash
 
-       python3 -m pip install catkin_pkg empy lark-parser pyparsing pyyaml setuptools argcomplete
+       python3 -m pip install catkin_pkg empy lark-parser lxml numpy pyparsing pyyaml setuptools argcomplete
 
 Disable System Integrity Protection (SIP)
 -----------------------------------------

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -12,7 +12,7 @@ System requirements
 
 We support OS X El Capitan and Sierra (10.11.x and 10.12.x).
 
-.. _osx-install-binary-installling-prerequisites:
+.. _Dashing_osx-install-binary-installling-prerequisites:
 
 Installing prerequisites
 ------------------------

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -1,0 +1,204 @@
+.. redirect-from::
+
+   OSX-Install-Binary
+   Installation/OSX-Install-Binary
+
+Installing ROS 2 on OS X
+========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This page explains how to install ROS 2 on OS X from a pre-built binary package.
+
+System requirements
+-------------------
+
+We support OS X El Capitan and Sierra (10.11.x and 10.12.x).
+
+.. _osx-install-binary-installling-prerequisites:
+
+Installing prerequisites
+------------------------
+
+You need the following things installed before installing ROS 2.
+
+
+*
+  **brew** *(needed to install more stuff; you probably already have this)*:
+
+
+  * Follow installation instructions at http://brew.sh/
+  *
+    *Optional*: Check that ``brew`` is happy with your system configuration by running:
+
+    .. code-block:: bash
+
+        brew doctor
+
+
+      Fix any problems that it identifies.
+
+*
+  Use ``brew`` to install more stuff:
+
+  .. code-block:: bash
+
+       brew install python3
+
+       # install asio and tinyxml2 for Fast-RTPS
+       brew install asio tinyxml2
+
+       # install dependencies for robot state publisher
+       brew install tinyxml eigen pcre poco
+
+       # OpenCV isn't a dependency of ROS 2, but it is used by some demos.
+       brew install opencv
+
+       # install OpenSSL for DDS-Security
+       brew install openssl
+
+       # install Qt for RViz
+       brew install qt freetype assimp
+
+       # install dependencies for rcl_logging_log4cxx
+       brew install log4cxx
+
+*
+  Install rqt dependencies
+
+  ``brew install sip pyqt5``
+
+  Fix some path names when looking for sip stuff during install (see `ROS 1 wiki <http://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source#Qt_naming_issue>`__):
+
+  ``ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5``
+
+  ``brew install graphviz``
+  ``python3 -m pip install pygraphviz pydot``
+
+*
+  Install SROS2 dependencies
+
+  ``python3 -m pip install lxml``
+
+*
+  Install additional runtime dependencies for command-line tools:
+
+  .. code-block:: bash
+
+       python3 -m pip install catkin_pkg empy lark-parser pyparsing pyyaml setuptools argcomplete
+
+Disable System Integrity Protection (SIP)
+-----------------------------------------
+
+OS X versions >=10.11 have System Integrity Protection enabled by default.
+So that SIP doesn't prevent processes from inheriting dynamic linker environment variables, such as ``DYLD_LIBRARY_PATH``, you'll need to disable it `following these instructions <https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html>`__.
+
+Downloading ROS 2
+-----------------
+
+
+* Go to the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for OS X; let's assume that it ends up at ``~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2``.
+
+  * Note: there may be more than one binary download option which might cause the file name to differ.
+
+*
+  Unpack it:
+
+  .. code-block:: bash
+
+       mkdir -p ~/ros2_install
+       cd ~/ros2_install
+       tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
+
+Install additional DDS implementations (optional)
+-------------------------------------------------
+
+ROS 2 builds on top of DDS.
+It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
+
+*For ROS 2 Bouncy and newer:*
+
+The package you downloaded has been built with *optional* support for three vendors.
+Run-time support for eProsima's Fast RTPS is included bundled by default.
+If you would like to use one of the other vendors you will need to install their software separately.
+
+*For ROS 2 Ardent and older:*
+
+If you downloaded a package that includes support for OpenSplice, you must install OpenSplice as detailed below.
+
+Enable OpenSplice support
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Download the latest release from https://github.com/ADLINK-IST/opensplice/releases and unpack it.
+For ROS 2 releases up to and including Ardent, do not do anything else at this point.
+For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable to the unpacked directory that contains the ``release.com`` script.
+
+Enable Connext support
+^^^^^^^^^^^^^^^^^^^^^^
+
+To use RTI Connext you will need to have obtained a license from RTI.
+
+You can install the OS X package of Connext version 5.3.1 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+
+After installing, run RTI launcher and point it to your license file.
+
+Set the ``NDDSHOME`` environment variable:
+
+.. code-block:: bash
+
+   export NDDSHOME=/Applications/rti_connext_dds-5.3.1
+
+You may need to increase shared memory resources following https://community.rti.com/kb/osx510.
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
+
+Set up the ROS 2 environment
+----------------------------
+
+Source the ROS 2 setup file:
+
+.. code-block:: bash
+
+   . ~/ros2_install/ros2-osx/setup.bash
+
+
+For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent).
+Only do this **after** you have sourced the ROS 2 one:
+
+.. code-block:: bash
+
+   . <path_to_opensplice>/x86_64.darwin10_clang/release.com
+
+
+
+Try some examples
+-----------------
+
+In one terminal, set up the ROS 2 environment as described above and then run a ``talker``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp talker
+
+
+In another terminal, set up the ROS 2 environment and then run a ``listener``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp listener
+
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+Hooray!
+
+If you have installed support for an optional vendor, see `this page </Tutorials/Working-with-multiple-RMW-implementations>` for details on how to use that vendor.
+
+If you run into issues, see `the troubleshooting section <osx-development-setup-troubleshooting>` on the source installation page.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -10,7 +10,7 @@ This page explains how to install ROS 2 on OS X from a pre-built binary package.
 System requirements
 -------------------
 
-We support OS X El Capitan and Sierra (10.11.x and 10.12.x).
+We support OS X Sierra (10.12.x).
 
 .. _Dashing_osx-install-binary-installling-prerequisites:
 

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-   OSX-Install-Binary
-   Installation/OSX-Install-Binary
-
 Installing ROS 2 on OS X
 ========================
 

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -81,7 +81,7 @@ Then you can continue installing other Python dependencies:
 
 .. code-block:: bash
 
-   > pip install -U catkin_pkg EmPy lark-parser pyparsing pyyaml
+   > pip install -U catkin_pkg EmPy lark-parser lxml numpy pyparsing pyyaml
 
 Next install testing tools like ``pytest`` and others:
 
@@ -375,6 +375,28 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    > python_d
    > import _ctypes
 
+* Once you have verified the operation of ``python_d``, it is necessary to reinstall a few dependencies with the debug-enabled libraries:
+
+.. code-block:: bash
+
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl
+
+* To verify the installation of these dependencies:
+
+.. code-block:: bash
+
+   > python_d
+   # No import errors should appear when executing the following lines
+   > from lxml import etree
+   > import numpy
+
+* When you wish to return to building release binaries, it is necessary to uninstall the debug variants and use the release variants:
+
+.. code-block:: bash
+
+   > python -m pip uninstall numpy lxml
+   > python -m pip install numpy lxml
 
 * To create executables python scripts(.exe), python_d should be used to invoke colcon
 
@@ -383,29 +405,3 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    > python_d path\to\colcon_executable build
 
 * Hooray, you're done!
-
-SROS2 Debug Mode
-^^^^^^^^^^^^^^^^
-
-In order to use SROS2 in Debug mode on Windows, a corresponding debug build for ``lxml`` must be installed.
-
-* A pre-built Python wheel binary for ``lxml`` debug is provided, to install:
-
-.. code-block:: bash
-
-   > pip install https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl
-
-* To verify installation
-
-.. code-block:: bash
-
-   > python_d
-   > from lxml import etree
-
-* No import errors should appear.
-
-* Note, in order to switch back to release, reinstall the release wheel of lxml via pip:
-
-.. code-block:: bash
-
-   > pip install lxml

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -341,16 +341,16 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
 
 * You'll need to quit and restart the command prompt after installing the above.
-* Get and extract the Python 3.7.0 source from the ``tgz``:
+* Get and extract the Python 3.7.3 source from the ``tgz``:
 
-  * https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz
-  * To keep these instructions concise, please extract it to ``C:\dev\Python-3.7.0``
+  * https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
+  * To keep these instructions concise, please extract it to ``C:\dev\Python-3.7.3``
 
 * Now, build the Python source in debug mode from a Visual Studio command prompt:
 
 .. code-block:: bash
 
-   > cd C:\dev\Python-3.7.0\PCbuild
+   > cd C:\dev\Python-3.7.3\PCbuild
    > get_externals.bat
    > build.bat -p x64 -d
 
@@ -359,7 +359,7 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
 .. code-block:: bash
 
-   > cd C:\dev\Python-3.7.0\PCbuild\amd64
+   > cd C:\dev\Python-3.7.3\PCbuild\amd64
    > copy python_d.exe C:\Python37 /Y
    > copy python37_d.dll C:\Python37 /Y
    > copy python3_d.dll C:\Python37 /Y

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -1,0 +1,416 @@
+.. redirect-from::
+
+    Windows-Development-Setup
+    Installation/Windows-Development-Setup
+
+Building ROS 2 on Windows
+=========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This guide is about how to setup a development environment for ROS2 on Windows.
+
+Prerequisites
+-------------
+
+First follow the steps for `Installing Prerequisites <windows-install-binary-installing-prerequisites>` on the Binary Installation page.
+
+Stop and return here when you reach the "Downloading ROS 2" section.
+
+Additional Prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When building from source you'll need a few additional prerequisites installed.
+
+Install Additional Prerequisites from Chocolatey
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First install git:
+
+.. code-block:: bash
+
+   > choco install -y git
+
+You will need to append the Git cmd folder ``C:\Program Files\Git\cmd`` to the PATH (you can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".
+In the resulting dialog, click "Environment Variables", the click "Path" on the bottom pane, then click "Edit" and add the path).
+
+Then install ``patch``:
+
+.. code-block:: bash
+
+   > choco install -y patch
+
+You may need to close the cmd prompt and open a new one, but at this point you should be able to run ``git``\ , ``python``\ , ``cmake``\ , and ``patch.exe --version``.
+
+Installing Developer Tools
+--------------------------
+
+Now we are ready to install some our tools that we use to help in developing ROS 2.
+
+Let's start with ``vcstool``:
+
+.. code-block:: bash
+
+   > pip install -U vcstool
+
+You can test it out by just running ``vcs`` (you should be able to do this in the same cmd prompt).
+
+Next, install ``colcon``:
+
+.. code-block:: bash
+
+   > pip install -U colcon-common-extensions
+
+You can test it out by just running ``colcon`` (you should be able to do this in the same cmd prompt).
+
+Also, you should install ``curl``:
+
+.. code-block:: bash
+
+   > choco install -y curl
+
+Install dependencies
+--------------------
+
+Next install the latest version of ``setuptools`` and ``pip``:
+
+.. code-block:: bash
+
+   > <PATH_TO_PYTHON_EXECUTABLE> -m pip install -U setuptools pip
+
+Where ``PATH_TO_PYTHON_EXECUTABLE`` looks like: ``c:\python37\python.exe``
+
+Then you can continue installing other Python dependencies:
+
+.. code-block:: bash
+
+   > pip install -U catkin_pkg EmPy lark-parser pyparsing pyyaml
+
+Next install testing tools like ``pytest`` and others:
+
+.. code-block:: bash
+
+   > pip install -U pytest coverage mock
+
+Next install linters and checkers like ``flake8`` and others:
+
+.. code-block:: bash
+
+   > pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8 pydocstyle
+
+Next install cppcheck:
+
+.. code-block:: bash
+
+   > choco install -y cppcheck
+
+You will need to add ``C:\Program Files\Cppcheck`` to the ``PATH``.
+
+Next install xmllint:
+
+* Download the `64 bit binary archives <https://www.zlatkovic.com/pub/libxml/64bit/>`__ of ``libxml2`` (and its dependencies ``iconv`` and ``zlib``) from https://www.zlatkovic.com/projects/libxml/
+* Unpack all archives into e.g. ``C:\xmllint``
+* Add ``C:\xmllint\bin`` to the ``PATH``.
+
+Install Qt5
+^^^^^^^^^^^
+
+This section is only required if you are building rviz, but it comes with our default set of sources, so if you don't know, then assume you are building it.
+
+First get the installer from Qt's website:
+
+https://www.qt.io/download
+
+Select the Open Source version and then the ``Qt Online Installer for Windows``.
+
+Run the installer and install Qt5.
+We recommend you install it to the default location of ``C:\Qt``, but if you choose somewhere else, make sure to update the paths below accordingly.
+When selecting components to install, the only thing you absolutely need for bouncy and later is the appropriate MSVC 64-bit component under the ``Qt`` -> ``Qt 5.10.0`` tree.
+We're using ``5.10.0`` as of the writing of this document and that's what we recommend since that's all we test on Windows, but later version will probably work too.
+For bouncy and later, be sure to select ``MSVC 2017 64-bit``. For ardent use ``MSVC 2015 64-bit``.
+After that, the default settings are fine.
+
+Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` where you intend to build so that CMake can find it:
+
+.. code-block:: bash
+
+   > set Qt5_DIR=C:\Qt\5.10.0\msvc2017_64
+   : You could set it permanently with ``setx -m Qt5_DIR C:\Qt\5.10.0\msvc2017_64`` instead, but that requires Administrator.
+
+Note, this path might change based on which MSVC version you're using or if you installed it to a different directory.
+
+RQt dependencies
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   > pip install -U pydot PyQt5
+
+Getting the Source Code
+-----------------------
+
+Now that we have the development tools we can get the ROS 2 source code.
+
+First setup a development folder, I use ``C:\dev\ros2``:
+
+.. code-block:: bash
+
+   > md \dev\ros2\src
+   > cd \dev\ros2
+
+Get the ``ros2.repos`` file which defines the repositories to clone from:
+
+.. code-block:: bash
+
+   # CMD
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos -o ros2.repos
+
+   # PowerShell
+   > curl https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos -o ros2.repos
+
+..
+
+   Note: if you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the URL above with ``master``. The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+
+
+Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
+
+.. code-block:: bash
+
+   # CMD
+   > vcs import src < ros2.repos
+
+   # PowerShell
+   > vcs import --input ros2.repos src
+
+Getting a DDS Vendor
+--------------------
+
+You'll also need a DDS Vendor available for ROS to build against.
+There is currently support for eProsima FastRTPS, Adlink's OpenSplice, and RTI's Connext DDS.
+The source distribution of ROS 2 includes FastRTPS, so it will always build unless explicitly ignored.
+
+Adlink OpenSplice
+^^^^^^^^^^^^^^^^^
+
+If you would like to also build against OpenSplice, you will need to first download the latest version of `OpenSplice <https://github.com/ADLINK-IST/opensplice/releases>`__.
+Then run something like the following command before building ROS 2, to set up the OpenSplice environment:
+
+.. code-block:: bash
+
+   call "C:\opensplice69\HDE\x86_64.win64\release.bat"
+
+where the exact paths may need to be slightly altered depending on where you selected to install OpenSplice.
+
+RTI Connext 5.3
+^^^^^^^^^^^^^^^
+
+If you would like to also build against RTI Connext, you will need to first visit the RTI website and obtain a license (evaluation or purchased) for RTI Connext DDS as well as the installer via their `downloads page <https://www.rti.com/downloads>`__.
+After installing, use the RTI Launcher to load your license file.
+Then before building ROS 2, set up the Connext environment:
+
+.. code-block:: bash
+
+   call "C:\Program Files\rti_connext_dds-5.3.1\resource\scripts\rtisetenv_x64Win64VS2017.bat"
+
+Note that this path might need to be slightly altered depending on where you selected to install RTI Connext DDS.
+The path above is the current default path as of version 5.3.1, but will change as the version numbers increment in the future.
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
+
+If you don't install any additional DDS vendors, ROS 2 will default to using eProsima's Fast-RTPS as the middleware.
+
+Building the ROS 2 Code
+-----------------------
+
+.. _windows-dev-build-ros2:
+
+To build ROS 2 you will need a Visual Studio Command Prompt (usually titled "x64 Native Tools Command Prompt for VS 2017" for bouncy and later or "x64 Native Tools Command Prompt for VS 2015" for ardent and earlier) running as Administrator.
+
+FastRTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
+
+To build the ``\dev\ros2`` folder tree:
+
+.. code-block:: bash
+
+   > colcon build --merge-install
+
+Note, we're using ``--merge-install`` here to avoid a ``PATH`` variable that is too long at the end of the build. If you're adapting these instructions to build a smaller workspace then you might be able to use the default behavior which is isolated install, i.e. where each package is installed to a different folder.
+
+Note, if you are doing a debug build use ``python_d path\to\colcon_executable`` ``colcon``.
+See `Extra stuff for debug mode`_ for more info on running Python code in debug builds on Windows.
+
+Testing and Running
+-------------------
+
+Note that the first time you run any executable you will have to allow access to the network through a Windows Firewall popup.
+
+You can run the tests using this command:
+
+.. code-block:: bash
+
+   > colcon test
+
+Afterwards you can get a summary of the tests using this command:
+
+.. code-block:: bash
+
+   > colcon test-result
+
+To run the examples, first open a clean new ``cmd.exe`` and set up the workspace.
+This is done by sourcing the ``local_setup.bat`` file, which will automatically set up the environment for any DDS vendors that support was built for.
+Then execute the examples, e.g.:
+
+.. code-block:: bash
+
+   > call install\local_setup.bat
+   > ros2 run demo_nodes_py talker
+
+In a separate shell you can do the same, but instead run the ``listener``\ :
+
+.. code-block:: bash
+
+   > call install\local_setup.bat
+   > ros2 run demo_nodes_py listener
+
+For more explanations see the `Python Programming </Tutorials/Python-Programming>` demo or `other tutorials </Tutorials>`.
+
+Note: it is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Alternative DDS Sources
+-----------------------
+
+The demos will attempt to build against any detected DDS vendor.
+The only bundled vendor is eProsima's Fast RTPS, which is included in the default set of sources for ROS 2.
+To build for other vendors, make sure that your chosen DDS vendor(s) are exposed in your environment when you run the build.
+If you would like to change which vendor is being used see: `Working with Multiple RMW Implementations </Tutorials/Working-with-multiple-RMW-implementations>`
+
+Troubleshooting
+---------------
+
+CMake error setting modification time
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you run into the CMake error ``file INSTALL cannot set modification time on ...`` when installing files it is likely that an anti virus software or Windows Defender are interfering with the build. E.g. for Windows Defender you can list the workspace location to be excluded to prevent it from scanning those files.
+
+260 Character Path Limit
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   The input line is too long.
+   The syntax of the command is incorrect.
+
+You may see path length limit errors when building your own libraries, or maybe even in this guide as ROS2 matures.
+
+Run ``regedit.exe``, navigate to ``Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem``, and set ``LongPathsEnabled`` to 0x00000001 (1).
+
+Hit the windows key and type ``Edit Group Policy``. Navigate to Local Computer Policy > Computer Configuration > Administrative Templates > System > Filesystem. Right click ``Enable Win32 long paths``, click Edit. In the dialog, select Enabled and click OK.
+
+Close and open your terminal to reset the environment and try building again.
+
+CMake Packages Unable to Find asio, tinyxml2, tinyxml, eigen, or log4cxx
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We've seen, but been unable to identify the root cause, that sometimes the chocolatey packages for ``asio``, ``tinyxml2``, etc. do not add important registry entries and that will cause CMake to be unable to find them when building ROS 2.
+
+It seems that uninstalling the chocolatey packages (with ``-n`` if the uninstall fails the first time) and then reinstalling them will fix the issue.
+
+patch.exe Opens a New Command Window and Asks for Administrator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This will also cause the build of packages which need to use patch to fail, even you allow it to use administrator rights.
+
+The solution, for now, is to make sure you're building in a Visual Studio command prompt which has been run as administrator. On some machines canceling the prompt without selecting "Yes" will also work.
+
+Extra stuff for Debug mode
+--------------------------
+
+If you want to be able to run all the tests in Debug mode, you'll need to install a few more things:
+
+
+* To be able to extract the Python source tarball, you can use PeaZip:
+
+.. code-block:: bash
+
+   > choco install -y peazip
+
+
+* You'll also need SVN, since some of the Python source-build dependencies are checked out via SVN:
+
+.. code-block:: bash
+
+   > choco install -y svn hg
+
+
+* You'll need to quit and restart the command prompt after installing the above.
+* Get and extract the Python 3.7.0 source from the ``tgz``:
+
+  * https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz
+  * To keep these instructions concise, please extract it to ``C:\dev\Python-3.7.0``
+
+* Now, build the Python source in debug mode from a Visual Studio command prompt:
+
+.. code-block:: bash
+
+   > cd C:\dev\Python-3.7.0\PCbuild
+   > get_externals.bat
+   > build.bat -p x64 -d
+
+
+* Finally, copy the build products into the Python37 installation directories, next to the Release-mode Python executable and DLL's:
+
+.. code-block:: bash
+
+   > cd C:\dev\Python-3.7.0\PCbuild\amd64
+   > copy python_d.exe C:\Python37 /Y
+   > copy python37_d.dll C:\Python37 /Y
+   > copy python3_d.dll C:\Python37 /Y
+   > copy python37_d.lib C:\Python37\libs /Y
+   > copy python3_d.lib C:\Python37\libs /Y
+   > for %I in (*_d.pyd) do copy %I C:\Python37\DLLs /Y
+
+
+* Now, from a fresh command prompt, make sure that ``python_d`` works:
+
+.. code-block:: bash
+
+   > python_d
+   > import _ctypes
+
+
+* To create executables python scripts(.exe), python_d should be used to invoke colcon
+
+.. code-block:: bash
+
+   > python_d path\to\colcon_executable build
+
+* Hooray, you're done!
+
+SROS2 Debug Mode
+^^^^^^^^^^^^^^^^
+
+In order to use SROS2 in Debug mode on Windows, a corresponding debug build for ``lxml`` must be installed.
+
+* A pre-built Python wheel binary for ``lxml`` debug is provided, to install:
+
+.. code-block:: bash
+
+   > pip install https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl
+
+* To verify installation
+
+.. code-block:: bash
+
+   > python_d
+   > from lxml import etree
+
+* No import errors should appear.
+
+* Note, in order to switch back to release, reinstall the release wheel of lxml via pip:
+
+.. code-block:: bash
+
+   > pip install lxml

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Windows-Development-Setup
-    Installation/Windows-Development-Setup
-
 Building ROS 2 on Windows
 =========================
 

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -12,7 +12,7 @@ System requirements
 
 As of beta-2 only Windows 10 is supported.
 
-.. _windows-install-binary-installing-prerequisites:
+.. _Dashing_windows-install-binary-installing-prerequisites:
 
 Installing prerequisites
 ------------------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Windows-Install-Binary
-    Installation/Windows-Install-Binary
-
 Installing ROS 2 on Windows
 ===========================
 

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -58,28 +58,8 @@ In the resulting dialog, click "Environment Variables", then click "Path" on the
 Install Visual Studio
 ^^^^^^^^^^^^^^^^^^^^^
 
-**A. Install Visual Studio 2015 if using Ardent or earlier**
 
-   If you already have a paid version of Visual Studio 2015 (Professional, Enterprise), skip this step.
-
-   Microsoft provides a free of charge version of Visual Studio 2015, named Community, which can be used to build applications that use ROS 2:
-
-   https://www.visualstudio.com/vs/older-downloads/
-
-   Make sure that the Visual C++ features are installed. First choose 'Custom installation':
-
-   .. image:: http://i.imgur.com/tUcOMOA.png
-
-   Next check Visual C++:
-
-   .. image:: http://i.imgur.com/yWVEUkm.png
-
-   Ensure that the correct features will be installed:
-
-   .. image:: http://i.imgur.com/VxdbA7G.png
-
-
-**B. Install Visual Studio 2017 if using Bouncy or a nightly**
+B. Install Visual Studio 2017 if using Bouncy or a nightly**
 
    If you already have a paid version of Visual Studio 2017 (Professional, Enterprise), skip this step.
 
@@ -109,8 +89,7 @@ Adlink OpenSplice
 ~~~~~~~~~~~~~~~~~
 
 If you want to use OpenSplice, you will need to download the latest supported version.
-* For ROS 2 Crystal version 6.9.181126OSS-HDE-x86_64.win-vs2017 or later is required.
-* For ROS 2 Bouncy version 6.7.180404OSS-HDE-x86_64.win-vs2017 or later is required.
+* For ROS 2 Dashing version 6.9.181126OSS-HDE-x86_64.win-vs2017 or later is required.
 
 Download the `latest supported version <https://github.com/ADLINK-IST/opensplice/releases>`__
 For ROS 2 releases up to and including Ardent, extract it but do not do anything else at this point.
@@ -119,7 +98,7 @@ For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable
 RTI Connext
 ~~~~~~~~~~~
 
-To use RTI Connext (available as of ROS 2 Bouncy) you will need to have obtained a license from RTI.
+To use RTI Connext you will need to have obtained a license from RTI.
 
 You can install the Windows package of Connext version 5.3.1 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
 
@@ -147,13 +126,6 @@ Assuming you unpacked it to ``C:\opencv``\ , type the following on a Command Pro
    setx -m OpenCV_DIR C:\opencv
 
 Since you are using a precompiled ROS version, we have to tell it where to find the OpenCV libraries. You have to extend the ``PATH`` variable to ``c:\opencv\x64\vc15\bin``
-
-In ardent and earlier
-~~~~~~~~~~~~~~~~~~~~~
-
-These releases used OpenCV 2. You can download a precompiled version of OpenCV 2.4.13.2 from https://github.com/ros2/ros2/releases/download/release-beta2/opencv-2.4.13.2-vc14.VS2015.zip
-
-Since you are using a precompiled ROS version, we have to tell it where to find the OpenCV libraries. Assuming you were extracting OpenCV to ``c:\`` you have to extend your ``PATH`` variable to ``c:\opencv-2.4.13.2-vc14.VS2015\x64\vc14\bin``
 
 Install dependencies
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -112,7 +112,10 @@ Install OpenCV
 
 Some of the examples require OpenCV to be installed.
 
-You can download a precompiled version of OpenCV 3.4.1 from https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.1-vc15.VS2017.zip
+We provide the following precompiled versions of OpenCV 3.4.6:
+
+* Visual Studio 2017: https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc15.VS2017.zip
+* Visual Studio 2019: https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip
 
 Assuming you unpacked it to ``C:\opencv``\ , type the following on a Command Prompt (requires Admin privileges):
 
@@ -156,7 +159,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg empy lark-parser opencv-python pyparsing pyyaml setuptools
+   python -m pip install -U catkin_pkg empy lark-parser lxml numpy opencv-python pyparsing pyyaml setuptools
 
 RQt dependencies
 ~~~~~~~~~~~~~~~~
@@ -164,13 +167,6 @@ RQt dependencies
 .. code-block:: bash
 
    python -m pip install -U pydot PyQt5
-
-SROS2 dependencies
-~~~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-   python -m pip install -U lxml
 
 Downloading ROS 2
 -----------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -1,0 +1,271 @@
+.. redirect-from::
+
+    Windows-Install-Binary
+    Installation/Windows-Install-Binary
+
+Installing ROS 2 on Windows
+===========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This page explains how to install ROS 2 on Windows from a pre-built binary package.
+
+System requirements
+-------------------
+
+As of beta-2 only Windows 10 is supported.
+
+.. _windows-install-binary-installing-prerequisites:
+
+Installing prerequisites
+------------------------
+
+Install Chocolatey
+^^^^^^^^^^^^^^^^^^
+
+Chocolatey is a package manager for Windows, install it by following their installation instructions:
+
+https://chocolatey.org/
+
+You'll use Chocolatey to install some other developer tools.
+
+Install Python
+^^^^^^^^^^^^^^
+
+Open a Command Prompt and type the following to install Python via Chocolatey:
+
+.. code-block:: bash
+
+   > choco install -y python
+
+Install OpenSSL
+^^^^^^^^^^^^^^^
+
+Download an OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__. Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2*. Don't download the Win32 or Light versions.
+
+Run the installer with default parameters. The following commands assume you used the default installation directory:
+
+* ``setx -m OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg``
+
+You will need to append the OpenSSL-Win64 bin folder to your PATH.
+You can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".
+In the resulting dialog, click "Environment Variables", then click "Path" on the bottom pane, finally click "Edit" and add the path below.
+
+* ``C:\OpenSSL-Win64\bin\``
+
+Install Visual Studio
+^^^^^^^^^^^^^^^^^^^^^
+
+**A. Install Visual Studio 2015 if using Ardent or earlier**
+
+   If you already have a paid version of Visual Studio 2015 (Professional, Enterprise), skip this step.
+
+   Microsoft provides a free of charge version of Visual Studio 2015, named Community, which can be used to build applications that use ROS 2:
+
+   https://www.visualstudio.com/vs/older-downloads/
+
+   Make sure that the Visual C++ features are installed. First choose 'Custom installation':
+
+   .. image:: http://i.imgur.com/tUcOMOA.png
+
+   Next check Visual C++:
+
+   .. image:: http://i.imgur.com/yWVEUkm.png
+
+   Ensure that the correct features will be installed:
+
+   .. image:: http://i.imgur.com/VxdbA7G.png
+
+
+**B. Install Visual Studio 2017 if using Bouncy or a nightly**
+
+   If you already have a paid version of Visual Studio 2017 (Professional, Enterprise), skip this step.
+
+.. warning:: Visual Studio 2017 v15.8 seems to have a compiler bug preventing from building some ROS 2 packages. Please try installing an older version of Visual Studio 2017.
+
+   Microsoft provides a free of charge version of Visual Studio 2017, named Community, which can be used to build applications that use ROS 2:
+
+   https://visualstudio.microsoft.com/downloads/
+
+   Make sure that the Visual C++ features are installed.
+   An easy way to make sure they're installed is to select the ``Desktop development with C++`` workflow during the install.
+
+   .. image:: https://i.imgur.com/2h0IxCk.png
+
+
+Install additional DDS implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 builds on top of DDS.
+It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
+
+The package you downloaded has been built with optional support for multiple vendors: eProsima FastRTPS, Adlink OpenSplice, and (as of ROS 2 Bouncy) RTI Connext as the middleware options.
+Run-time support for eProsima's Fast RTPS is included bundled by default.
+If you would like to use one of the other vendors you will need to install their software separately.
+
+Adlink OpenSplice
+~~~~~~~~~~~~~~~~~
+
+If you want to use OpenSplice, you will need to download the latest supported version.
+* For ROS 2 Crystal version 6.9.181126OSS-HDE-x86_64.win-vs2017 or later is required.
+* For ROS 2 Bouncy version 6.7.180404OSS-HDE-x86_64.win-vs2017 or later is required.
+
+Download the `latest supported version <https://github.com/ADLINK-IST/opensplice/releases>`__
+For ROS 2 releases up to and including Ardent, extract it but do not do anything else at this point.
+For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable to the unpacked directory that contains the ``release.bat`` script.
+
+RTI Connext
+~~~~~~~~~~~
+
+To use RTI Connext (available as of ROS 2 Bouncy) you will need to have obtained a license from RTI.
+
+You can install the Windows package of Connext version 5.3.1 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+
+After installing, run RTI launcher and point it to your license file.
+
+Set the ``NDDSHOME`` environment variable:
+
+.. code-block:: bash
+
+   set "NDDSHOME=C:\Program Files\rti_connext_dds-5.3.1"
+
+If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
+
+Install OpenCV
+^^^^^^^^^^^^^^
+
+Some of the examples require OpenCV to be installed.
+
+You can download a precompiled version of OpenCV 3.4.1 from https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.1-vc15.VS2017.zip
+
+Assuming you unpacked it to ``C:\opencv``\ , type the following on a Command Prompt (requires Admin privileges):
+
+.. code-block:: bash
+
+   setx -m OpenCV_DIR C:\opencv
+
+Since you are using a precompiled ROS version, we have to tell it where to find the OpenCV libraries. You have to extend the ``PATH`` variable to ``c:\opencv\x64\vc15\bin``
+
+In ardent and earlier
+~~~~~~~~~~~~~~~~~~~~~
+
+These releases used OpenCV 2. You can download a precompiled version of OpenCV 2.4.13.2 from https://github.com/ros2/ros2/releases/download/release-beta2/opencv-2.4.13.2-vc14.VS2015.zip
+
+Since you are using a precompiled ROS version, we have to tell it where to find the OpenCV libraries. Assuming you were extracting OpenCV to ``c:\`` you have to extend your ``PATH`` variable to ``c:\opencv-2.4.13.2-vc14.VS2015\x64\vc14\bin``
+
+Install dependencies
+^^^^^^^^^^^^^^^^^^^^
+
+There are a few dependencies not available in the Chocolatey package database. In order to ease the manual installation process, we provide the necessary Chocolatey packages.
+
+As some chocolatey packages rely on it, we start by installing CMake
+
+.. code-block:: bash
+
+   > choco install -y cmake
+
+You will need to append the CMake bin folder ``C:\Program Files\CMake\bin`` to your PATH.
+
+Please download these packages from `this <https://github.com/ros2/choco-packages/releases/latest>`__ GitHub repository.
+
+
+* asio.1.12.1.nupkg
+* eigen-3.3.4.nupkg
+* tinyxml-usestl.2.6.2.nupkg
+* tinyxml2.6.0.0.nupkg
+* log4cxx.0.10.0.nupkg
+
+Once these packages are downloaded, open an administrative shell and execute the following command:
+
+.. code-block:: bash
+
+   > choco install -y -s <PATH\TO\DOWNLOADS\> asio eigen tinyxml-usestl tinyxml2 log4cxx
+
+Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
+
+You must also install some python dependencies for command-line tools:
+
+.. code-block:: bash
+
+   python -m pip install -U catkin_pkg empy lark-parser opencv-python pyparsing pyyaml setuptools
+
+RQt dependencies
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   python -m pip install -U pydot PyQt5
+
+SROS2 dependencies
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   python -m pip install -U lxml
+
+Downloading ROS 2
+-----------------
+
+
+* Go the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
+
+  * Notes:
+
+    * there may be more than one binary download option which might cause the file name to differ.
+    * [ROS Bouncy only] To download the ROS 2 debug libraries you'll need to download ``ros2-bouncy-windows-Debug-AMD64.zip``
+
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2``\ ).
+
+  * Note (Ardent and earlier): There seems to be an issue where extracting the zip file with 7zip causes RViz to crash on startup. Extract the zip file using the Windows explorer to prevent this.
+
+Set up the ROS 2 environment
+----------------------------
+
+Start a command shell and source the ROS 2 setup file to set up the workspace:
+
+.. code-block:: bash
+
+   > call C:\dev\ros2\local_setup.bat
+
+For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent; this step can be skipped).
+It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
+Only do this step **after** you have sourced the ROS 2 setup file:
+
+.. code-block:: bash
+
+   > call "C:\opensplice69\HDE\x86_64.win64\release.bat"
+
+Try some examples
+-----------------
+
+In a command shell, set up the ROS 2 environment as described above and then run a ``talker``\ :
+
+.. code-block:: bash
+
+   > ros2 run demo_nodes_cpp talker
+
+Start another command shell and run a ``listener``\ :
+
+.. code-block:: bash
+
+   > ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+Hooray!
+
+If you have installed support for an optional vendor, see `this page </Tutorials/Working-with-multiple-RMW-implementations>` for details on how to use that vendor.
+
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+
+* If at one point your example would not start because of missing dll's, please verify that all libraries from external dependencies such as OpenCV are located inside your ``PATH`` variable.
+* If you forget to call the ``local_setup.bat`` file from your terminal, the demo programs will most likely crash immediately.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.


### PR DESCRIPTION
These docs are based on the exsting Crystal docs with conditional prose
for earlier rosdistros removed and details changed to their Dashing
counterparts.

@mjcarroll if you'd be kind enough to add the instructions for the numpy debug wheel (and numpy on Windows in general) I'd be grateful.

I also need to make another pass through the version numbers in the Mac and Windows instructions before this is ready.

Anyone else who has instruction updates can commit directly to this branch as far as I'm concerned.