### PR TITLE
Fix rosdep setup instructions for Linux binary installations

### DIFF
--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -49,8 +49,9 @@ Installing and initializing rosdep
 
 .. code-block:: bash
 
+       sudo apt update
        sudo apt install -y python-rosdep
-       rosdep init # if already initialized you may continue
+       sudo rosdep init # if already initialized you may continue
        rosdep update
 
 

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -44,8 +44,9 @@ Installing and initializing rosdep
 
 .. code-block:: bash
 
+       sudo apt update
        sudo apt install -y python-rosdep
-       rosdep init
+       sudo rosdep init
        rosdep update
 
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -44,8 +44,9 @@ Installing and initializing rosdep
 
 .. code-block:: bash
 
+       sudo apt update
        sudo apt install -y python-rosdep
-       rosdep init
+       sudo rosdep init
        rosdep update
 
 


### PR DESCRIPTION
Precisely what the title says. Applied the same fix across distros.