### PR TITLE
Embed distro name in workspace directory

### DIFF
--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -93,8 +93,8 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_ws/src
-   cd ~/ros2_ws
+   mkdir -p ~/ros2_crystal/src
+   cd ~/ros2_crystal
    wget https://raw.githubusercontent.com/ros2/ros2/crystal/ros2.repos
    vcs import src < ros2.repos
 
@@ -220,7 +220,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 
 .. code-block:: bash
 
-   cd ~/ros2_ws/
+   cd ~/ros2_crystal/
    # On Ubuntu Linux Bionic Beaver 18.04
    colcon build --symlink-install
    # On Ubuntu Linux Xenial Xerus 16.04
@@ -249,14 +249,14 @@ In one terminal, source the setup file and then run a ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/local_setup.bash
+   . ~/ros2_crystal/install/local_setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/local_setup.bash
+   . ~/ros2_crystal/install/local_setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.

--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -40,8 +40,8 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_install
-       cd ~/ros2_install
+       mkdir -p ~/ros2_crystal
+       cd ~/ros2_crystal
        tar xf ~/Downloads/ros2-crystal-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
@@ -133,14 +133,14 @@ In one terminal, source the setup file and then run a ``talker``:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_crystal/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_crystal/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -169,7 +169,7 @@ In another terminal, start the bridge:
 .. code-block:: bash
 
    . /opt/ros/melodic/setup.bash
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_crystal/ros2-linux/setup.bash
    ros2 run ros1_bridge dynamic_bridge
 
 For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.

--- a/source/Installation/Crystal/OSX-Development-Setup.rst
+++ b/source/Installation/Crystal/OSX-Development-Setup.rst
@@ -115,8 +115,8 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_ws/src
-   cd ~/ros2_ws
+   mkdir -p ~/ros2_crystal/src
+   cd ~/ros2_crystal
    wget https://raw.githubusercontent.com/ros2/ros2/crystal/ros2.repos
    vcs import src < ros2.repos
 
@@ -141,7 +141,7 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this t
 
 .. code-block:: bash
 
-   cd ~/ros2_ws/
+   cd ~/ros2_crystal/
    colcon build --symlink-install
 
 
