### PR TITLE
adding explicit directions for rosidl_target_interfaces to custom interfaces tutorial

### DIFF
--- a/source/Tutorials/Defining-custom-interfaces-(msg-srv).rst
+++ b/source/Tutorials/Defining-custom-interfaces-(msg-srv).rst
@@ -13,4 +13,10 @@ By convention, ``.msg`` files go into a package subdirectory called ``msg`` and 
 
 Having written your ``.msg`` and/or ``.srv`` files, you need to add some code to your package's ``CMakelists.txt`` file to make the code generators run over your definitions. In lieu of a more complete tutorial on this topic, consult the `pendulum_msgs package <https://github.com/ros2/demos/tree/master/pendulum_msgs>`__ as an example. You can see the relevant CMake calls in that packages's `CMakeLists.txt file <https://github.com/ros2/demos/blob/master/pendulum_msgs/CMakeLists.txt>`__.
 
-Note that the ``package.xml`` format must equal 3 for this to build, this is because the ``member_of_group`` command requires format 3. ROS2's create package generates the ``package.xml`` with a default format of 2.
+If the interfaces are created in the same package that utilizes them, you'll need to link against them using the ``rosidl_target_interfaces`` macro.
+
+.. code-block:: cmake
+
+   rosidl_target_interfaces(MY_LIBRARY_NAME ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+Note that the ``package.xml`` format must equal 3 for this to build, this is because the ``member_of_group`` command requires format 3. ROS2's create package generates the ``package.xml`` with a default format of 2, e.i. ``<member_of_group>rosidl_interface_packages</member_of_group>`` required for packages with custom interfaces.


### PR DESCRIPTION
From this comment in discourse: 

https://discourse.ros.org/t/ros2-how-to-use-custom-message-in-project-where-its-declared/2071/2?u=smac

And also my personal set of notes, this was a pretty hard thing to find so adding a reference to it in docs would be great for other users!