### PR TITLE
Adding "latest" install instructions

### DIFF
--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -10,6 +10,7 @@ Installation
    Installation/Dashing
    Installation/Install-Connext-Security-Plugins
    Installation/Install-Connext-University-Eval
+   Installation/Upcoming-Release
 
 ROS 2 Installation Options
 --------------------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -96,7 +96,7 @@ Create a workspace and clone all repos:
 
    If you want to get all of the latest bug fixes then you can try the "tip" of development by replacing ``release-latest`` in the URL above with ``master``.
    The ``release-latest`` is preferred by default because it goes through more rigorous testing on release than changes to master do.
-   See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`.
+   See also `Maintaining a Source Checkout <Maintaining-a-Source-Checkout>`. See also `latest install guide <../Latest>`
 
 Install dependencies using rosdep
 ---------------------------------

--- a/source/Installation/Upcoming-Release.rst
+++ b/source/Installation/Upcoming-Release.rst
@@ -1,0 +1,6 @@
+.. redirect-from::
+
+   Installation/Latest
+
+Install the latest ROS 2 developments from source
+=================================================


### PR DESCRIPTION
First commit is just to clarify the redirect/dummy-page structure

Issue: https://github.com/osrf/doc_requests/issues/1

The addition to Linux-Development-Setup.rst is just to clarify how the dummy page will be linked.

Signed-off-by: maryaB-osr <marya@openrobotics.org>