### PR TITLE
Tutorials are only for eloquent

### DIFF
--- a/source/Installation/Eloquent.rst
+++ b/source/Installation/Eloquent.rst
@@ -1,3 +1,5 @@
+.. _EloquentInstall:
+
 Installing ROS 2 Eloquent Elusor
 ================================
 

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -13,6 +13,11 @@ These tutorials are under construction, so please share your `feedback <https://
 
 .. Feedback is placeholder for actual feedback solution in development
 
+.. note::
+
+  Currently, the beginner level tutorials target **Eloquent**. 
+  Certain features may not be available for older distributions.
+
 Users
 ^^^^^
 

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -15,7 +15,7 @@ These tutorials are under construction, so please share your `feedback <https://
 
 .. note::
 
-  Currently, the beginner level tutorials target **Eloquent**. 
+  Currently, the beginner level tutorials target **Eloquent**.
   Certain features may not be available for older distributions.
 
 Users

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -32,7 +32,7 @@ In other words, you won’t be able to use ROS 2.
 Prerequisites
 -------------
 
-Before starting these tutorials, install ROS 2 by following the instructions on the ROS 2 :ref:`InstallationGuide` page.
+Before starting these tutorials, install ROS 2 by following the instructions on the ROS 2 :ref:`EloquentInstall` page.
 
 The commands used in this tutorial assume you followed the binary packages installation guide for your operating system (Debian packages for Linux).
 You can still follow along if you built from source, but the path to your setup files will likely be different.
@@ -55,11 +55,11 @@ You will need to run this command on every new shell you open to have access to 
 
         source /opt/ros/<distro>/setup.bash
 
-      For example, if you installed ROS 2 Dashing:
+      For example, if you installed ROS 2 Eloquent:
 
       .. code-block:: bash
 
-        source /opt/ros/dashing/setup.bash
+        source /opt/ros/eloquent/setup.bash
 
    .. group-tab:: macOS
 
@@ -134,7 +134,7 @@ Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set:
 
     ROS_VERSION=2
     ROS_PYTHON_VERSION=3
-    ROS_DISTRO=dashing
+    ROS_DISTRO=eloquent
 
 If the environment variables are not set correctly, return to the ROS 2 package installation section of the installation guide you followed.
 If you need more specific help (because environment setup files can come from different places), you can `get answers <https://answers.ros.org>`__ from the community.

--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -55,11 +55,11 @@ Depending on how you installed ROS 2 (from source or binaries), and which platfo
 
         source /opt/ros/<distro>/setup.bash
 
-      For example, if you installed ROS 2 Dashing:
+      For example, if you installed ROS 2 Eloquent:
 
       .. code-block:: bash
 
-        source /opt/ros/dashing/setup.bash
+        source /opt/ros/eloquent/setup.bash
 
    .. group-tab:: macOS
 
@@ -166,11 +166,11 @@ Run the following command, replacing ``<distro>`` with your distro:
 
   sudo rosdep install -i --from-path src --rosdistro <distro> -y
 
-For example, if you're using Dashing, you would run:
+For example, if you're using Eloquent, you would run:
 
 .. code-block:: bash
 
-  sudo rosdep install -i --from-path src --rosdistro dashing -y
+  sudo rosdep install -i --from-path src --rosdistro eloquent -y
 
 If you already have all your dependencies, the console will return:
 


### PR DESCRIPTION
Not that it completely Fixes #404, but the note here lets users know that the tutorials are meant for eloquent. Temporary fix until we can manage versioning or backporting to dashing. 

Signed-off-by: maryaB-osr <marya@openrobotics.org>