### PR TITLE
Sros2 fixups

### DIFF
--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -53,9 +53,6 @@ Install development tools and ROS tools
      cmake \
      git \
      python3-colcon-common-extensions \
-     python3-lark-parser \
-     python3-lxml \
-     python3-numpy \
      python3-pip \
      python-rosdep \
      python3-vcstool \

--- a/source/Roadmap.rst
+++ b/source/Roadmap.rst
@@ -105,7 +105,6 @@ The trailing stars indicate the rough effort: 1 star for small, 2 stars for medi
 * security improvements:
 
   * more granularity in security configuration (allow authentication only, authentication and encryption, etc) [\*]
-  * extend access control permission generation to support services [\*]
   * integrate DDS-Security logging plugin (unified way to aggregate security events and report them to the users through a ROS interface) [\*\*]
   * key storage security (right now, keys are just stored in the filesystem) [\*\*]
   * more user friendly interface (make it easier to specify security config). Maybe a Qt GUI? This GUI could also assist in distributing keys somehow. [\*\*\*]


### PR DESCRIPTION
[Roadmap fixup](https://github.com/ros2/ros2_documentation/commit/8a3f2405050ca6cebe53c6e486b739484b7f8d55): SROS2 permission generation support for services was added in https://github.com/ros2/sros2/pull/71

[Dependencies fixup](https://github.com/ros2/ros2_documentation/commit/7d83b3f0897568e7feaafb23113d27b0ad2b7406): These dependencies are package dependencies and get installed by rosdep in the `Install dependencies using rosdep` section below