### PR TITLE
New tutorial for creating a package in ROS 2

### DIFF
--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -19,6 +19,8 @@ Beginner level
    Tutorials/Topics/UnderstandingROS2Topics
    Tutorials/Services/UnderstandingROS2Services
 
+   Tutorials/CreatingAROS2Package
+
 Miscellaneous
 -------------
 

--- a/source/Tutorials/CreatingAROS2Package.rst
+++ b/source/Tutorials/CreatingAROS2Package.rst
@@ -51,7 +51,7 @@ ROS Python and CMake packages each have their own minimum required contents:
       * ``package.xml`` file containing meta information about the package
       * ``setup.py`` containing instructions for how to install the package
       * ``setup.cfg`` is required when a package has executables, so ``ros2 run`` can find them
-      * ``your_package_name`` - a directory used by ROS 2 tools to find your package
+      * ``your_package_name`` - a file used by ROS 2 tools to find your package
 
 The simplest possible package may have a file structure that looks like:
 
@@ -79,7 +79,7 @@ The simplest possible package may have a file structure that looks like:
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A single workspace can contain as many packages as you want, each in their own folder.
-You can also have a combination of CMake and Python packages in one workspace.
+You can also have packages of different build types in one workspace (CMake, Python, etc.).
 You cannot have nested packages.
 
 Best practice is to have a ``src`` folder within your workspace, and to create your packages in there.

