### PR TITLE
Document how to create simple launch files

### DIFF
--- a/source/Tutorials/Launch-system.rst
+++ b/source/Tutorials/Launch-system.rst
@@ -9,8 +9,7 @@ ROS 2 launch system
 -------------------
 
 The launch system in ROS 2 is responsible for helping the user describe the configuration of their system and then execute it as described.
-The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS specific conventions which make it easy
-to reuse components throughout the system by giving them each different configurations.
+The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS specific conventions which make it easy to reuse components throughout the system by giving them each different configurations.
 It is also responsible for monitoring the state of the processes launched, and reporting and/or reacting to changes in the state of those processes.
 
 The ROS 2 Bouncy release includes a framework in which launch files, written in Python, can start and stop different nodes as well as trigger and act on various events.
@@ -22,7 +21,7 @@ Writing a ROS 2 launch file
 ---------------------------
 
 If you haven't already, make sure you go through the quickstart tutorial on how to create a ROS 2 package.
-ROS 2 uses Python to create launch files which are executed by the ROS 2 CLI verb, ``launch``.
+One way to create launch files in ROS 2 is using a Python file, which are executed by the ROS 2 CLI tool, ``ros2 launch``.
 We start by creating a ROS 2 package using ``ros2 pkg create <pkg-name> --dependencies [deps]`` in our workspace and creating a new ``launch`` directory.
 
 Python Packages
@@ -118,10 +117,10 @@ Example of ROS 2 launch concepts
 The launch file in `this example <https://github.com/ros2/launch_ros/blob/master/launch_ros/examples/lifecycle_pub_sub_launch.py>`__
 launches two nodes, one of which is a node with a `managed lifecycle <Managed-Nodes>` (a "lifecycle node").
 Lifecycle nodes launched through ``launch_ros`` automatically emit *events* when they transition between states.
-The events can then be acted on through the launch framework, e.g. by emitting other events (such as requesting another state transition, which lifecycle nodes launched through ``launch_ros`` automatically have event handlers for)
-or triggering other *actions* (e.g. starting another node).
+The events can then be acted on through the launch framework.
+For example, by emitting other events (such as requesting another state transition, which lifecycle nodes launched through ``launch_ros`` automatically have event handlers for) or triggering other *actions* (e.g. starting another node).
 
-In the aforementioned example, various transition requests are requested of the ``talker`` lifecycle node, and  its transition events are reacted to by, for example, launching a ``listener`` node when the lifecycle talker reaches the appropriate state.
+In the aforementioned example, various transition requests are requested of the ``talker`` lifecycle node, and its transition events are reacted to by, for example, launching a ``listener`` node when the lifecycle talker reaches the appropriate state.
 
 Documentation
 -------------


### PR DESCRIPTION
This PR updates the ROS 2 launch system documentation by providing an example on how to write your own launch file as well as setting up your package.

It outlines specifically what to change when you have a Python or C++ package, as well as sample setup and usage.