### PR TITLE
Minor improvements to action tutorials

### DIFF
--- a/source/Tutorials/Actions.rst
+++ b/source/Tutorials/Actions.rst
@@ -25,6 +25,8 @@ Prequisites
 
 - Setup a workspace and create a package named ``action_tutorials``:
 
+  Remember to source your ROS 2 installation.
+
   Linux / OSX:
 
   .. code-block:: bash

--- a/source/Tutorials/Actions/Creating-an-Action.rst
+++ b/source/Tutorials/Actions/Creating-an-Action.rst
@@ -89,6 +89,6 @@ We can check that our action built successfully with the command line tool:
     # On Windows: call install/setup.bat
     . install/setup.bash
     # Check that our action definition exists
-    ros2 action show action_tutorials/Fibonacci
+    ros2 action show action_tutorials/action/Fibonacci
 
 You should see the Fibonacci action definition printed to the screen.

--- a/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Client-Python.rst
@@ -80,7 +80,10 @@ Let's test our action client by first running an action server built in the tuto
 
 .. code-block:: bash
 
-    ros2 run action_tutorials fibonacci_action_server.py
+    # Linux/OSX
+    python3 fibonacci_action_server.py
+    # Windows
+    python fibonacci_action_server.py
 
 In another terminal, run the action client:
 

--- a/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
+++ b/source/Tutorials/Actions/Writing-an-Action-Server-Python.rst
@@ -60,7 +60,7 @@ In another terminal, we can use the command line interface to send a goal:
 
 .. code-block:: bash
 
-    ros2 action send_goal fibonacci action_tutorials/Fibonacci "{order: 5}"
+    ros2 action send_goal fibonacci action_tutorials/action/Fibonacci "{order: 5}"
 
 You should see our logged message "Executing goal..." followed by a warning that the goal state was not set.
 By default, if the goal handle state is not set in the execute callback it assumes the *aborted* state.
@@ -107,4 +107,4 @@ After restarting the action server, we can confirm that feedback is now publishe
 
 .. code-block:: bash
 
-    ros2 action send_goal --feedback fibonacci action_tutorials/Fibonacci "{order: 5}"
+    ros2 action send_goal --feedback fibonacci action_tutorials/action/Fibonacci "{order: 5}"


### PR DESCRIPTION
* Use the full namespace for action types.
* Reminder to source ROS installation.
* Start action server with Python instead of 'ros2 run'.
  We don't rely on the availability of the released version of action_tutorials.

The last point addresses multiple concerns brought up in https://github.com/ros2/ros2_documentation/issues/209: 1) the availability of `action_tutorials` and 2) avoid hiding the action server script with a user overlay.