### PR TITLE
Update ipc tutorial

### DIFF
--- a/source/Tutorials/Intra-Process-Communication.rst
+++ b/source/Tutorials/Intra-Process-Communication.rst
@@ -49,7 +49,7 @@ This demo is designed to show that the intra process publish/subscribe connectio
 
 First let's take a look at the source:
 
-https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+https://github.com/ros2/demos/blob/2927fb7cc71b44d7d07b084f2f0bb6ba1d4dba9b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
 
 .. code-block:: c++
 
@@ -58,6 +58,7 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeli
    #include <cstdio>
    #include <memory>
    #include <string>
+   #include <utility>
 
    #include "rclcpp/rclcpp.hpp"
    #include "std_msgs/msg/int32.hpp"
@@ -68,10 +69,10 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeli
    struct Producer : public rclcpp::Node
    {
      Producer(const std::string & name, const std::string & output)
-     : Node(name, "", true)
+     : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
      {
        // Create a publisher on the output topic.
-       pub_ = this->create_publisher<std_msgs::msg::Int32>(output, rmw_qos_profile_default);
+       pub_ = this->create_publisher<std_msgs::msg::Int32>(output, 10);
        std::weak_ptr<std::remove_pointer<decltype(pub_.get())>::type> captured_pub = pub_;
        // Create a timer which publishes on the output topic at ~1Hz.
        auto callback = [captured_pub]() -> void {
@@ -85,7 +86,7 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeli
            printf(
              "Published message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
              reinterpret_cast<std::uintptr_t>(msg.get()));
-           pub_ptr->publish(msg);
+           pub_ptr->publish(std::move(msg));
          };
        timer_ = this->create_wall_timer(1s, callback);
      }
@@ -98,15 +99,17 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeli
    struct Consumer : public rclcpp::Node
    {
      Consumer(const std::string & name, const std::string & input)
-     : Node(name, "", true)
+     : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
      {
        // Create a subscription on the input topic which prints on receipt of new messages.
        sub_ = this->create_subscription<std_msgs::msg::Int32>(
-         input, [](std_msgs::msg::Int32::UniquePtr msg) {
-         printf(
-           " Received message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
-           reinterpret_cast<std::uintptr_t>(msg.get()));
-       }, rmw_qos_profile_default);
+         input,
+         10,
+         [](std_msgs::msg::Int32::UniquePtr msg) {
+           printf(
+             " Received message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
+             reinterpret_cast<std::uintptr_t>(msg.get()));
+         });
      }
 
      rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_;
@@ -124,6 +127,9 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeli
      executor.add_node(producer);
      executor.add_node(consumer);
      executor.spin();
+
+     rclcpp::shutdown();
+
      return 0;
    }
 
@@ -174,7 +180,7 @@ The cyclic pipeline demo
 This demo is similar to the previous one, but instead of the producer creating a new message for each iteration, this demo only ever uses one message instance.
 This is achieved by creating a cycle in the graph and "kicking off" communication by externally making one of the nodes publish before spinning the executor:
 
-https://github.com/ros2/demos/blob/master/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
+https://github.com/ros2/demos/blob/2927fb7cc71b44d7d07b084f2f0bb6ba1d4dba9b/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
 
 .. code-block:: c++
 
@@ -183,6 +189,7 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/cyclic_pipeline
    #include <cstdio>
    #include <memory>
    #include <string>
+   #include <utility>
 
    #include "rclcpp/rclcpp.hpp"
    #include "std_msgs/msg/int32.hpp"
@@ -193,32 +200,34 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/cyclic_pipeline
    struct IncrementerPipe : public rclcpp::Node
    {
      IncrementerPipe(const std::string & name, const std::string & in, const std::string & out)
-     : Node(name, "", true)
+     : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
      {
        // Create a publisher on the output topic.
-       pub = this->create_publisher<std_msgs::msg::Int32>(out, rmw_qos_profile_default);
+       pub = this->create_publisher<std_msgs::msg::Int32>(out, 10);
        std::weak_ptr<std::remove_pointer<decltype(pub.get())>::type> captured_pub = pub;
        // Create a subscription on the input topic.
        sub = this->create_subscription<std_msgs::msg::Int32>(
-         in, [captured_pub](std_msgs::msg::Int32::UniquePtr msg) {
-         auto pub_ptr = captured_pub.lock();
-         if (!pub_ptr) {
-           return;
-         }
-         printf(
-           "Received message with value:         %d, and address: 0x%" PRIXPTR "\n", msg->data,
-           reinterpret_cast<std::uintptr_t>(msg.get()));
-         printf("  sleeping for 1 second...\n");
-         if (!rclcpp::sleep_for(1s)) {
-           return;    // Return if the sleep failed (e.g. on ctrl-c).
-         }
-         printf("  done.\n");
-         msg->data++;    // Increment the message's data.
-         printf(
-           "Incrementing and sending with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
-           reinterpret_cast<std::uintptr_t>(msg.get()));
-         pub_ptr->publish(msg);    // Send the message along to the output topic.
-       }, rmw_qos_profile_default);
+         in,
+         10,
+         [captured_pub](std_msgs::msg::Int32::UniquePtr msg) {
+           auto pub_ptr = captured_pub.lock();
+           if (!pub_ptr) {
+             return;
+           }
+           printf(
+             "Received message with value:         %d, and address: 0x%" PRIXPTR "\n", msg->data,
+             reinterpret_cast<std::uintptr_t>(msg.get()));
+           printf("  sleeping for 1 second...\n");
+           if (!rclcpp::sleep_for(1s)) {
+             return;    // Return if the sleep failed (e.g. on ctrl-c).
+           }
+           printf("  done.\n");
+           msg->data++;    // Increment the message's data.
+           printf(
+             "Incrementing and sending with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
+             reinterpret_cast<std::uintptr_t>(msg.get()));
+           pub_ptr->publish(std::move(msg));    // Send the message along to the output topic.
+         });
      }
 
      rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub;
