### PR TITLE
Change semantics and fix punctuation

### DIFF
--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -91,20 +91,10 @@ Adlink OpenSplice
 
 To use OpenSplice you can install a Debian package built by OSRF.
 
-Crystal and later:
-
 .. code-block:: bash
 
        sudo apt update && sudo apt install -q -y \
            libopensplice69
-
-Bouncy and earlier:
-
-.. code-block:: bash
-
-       sudo apt update && sudo apt install -q -y \
-           libopensplice69
-
 
 RTI Connext (version 5.3.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -91,7 +91,7 @@ Adlink OpenSplice
 
 To use OpenSplice you can install a Debian package built by OSRF.
 
-Crystal and above:
+Crystal and later:
 
 .. code-block:: bash
 
@@ -119,7 +119,7 @@ To install the libs-only Debian package:
        sudo apt update && sudo apt install -q -y \
            rti-connext-dds-5.3.1
 
-You will need to accept a license agreement from RTI, and will find an 'rti_license.dat file in the installation.
+You will need to accept a license agreement from RTI, and will find an 'rti_license.dat' file in the installation.
 
 Add the following line to your ``.bashrc`` file pointing to your copy of the license (and source it).
 


### PR DESCRIPTION
I feel like since "Bouncy and earlier" is used then "Crystal and later" should be used instead of "Crystal and above."