### PR TITLE
Separate commands with empty lines

### DIFF
--- a/source/Installation/Crystal/OSX-Install-Binary.rst
+++ b/source/Installation/Crystal/OSX-Install-Binary.rst
@@ -75,6 +75,7 @@ You need the following things installed before installing ROS 2.
   ``ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5``
 
   ``brew install graphviz``
+
   ``python3 -m pip install pygraphviz pydot``
 
 *

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -70,6 +70,7 @@ You need the following things installed before installing ROS 2.
   ``ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5``
 
   ``brew install graphviz``
+
   ``python3 -m pip install pygraphviz pydot``
 
 *


### PR DESCRIPTION
Before the commands were rendering on the same line, now they render on separate lines.