@@ -242,11 +251,14 @@ https://github.com/ros2/demos/blob/master/intra_process_demo/src/cyclic_pipeline
      printf(
        "Published first message with value:  %d, and address: 0x%" PRIXPTR "\n", msg->data,
        reinterpret_cast<std::uintptr_t>(msg.get()));
-     pipe1->pub->publish(msg);
+     pipe1->pub->publish(std::move(msg));
 
      executor.add_node(pipe1);
      executor.add_node(pipe2);
      executor.spin();
+
+     rclcpp::shutdown();
+
      return 0;
    }
 
@@ -368,7 +380,7 @@ As you can see in the example image above, we have one image with all of the poi
 
 The link between the ``camera_node`` and the ``watermark_node`` can use the same pointer without copying because there is only one intra process subscription to which the message should be delivered. But for the link between the ``watermark_node`` and the two image view nodes the relationship is one to many, so if the image view nodes were using ``unique_ptr`` callbacks then it would be impossible to deliver the ownership of the same pointer to both. It can be, however, delivered to one of them. Which one would get the original pointer is not defined, but instead is simply the last to be delivered.
 
-Note that the image view nodes are not subscribed with ``unique_ptr`` callbacks. Instead they are subscribed with ``const shared_ptr``\ s. This means the system could have delivered the same ``shared_ptr`` to both callbacks. Currently the intra process system is not that intelligent and so it stores the message internally as a ``unique_ptr`` and copies it into a ``shared_ptr`` for each callback until the last one. On the last callback, regardless of the type, the ownership is transferred out of intra process storage and, in the case of the image view, the ownership is moved into a new ``shared_ptr`` and delivered. Thus, one of the image view nodes gets a copy and the other gets the original.
+Note that the image view nodes are not subscribed with ``unique_ptr`` callbacks. Instead they are subscribed with ``const shared_ptr``\ s. This means the system deliveres the same ``shared_ptr`` to both callbacks. When the first intraprocess subscription is handled, the internally stored ``unique_ptr`` is promoted to a ``shared_ptr``. Each of the callbacks will receive shared ownership of the same message.
 
 Pipeline with interprocess viewer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -393,34 +405,10 @@ Room for Improvement
 
 Let's start by looking at what we at OSRF know we can do better or differently and move on from there.
 
-Intra Process Manager Storage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-At the core of the intra process implementation is something called the intra process manager. It is the shared state between nodes (not necessarily global) which facilitates intra process communication. The intra process manager has a lot of room for improvement, but one thing on our short list is to have it be more intelligent about how to store the user's data internally. In the example with two image view nodes all in the same process, we could have delivered the user's provided pointer to both image view nodes as copies of a single ``shared_ptr``. This is possible only because of the intra process graph's structure, but given any relationship of a publisher to one or more intra process subscriptions there should be a preferred solution.
-
-For example, imagine if there was a publisher connected to three intra process subscriptions where one was subscribed as a ``unique_ptr`` and the other two were subscribed as a ``shared_ptr``. If you store the the message as a ``unique_ptr`` then you must make a copy for each of the ``shared_ptr`` but you can deliver to the ``unique_ptr`` callback without a copy. But if you instead stored the message as a ``shared_ptr`` then you give that ``shared_ptr`` to the two ``shared_ptr`` callbacks and make one copy for the ``unique_ptr`` callback, which would save on copies. In both cases we've assumed that only one copy of the message should be stored, i.e. we will not store a ``unique_ptr`` of the message as well as a ``shared_ptr`` copy. There is a performance trade-off when decided whether to make those copies or not, so one thing to figure out moving forward is how and when to expose this trade-off to the developer.
-
-This problem gets more interesting when we start doing Type Masquerading :smile:, which we'll talk about below.
-
-Avoiding Unnecessary Interprocess Publishes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Currently we're relying on the middleware, the DDS vendor, to avoid publishing to the wire unnecessarily, but no matter what we have to give the middleware a copy of the user's message. We could avoid this copy given to the system if we could know if it is needed. We can do this currently by checking to see if there are any non intra process subscriptions currently attached to the publisher. The problem with this becomes apparent when we go to implement latching, which we'll see more about below.
-
-Avoiding Memory Allocation
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In other parts of the system we've worked really hard to allow users to avoid memory allocation. This has performance benefits and may be required for real-time or embedded scenarios. We cannot currently do that with intra process. Mostly this is because we haven't had time to figure out the right interfaces, but the general problem is that if a message needs to be delivered to more than one subscription, or if the user gives us a ``const &`` or ``const shared_ptr`` when publishing, we need to make a copy. And the destination of the copy is currently created using ``new`` and is not configurable. We expect to resolve that in the future.
-
 Performance, Performance, Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is a very rough first draft. There is a lot of room for improvement, even beyond what has been enumerated above. We'll start to improve performance as we dig into the details of the system, build up a better understanding of exactly what our middleware vendors are doing, and try alternative strategies for implementing intra process.
