### PR TITLE
Main README does not mention the sphinx-tab requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ In the root directory are the files required to locally build the site for testi
 
 ### Prerequisites
 
-You must have sphinx installed. On Debian or Ubuntu you can install it using apt:
+You must have sphinx and the sphinx-tabs extension installed, preferrably using pip:
 
 ```
-apt-get install python3-sphinx
+pip3 install sphinx sphinx-tabs
 ```
 
 For other distributions please refer to http://www.sphinx-doc.org/en/master/usage/installation.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pip
+Sphinx
+sphinx-tabs


### PR DESCRIPTION
Change the main README to say to use pip for sphinx and the required sphinx-tab installation.