### PR TITLE
Fix $ROS_DISTRO in colcon tutorial

### DIFF
--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -121,7 +121,7 @@ Let's clone the `examples <https://github.com/ros2/examples>`__ repository into 
 .. code-block:: bash
 
     cd ~/ros2_example_ws/src/examples/
-    git checkout ROSDISTRO
+    git checkout $ROS_DISTRO
     cd ~/ros2_example_ws
 
 Now the workspace should have the source code to the ROS 2 examples:


### PR DESCRIPTION
I didn't check if the environment variable was renamed or not, but wasn't working with the crystal.