-
-What's Missing
-^^^^^^^^^^^^^^
-
-Aforementioned are some things we can improve with what's already there. But there are also some things we'd like to add on top of this that are pretty interesting and some things that are just necessary.
 
 Latching
 ~~~~~~~~
@@ -441,29 +429,3 @@ Imagine the image pipeline demo above, but rather than passing ``sensor_msgs/Ima
 In ROS 1, this is accomplished by serializing/deserializing the third party type when handling it. This means that with intra process you'll be serializing when passing it between nodelets. But in ROS 2 we want to do it in the most performant way possible. Similar to how these demos have been demonstrating that an instance of a message can be used through the whole pipeline in certain cases, we'd like to do the same with third party types. So conceivably you could have the image pipeline with a single ``cv::Mat`` which never gets copied by the middleware. To do this requires some additional intelligence in the intra process manager, but we've already got a design and some proof of concepts in the works.
 
 Given these features, hopefully there will come a point where you can trust the middleware to handle your data as efficiently as is possible. This will allow you to write performant algorithms without sacrificing modularity or introspection!
-
-Tooling
-~~~~~~~
-
-One of the sticking points of Nodelets in ROS 1 was the complexity of defining, building, and using them.
-We've not tackled that problem yet, but we are working on it. We've got a port of class loader (https://github.com/ros/class_loader/tree/ros2) and pluginlib (https://github.com/ros/pluginlib/tree/ros2) for ROS 2, but we only have prototypes of the CMake infrastructure which will help users build and run their nodes. Here's a sketch of the design we expect:
-
-.. code-block:: cmake
-
-   add_node(my_node src/my_node.cpp)
-   target_link_libraries(my_node ${external_dependency_LIBRARIES} ...)
-
-We'll provide an interface similar to CMake's ``add_executable`` or ``add_library``. This doesn't preclude the idea of providing a more automatic solution a la ``ament_cmake_auto``.
-
-This simple CMake entry will generate a few things:
-
-
-* A marker file used to discover the node by pluginlib.
-* A shared library for your node.
-* An executable for your node.
-
-  * The executable can run the node in its own process, or serve as a proxy while the node runs in a different container.
-
-We'll also need to develop the container, which can run nodes inside of itself and is controlled externally by ROS primitives like Services.
-
-We've got a lot of work to do, but hopefully this tutorial gives you a sense of where we're going and what we're trying to do in terms of performance and features.

--- a/source/Tutorials/Intra-Process-Communication.rst
+++ b/source/Tutorials/Intra-Process-Communication.rst
@@ -49,7 +49,7 @@ This demo is designed to show that the intra process publish/subscribe connectio
 
 First let's take a look at the source:
 
-https://github.com/ros2/demos/blob/2927fb7cc71b44d7d07b084f2f0bb6ba1d4dba9b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
 
 .. code-block:: c++
 
@@ -180,7 +180,7 @@ The cyclic pipeline demo
 This demo is similar to the previous one, but instead of the producer creating a new message for each iteration, this demo only ever uses one message instance.
 This is achieved by creating a cycle in the graph and "kicking off" communication by externally making one of the nodes publish before spinning the executor:
 
-https://github.com/ros2/demos/blob/2927fb7cc71b44d7d07b084f2f0bb6ba1d4dba9b/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
+https://github.com/ros2/demos/blob/master/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
 
 .. code-block:: c++
 


### PR DESCRIPTION
- Update code snippets
- Update what happens in the two image viewers
- Update `room for improvement` section. Really, just deleted things. Please add more ideas.

The image of `Pipeline with two image viewers` should be updated, to show the same address in both image viewers.