### PR TITLE
Index didn't generate for files in nested directories

### DIFF
--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -25,15 +25,15 @@ Users
    :maxdepth: 1
 
    Tutorials/Configuring-ROS2-Environment
-   Tutorials/Turtlesim/Introducing-Turtlesim
+   Tutorials/Introducing-Turtlesim
    Tutorials/Understanding-ROS2-Nodes
-   Tutorials/Topics/Understanding-ROS2-Topics
-   Tutorials/Services/Understanding-ROS2-Services
-   Tutorials/Parameters/Understanding-ROS2-Parameters
+   Tutorials/Understanding-ROS2-Topics
+   Tutorials/Understanding-ROS2-Services
+   Tutorials/Understanding-ROS2-Parameters
    Tutorials/Understanding-ROS2-Actions
-   Tutorials/Rqt-Console/Using-Rqt-Console
-   Tutorials/Launch-Files/Creating-Launch-Files
-   Tutorials/Ros2bag/Recording-And-Playing-Back-Data
+   Tutorials/Using-Rqt-Console
+   Tutorials/Creating-Launch-Files
+   Tutorials/Recording-And-Playing-Back-Data
 
 Developers
 ^^^^^^^^^^
@@ -41,7 +41,7 @@ Developers
 .. toctree::
    :maxdepth: 1
 
-   Tutorials/Workspace/Creating-A-Workspace
+   Tutorials/Creating-A-Workspace
    Tutorials/Creating-A-ROS2-Package
    Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber
    Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber

--- a/source/Tutorials/Creating-A-Workspace.rst
+++ b/source/Tutorials/Creating-A-Workspace.rst
@@ -332,7 +332,7 @@ Return to the second terminal (where the overlay is sourced) and run turtlesim a
 
 You will see the title bar on the turtlesim window now says “MyTurtleSim”.
 
-.. image:: overlay.png
+.. image:: Workspace/overlay.png
 
 Even though your main ROS 2 environment was sourced in this terminal earlier, the overlay of your ``dev_ws`` environment takes precedence over the contents of the underlay.
 
@@ -343,7 +343,7 @@ Run turtlesim again:
 
   ros2 run turtlesim turtlesim_node
 
-.. image:: underlay.png
+.. image:: Workspace/underlay.png
 
 You can see that modifications in the overlay did not actually affect anything in the underlay.
 

--- a/source/Tutorials/Creating-Launch-Files.rst
+++ b/source/Tutorials/Creating-Launch-Files.rst
@@ -214,7 +214,7 @@ To see the system in action, run the ``ros2 topic pub`` command on the ``/turtle
 
 You will see both turtles following the same path.
 
-.. image:: mimic.png
+.. image:: Launch-Files/mimic.png
 
 4 Introspect the system with rqt_graph
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -227,7 +227,7 @@ Run the command:
 
   rqt_graph
 
-.. image:: mimic_graph.png
+.. image:: Launch-Files/mimic_graph.png
 
 A hidden node (the ``ros2 topic pub`` command you ran) is publishing data to the ``/turtlesim1/turtle1/cmd_vel`` topic on the left, which the ``/turtlesim1/sim`` node is subscribed to.
 The rest of the graph shows what was described earlier: ``mimic`` is subscribed to ``/turtlesim1/sim``'s pose topic, and publishes to ``/turtlesim2/sim``'s velocity command topic.

--- a/source/Tutorials/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Introducing-Turtlesim.rst
@@ -84,7 +84,7 @@ To start turtlesim, enter the following command in your terminal:
 
 The simulator window should appear, with a random turtle in the center.
 
-.. image:: turtlesim.png
+.. image:: Turtlesim/turtlesim.png
 
 In the terminal under the command, you will see messages from the node:
 
@@ -170,7 +170,7 @@ No worries; just select **Plugins** > **Services** > **Service Caller** from the
   It may take some time for rqt to locate all the plugins itself.
   If you click on **Plugins**, but don’t see **Services** or any other options, you should close rqt, enter the command ``rqt --force-discover`` in your terminal.
 
