### PR TITLE
Update RTI Connext installation details for 6.0.0--5.3.1 clarity

### DIFF
--- a/source/Installation/Crystal/Install-Connext-University-Eval.rst
+++ b/source/Installation/Crystal/Install-Connext-University-Eval.rst
@@ -1,0 +1,30 @@
+Installing University or Evaluation Versions of RTI Connext DDS
+===============================================================
+
+A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for 
+Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.
+
+A full-suite installation of RTI Connext DDS is available for many additional platforms, for Universities, evaluation, or purchase.
+This installation includes diagnostic tools, layered services, and security.  See below for installation details.
+
+.. note::
+    As of the ROS2 'Dashing' release, the Connext RMW layer in ROS2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
+    
+    The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS2.
+
+RTI University Program
+----------------------
+
+University research and classroom users are eligible for a free academic license through the `RTI University Program <https://www.rti.com/free-trial/university-program>`__.
+This includes an extendable full-year license to the unabridged version of Connext DDS Secure, which includes diagnotic tools and layered services.
+
+
+RTI Connext DDS Evaluation
+--------------------------
+
+To install RTI Connext DDS **version 5.3.1** Evalution:
+ * Visit the `RTI Free Trial (5.3.1) site <https://www.rti.com/free-trial-5.3.1>`__.
+ * Register using the online form.
+ * When directed to the download page, choose the **version 5.3.1** installer for your platform.
+ * Install RTI Connext 5.3.1 by running the installation program.  When finished, it will run the RTI Launcher.
+ * Use the RTI Launcher to install the license file (rti_license.dat) if needed.  The launcher may also be used to launch the diagnostic tools and services.

--- a/source/Installation/Crystal/Install-Connext-University-Eval.rst
+++ b/source/Installation/Crystal/Install-Connext-University-Eval.rst
@@ -4,7 +4,7 @@ Installing University or Evaluation Versions of RTI Connext DDS
 A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for 
 Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.
 
-A full-suite installation of RTI Connext DDS is available for many additional platforms, for Universities, evaluation, or purchase.
+A full-suite installation of RTI Connext DDS is available for many additional platforms, for universities, evaluation, or purchase.
 This installation includes diagnostic tools, layered services, and security.  See below for installation details.
 
 .. note::
@@ -15,8 +15,9 @@ This installation includes diagnostic tools, layered services, and security.  Se
 RTI University Program
 ----------------------
 
-University research and classroom users are eligible for a free academic license through the `RTI University Program <https://www.rti.com/free-trial/university-program>`__.
-This includes an extendable full-year license to the unabridged version of Connext DDS Secure, which includes diagnotic tools and layered services.
+University researchers and classroom users may be eligible for a free academic license through the `RTI University Program <https://www.rti.com/free-trial/university-program>`__.
+This includes a one-year (renewable) license to the unabridged version of Connext DDS Secure, which includes diagnostic tools and layered services.
+The university license application can be found `here <https://www.rti.com/free-trial/university-program>`__.
 
 
 RTI Connext DDS Evaluation

--- a/source/Installation/Crystal/Install-Connext-University-Eval.rst
+++ b/source/Installation/Crystal/Install-Connext-University-Eval.rst
@@ -1,7 +1,12 @@
+.. redirect-from::
+
+   Install-Connext-University-Eval
+   Installation/Install-Connext-University-Eval
+
 Installing University or Evaluation Versions of RTI Connext DDS
 ===============================================================
 
-A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for 
+A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for
 Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.
 
 A full-suite installation of RTI Connext DDS is available for many additional platforms, for universities, evaluation, or purchase.
@@ -9,7 +14,7 @@ This installation includes diagnostic tools, layered services, and security.  Se
 
 .. note::
     As of the ROS2 'Dashing' release, the Connext RMW layer in ROS2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
-    
+
     The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS2.
 
 RTI University Program

