### PR TITLE
Update source install instructions for Crystal

### DIFF
--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -98,12 +98,8 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_ws/src
    cd ~/ros2_ws
-   wget https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/crystal/ros2.repos
    vcs import src < ros2.repos
-
-..
-
-   Note: if you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-crystal-20190408`` in the URL above with ``crystal``. The ``release-crystal-20190408`` is preferred by default because it goes through more rigorous testing on release than changes to ``crystal`` do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
 
 
 Install dependencies using rosdep

--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -98,12 +98,12 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_ws/src
    cd ~/ros2_ws
-   wget https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos
    vcs import src < ros2.repos
 
 ..
 
-   Note: if you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the URL above with ``master``. The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+   Note: if you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-crystal-20190408`` in the URL above with ``crystal``. The ``release-crystal-20190408`` is preferred by default because it goes through more rigorous testing on release than changes to ``crystal`` do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
 
 
 Install dependencies using rosdep

--- a/source/Installation/Crystal/OSX-Development-Setup.rst
+++ b/source/Installation/Crystal/OSX-Development-Setup.rst
@@ -113,13 +113,13 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_ws/src
    cd ~/ros2_ws
-   wget https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos
    vcs import src < ros2.repos
 
 
 .. note::
 
-   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the url above with ``master``. The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-crystal-20190408`` in the url above with ``crystal``. The ``release-crystal-20190408`` is preferred by default because it goes through more rigorous testing on release than changes to ``crystal`` do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
 
 
 Install additional DDS vendors (optional)

--- a/source/Installation/Crystal/OSX-Development-Setup.rst
+++ b/source/Installation/Crystal/OSX-Development-Setup.rst
@@ -113,14 +113,8 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_ws/src
    cd ~/ros2_ws
-   wget https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/crystal/ros2.repos
    vcs import src < ros2.repos
-
-
-.. note::
-
-   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-crystal-20190408`` in the url above with ``crystal``. The ``release-crystal-20190408`` is preferred by default because it goes through more rigorous testing on release than changes to ``crystal`` do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
-
 
 Install additional DDS vendors (optional)
 -----------------------------------------

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -167,14 +167,14 @@ Get the ``ros2.repos`` file which defines the repositories to clone from:
 .. code-block:: bash
 
    # CMD
-   > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos -o ros2.repos
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos -o ros2.repos
 
    # PowerShell
-   > curl https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos -o ros2.repos
+   > curl https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos -o ros2.repos
 
 .. note::
 
-   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the URL above with ``master``. The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-crystal-20190408`` in the URL above with ``crystal``. The ``release-crystal-20190408`` is preferred by default because it goes through more rigorous testing on release than changes to ``crystal`` do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
 
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -167,15 +167,10 @@ Get the ``ros2.repos`` file which defines the repositories to clone from:
 .. code-block:: bash
 
    # CMD
-   > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos -o ros2.repos
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/crystal/ros2.repos -o ros2.repos
 
    # PowerShell
-   > curl https://raw.githubusercontent.com/ros2/ros2/release-crystal-20190408/ros2.repos -o ros2.repos
-
-.. note::
-
-   If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-crystal-20190408`` in the URL above with ``crystal``. The ``release-crystal-20190408`` is preferred by default because it goes through more rigorous testing on release than changes to ``crystal`` do. See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
-
+   > curl https://raw.githubusercontent.com/ros2/ros2/crystal/ros2.repos -o ros2.repos
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
 


### PR DESCRIPTION
Point to the crystal release and development versions of the repos file.
Since we don't have a generic `release-crystal-latest`, the documentation points to
the repos file for Crystal patch release 4.