### PR TITLE
Fix broken tinyxml2 dependency on Mac

### DIFF
--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -43,7 +43,8 @@ You need the following things installed before installing ROS 2.
        brew install python3
 
        # install asio and tinyxml2 for Fast-RTPS
-       brew install asio tinyxml2
+       brew install asio
+       brew install https://raw.githubusercontent.com/osrf/homebrew-simulation/master/Formula/tinyxml2@6.2.0.rb
 
        # install dependencies for robot state publisher
        brew install tinyxml eigen pcre poco


### PR DESCRIPTION
The FastRTPS in the [binary distribution on Mac of ROS2 Dashing Patch Release 1](https://github.com/ros2/ros2/releases/tag/release-dashing-20190614) searches for `tinyxml2@6.2.0`. So if you only `brew install tinyxml2`, it fails with something like
```
Failed to load entry point 'test': dlopen(/opt/ros/dashing/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: /usr/local/opt/tinyxml2@6.2.0/lib/libtinyxml2.6.dylib
  Referenced from: /opt/ros/dashing/lib/libbuiltin_interfaces__rosidl_typesupport_fastrtps_c.dylib
  Reason: image not found
```

This seems to be a regression introduced in Patch Release 1. Both the [Crystal Patch 4](https://github.com/ros2/ros2/releases/tag/release-crystal-20190408) and [Dashing initial release](https://github.com/ros2/ros2/releases/tag/release-dashing-20190531) seem to work with tinyxml2 version 7.0.1.