@@ -152,7 +152,7 @@ In a clean new terminal, source the setup file (this will automatically set up t
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/setup.bash
+   . ~/ros2_crystal/install/setup.bash
    ros2 run demo_nodes_cpp talker
 
 
@@ -160,7 +160,7 @@ In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/setup.bash
+   . ~/ros2_crystal/install/setup.bash
    ros2 run demo_nodes_cpp listener
 
 
@@ -235,8 +235,8 @@ If you are seeing library loading issues at runtime (either running tests or run
 
 .. code-block:: bash
 
-   ImportError: dlopen(.../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
-     Referenced from: .../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
+   ImportError: dlopen(.../ros2_crystal/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
+     Referenced from: .../ros2_crystal/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
      Reason: image not found
 
 then you probably have System Integrity Protection enabled.

--- a/source/Installation/Crystal/OSX-Install-Binary.rst
+++ b/source/Installation/Crystal/OSX-Install-Binary.rst
@@ -110,8 +110,8 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_install
-       cd ~/ros2_install
+       mkdir -p ~/ros2_crystal
+       cd ~/ros2_crystal
        tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
 
 Install additional DDS implementations (optional)
@@ -161,7 +161,7 @@ Source the ROS 2 setup file:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-osx/setup.bash
+   . ~/ros2_crystal/ros2-osx/setup.bash
 
 
 For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent).

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -155,12 +155,12 @@ Getting the Source Code
 
 Now that we have the development tools we can get the ROS 2 source code.
 
-First setup a development folder, I use ``C:\dev\ros2``:
+First setup a development folder, I use ``C:\dev\ros2_crystal``:
 
 .. code-block:: bash
 
-   > md \dev\ros2\src
-   > cd \dev\ros2
+   > md \dev\ros2_crystal\src
+   > cd \dev\ros2_crystal
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
@@ -230,7 +230,7 @@ To build ROS 2 you will need a Visual Studio Command Prompt (usually titled "x64
 
 FastRTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
 
-To build the ``\dev\ros2`` folder tree:
+To build the ``\dev\ros2_crystal`` folder tree:
 
 .. code-block:: bash
 

--- a/source/Installation/Crystal/Windows-Install-Binary.rst
+++ b/source/Installation/Crystal/Windows-Install-Binary.rst
@@ -215,7 +215,7 @@ Downloading ROS 2
     * there may be more than one binary download option which might cause the file name to differ.
     * [ROS Bouncy only] To download the ROS 2 debug libraries you'll need to download ``ros2-bouncy-windows-Debug-AMD64.zip``
 
-* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2``\ ).
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_crystal``\ ).
 
   * Note (Ardent and earlier): There seems to be an issue where extracting the zip file with 7zip causes RViz to crash on startup. Extract the zip file using the Windows explorer to prevent this.
 
@@ -226,7 +226,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2\local_setup.bat
+   > call C:\dev\ros2_crystal\local_setup.bat
 
 For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent; this step can be skipped).
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -87,8 +87,8 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_ws/src
-   cd ~/ros2_ws
+   mkdir -p ~/ros2_dashing/src
+   cd ~/ros2_dashing
    wget https://raw.githubusercontent.com/ros2/ros2/dashing/ros2.repos
    vcs import src < ros2.repos
 
@@ -206,7 +206,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 
 .. code-block:: bash
 
-   cd ~/ros2_ws/
+   cd ~/ros2_dashing/
    colcon build --symlink-install
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
@@ -233,14 +233,14 @@ In one terminal, source the setup file and then run a ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/local_setup.bash
+   . ~/ros2_dashing/install/local_setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/local_setup.bash
+   . ~/ros2_dashing/install/local_setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -35,8 +35,8 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_install
-       cd ~/ros2_install
+       mkdir -p ~/ros2_dashing
+       cd ~/ros2_dashing
        tar xf ~/Downloads/ros2-dashing-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
@@ -128,14 +128,14 @@ In one terminal, source the setup file and then run a ``talker``:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_dashing/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_dashing/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -164,7 +164,7 @@ In another terminal, start the bridge:
 .. code-block:: bash
 
    . /opt/ros/melodic/setup.bash
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_dashing/ros2-linux/setup.bash
    ros2 run ros1_bridge dynamic_bridge
 
 For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.

--- a/source/Installation/Dashing/OSX-Development-Setup.rst
+++ b/source/Installation/Dashing/OSX-Development-Setup.rst
@@ -114,8 +114,8 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_ws/src
-   cd ~/ros2_ws
+   mkdir -p ~/ros2_dashing/src
+   cd ~/ros2_dashing
    wget https://raw.githubusercontent.com/ros2/ros2/dashing/ros2.repos
    vcs import src < ros2.repos
 
@@ -140,7 +140,7 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this t
 
 .. code-block:: bash
 
-   cd ~/ros2_ws/
+   cd ~/ros2_dashing/
    colcon build --symlink-install
 
 
@@ -151,7 +151,7 @@ In a clean new terminal, source the setup file (this will automatically set up t
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/setup.bash
+   . ~/ros2_dashing/install/setup.bash
    ros2 run demo_nodes_cpp talker
 
 
@@ -159,7 +159,7 @@ In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/setup.bash
+   . ~/ros2_dashing/install/setup.bash
    ros2 run demo_nodes_cpp listener
 
 
@@ -233,8 +233,8 @@ If you are seeing library loading issues at runtime (either running tests or run
 
 .. code-block:: bash
 
-   ImportError: dlopen(.../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
-     Referenced from: .../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
+   ImportError: dlopen(.../ros2_dashing/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
+     Referenced from: .../ros2_dashing/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
      Reason: image not found
 
 then you probably have System Integrity Protection enabled.

--- a/source/Installation/Dashing/OSX-Install-Binary.rst
+++ b/source/Installation/Dashing/OSX-Install-Binary.rst
@@ -119,8 +119,8 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_install
-       cd ~/ros2_install
+       mkdir -p ~/ros2_dashing
+       cd ~/ros2_dashing
        tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
 
 Install additional DDS implementations (optional)
@@ -164,7 +164,7 @@ Source the ROS 2 setup file:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-osx/setup.bash
+   . ~/ros2_dashing/ros2-osx/setup.bash
 
 
 For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent).

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -148,12 +148,12 @@ Getting the Source Code
 
 Now that we have the development tools we can get the ROS 2 source code.
 
-First setup a development folder, I use ``C:\dev\ros2``:
+First setup a development folder, I use ``C:\dev\ros2_dashing``:
 
 .. code-block:: bash
 
-   > md \dev\ros2\src
-   > cd \dev\ros2
+   > md \dev\ros2_dashing\src
+   > cd \dev\ros2_dashing
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
@@ -223,7 +223,7 @@ To build ROS 2 you will need a Visual Studio Command Prompt ("x64 Native Tools C
 
 FastRTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
 
-To build the ``\dev\ros2`` folder tree:
+To build the ``\dev\ros2_dashing`` folder tree:
 
 .. code-block:: bash
 

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -178,7 +178,7 @@ Downloading ROS 2
 
     To download the ROS 2 debug libraries you'll need to download ``ros2-dashing-*-windows-debug-AMD64.zip``
 
-* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2``\ ).
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_dashing``\ ).
 
 
 Set up the ROS 2 environment
@@ -188,7 +188,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2\local_setup.bat
+   > call C:\dev\ros2_dashing\local_setup.bat
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -89,8 +89,8 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_ws/src
-   cd ~/ros2_ws
+   mkdir -p ~/ros2_eloquent/src
+   cd ~/ros2_eloquent
    wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
    vcs import src < ros2.repos
 
@@ -208,7 +208,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 
 .. code-block:: bash
 
-   cd ~/ros2_ws/
+   cd ~/ros2_eloquent/
    colcon build --symlink-install
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
@@ -235,14 +235,14 @@ In one terminal, source the setup file and then run a ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/local_setup.bash
+   . ~/ros2_eloquent/install/local_setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/local_setup.bash
+   . ~/ros2_eloquent/install/local_setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -35,8 +35,8 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_install
-       cd ~/ros2_install
+       mkdir -p ~/ros2_eloquent
+       cd ~/ros2_eloquent
        tar xf ~/Downloads/ros2-eloquent-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
@@ -128,14 +128,14 @@ In one terminal, source the setup file and then run a ``talker``:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_eloquent/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_eloquent/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -164,7 +164,7 @@ In another terminal, start the bridge:
 .. code-block:: bash
 
    . /opt/ros/melodic/setup.bash
-   . ~/ros2_install/ros2-linux/setup.bash
+   . ~/ros2_eloquent/ros2-linux/setup.bash
    ros2 run ros1_bridge dynamic_bridge
 
 For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.

--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -118,8 +118,8 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_ws/src
-   cd ~/ros2_ws
+   mkdir -p ~/ros2_eloquent/src
+   cd ~/ros2_eloquent
    wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
    vcs import src < ros2.repos
 
@@ -144,7 +144,7 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this t
 
 .. code-block:: bash
 
-   cd ~/ros2_ws/
+   cd ~/ros2_eloquent/
    colcon build --symlink-install
 
 
@@ -155,7 +155,7 @@ In a clean new terminal, source the setup file (this will automatically set up t
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/setup.bash
+   . ~/ros2_eloquent/install/setup.bash
    ros2 run demo_nodes_cpp talker
 
 
@@ -163,7 +163,7 @@ In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_ws/install/setup.bash
+   . ~/ros2_eloquent/install/setup.bash
    ros2 run demo_nodes_cpp listener
 
 
@@ -237,8 +237,8 @@ If you are seeing library loading issues at runtime (either running tests or run
 
 .. code-block:: bash
 
-   ImportError: dlopen(.../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
-     Referenced from: .../ros2_install/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
+   ImportError: dlopen(.../ros2_eloquent/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so, 2): Library not loaded: @rpath/librcl_interfaces__rosidl_typesupport_c.dylib
+     Referenced from: .../ros2_eloquent/ros2-osx/lib/python3.7/site-packages/rclpy/_rclpy.cpython-37m-darwin.so
      Reason: image not found
 
 then you probably have System Integrity Protection enabled.

--- a/source/Installation/Eloquent/OSX-Install-Binary.rst
+++ b/source/Installation/Eloquent/OSX-Install-Binary.rst
@@ -119,8 +119,8 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_install
-       cd ~/ros2_install
+       mkdir -p ~/ros2_eloquent
+       cd ~/ros2_eloquent
        tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
 
 Install additional DDS implementations (optional)
@@ -164,7 +164,7 @@ Source the ROS 2 setup file:
 
 .. code-block:: bash
 
-   . ~/ros2_install/ros2-osx/setup.bash
+   . ~/ros2_eloquent/ros2-osx/setup.bash
 
 
 For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent).

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -150,12 +150,12 @@ Getting the Source Code
 
 Now that we have the development tools we can get the ROS 2 source code.
 
-First setup a development folder, I use ``C:\dev\ros2``:
+First setup a development folder, I use ``C:\dev\ros2_eloquent``:
 
 .. code-block:: bash
 
-   > md \dev\ros2\src
-   > cd \dev\ros2
+   > md \dev\ros2_eloquent\src
+   > cd \dev\ros2_eloquent
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
@@ -225,7 +225,7 @@ To build ROS 2 you will need a Visual Studio Command Prompt ("x64 Native Tools C
 
 FastRTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
 
-To build the ``\dev\ros2`` folder tree:
+To build the ``\dev\ros2_eloquent`` folder tree:
 
 .. code-block:: bash
 

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -178,7 +178,7 @@ Downloading ROS 2
 
     To download the ROS 2 debug libraries you'll need to download ``ros2-eloquent-*-windows-debug-AMD64.zip``
 
-* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2``\ ).
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_eloquent``\ ).
 
 
 Set up the ROS 2 environment
@@ -188,7 +188,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2\local_setup.bat
+   > call C:\dev\ros2_eloquent\local_setup.bat
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 


### PR DESCRIPTION
This is so we can tell users they can switch between multiple distro installations by sourcing their `...\ros2_<distro>\...` workspace regardless of the platform. This is mentioned in the [Environment Config tutorial](https://github.com/ros2/ros2_documentation/pull/334), specifically what [this line](https://github.com/ros2/ros2_documentation/pull/334/files#diff-806c86d64b6ccbce3fdaec6cf4bbfe01R26) is referencing to.

Fixes #340 

Signed-off-by: maryaB-osr <marya@openrobotics.org>