### PR TITLE
New explanation for different install methods

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = []
+exclude_patterns = ['_*.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/source/Installation/Crystal.rst
+++ b/source/Installation/Crystal.rst
@@ -33,3 +33,4 @@ We support building ROS 2 from source on the following platforms:
 * `OS X <Crystal/OSX-Development-Setup>`
 * `Windows <Crystal/Windows-Development-Setup>`
 
+.. include:: _Install-Types.rst

--- a/source/Installation/Dashing.rst
+++ b/source/Installation/Dashing.rst
@@ -33,3 +33,4 @@ We support building ROS 2 from source on the following platforms:
 * `OS X <Dashing/OSX-Development-Setup>`
 * `Windows <Dashing/Windows-Development-Setup>`
 
+.. include:: _Install-Types.rst

--- a/source/Installation/_Install-Types.rst
+++ b/source/Installation/_Install-Types.rst
@@ -10,11 +10,12 @@ This is great for people who want to dive in and start using ROS 2 as-is, right 
 
 Linux users have two further options:
 
-- Debian packages. A combination of syncs and patch releases.
+- Debian packages.
+  A combination of syncs and patch releases.
   Semi-frequent syncs incorporate changes to higher-level packages.
   Less-frequent patch releases incorporate changes to ROS 2's core packages along with changes from recent syncs.
 
-- "fat" archive. Archived code of most recent patch release (won't include syncs since the last patch release).
+- "fat" archive. Archived code of the most recent patch release (won't include syncs since the last patch release).
 
 Installing from Debian packages is the recommended method.
 It's more convenient and updates alongside regular system updates.

--- a/source/Installation/_Install-Types.rst
+++ b/source/Installation/_Install-Types.rst
@@ -6,7 +6,7 @@ Installing from binary packages or from source will both result in a fully-funct
 Differences between the options only depend on what you plan to do with ROS 2.
 
 **Binary packages** are for general use.
-They will give you an already-built, unalterable (or highly-difficult-to-alter) install of ROS 2.
+They will give you an already-built install of ROS 2.
 This is great for people who want to dive in and start using ROS 2 as-is, right away.
 
 Linux users have two further options:
@@ -18,4 +18,4 @@ Linux users have two further options:
 
 **Building from source** is meant for developers looking to alter or explicitly omit parts of ROS 2's base.
 
-.. TODO: add reference to "General Install" instructions "...if you don't see your operating system" 
+.. TODO: add reference to "General Install" instructions "...if you don't see your operating system"

--- a/source/Installation/_Install-Types.rst
+++ b/source/Installation/_Install-Types.rst
@@ -8,7 +8,7 @@ Differences between the options depend on what you plan to do with ROS 2.
 **Binary packages** are for general use and provide an already-built install of ROS 2.
 This is great for people who want to dive in and start using ROS 2 as-is, right away.
 
-Linux users have two further options:
+Linux users have two options for installing binary packages:
 
 - Debian packages.
   A combination of syncs and patch releases.
@@ -19,10 +19,11 @@ Linux users have two further options:
 
 Installing from Debian packages is the recommended method.
 It's more convenient and updates alongside regular system updates.
-However, you need sudo access in order to install Debian packages.
-If you don't have sudo access, the "fat" archive is the next best choice.
+However, you need root access in order to install Debian packages.
+If you don't have root access, the "fat" archive is the next best choice.
 
-OS X and Windows users who choose to install from binary packages only have the "fat" archive option (Debian packages are exclusive to Ubuntu/Debian).
+OS X and Windows users who choose to install from binary packages only have the "fat" archive option
+(Debian packages are exclusive to Ubuntu/Debian).
 
 **Building from source** is meant for developers looking to alter or explicitly omit parts of ROS 2's base.
 

--- a/source/Installation/_Install-Types.rst
+++ b/source/Installation/_Install-Types.rst
@@ -3,18 +3,25 @@ Which install should you choose?
 --------------------------------
 
 Installing from binary packages or from source will both result in a fully-functional and usable ROS 2 install.
-Differences between the options only depend on what you plan to do with ROS 2.
+Differences between the options depend on what you plan to do with ROS 2.
 
-**Binary packages** are for general use.
-They will give you an already-built install of ROS 2.
+**Binary packages** are for general use and provide an already-built install of ROS 2.
 This is great for people who want to dive in and start using ROS 2 as-is, right away.
 
 Linux users have two further options:
 
-- Debian packages, which updates after every handful of improvements are made.
-- The "fat" archive, which updates nightly (so it includes improvements made day-to-day).
+- Debian packages. A combination of syncs and patch releases.
+  Semi-frequent syncs incorporate changes to higher-level packages.
+  Less-frequent patch releases incorporate changes to ROS 2's core packages along with changes from recent syncs.
 
- ..  why would someone choose one over the other?
+- "fat" archive. Archived code of most recent patch release (won't include syncs since the last patch release).
+
+Installing from Debian packages is the recommended method.
+It's more convenient and updates alongside regular system updates.
+However, you need sudo access in order to install Debian packages.
+If you don't have sudo access, the "fat" archive is the next best choice.
+
+OS X and Windows users who choose to install from binary packages only have the "fat" archive option (Debian packages are exclusive to Ubuntu/Debian).
 
 **Building from source** is meant for developers looking to alter or explicitly omit parts of ROS 2's base.
 

--- a/source/Installation/_Install-Types.rst
+++ b/source/Installation/_Install-Types.rst
@@ -1,0 +1,21 @@
+
+Which install should you choose?
+--------------------------------
+
+Installing from binary packages or from source will both result in a fully-functional and usable ROS 2 install.
+Differences between the options only depend on what you plan to do with ROS 2.
+
+**Binary packages** are for general use.
+They will give you an already-built, unalterable (or highly-difficult-to-alter) install of ROS 2.
+This is great for people who want to dive in and start using ROS 2 as-is, right away.
+
+Linux users have two further options:
+
+- Debian packages, which updates after every handful of improvements are made.
+- The "fat" archive, which updates nightly (so it includes improvements made day-to-day).
+
+ ..  why would someone choose one over the other?
+
+**Building from source** is meant for developers looking to alter or explicitly omit parts of ROS 2's base.
+
+.. TODO: add reference to "General Install" instructions "...if you don't see your operating system" 

--- a/source/Installation/_Install-Types.rst
+++ b/source/Installation/_Install-Types.rst
@@ -12,8 +12,9 @@ Linux users have two options for installing binary packages:
 
 - Debian packages.
   A combination of syncs and patch releases.
-  Semi-frequent syncs incorporate changes to higher-level packages.
-  Less-frequent patch releases incorporate changes to ROS 2's core packages along with changes from recent syncs.
+
+  - Semi-frequent syncs incorporate changes to higher-level packages.
+  - Less-frequent patch releases incorporate changes to ROS 2's core packages along with changes from recent syncs.
 
 - "fat" archive. Archived code of the most recent patch release (won't include syncs since the last patch release).
 


### PR DESCRIPTION
Non-software engineers might benefit from an explanation of what the different install methods entail. 

I'm specifically looking for feedback on my descriptions of each install type (are they correct/complete), as well as an extra note about the benefits of installing binary packages from debian over the "fat" archive or vice versa.

Signed-off-by: maryaB-osr <marya@openrobotics.org>