### PR TITLE
add net-tools as network check dependency

### DIFF
--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -52,6 +52,7 @@ Install development tools and ROS tools
      build-essential \
      cmake \
      git \
+     net-tools \
      python3-colcon-common-extensions \
      python3-pip \
      python-rosdep \


### PR DESCRIPTION
Add net-tools to use terminal cmd `ifconfig` on Linux system for network check. `ifconfig` is already available by default on OSX. Fix https://github.com/ros2/ros2cli/issues/378 