### PR TITLE
Fix broken link in Launch files migration guide tutorial.

### DIFF
--- a/source/Tutorials/Launch-files-migration-guide.rst
+++ b/source/Tutorials/Launch-files-migration-guide.rst
@@ -209,7 +209,7 @@ Example
 Passing an argument via the command line
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See `ROS 2 launch tutorial <Launch-system>`__.
+See `ROS 2 launch tutorial <Launch-system>`.
 
 
 env


### PR DESCRIPTION
Precisely what the title says. Closes https://github.com/ros-infrastructure/rosindex/issues/185.