-.. image:: rqt.png
+.. image:: Turtlesim/rqt.png
 
 Use the refresh button to the left of the **Service** dropdown list to ensure all the services of your turtlesim node are available.
 
@@ -187,7 +187,7 @@ You can see that this expression corresponds to the **name** value, and is of ty
 
 Enter new coordinates for the turtle to spawn at, like ``x = 1.0`` and ``y = 1.0``.
 
-.. image:: spawn.png
+.. image:: Turtlesim/spawn.png
 
 .. note::
 
@@ -208,7 +208,7 @@ If you refresh the service list in rqt, you will also see that now there are ser
 
 Now let's give turtle1 a unique pen using the ``/set_pen`` service:
 
-.. image:: set_pen.png
+.. image:: Turtlesim/set_pen.png
 
 The values for **r**, **g** and **b**, between 0 and 255, will set the color of the pen turtle1 draws with, and **width** sets the thickness of the line.
 
@@ -217,7 +217,7 @@ Don't forget to call the service after updating the values.
 
 If you return to the terminal where ``turtle_teleop_node`` is running and press the arrow keys, you will see turtle1’s pen has changed.
 
-.. image:: new_pen.png
+.. image:: Turtlesim/new_pen.png
 
 You've probably noticed that there's no way to move turtle2.
 You can accomplish this by remapping turtle1's ``cmd_vel`` topic onto turtle2.
@@ -243,7 +243,7 @@ In a new terminal, source ROS 2, and run:
 
 Now you can move turtle2 when this terminal is active, and turtle1 when the other terminal running the ``turtle_teleop_key`` is active.
 
-.. image:: remap.png
+.. image:: Turtlesim/remap.png
 
 7 Close turtlesim
 ^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Recording-And-Playing-Back-Data.rst
@@ -143,7 +143,7 @@ Now ``ros2 bag`` is recording the data published on the ``/turtle1/cmd_vel`` top
 Return to the teleop terminal and move the turtle around again.
 The movements don’t matter, but try to make a recognizable pattern to see when you replay the data later.
 
-.. image:: record.png
+.. image:: Ros2bag/record.png
 
 Press ``Ctrl+C`` to stop recording.
 
@@ -226,7 +226,7 @@ The terminal will return the message:
 
 Your turtle will follow the same path you entered while recording (though not 100% exactly; turtlesim is sensitive to small changes in the system’s timing).
 
-.. image:: playback.png
+.. image:: Ros2bag/playback.png
 
 Because the ``subset`` file recorded the ``/turtle1/pose`` topic, the ``ros2 bag play`` command won’t quit for as long as you had turtlesim running, even if you weren’t moving.
 

--- a/source/Tutorials/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Understanding-ROS2-Parameters.rst
@@ -128,7 +128,7 @@ Your terminal should return the message:
 
 And the background of your turtlesim window should change colors:
 
-.. image:: set.png
+.. image:: Parameters/set.png
 
 Setting parameters with the ``set`` command will only change them in your current session, not permanently.
 However, you can save your settings changes and reload them next time you start a node.

--- a/source/Tutorials/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Understanding-ROS2-Services.rst
@@ -224,7 +224,7 @@ For example, you know that ``Empty`` typed services don’t have any arguments:
 
 This command will clear the turtlesim window of any lines your turtle has drawn.
 
-.. image:: clear.png
+.. image:: Services/clear.png
 
 Now let’s spawn a new turtle by calling ``/spawn`` and inputting arguments.
 Input ``<arguments>`` in a service call from the command-line need to be in YAML syntax.
@@ -247,7 +247,7 @@ You will get this method-style view of what’s happening, and then the service 
 
 Your turtlesim window will update with the newly spawned turtle right away:
 
-.. image:: spawn.png
+.. image:: Services/spawn.png
 
 Summary
 -------

--- a/source/Tutorials/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Understanding-ROS2-Topics.rst
@@ -75,7 +75,7 @@ Additionally, the number of **Namespaces** should be 0.
 
 .. todo: the above 4 sentences can be removed once the “nodes only” problem is fixed
 
