### PR TITLE
update ros2 topic info console output

### DIFF
--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -175,7 +175,7 @@ Which will return:
 
 .. code-block:: bash
 
-  Topic: /turtle1/cmd_vel
+  Type: geometry_msgs/msg/Twist
   Publisher count: 1
   Subscriber count: 2
 


### PR DESCRIPTION
As requested in https://github.com/ros2/ros2cli/pull/379#pullrequestreview-306925329

@mjcarroll I don't know if these tutorials are versioned, but if they are not specific to eloquent, merging this change will make the tutorial inaccurate for LTS / Dashing users

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>