### PR TITLE
Updates to the Fedora development setup.

### DIFF
--- a/source/Installation/Dashing/Fedora-Development-Setup.rst
+++ b/source/Installation/Dashing/Fedora-Development-Setup.rst
@@ -8,12 +8,13 @@ First install a bunch of dependencies:
 
 .. code-block:: bash
 
-   $ sudo dnf install cppcheck cmake libXaw-devel opencv-devel poco-devel poco-foundation python3-empy python3-devel python3-nose python3-pip python3-pyparsing python3-pytest python3-pytest-cov python3-pytest-runner python3-setuptools python3-yaml tinyxml-devel eigen3-devel python3-pydocstyle python3-pyflakes python3-coverage python3-mock python3-pep8 uncrustify python3-argcomplete python3-flake8 python3-flake8-import-order asio-devel tinyxml2-devel libyaml-devel python3-lxml python3-vcstool python3-lark-parser
+   $ sudo dnf install cppcheck cmake gcc-c++ redhat-rpm-config make patch liblsan wget libXaw-devel opencv-devel poco-devel poco-foundation python3-empy python3-devel python3-nose python3-pip python3-pyparsing python3-pytest python3-pytest-cov python3-pytest-runner python3-setuptools python3-yaml tinyxml-devel eigen3-devel python3-pydocstyle python3-pyflakes python3-coverage python3-mock python3-pep8 uncrustify python3-argcomplete python3-flake8 python3-flake8-import-order asio-devel tinyxml2-devel libyaml-devel python3-lxml python3-vcstool python3-lark-parser python3-rosdep
 
-Then install lark-parser from pip:
+Then install colcon from pip:
 
 .. code-block:: bash
 
-   $ pip3 install lark-parser==0.7.1
+   $ pip3 install --upgrade colcon-common-extensions pytest>=3.10
 
-With this done, you can follow the rest of the `instructions <linux-dev-get-ros2-code>` to fetch and build ROS2.
+With this done, you can follow the rest of the `instructions <#get-ros-2-code>` to fetch and build ROS2.
+

--- a/source/Installation/Dashing/Fedora-Development-Setup.rst
+++ b/source/Installation/Dashing/Fedora-Development-Setup.rst
@@ -4,17 +4,53 @@ Building ROS 2 on Fedora Linux
 How to setup the development environment?
 -----------------------------------------
 
-First install a bunch of dependencies:
+The following system dependencies are required to build ROS 2 on Fedora. They can be installed with ``dnf`` as follows:
 
 .. code-block:: bash
 
-   $ sudo dnf install cppcheck cmake gcc-c++ redhat-rpm-config make patch liblsan wget libXaw-devel opencv-devel poco-devel poco-foundation python3-empy python3-devel python3-nose python3-pip python3-pyparsing python3-pytest python3-pytest-cov python3-pytest-runner python3-setuptools python3-yaml tinyxml-devel eigen3-devel python3-pydocstyle python3-pyflakes python3-coverage python3-mock python3-pep8 uncrustify python3-argcomplete python3-flake8 python3-flake8-import-order asio-devel tinyxml2-devel libyaml-devel python3-lxml python3-vcstool python3-lark-parser python3-rosdep
+   $ sudo dnf install \
+     asio-devel \
+     cmake \
+     cppcheck \
+     eigen3-devel \
+     gcc-c++ \
+     liblsan \
+     libXaw-devel \
+     libyaml-devel \
+     make \
+     opencv-devel \
+     patch \
+     python3-argcomplete \
+     python3-colcon-common-extensions \
+     python3-coverage \
+     python3-devel \
+     python3-empy \
+     python3-lark-parser \
+     python3-lxml \
+     python3-mock \
+     python3-nose \
+     python3-pep8 \
+     python3-pip \
+     python3-pydocstyle \
+     python3-pyflakes \
+     python3-pyparsing \
+     python3-pytest \
+     python3-pytest-cov \
+     python3-pytest-runner \
+     python3-rosdep \
+     python3-setuptools \
+     python3-vcstool \
+     python3-yaml \
+     poco-devel \
+     poco-foundation \
+     python3-flake8 \
+     python3-flake8-import-order \
+     redhat-rpm-config \
+     tinyxml-devel \
+     tinyxml2-devel \
+     uncrustify \
+     wget
 
-Then install colcon from pip:
-
-.. code-block:: bash
-
-   $ pip3 install --upgrade colcon-common-extensions pytest>=3.10
 
 With this done, you can follow the rest of the `instructions <Dashing_linux-dev-get-ros2-code>` to fetch and build ROS2.
 

--- a/source/Installation/Dashing/Fedora-Development-Setup.rst
+++ b/source/Installation/Dashing/Fedora-Development-Setup.rst
@@ -16,5 +16,5 @@ Then install colcon from pip:
 
    $ pip3 install --upgrade colcon-common-extensions pytest>=3.10
 
-With this done, you can follow the rest of the `instructions <#get-ros-2-code>` to fetch and build ROS2.
+With this done, you can follow the rest of the `instructions <Dashing_linux-dev-get-ros2-code>` to fetch and build ROS2.
 


### PR DESCRIPTION
Updates to support the build-from-source instructions.  Tested by following the from source installation instructions with these updates in a fedora:30 docker container.  See the commit message for more details on the individual changes.

Even with the changes in this PR, ros2 dashing still fails to build on a clean Fedora install in some cases due to https://github.com/ros2/rosidl_python/issues/66 and https://github.com/ros2/rviz/issues/402.