### PR TITLE
Launch file setup path fix

### DIFF
--- a/source/Tutorials/Launch-system.rst
+++ b/source/Tutorials/Launch-system.rst
@@ -55,7 +55,7 @@ Inside our ``setup.py`` file:
         data_files=[
             # ... Other data files
             # Include all launch files. This is the most important line here!
-            (os.path.join('share', package_name, 'launch'), glob('*.launch.py'))
+            (os.path.join('share', package_name), glob('launch/*.launch.py'))
         ]
     )
 


### PR DESCRIPTION
An original path
```python
(os.path.join('share', package_name, 'launch'), glob('*.launch.py'))
```
don't install files from `mypkg/launch` location, but
```python
(os.path.join('share', package_name), glob('launch/*.launch.py'))
````
does.