### PR TITLE
Add missing instructions for OpenSSL installation on macOS

### DIFF
--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -58,6 +58,11 @@ You need the following things installed to build ROS 2:
        # install console_bridge for rosbag2
        brew install console_bridge
 
+       # install OpenSSL for DDS-Security
+       brew install openssl
+       # if you are using ZSH, then replace '.bashrc' with '.zshrc'
+       echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
+
        # install dependencies for rcl_logging_log4cxx
        brew install log4cxx
 

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -53,6 +53,8 @@ You need the following things installed before installing ROS 2.
 
        # install OpenSSL for DDS-Security
        brew install openssl
+       # if you are using ZSH, then replace '.bashrc' with '.zshrc'
+       echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
 
        # install Qt for RViz
        brew install qt freetype assimp


### PR DESCRIPTION
Resolves https://github.com/ros2/ros2_documentation/issues/231