### PR TITLE
Move instruction for installing ROS2

### DIFF
--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -25,13 +25,6 @@ The source code can be found in the `colcon GitHub organization <https://github.
 Prerequisites
 -------------
 
-Install ROS 2
-^^^^^^^^^^^^^
-
-Make sure that you have installed ROS 2 following the `installation instructions <../Installation>`.
-
-.. attention:: If installing from Debian packages, this tutorial requires the "Desktop installation".
-
 Install colcon
 ^^^^^^^^^^^^^^
 
@@ -55,6 +48,16 @@ Windows
 .. code-block:: bash
 
     pip install -U colcon-common-extensions
+
+
+Install ROS 2
+^^^^^^^^^^^^^
+
+To build the samples, you will need to install ROS2
+
+Follow the `installation instructions <../Installation>`.
+
+.. attention:: If installing from Debian packages, this tutorial requires the "Desktop installation".
 
 Basics
 ------


### PR DESCRIPTION
As I understand it, ROS2 is not necessary for colcon to work. Since colcon can be used to build ROS1 packages, which may be used as a migration strategy for ROS2 (i.e. make sure your system builds on colcon, then migrate nodes to ROS2), it seems prudent to remove ROS2 installation from the list of prerequisites.