--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -195,19 +195,20 @@ If you want to install the Connext DDS-Security plugins please refer to `this pa
 Official binary packages from RTI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can install the Connext 5.3.1 package for Linux provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
-
-To use RTI Connext you will need to have obtained a license from RTI.
-Add the following line to your ``.bashrc`` file pointing to your copy of the license.
-
-.. code-block:: bash
-
-   export RTI_LICENSE_FILE=path/to/rti_license.dat
+You can install the Connext 5.3.1 package for Linux provided by RTI, via options available for `university, purchase or evaluation <Install-Connext-University-Eval>`.
 
 After downloading, use ``chmod +x`` on the ``.run`` executable and then execute it.
 Note that if you're installing to a system directory use ``sudo`` as well.
 
 The default location is ``~/rti_connext_dds-5.3.1``
+
+After installation, run RTI launcher and point it to your license file (obtained from RTI).
+
+Add the following line to your ``.bashrc`` file pointing to your copy of the license.
+
+.. code-block:: bash
+
+   export RTI_LICENSE_FILE=path/to/rti_license.dat
 
 Source the setup file to set the ``NDDSHOME`` environment variable.
 

--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -108,8 +108,8 @@ Bouncy and earlier:
 RTI Connext (version 5.3.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To use RTI Connext DDS there are full-suite install options available for `university, purchase or evaluation <Install-Connext-University-Eval>` 
-or you can install a libraries-only Debian package of RTI Connext 5.3.1, available from the OSRF Apt respository 
+To use RTI Connext DDS there are full-suite install options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
+or you can install a libraries-only Debian package of RTI Connext 5.3.1, available from the OSRF Apt respository
 under a `non-commercial license <https://www.rti.com/ncl>`__.
 
 To install the libs-only Debian package:

