### PR TITLE
fix install signature in ament tutorial

### DIFF
--- a/source/Tutorials/Ament-CMake-Documentation.rst
+++ b/source/Tutorials/Ament-CMake-Documentation.rst
@@ -138,7 +138,7 @@ When building a reusable library, some information needs to be exported for down
       DESTINATION include
     )
 
-    install(my_library
+    install(
       TARGETS my_library
       EXPORT export_my_library
       LIBRARY DESTINATION lib


### PR DESCRIPTION
Based on https://answers.ros.org/question/330905/why-cant-i-call-cmake-install-like-in-the-docs/

Addresses https://github.com/ros2/ros2_documentation/pull/133/files#r314823400