### PR TITLE
Replicate python3-argcomplete install instructions for Linux binary installations

### DIFF
--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -74,6 +74,30 @@ Installing the python3 libraries
 
        sudo apt install -y libpython3-dev
 
+Environment setup
+-----------------
+
+Install argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete to autocompletion. So if you want autocompletion, installing argcomplete is necessary.
+
+Ubuntu 18.04
+~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
+Ubuntu 16.04 (argcomplete >= 0.8.5)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install ``argcomplete`` on Ubuntu 16.04 (Xenial), you'll need to use pip, because the version available through ``apt`` will not work due to a bug in that version of ``argcomplete``:
+
+.. code-block:: bash
+
+   sudo apt install python3-pip
+   sudo pip3 install argcomplete
 
 Install additional DDS implementations (optional)
 -------------------------------------------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -61,6 +61,7 @@ Set your rosdistro according to the release you downloaded.
 #. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
    Follow the normal install instructions: http://wiki.ros.org/melodic/Installation/Ubuntu
 
+
 Installing the python3 libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -68,6 +69,18 @@ Installing the python3 libraries
 
        sudo apt install -y libpython3-dev
 
+Environment setup
+-----------------
+
+Installing python3 argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete for autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
 
 Install additional DDS implementations (optional)
 -------------------------------------------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -68,6 +68,18 @@ Installing the python3 libraries
 
        sudo apt install -y libpython3-dev
 
+Environment setup
+-----------------
+
+Installing python3 argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete for autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
 
 Install additional DDS implementations (optional)
 -------------------------------------------------


### PR DESCRIPTION
Precisely what the title says.