### PR TITLE
This last link probably should be to the print version.

### DIFF
--- a/source/Marketing.rst
+++ b/source/Marketing.rst
@@ -14,5 +14,5 @@ Available formats:
 * :download:`A4 (for web/email) <Marketing/ros2-brochure-a4-web.pdf>`
 * :download:`A4 (for print) <Marketing/ros2-brochure-a4-print.pdf>`
 * :download:`US Letter (for web/email) <Marketing/ros2-brochure-ltr-web.pdf>`
-* :download:`US Letter (for web/email) <Marketing/ros2-brochure-ltr-web.pdf>`
+* :download:`US Letter (for print) <Marketing/ros2-brochure-ltr-print.pdf>`
 


### PR DESCRIPTION
It's likely a mistake that the letter size web version is linked twice
and the letter size print version isn't linked at all.