### PR TITLE
Use correct rst syntax for inline literal.

### DIFF
--- a/source/Tutorials/Managed-Nodes.rst
+++ b/source/Tutorials/Managed-Nodes.rst
@@ -6,4 +6,4 @@ Management of nodes with managed lifecycles
 ===========================================
 
 This page lives now directly side-by-side with the `code <https://github.com/ros2/demos/blob/master/lifecycle/README.rst>`__.
-For more information about the `lifecycle` package, refer to `rosindex <https://index.ros.org/p/lifecycle/github-ros2-demos/>`__.
+For more information about the ``lifecycle`` package, refer to `rosindex <https://index.ros.org/p/lifecycle/github-ros2-demos/>`__.


### PR DESCRIPTION
Fixes build failure introduced by #250 