### PR TITLE
Remove bouncy from active rosdistros.

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -21,7 +21,7 @@ List of Distributions
    <style>
      .distros td {border: 0px;}
      .distros tbody tr {background-color: #c0c0c0;}
-     .distros tbody tr:nth-child(1), .distros tbody tr:nth-child(2), .distros tbody tr:nth-child(3) {background-color: #33cc66;}
+     .distros tbody tr:nth-child(1), .distros tbody tr:nth-child(2) {background-color: #33cc66;}
      .distros td {vertical-align: middle;}
    </style>
 


### PR DESCRIPTION
Bouncy is no longer active so remove the green coloring from the 3rd
child entry.