### PR TITLE
fix xcodebuild error on Mojave

### DIFF
--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -305,21 +305,21 @@ If you recently installed Xcode, you may encounter this error:
 
 To resolve this error, you will need to:
 
-0. Double check that you have the command line tool installed:
+1. Double check that you have the command line tool installed:
 
 .. code-block:: bash
 
    $ xcode-select --install
 
-1. Accept the terms and conditions of Xcode by typing in terminal:
+2. Accept the terms and conditions of Xcode by typing in terminal:
 
 .. code-block:: bash
 
    $ sudo xcodebuild -license accept
 
-2. Ensure Xcode app is in the ``/Applications`` directory (NOT ``/Users/{user}/Applications``)
+3. Ensure Xcode app is in the ``/Applications`` directory (NOT ``/Users/{user}/Applications``)
 
-3. Point ``xcode-select`` to the Xcode app Developer directory using the following command:
+4. Point ``xcode-select`` to the Xcode app Developer directory using the following command:
 
 .. code-block:: bash
 

--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -307,7 +307,7 @@ To resolve this error, you will need to:
 
 0. Double check that you have the command line tool installed:
 
-..code-block:: bash
+.. code-block:: bash
 
    $ xcode-select --install
 

--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -292,3 +292,29 @@ But this will break opencv, so you'll also need to update it to continue working
 
 The first command is necessary to avoid things built against the system libjpeg (etc.) from getting the version in /usr/local/lib.
 The others are updating things built by Homebrew so that they can find the version of libjpeg (etc.) without having them in /usr/local/lib.
+
+Xcode-select error: tool ``xcodebuild`` requires Xcode, but active developer directory is a command line instance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you recently installed Xcode, you may encounter this error:
+
+.. code-block:: bash
+
+   Xcode: xcode-select: error: tool 'xcodebuild' requires Xcode,
+   but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
+
+To resolve this error, you will need to:
+
+1. Accept the terms and conditions of Xcode by typing in terminal:
+
+.. code-block:: bash
+
+   $ sudo xcodebuild -license accept
+
+2. Ensure Xcode app is in the ``/Applications`` directory (NOT ``/Users/{user}/Applications``)
+
+3. Point ``xcode-select`` to the Xcode app Developer directory using the following command:
+
+.. code-block:: bash
+
+   $ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer

--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -305,6 +305,12 @@ If you recently installed Xcode, you may encounter this error:
 
 To resolve this error, you will need to:
 
+0. Double check that you have the command line tool installed:
+
+..code-block:: bash
+
+   $ xcode-select --install
+
 1. Accept the terms and conditions of Xcode by typing in terminal:
 
 .. code-block:: bash


### PR DESCRIPTION
adds solution to fix one of the potential errors users may encounter when building ``eloquent`` from source on ``Mojave``. 