### PR TITLE
Dashing Notes for OpenCV, Numpy, and LXML

### DIFF
--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -53,6 +53,8 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-lark-parser \
+     python3-lxml \
+     python3-numpy \
      python3-pip \
      python-rosdep \
      python3-vcstool \

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -82,7 +82,7 @@ You need the following things installed before installing ROS 2.
 
   .. code-block:: bash
 
-       python3 -m pip install catkin_pkg empy lark-parser pyparsing pyyaml setuptools argcomplete
+       python3 -m pip install catkin_pkg empy lark-parser lxml numpy pyparsing pyyaml setuptools argcomplete
 
 Disable System Integrity Protection (SIP)
 -----------------------------------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -81,7 +81,7 @@ Then you can continue installing other Python dependencies:
 
 .. code-block:: bash
 
-   > pip install -U catkin_pkg EmPy lark-parser pyparsing pyyaml
+   > pip install -U catkin_pkg EmPy lark-parser numpy pyparsing pyyaml
 
 Next install testing tools like ``pytest`` and others:
 
@@ -375,6 +375,28 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    > python_d
    > import _ctypes
 
+* Once you have verified the operation of ``python_d``, it is necessary to reinstall a few dependencies with the debug-enabled libraries:
+
+.. code-block:: bash
+
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl 
+
+* To verify the installation of these dependencies:
+
+.. code-block:: bash
+
+   > python_d
+   # No import errors should appear when executing the following lines
+   > from lxml import etree
+   > import numpy
+
+* When you wish to return to building release binaries, it is necessary to uninstall the debug variants and use the release variants:
+
+.. code-block:: bash
+
+   > python -m pip uninstall numpy lxml 
+   > python -m pip install numpy lxml
 
 * To create executables python scripts(.exe), python_d should be used to invoke colcon
 

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -81,7 +81,7 @@ Then you can continue installing other Python dependencies:
 
 .. code-block:: bash
 
-   > pip install -U catkin_pkg EmPy lark-parser numpy pyparsing pyyaml
+   > pip install -U catkin_pkg EmPy lark-parser lxml numpy pyparsing pyyaml
 
 Next install testing tools like ``pytest`` and others:
 
@@ -380,7 +380,7 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 .. code-block:: bash
 
    > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.16.2-cp37-cp37dm-win_amd64.whl
-   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl 
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl
 
 * To verify the installation of these dependencies:
 
@@ -395,7 +395,7 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
 .. code-block:: bash
 
-   > python -m pip uninstall numpy lxml 
+   > python -m pip uninstall numpy lxml
    > python -m pip install numpy lxml
 
 * To create executables python scripts(.exe), python_d should be used to invoke colcon
@@ -405,29 +405,3 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    > python_d path\to\colcon_executable build
 
 * Hooray, you're done!
-
-SROS2 Debug Mode
-^^^^^^^^^^^^^^^^
-
-In order to use SROS2 in Debug mode on Windows, a corresponding debug build for ``lxml`` must be installed.
-
-* A pre-built Python wheel binary for ``lxml`` debug is provided, to install:
-
-.. code-block:: bash
-
-   > pip install https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.3.2-cp37-cp37dm-win_amd64.whl
-
-* To verify installation
-
-.. code-block:: bash
-
-   > python_d
-   > from lxml import etree
-
-* No import errors should appear.
-
-* Note, in order to switch back to release, reinstall the release wheel of lxml via pip:
-
-.. code-block:: bash
-
-   > pip install lxml

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -159,7 +159,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg empy lark-parser numpy opencv-python pyparsing pyyaml setuptools
+   python -m pip install -U catkin_pkg empy lark-parser lxml numpy opencv-python pyparsing pyyaml setuptools
 
 RQt dependencies
 ~~~~~~~~~~~~~~~~
@@ -167,13 +167,6 @@ RQt dependencies
 .. code-block:: bash
 
    python -m pip install -U pydot PyQt5
-
-SROS2 dependencies
-~~~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-   python -m pip install -U lxml
 
 Downloading ROS 2
 -----------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -112,7 +112,10 @@ Install OpenCV
 
 Some of the examples require OpenCV to be installed.
 
-You can download a precompiled version of OpenCV 3.4.1 from https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.1-vc15.VS2017.zip
+We provide the following precompiled versions of OpenCV 3.4.6:
+
+* Visual Studio 2017: https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc15.VS2017.zip
+* Visual Studio 2019: https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip
 
 Assuming you unpacked it to ``C:\opencv``\ , type the following on a Command Prompt (requires Admin privileges):
 
@@ -156,7 +159,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg empy lark-parser opencv-python pyparsing pyyaml setuptools
+   python -m pip install -U catkin_pkg empy lark-parser numpy opencv-python pyparsing pyyaml setuptools
 
 RQt dependencies
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Edit: I collapsed the sros2-specific sections in a few places and included lxml in the default pip invocations where relevant.  I think that it's probably more consistent to just get sros2 by default, and people could remove that if they aren't interested in using it.