--- a/source/Tutorials/CreatingAROS2Package.rst
+++ b/source/Tutorials/CreatingAROS2Package.rst
@@ -1,0 +1,465 @@
+.. _CreatePkg:
+
+Creating a ROS 2 package
+========================
+
+**Goal:** Create a new package using either CMake or Python, and run its executable.
+
+**Tutorial level:** Beginner
+
+**Time:** 15 minutes
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+Background
+----------
+
+A package can be considered a container for your ROS 2 code.
+If you want to be able to install your code or share it with others, then you’ll need it organized in a package.
+With packages, you can release your ROS 2 work and allow others to build and use it easily.
+
+Package creation in ROS 2 uses ament as its build system and colcon as its build tool.
+You can create a package using either CMake or Python.
+
+
+Prerequisites
+-------------
+
+.. Create a ROS 2 workspace by following the instructions in the :ref:`previous tutorial <ROS2Workspace>`.
+.. You will create your package in this workspace.
+
+
+Tasks
+-----
+
+1 What makes up a ROS 2 package?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS Python and CMake packages each have their own minimum required contents:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      * ``package.xml`` file containing meta information about the package
+      * ``CMakeLists.txt`` file that describes how to build the code within the package
+
+   .. group-tab:: Python
+
+      * ``package.xml`` file containing meta information about the package
+      * ``setup.py`` containing instructions for how to install the package
+      * An ament index marker file that lets certain package-related ROS 2 tools know your package exists when installed
+
+The simplest possible package may have a file structure that looks like:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        my_package/
+             CMakeLists.txt
+             package.xml
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        my_package/
+              setup.py
+              package.xml
+              resource/my_package
+
+
+2 Packages in a workspace
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A single workspace can contain as many packages as you want, each in their own folder.
+You cannot have nested packages.
+
+Best practice is to have a ``src`` folder within your workspace, and to create your packages in there.
+This keeps the top level of the workspace “clean”.
+
+A trivial workspace might look like:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        workspace_folder/
+            src/
+              package_1/
+                  CMakeLists.txt
+                  package.xml
+              ...
+              package_n/
+                  CMakeLists.txt
+                 package.xml
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        workspace_folder/
+            src/
+              package_1/
+                  setup.py
+                  package.xml
+                  resource/my_package
+              ...
+              package_n/
+                  setup.py
+                  package.xml
+                  resource/my_package
+
+3 Create a package
+^^^^^^^^^^^^^^^^^^
+
+First, :ref:`source your ROS 2 installation <ConfigROS2>`.
+
+Let’s use the workspace you created in the previous tutorial, ``dev_ws``, for your new package.
+
+.. add link :ref:`previous tutorial <ROS2Workspace>`
+
+Make sure you are in the ``src`` folder before running the package creation command.
+
+.. code-block:: bash
+
+    cd dev_ws/src
+
+The syntax for creating a new package in ROS 2 is:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        ros2 pkg create --build-type ament_cmake <package_name>
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        ros2 pkg create --build-type ament_python <package_name>
+
+For this tutorial, you will use the optional argument ``--node-name`` which creates a simple Hello World type executable in the package.
+
+Enter the following command in your terminal:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        ros2 pkg create --build-type ament_cmake --node-name my_node my_package
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        ros2 pkg create --build-type ament_python --node-name my_node my_package
+
+You will now have a new folder within your workspace’s ``src`` directory called ``my_package``.
+
+After running the command, your terminal will return the message:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        going to create a new package
+        package name: my_package
+        destination directory: /home/user/dev_ws/src
+        package format: 3
+        version: 0.0.0
+        description: TODO: Package description
+        maintainer: ['<name> <email>']
+        licenses: ['TODO: License declaration']
+        build type: ament_cmake
+        dependencies: []
+        node_name: my_node
+        creating folder ./my_package
+        creating ./my_package/package.xml
+        creating source and include folder
+        creating folder ./my_package/src
+        creating folder ./my_package/include/my_package
+        creating ./my_package/CMakeLists.txt
+        creating ./my_package/src/my_node.cpp
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        going to create a new package
+        package name: my_package
+        destination directory: /home/user/dev_ws/src
+        package format: 3
+        version: 0.0.0
+        description: TODO: Package description
+        maintainer: ['<name> <email>']
+        licenses: ['TODO: License declaration']
+        build type: ament_python
+        dependencies: []
+        node_name: my_node
+        creating folder ./my_package
+        creating ./my_package/package.xml
+        creating source folder
+        creating folder ./my_package/my_package
+        creating ./my_package/setup.py
+        creating ./my_package/setup.cfg
+        creating folder ./my_package/resource
+        creating ./my_package/resource/my_package
+        creating ./my_package/my_package/__init__.py
+        creating folder ./my_package/test
+        creating ./my_package/test/test_copyright.py
+        creating ./my_package/test/test_flake8.py
+        creating ./my_package/test/test_pep257.py
+        creating ./my_package/my_package/my_node.py
+
+You can see the automatically generated files that ament sets up a new package with.
+
+4 Build a package
+^^^^^^^^^^^^^^^^^
+
+Putting packages in a workspace is especially valuable because you can build many packages at once by running ``colcon build`` in the workspace root.
+Otherwise, you would have to build each package individually.
+
+Return to the root of your workspace:
+
+.. code-block:: bash
+
+    cd ~/dev_ws
+
+Now you can build your packages:
+
+.. code-block:: bash
+
+    colcon build
+
+(If you’re on Windows, it’s best to always use ``colcon build --merge-install``)
+
+Recall from the last tutorial that you also have the ``ros_tutorials`` packages in your ``dev_ws``.
+You might’ve noticed that running ``colcon build`` also built the ``turtlesim`` package.
+That’s fine when you only have a few packages in your workspace, but when there are many packages, ``colcon build`` can take a long time.
+
+To build only the ``my_package`` package next time, you can run:
+
+.. code-block:: bash
+
+    colcon build --packages-select my_package
+
+4.1 Source the setup file
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To use your new package and executable, first open a new terminal and source your main ROS 2 installation.
+
+Then, from inside the ``dev_ws`` directory, run the following command to source your workspace:
+
+.. code-block:: bash
+
+    . install/setup.bash
+
+Now that your workspace has been added to your path, you will be able to use your new package’s executables.
+
+4.2 Use the package
+~~~~~~~~~~~~~~~~~~~
+
+To run the executable you created using the ``--node-name`` argument during package creation, enter the command:
+
+.. code-block:: bash
+
+  ros2 run my_package my_node
+
+Which will return a message to your terminal:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        hello world my_package package
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        Hi from my_package.
+
+5 Examine package contents
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Inside ``dev_ws/src/my_package``, you will see the files and folders that ``ros2 pkg create`` automatically generated:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      .. code-block:: bash
+
+        CMakeLists.txt  include  package.xml  src
+
+      ``my_node.cpp`` is inside the ``src`` directory.
+      This is where all your custom C++ nodes will go in the future.
+
+   .. group-tab:: Python
+
+      .. code-block:: bash
+
+        my_package  package.xml  resource  setup.cfg  setup.py  test
+
+      ``my_node.py`` is inside the ``my_package`` directory.
+      This is where all your custom Python nodes will go in the future.
+
+5.1 Customize package.xml
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You may have noticed in the return message after creating your package that two fields, description and licenses, contained ``TODO`` notes.
+That’s because the package description and license declaration are not automatically set, but are required if you ever want to release your package.
+
+From ``dev_ws/src/my_package``, open ``package.xml`` using your preferred text editor:
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+    .. code-block:: xml
+     :linenos:
+
+     <?xml version="1.0"?>
+     <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+     <package format="3">
+      <name>my_package</name>
+      <version>0.0.0</version>
+      <description>TODO: Package description</description>
+      <maintainer email="...">...</maintainer>
+      <license>TODO: License declaration</license>
+
+      <buildtool_depend>ament_cmake</buildtool_depend>
+
+      <test_depend>ament_lint_auto</test_depend>
+      <test_depend>ament_lint_common</test_depend>
+
+      <export>
+        <build_type>ament_cmake</build_type>
+      </export>
+     </package>
+
+   .. group-tab:: Python
+
+    .. code-block:: xml
+     :linenos:
+
+     <?xml version="1.0"?>
+     <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+     <package format="3">
+      <name>my_package</name>
+      <version>0.0.0</version>
+      <description>TODO: Package description</description>
+      <maintainer email="...">...</maintainer>
+      <license>TODO: License declaration</license>
+
+      <buildtool_depend>ament_python</buildtool_depend>
+
+      <test_depend>ament_copyright</test_depend>
+      <test_depend>ament_flake8</test_depend>
+      <test_depend>ament_pep257</test_depend>
+      <test_depend>python3-pytest</test_depend>
+
+      <export>
+        <build_type>ament_python</build_type>
+      </export>
+     </package>
+
+Edit the description on line 6 to summarize the package:
+
+.. code-block:: xml
+
+  <description>Beginner developer tutorials practice package</description>
+
+Then, update the license on line 8.
+You can read more about open source licenses `here <https://opensource.org/licenses/alphabetical>`__.
+
+Since this package is only for practice, it’s safe to use any license:
+
+.. code-block:: xml
+
+  <license>BSD</license>
+
+Don’t forget to save once you’re done editing.
+
+Below the license tag, you will see some tag names ending with ``_depend``.
+This is where your ``package.xml`` would list its dependencies on other packages, for colcon to search for.
+``my_package`` is simple and doesn’t have any dependencies, but you will see this space being utilized in upcoming tutorials.
+
+.. tabs::
+
+   .. group-tab:: CMake
+
+      You’re all done for now!
+
+   .. group-tab:: Python
+
+      The ``setup.py`` file contains the same description and license fields as ``package.xml``, so you need to set those as well.
+      The description and licenses need to match exactly in both files.
+
+      Open ``setup.py`` with your preferred text editor.
+
+      .. code-block:: python
+       :linenos:
+
+       from setuptools import setup
+
+       package_name = 'my_py_pkg'
+
+       setup(
+        name=package_name,
+        version='0.0.0',
+        packages=[package_name],
+        data_files=[
+            ('share/ament_index/resource_index/packages',
+                    ['resource/' + package_name]),
+            ('share/' + package_name, ['package.xml']),
+          ],
+        install_requires=['setuptools'],
+        zip_safe=True,
+        maintainer='...',
+        maintainer_email='...',
+        description='TODO: Package description',
+        license='TODO: License declaration',
+        tests_require=['pytest'],
+        entry_points={
+            'console_scripts': [
+                    'my_node = my_py_pkg.my_node:main'
+            ],
+          },
+       )
+
+      Edit lines 18 and 19 to match ``package.xml``:
+
+      .. code-block:: python
+
+        description='Beginner developer tutorials practice package',
+        license='BSD',
+
+      Don’t forget to save the file.
+
+
+Summary
+-------
+
+You’ve created a package to organize your code and make it easy to use for others.
+
+You used ament to create your package and automatically populate it with the necessary files, and then you used colcon to build it so you can use its executables in your local environment.
+
+
+.. todo: "Next steps section" link to "Understanding ROS 2 services" once all tutorials are done (no empty references)


### PR DESCRIPTION
I was a little confused about the "minimum required contents" in section 1.
@sloretz Technically `setup.cfg` is not required unless the package has an executable, right? So it's not really a minimum requirement? I'm not sure, let me know if it should still be included.

Also I'm not sure where to make an issue about needing to backport the `ros2 pkg create --build-type ament_cmake...` command to Dashing.

My environment populated the name and email for me during package creation, but I'm assuming that's not the norm, so I need someone else to show me what that would look like if it wasn't automatically populated. I think the missing name and email fields are another TODO, so potentially have to make a handful of edits for that.

Signed-off-by: maryaB-osr <marya@openrobotics.org>