### PR TITLE
Update qos tutorial after migration from arguments to ros parameters

### DIFF
--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -67,7 +67,8 @@ In a separate terminal, source the install file and run the publisher node:
 
    ros2 run image_tools cam2image
 
-This will publish an image from your webcam. In case you don't have a camera attached to your computer, there is a commandline option which publishes predefined images.
+This will publish an image from your webcam.
+In case you don't have a camera attached to your computer, there is a commandline option which publishes predefined images.
 
 .. code-block:: bash
 

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -162,6 +162,7 @@ We see now that some of the frame on the ``showimage`` side were dropped, the fr
 
 
 .. note::
+
    Before Eloquent, use ``-x 640 -y 480`` for changing the resolution and ``-r 0`` for best effort communication.
 
 .. image:: https://raw.githubusercontent.com/ros2/demos/master/image_tools/doc/qos-best-effort.png

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -149,17 +149,20 @@ We are going to use the Linux network traffic control utility, ``tc`` (http://li
    sudo tc qdisc add dev lo root netem loss 5%
 
 This magical incantation will simulate 5% packet loss over the local loopback device.
-If you use a higher resolution of the images (e.g. ``-x 640 -y 480``) you might want to try a lower packet loss rate (e.g. ``1%``).
+If you use a higher resolution of the images (e.g. ``--ros-args -p width:=640 -p height:=480``) you might want to try a lower packet loss rate (e.g. ``1%``).
 
 Next we start the ``cam2image`` and ``showimage``, and we'll soon notice that both programs seem to have slowed down the rate at which images are transmitted.
 This is caused by the behavior of the default QoS settings.
 Enforcing reliability on a lossy channel means that the publisher (in this case, ``cam2image``) will resend the network packets until it receives acknowledgement from the consumer (i.e. ``showimage``).
 
 Let's now try running both programs, but with more suitable settings.
-First of all, we'll use the ``-r 0`` option to enable best effort communication.
+First of all, we'll use the ``-p reliability:=best_effort`` option to enable best effort communication.
 The publisher will now just attempt to deliver the network packets, and don't expect acknowledgement from the consumer.
 We see now that some of the frame on the ``showimage`` side were dropped, the frame numbers in the shell running ``showimage`` won't be consecutive anymore:
 
+
+.. note::
+   Before Eloquent, use ``-x 640 -y 480`` for changing the resolution and ``-r 0`` for best effort communication.
 
 .. image:: https://raw.githubusercontent.com/ros2/demos/master/image_tools/doc/qos-best-effort.png
    :target: https://raw.githubusercontent.com/ros2/demos/master/image_tools/doc/qos-best-effort.png

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -73,7 +73,7 @@ This will publish an image from your webcam. In case you don't have a camera att
 
    ros2 run image_tools cam2image --ros-args -p burger_mode:=True
 
-..note::
+.. note::
 
    Before Eloquent, this tutorial was using CLI arguments instead of parameters.
    In that case, run ``ros2 run image_tools cam2image -b``

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -71,7 +71,12 @@ This will publish an image from your webcam. In case you don't have a camera att
 
 .. code-block:: bash
 
-   ros2 run image_tools cam2image -b
+   ros2 run image_tools cam2image --ros-args -p burger_mode:=True
+
+..note::
+
+   Before Eloquent, this tutorial was using CLI arguments instead of parameters.
+   In that case, run ``ros2 run image_tools cam2image -b``
 
 In this window, you'll see terminal output:
 
@@ -115,48 +120,11 @@ In one of your terminals, add a -h flag to the original command:
 
 .. code-block:: bash
 
-   ros2 run image_tools showimage -- -h
+   ros2 run image_tools showimage -h
 
-You'll see a list of the possible options you can pass to the demo.
+.. note::
 
-``-h``: The help message.
-
-``-r``: Reliability.
-There are two options for this policy: reliable or best effort.
-Reliable means that values may be reset and the underlying DDS publisher might block, in order for messages to get delivered in order.
-Best effort means that messages will get sent as is, and they may get dropped or lost without effecting the behavior of the publisher.
-
-``-k``: History policy (the "k" stands for "keep").
-Determines how DDS buffers messages in the time between the user code that called ``publish`` and the time when the message actually gets sent.
-There are two options for history: KEEP_ALL and KEEP_LAST.
-KEEP_ALL will buffer all messages before they get sent.
-KEEP_LAST limits the number of buffered messages to a depth specified by the user.
-
-``-d``: Queue depth.
-Only used if the history policy is set to KEEP_LAST.
-The queue depth determines the maximum number of not yet received messages that get buffered on the sender's side before messages start getting dropped.
-
-``-t TOPIC``: Topic to use.
-The topic to use (default: image)
-
-If you run ``cam2image -h``, you'll see the same set of command line options and some additional ones:
-
-``-s``: Toggle displaying the input camera stream.
-If you run ``cam2image -s`` by itself, you'll see a camera window.
-If you also run ``showimage``, you'll see two camera windows.
-
-``-x`` and ``-y``: Set the size of the camera feed (x sets the width, y sets the height).
-
-``-b``: Produce images of burgers rather than connecting to a camera
-
-``-f``: Publish frequency in Hz. (default: 30)
-
-The default quality of service settings are tuned for maximum reliability: the reliability policy is reliable, and the history policy is "keep all".
-
-It's worth noting that both ends must have the same reliability settings for this to work.
-If the consumer requires the publisher to be reliable, DDS will not match them and there won't be any exchange between them.
-
-We won't see much of a difference if we change the quality of service settings, since the publisher and subscriber are passing messages over inter-process communication, and messages are unlikely to get dropped if they are travelling within the same machine.
+   Before Eloquent, use ``ros2 run image_tools showimage -- -h``.
 
 Add network traffic
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update after https://github.com/ros2/demos/pull/398.