--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -108,21 +108,31 @@ Bouncy and earlier:
 RTI Connext (version 5.3.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To use RTI Connext you will need to have obtained a license from RTI.
+To use RTI Connext DDS there are full-suite install options available for `university, purchase or evaluation <Install-Connext-University-Eval>` 
+or you can install a libraries-only Debian package of RTI Connext 5.3.1, available from the OSRF Apt respository 
+under a `non-commercial license <https://www.rti.com/ncl>`__.
+
+To install the libs-only Debian package:
+.. code-block:: bash
+
+       sudo apt update && sudo apt install -q -y \
+           rti-connext-dds-5.3.1
+
+You will need to accept a license agreement from RTI, and will find an 'rti_license.dat file in the installation.
+
 Add the following line to your ``.bashrc`` file pointing to your copy of the license (and source it).
 
 .. code-block:: bash
 
    export RTI_LICENSE_FILE=path/to/rti_license.dat
 
-You can install a Debian package of RTI Connext built by OSRF.
-You will need to accept a license from RTI.
+All options need you to source the setup file to set the ``NDDSHOME`` environment variable:
 
 .. code-block:: bash
 
-       sudo apt update && sudo apt install -q -y \
-           rti-connext-dds-5.3.1
+   cd /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts && source ./rtisetenv_x64Linux3gcc5.4.0.bash; cd -
 
+Note: the above may need modification to match your RTI installation location
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
 

--- a/source/Installation/Crystal/Linux-Install-Debians.rst
+++ b/source/Installation/Crystal/Linux-Install-Debians.rst
@@ -142,6 +142,8 @@ If you want to install the Connext DDS-Security plugins please refer to `this pa
 
 .. _linux-ros1-add-pkgs:
 
+`University, purchase or evaluation <Install-Connext-University-Eval>` options are also available for RTI Connext.
+
 Install additional packages using ROS 1 packages
 ------------------------------------------------
 

--- a/source/Installation/Crystal/OSX-Development-Setup.rst
+++ b/source/Installation/Crystal/OSX-Development-Setup.rst
@@ -197,9 +197,7 @@ Source the ``release.com`` file provided to set up the environment before buildi
 RTI Connext (5.3)
 ^^^^^^^^^^^^^^^^^
 
-To use RTI Connext you will need to have obtained a license from RTI.
-
-You can install the OS X package of Connext version 5.3 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+If you would like to also build against RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`.
 
 You also need a Java runtime installed to run the RTI code generator, which you can get `here <https://support.apple.com/kb/DL1572?locale=en_US>`__.
 

--- a/source/Installation/Crystal/OSX-Install-Binary.rst
+++ b/source/Installation/Crystal/OSX-Install-Binary.rst
@@ -140,9 +140,7 @@ For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable
 Enable Connext support
 ^^^^^^^^^^^^^^^^^^^^^^
 
-To use RTI Connext you will need to have obtained a license from RTI.
-
-You can install the OS X package of Connext version 5.3.1 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+To use RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
 After installing, run RTI launcher and point it to your license file.
 

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -209,15 +209,17 @@ where the exact paths may need to be slightly altered depending on where you sel
 RTI Connext 5.3
 ^^^^^^^^^^^^^^^
 
-If you would like to also build against RTI Connext, you will need to first visit the RTI website and obtain a license (evaluation or purchased) for RTI Connext DDS as well as the installer via their `downloads page <https://www.rti.com/downloads>`__.
+If you would like to also build against RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`.
+
 After installing, use the RTI Launcher to load your license file.
+
 Then before building ROS 2, set up the Connext environment:
 
 .. code-block:: bash
 
    call "C:\Program Files\rti_connext_dds-5.3.1\resource\scripts\rtisetenv_x64Win64VS2017.bat"
 
-Note that this path might need to be slightly altered depending on where you selected to install RTI Connext DDS.
+Note that this path might need to be slightly altered depending on where you selected to install RTI Connext DDS, and which version of Visual Studio was selected.
 The path above is the current default path as of version 5.3.1, but will change as the version numbers increment in the future.
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.

--- a/source/Installation/Crystal/Windows-Install-Binary.rst
+++ b/source/Installation/Crystal/Windows-Install-Binary.rst
@@ -119,9 +119,7 @@ For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable
 RTI Connext
 ~~~~~~~~~~~
 
-To use RTI Connext (available as of ROS 2 Bouncy) you will need to have obtained a license from RTI.
-
-You can install the Windows package of Connext version 5.3.1 provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
+To use RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
 After installing, run RTI launcher and point it to your license file.
 

--- a/source/Installation/Dashing/Install-Connext-University-Eval.rst
+++ b/source/Installation/Dashing/Install-Connext-University-Eval.rst
@@ -1,0 +1,30 @@
+Installing University or Evaluation Versions of RTI Connext DDS
+===============================================================
+
+A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for 
+Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.
+
+A full-suite installation of RTI Connext DDS is available for many additional platforms, for Universities, evaluation, or purchase.
+This installation includes diagnostic tools, layered services, and security.  See below for installation details.
+
+.. note::
+    As of the ROS2 'Dashing' release, the Connext RMW layer in ROS2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
+    
+    The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS2.
+
+RTI University Program
+----------------------
+
+University research and classroom users are eligible for a free academic license through the `RTI University Program <https://www.rti.com/free-trial/university-program>`__.
+This includes an extendable full-year license to the unabridged version of Connext DDS Secure, which includes diagnostic tools and layered services.
+
+
+RTI Connext DDS Evaluation
+--------------------------
+
+To install RTI Connext DDS **version 5.3.1** Evalution:
+ * Visit the `RTI Free Trial (5.3.1) site <https://www.rti.com/free-trial-5.3.1>`__.
+ * Register using the online form.
+ * When directed to the download page, choose the **version 5.3.1** installer for your platform.
+ * Install RTI Connext 5.3.1 by running the installation program.  When finished, it will run the RTI Launcher.
+ * Use the RTI Launcher to install the license file (rti_license.dat) if needed.  The launcher may also be used to launch the diagnostic tools and services.

--- a/source/Installation/Dashing/Install-Connext-University-Eval.rst
+++ b/source/Installation/Dashing/Install-Connext-University-Eval.rst
@@ -1,7 +1,7 @@
 Installing University or Evaluation Versions of RTI Connext DDS
 ===============================================================
 
-A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for 
+A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for
 Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.
 
 A full-suite installation of RTI Connext DDS is available for many additional platforms, for universities, evaluation, or purchase.
@@ -9,7 +9,7 @@ This installation includes diagnostic tools, layered services, and security.  Se
 
 .. note::
     As of the ROS2 'Dashing' release, the Connext RMW layer in ROS2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
-    
+
     The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS2.
 
 RTI University Program

--- a/source/Installation/Dashing/Install-Connext-University-Eval.rst
+++ b/source/Installation/Dashing/Install-Connext-University-Eval.rst
@@ -4,7 +4,7 @@ Installing University or Evaluation Versions of RTI Connext DDS
 A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <Linux-Install-Debians>` for 
 Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.
 
-A full-suite installation of RTI Connext DDS is available for many additional platforms, for Universities, evaluation, or purchase.
+A full-suite installation of RTI Connext DDS is available for many additional platforms, for universities, evaluation, or purchase.
 This installation includes diagnostic tools, layered services, and security.  See below for installation details.
 
 .. note::
@@ -15,8 +15,9 @@ This installation includes diagnostic tools, layered services, and security.  Se
 RTI University Program
 ----------------------
 
-University research and classroom users are eligible for a free academic license through the `RTI University Program <https://www.rti.com/free-trial/university-program>`__.
-This includes an extendable full-year license to the unabridged version of Connext DDS Secure, which includes diagnostic tools and layered services.
+University researchers and classroom users may be eligible for a free academic license through the `RTI University Program <https://www.rti.com/free-trial/university-program>`__.
+This includes a one-year (renewable) license to the unabridged version of Connext DDS Secure, which includes diagnostic tools and layered services.
+The university license application can be found `here <https://www.rti.com/free-trial/university-program>`__.
 
 
 RTI Connext DDS Evaluation

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -185,19 +185,20 @@ If you want to install the Connext DDS-Security plugins please refer to `this pa
 Official binary packages from RTI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can install the Connext 5.3.1 package for Linux provided by RTI from their `downloads page <https://www.rti.com/downloads>`__.
-
-To use RTI Connext you will need to have obtained a license from RTI.
-Add the following line to your ``.bashrc`` file pointing to your copy of the license.
-
-.. code-block:: bash
-
-   export RTI_LICENSE_FILE=path/to/rti_license.dat
+You can install the Connext 5.3.1 package for Linux provided by RTI, via options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
 After downloading, use ``chmod +x`` on the ``.run`` executable and then execute it.
 Note that if you're installing to a system directory use ``sudo`` as well.
 
 The default location is ``~/rti_connext_dds-5.3.1``
+
+After installation, run RTI launcher and point it to your license file (obtained from RTI).
+
+Add the following line to your ``.bashrc`` file pointing to your copy of the license.
+
+.. code-block:: bash
+
+   export RTI_LICENSE_FILE=path/to/rti_license.dat
 
 Source the setup file to set the ``NDDSHOME`` environment variable.
 

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -93,8 +93,8 @@ To use OpenSplice you can install a Debian package built by OSRF.
 RTI Connext (version 5.3.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To use RTI Connext DDS there are full-suite install options available for `university, purchase or evaluation <Install-Connext-University-Eval>` 
-or you can install a libraries-only Debian package of RTI Connext 5.3.1, available from the OSRF Apt respository 
+To use RTI Connext DDS there are full-suite install options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
+or you can install a libraries-only Debian package of RTI Connext 5.3.1, available from the OSRF Apt respository
 under a `non-commercial license <https://www.rti.com/ncl>`__.
 
 To install the libs-only Debian package:

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -93,21 +93,31 @@ To use OpenSplice you can install a Debian package built by OSRF.
 RTI Connext (version 5.3.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To use RTI Connext you will need to have obtained a license from RTI.
+To use RTI Connext DDS there are full-suite install options available for `university, purchase or evaluation <Install-Connext-University-Eval>` 
+or you can install a libraries-only Debian package of RTI Connext 5.3.1, available from the OSRF Apt respository 
+under a `non-commercial license <https://www.rti.com/ncl>`__.
+
+To install the libs-only Debian package:
+.. code-block:: bash
+
+       sudo apt update && sudo apt install -q -y \
+           rti-connext-dds-5.3.1
+
+You will need to accept a license agreement from RTI, and will find an 'rti_license.dat file in the installation.
+
 Add the following line to your ``.bashrc`` file pointing to your copy of the license (and source it).
 
 .. code-block:: bash
 
    export RTI_LICENSE_FILE=path/to/rti_license.dat
 
-You can install a Debian package of RTI Connext built by OSRF.
-You will need to accept a license from RTI.
+All options need you to source the setup file to set the ``NDDSHOME`` environment variable:
 
 .. code-block:: bash
 
-       sudo apt update && sudo apt install -q -y \
-           rti-connext-dds-5.3.1
+   cd /opt/rti.com/rti_connext_dds-5.3.1/resource/scripts && source ./rtisetenv_x64Linux3gcc5.4.0.bash; cd -
 
+Note: the above may need modification to match your RTI installation location
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
 

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -124,6 +124,8 @@ If you want to install the Connext DDS-Security plugins please refer to `this pa
 
 .. _Dashing_linux-ros1-add-pkgs:
 
+`University, purchase or evaluation <Install-Connext-University-Eval>` options are also available for RTI Connext.
+
 Install additional packages using ROS 1 packages
 ------------------------------------------------
 

--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -201,14 +201,7 @@ Source the ``release.com`` file provided to set up the environment before buildi
 RTI Connext (5.3)
 ^^^^^^^^^^^^^^^^^
 
-RTI Connext 5.3 is not available for download unless you have a support subscription from them.
-In that case, you can download it after logging in `RTI support page <https://rti.com/support>`__.
-
-.. note::
-
-   A free trial download of RTI Connext 6.0 is available in RTI website, although we aren't currently supporting that version.
-
-You will also need a license in order to be able to use it.
+If you would like to also build against RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
 You also need a Java runtime installed to run the RTI code generator, which you can get `here <https://support.apple.com/kb/DL1572?locale=en_US>`__.
 

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -143,14 +143,7 @@ For ROS 2 releases later than Ardent, set the ``OSPL_HOME`` environment variable
 Enable Connext support
 ^^^^^^^^^^^^^^^^^^^^^^
 
-RTI Connext 5.3 is not available for download unless you have a support subscription from them.
-In that case, you can download it after logging in `RTI support page <https://rti.com/support>`__.
-
-.. note::
-
-   A free trial download of RTI Connext 6.0 is available in RTI website, although we aren't currently supporting that version.
-
-You will also need a license in order to be able to use it.
+To use RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
 After installing, run RTI launcher and point it to your license file.
 

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -202,25 +202,18 @@ where the exact paths may need to be slightly altered depending on where you sel
 RTI Connext 5.3
 ^^^^^^^^^^^^^^^
 
-RTI Connext 5.3 is not available for download unless you have a support subscription from them.
-In that case, you can download it after logging in `RTI support page <https://rti.com/support>`__.
+If you would like to also build against RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
-.. note::
-
-   A free trial download of RTI Connext 6.0 is available in RTI website, although we aren't currently supporting that version.
-
-You will also need a license in order to be able to use it.
 After installing, use the RTI Launcher to load your license file.
+
 Then before building ROS 2, set up the Connext environment:
 
 .. code-block:: bash
 
    call "C:\Program Files\rti_connext_dds-5.3.1\resource\scripts\rtisetenv_x64Win64VS2017.bat"
 
-.. note::
-
-   This path might need to be slightly altered depending on where you selected to install RTI Connext DDS.
-   The path above is the current default path as of version 5.3.1, but will change as the version numbers increment in the future.
+Note that this path might need to be slightly altered depending on where you selected to install RTI Connext DDS, and which version of Visual Studio was selected.
+The path above is the current default path as of version 5.3.1, but will change as the version numbers increment in the future.
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <Install-Connext-Security-Plugins>`.
 

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -93,14 +93,7 @@ After unpacking, set the ``OSPL_HOME`` environment variable so that it points to
 RTI Connext
 ~~~~~~~~~~~
 
-RTI Connext 5.3 is not available for download unless you have a support subscription from them.
-In that case, you can download it after logging in `RTI support page <https://rti.com/support>`__.
-
-.. note::
-
-   A free trial download of RTI Connext 6.0 is available in RTI website, although we aren't currently supporting that version.
-
-You will also need a license in order to be able to use it.
+To use RTI Connext DDS there are options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
 
 After installing, run RTI launcher and point it to your license file.
 


### PR DESCRIPTION
Added details and direct links to installing v5.3.1 of RTI Connext (instead of v6.0.0).
Also added links to RTI university program, a free option for academic users.