-.. image:: rqt_graph.png
+.. image:: Topics/rqt_graph.png
 
 You should see the above nodes and topic, and if you hover your mouse over any of the elements, the color highlighting as well.
 
@@ -116,7 +116,7 @@ These attributes, particularly the type, are how nodes know they’re talking ab
 
 If you’re wondering where all these topics are in rqt_graph, you can uncheck all the boxes under **Hide:**
 
-.. image:: unhide.png
+.. image:: Topics/unhide.png
 
 For now, though, leave those options checked to avoid confusion.
 
@@ -155,7 +155,7 @@ Watch the terminal where your ``echo`` is running at the same time, and you’ll
 
 Now return to rqt_graph and uncheck the **Debug** box.
 
-.. image:: debug.png
+.. image:: Topics/debug.png
 
 ``/_ros2cli_22409`` is the node created by the ``echo`` we just ran (the number will change).
 Now you can see that the publisher is publishing data over the ``cmd_vel`` topic, and two subscribers are subscribed.
@@ -263,7 +263,7 @@ You will receive the following message in the terminal:
 
 And you will see your turtle move like so:
 
-.. image:: pub_once.png
+.. image:: Topics/pub_once.png
 
 The turtle (and commonly the real robots which it is meant to emulate) require a steady stream of commands to operate continuously.
 So, to get the turtle to keep moving, you can run:
@@ -274,12 +274,12 @@ So, to get the turtle to keep moving, you can run:
 
 The difference here is the removal of the ``--once`` option and the addition of the ``--rate 1`` option, which tells ``ros2 topic pub`` to publish the command in a steady stream at 1 Hz.
 
-.. image:: pub_stream.png
+.. image:: Topics/pub_stream.png
 
 You can refresh rqt_graph to see what’s happening graphically.
 You will see the ``ros 2 topic pub ...`` node (``/_ros2cli_publisher_…``) is publishing over the ``/turtle1/cmd_vel`` topic, and is being received by both the ``ros2 topic echo ...`` node (``/_ros2cli_24…``) and the ``/turtlesim`` node now.
 
-.. image:: rqt_graph2.png
+.. image:: Topics/rqt_graph2.png
 
 Finally, you can run ``echo`` on the ``pose`` topic and recheck rqt_graph:
 
@@ -287,7 +287,7 @@ Finally, you can run ``echo`` on the ``pose`` topic and recheck rqt_graph:
 
   ros2 topic echo /turtle1/pose
 
-.. image:: rqt_graph3.png
+.. image:: Topics/rqt_graph3.png
 
 In this case, ``/turtlesim`` is now publishing to the ``pose`` topic, and a new ``echo`` node is subscribed.
 

--- a/source/Tutorials/Using-Rqt-Console.rst
+++ b/source/Tutorials/Using-Rqt-Console.rst
@@ -46,7 +46,7 @@ Start ``rqt_console`` in a new terminal with the following command:
 
 The ``rqt_console`` window will open:
 
-.. image:: console.png
+.. image:: Rqt-Console/console.png
 
 The first section of the console is where log messages from your system will display.
 
@@ -75,7 +75,7 @@ In a new terminal, enter the ``ros2 topic pub`` command (discussed in detail in 
 Since the above command is publishing the topic at a steady rate, the turtle is continuously running into the wall.
 In ``rqt_console`` you will see the same message with the ``Warn`` severity level displayed over and over, like so:
 
-.. image:: warn.png
+.. image:: Rqt-Console/warn.png
 
 Press ``Ctrl+C`` in the terminal where you ran the ``ros2 topic pub`` command to stop your turtle from running into the wall.
 


### PR DESCRIPTION
I noticed that the tutorials in nested directories (like `Tutorials/Topics/Understanding-ROS2-Topics`) didn't have the auto-generated index on the left side of the page and also didn't have the title of the tutorial in the tab (it just said "ROS 2 Overview"). So taking them out of their nested dirs should fix that.

Signed-off-by: maryaB-osr <marya@openrobotics.org>