### PR TITLE
Use the debian path for the debian tutorials.

### DIFF
--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -68,14 +68,14 @@ In one terminal, source the setup file and then run a ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_dashing/install/local_setup.bash
+   source /opt/ros/dashing/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_dashing/install/local_setup.bash
+   source /opt/ros/dashing/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -89,8 +89,6 @@ You may want to add this to your ``.bashrc``.
 
    echo "source /opt/ros/dashing/setup.bash" >> ~/.bashrc
 
-.. _Dashing_linux-install-additional-rmw-implementations:
-
 Try some examples
 -----------------
 
@@ -110,6 +108,8 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 Hooray!
 
 See the `demos </Tutorials>` for other things to try.
+
+.. _Dashing_linux-install-additional-rmw-implementations:
 
 Install additional RMW implementations
 --------------------------------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -61,28 +61,6 @@ No GUI tools.
 
 See specific sections below for how to also install the :ref:`ros1_bridge <Dashing_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Dashing_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Dashing_linux-install-additional-rmw-implementations>`.
 
-Try some examples
------------------
-
-In one terminal, source the setup file and then run a ``talker``\ :
-
-.. code-block:: bash
-
-   source /opt/ros/dashing/setup.bash
-   ros2 run demo_nodes_cpp talker
-
-In another terminal source the setup file and then run a ``listener``\ :
-
-.. code-block:: bash
-
-   source /opt/ros/dashing/setup.bash
-   ros2 run demo_nodes_py listener
-
-You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
-Hooray!
-
-See the `demos </Tutorials>` for other things to try.
-
 Environment setup
 -----------------
 
@@ -95,7 +73,6 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install python3-argcomplete
-
 
 Sourcing the setup script
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,6 +90,26 @@ You may want to add this to your ``.bashrc``.
    echo "source /opt/ros/dashing/setup.bash" >> ~/.bashrc
 
 .. _Dashing_linux-install-additional-rmw-implementations:
+
+Try some examples
+-----------------
+
+In one terminal, source the setup file and then run a ``talker``\ :
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a ``listener``\ :
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+Hooray!
+
+See the `demos </Tutorials>` for other things to try.
 
 Install additional RMW implementations
 --------------------------------------


### PR DESCRIPTION
The workspace directory is not mentioned anywhere else in the tutorial. Are those packages guaranteed to be installed in `/opt` for all the options above possible selections?