### PR TITLE
Add "versioning" to topic info return

### DIFF
--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -173,11 +173,23 @@ Another way to look at this is running:
 
 Which will return:
 
-.. code-block:: bash
+.. tabs::
 
-  Type: geometry_msgs/msg/Twist
-  Publisher count: 1
-  Subscriber count: 2
+  .. group-tab:: Eloquent
+
+    .. code-block:: bash
+
+      Type: geometry_msgs/msg/Twist
+      Publisher count: 1
+      Subscriber count: 2
+
+  .. group-tab:: Dashing/earlier
+
+    .. code-block::
+
+      Topic: /turtle1/cmd_vel
+      Publisher count: 1
+      Subscriber count: 2
 
 6 ros2 interface show
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Because of #387 / [ros2ros2cli#379](https://github.com/ros2/ros2cli/pull/379#pullrequestreview-306925329)

Now if they're on dashing/earlier they can still see their expected output

Signed-off-by: maryaB-osr <marya@openrobotics.org>