### PR TITLE
Use CMAKE_CXX_STANDARD in the migration guide

### DIFF
--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -329,16 +329,16 @@ ROS client library
 Boost
 ~~~~~
 
-Much of the functionality previously provided by Boost has been integrated into C++11.
+Much of the functionality previously provided by Boost has been integrated into the C++ standard library.
 As such we would like to take advantage of the new core features and avoid the dependency on boost where possible.
 
 Shared Pointers
 """""""""""""""
 
-To switch shared pointers from boost to C++11 replace instances of:
+To switch shared pointers from boost to standard C++ replace instances of:
 
 
-* ``#include <boost/shared_ptr.hpp>`` with ``<memory>``
+* ``#include <boost/shared_ptr.hpp>`` with ``#include <memory>``
 * ``boost::shared_ptr`` with ``std::shared_ptr``
 
 There may also be variants such as ``weak_ptr`` which you want to convert as well.
@@ -545,7 +545,7 @@ Changing C++ library calls
 
 Instead of passing the node's name to the library initialization call, we do
 the initialization, then pass the node name to the creation of the node object
-(we can use the ``auto`` keyword because now we're requiring a C++11 compiler):
+(we can use the ``auto`` keyword because now we're requiring a C++14 compiler):
 
 .. code-block:: cpp
 

--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -57,11 +57,11 @@ In your ``package.xml``:
 
 In your ``CMakeLists.txt``:
 
-* Start by enabling C++11
+* Start by enabling C++14
 
 .. code-block:: cmake
 
-   set(CMAKE_CXX_STANDARD 11)
+   set(CMAKE_CXX_STANDARD 14)
 
 
 * Add ``find_package(rosidl_default_generators REQUIRED)``
@@ -757,15 +757,15 @@ ROS 2 relies on a higher version of CMake:
    #cmake_minimum_required(VERSION 2.8.3)
    cmake_minimum_required(VERSION 3.5)
 
-ROS 2 relies on the C++11 standard.
-Depending on what compiler you're using, support for C++11 might not be enabled
+ROS 2 relies on the C++14 standard.
+Depending on what compiler you're using, support for C++14 might not be enabled
 by default.
 Using ``gcc`` 5.3 (which is what is used on Ubuntu Xenial), we need to enable it
 explicitly, which we do by adding this line near the top of the file:
 
 .. code-block:: cmake
 
-   set(CMAKE_CXX_STANDARD 11)
+   set(CMAKE_CXX_STANDARD 14)
 
 Using ``catkin``, we specify the packages we want to build against by passing them
 as ``COMPONENTS`` arguments when initially finding ``catkin`` itself.
@@ -834,7 +834,7 @@ Putting it all together, the new ``CMakeLists.txt`` looks like this:
    #cmake_minimum_required(VERSION 2.8.3)
    cmake_minimum_required(VERSION 3.5)
    project(talker)
-   set(CMAKE_CXX_STANDARD 11)
+   set(CMAKE_CXX_STANDARD 14)
    #find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
    find_package(ament_cmake REQUIRED)
    find_package(rclcpp REQUIRED)

--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -61,9 +61,7 @@ In your ``CMakeLists.txt``:
 
 .. code-block:: cmake
 
-   if(NOT WIN32)
-     add_definitions(-std=c++11)
-   endif()
+   set(CMAKE_CXX_STANDARD 11)
 
 
 * Add ``find_package(rosidl_default_generators REQUIRED)``
@@ -767,7 +765,7 @@ explicitly, which we do by adding this line near the top of the file:
 
 .. code-block:: cmake
 
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+   set(CMAKE_CXX_STANDARD 11)
 
 Using ``catkin``, we specify the packages we want to build against by passing them
 as ``COMPONENTS`` arguments when initially finding ``catkin`` itself.
@@ -836,7 +834,7 @@ Putting it all together, the new ``CMakeLists.txt`` looks like this:
    #cmake_minimum_required(VERSION 2.8.3)
    cmake_minimum_required(VERSION 3.5)
    project(talker)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+   set(CMAKE_CXX_STANDARD 11)
    #find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
    find_package(ament_cmake REQUIRED)
    find_package(rclcpp REQUIRED)


### PR DESCRIPTION
Use CMAKE_CXX_STANDARD in the migration guide instead of adding "-std=..." to CMAKE_CXX_FLAGS. CMAKE_CXX_STANDARD is the recommended way to state the required C++ standard as it works across all compilers supported by CMake.