### PR TITLE
Change code-block 'bash' argument to 'console'

### DIFF
--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -51,25 +51,25 @@ You will need to run this command on every new shell you open to have access to 
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         source /opt/ros/<distro>/setup.bash
 
       For example, if you installed ROS 2 Eloquent:
 
-      .. code-block:: bash
+      .. code-block:: console
 
         source /opt/ros/eloquent/setup.bash
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         . ~/ros2_install/ros2-osx/setup.bash
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         call C:\dev\ros2\local_setup.bat
 
@@ -86,13 +86,13 @@ If you don’t want to have to source the setup file every time you open a new s
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         echo "source /opt/ros/<distro>/setup.bash" >> ~/.bashrc
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         echo "source ~/ros2_install/ros2-osx/setup.bash" >> ~/.bash_profile
 
@@ -112,25 +112,25 @@ If you ever have problems finding or using your ROS 2 packages, make sure that y
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         printenv | grep -i ROS
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         printenv | grep -i ROS
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         set | findstr -i ROS
 
 Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set:
 
-.. code-block:: bash
+.. code-block:: console
 
     ROS_VERSION=2
     ROS_PYTHON_VERSION=3
@@ -151,37 +151,37 @@ Once you have determined a unique integer for yourself, you can set the environm
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         export ROS_DOMAIN_ID=<your_domain_id>
 
       To maintain this setting between shell sessions, you can add the command to your shell startup script:
 
-      .. code-block:: bash
+      .. code-block:: console
 
         echo "export ROS_DOMAIN_ID=<your_domain_id>" >> ~/.bashrc
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         export ROS_DOMAIN_ID=<your_domain_id>
 
       To maintain this setting between shell sessions, you can add the command to your shell startup script:
 
-      .. code-block:: bash
+      .. code-block:: console
 
         echo "export ROS_DOMAIN_ID=<your_domain_id>" >> ~/.bash_profile
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         set ROS_DOMAIN_ID=<your_domain_id>
 
       If you want to make this permanant between shell sessions, also run:
 
-      .. code-block:: bash
+      .. code-block:: console
 
         setx ROS_DOMAIN_ID=<your_domain_id>
 

--- a/source/Tutorials/Creating-A-ROS2-Package.rst
+++ b/source/Tutorials/Creating-A-ROS2-Package.rst
@@ -51,7 +51,7 @@ The simplest possible package may have a file structure that looks like:
 
    .. group-tab:: CMake
 
-      .. code-block:: bash
+      .. code-block:: console
 
         my_package/
              CMakeLists.txt
@@ -59,7 +59,7 @@ The simplest possible package may have a file structure that looks like:
 
    .. group-tab:: Python
 
-      .. code-block:: bash
+      .. code-block:: console
 
         my_package/
               setup.py
@@ -79,7 +79,7 @@ This keeps the top level of the workspace “clean”.
 
 A trivial workspace might look like:
 
-.. code-block::
+.. code-block:: console
 
   workspace_folder/
       src/
@@ -116,7 +116,7 @@ Let’s use the workspace you created in the previous tutorial, ``dev_ws``, for 
 
 Make sure you are in the ``src`` folder before running the package creation command.
 
-.. code-block:: bash
+.. code-block:: console
 
     cd dev_ws/src
 
@@ -126,13 +126,13 @@ The command syntax for creating a new package in ROS 2 is:
 
    .. group-tab:: CMake
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ros2 pkg create --build-type ament_cmake <package_name>
 
    .. group-tab:: Python
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ros2 pkg create --build-type ament_python <package_name>
 
@@ -144,13 +144,13 @@ Enter the following command in your terminal:
 
    .. group-tab:: CMake
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ros2 pkg create --build-type ament_cmake --node-name my_node my_package
 
    .. group-tab:: Python
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ros2 pkg create --build-type ament_python --node-name my_node my_package
 
@@ -162,7 +162,7 @@ After running the command, your terminal will return the message:
 
    .. group-tab:: CMake
 
-      .. code-block:: bash
+      .. code-block:: console
 
         going to create a new package
         package name: my_package
@@ -185,7 +185,7 @@ After running the command, your terminal will return the message:
 
    .. group-tab:: Python
 
-      .. code-block:: bash
+      .. code-block:: console
 
         going to create a new package
         package name: my_package
@@ -223,7 +223,7 @@ Otherwise, you would have to build each package individually.
 
 Return to the root of your workspace:
 
-.. code-block:: bash
+.. code-block:: console
 
     cd ~/dev_ws
 
@@ -233,19 +233,19 @@ Now you can build your packages:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       colcon build
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       colcon build
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       colcon build --merge-install
 
@@ -257,7 +257,7 @@ That’s fine when you only have a few packages in your workspace, but when ther
 
 To build only the ``my_package`` package next time, you can run:
 
-.. code-block:: bash
+.. code-block:: console
 
     colcon build --packages-select my_package
 
@@ -268,7 +268,7 @@ To use your new package and executable, first open a new terminal and source you
 
 Then, from inside the ``dev_ws`` directory, run the following command to source your workspace:
 
-.. code-block:: bash
+.. code-block:: console
 
     . install/setup.bash
 
@@ -279,7 +279,7 @@ Now that your workspace has been added to your path, you will be able to use you
 
 To run the executable you created using the ``--node-name`` argument during package creation, enter the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run my_package my_node
 
@@ -289,13 +289,13 @@ Which will return a message to your terminal:
 
    .. group-tab:: CMake
 
-      .. code-block:: bash
+      .. code-block:: console
 
         hello world my_package package
 
    .. group-tab:: Python
 
-      .. code-block:: bash
+      .. code-block:: console
 
         Hi from my_package.
 
@@ -308,7 +308,7 @@ Inside ``dev_ws/src/my_package``, you will see the files and folders that ``ros2
 
    .. group-tab:: CMake
 
-      .. code-block:: bash
+      .. code-block:: console
 
         CMakeLists.txt  include  package.xml  src
 
@@ -317,7 +317,7 @@ Inside ``dev_ws/src/my_package``, you will see the files and folders that ``ros2
 
    .. group-tab:: Python
 
-      .. code-block:: bash
+      .. code-block:: console
 
         my_package  package.xml  resource  setup.cfg  setup.py  test
 

--- a/source/Tutorials/Getting-Started-With-Ros2doctor.rst
+++ b/source/Tutorials/Getting-Started-With-Ros2doctor.rst
@@ -43,7 +43,7 @@ Tasks
 Let’s examine your general ROS 2 setup as a whole with ``ros2doctor``.
 First, source ROS 2 in a new terminal, then enter the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 doctor
 
@@ -51,7 +51,7 @@ This will conduct checks over all your setup modules and return warnings and err
 
 If your ROS 2 setup is in perfect shape, you’ll see a message similar to this:
 
-.. code-block::
+.. code-block:: console
 
     All <n> checks passed
 
@@ -60,13 +60,13 @@ A ``UserWarning`` doesn’t mean your setup is unusable; it’s more likely just
 
 If you do receive a warning, it will look something like this:
 
-.. code-block::
+.. code-block:: console
 
     <path>: <line>: UserWarning: <message>
 
 For example, ros2doctor will find this warning if you’re using an unstable ROS 2 distribution:
 
-.. code-block::
+.. code-block:: console
 
     UserWarning: Distribution <distro> is not fully supported or tested. To get more consistent features, download a stable version at https://index.ros.org/doc/ros2/Installation/
 
@@ -78,7 +78,7 @@ If it does find a rare error in your setup, indicated by ``UserWarning: ERROR:``
 
 You will see a message similar to this following the list of issue feedback:
 
-.. code-block::
+.. code-block:: console
 
   1/3 checks failed
 
@@ -95,13 +95,13 @@ To see ``ros2doctor`` working on a running system, let's run Turtlesim, which ha
 
 Start up the system by opening a new terminal, sourcing ROS 2, and entering the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
 Open another terminal and source ROS 2 to run the teleop controls:
 
-.. code-block::
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
@@ -109,7 +109,7 @@ Now run ``ros2doctor`` again in its own terminal.
 You will see the warnings and errors you had the last time you ran ``ros2doctor`` on your setup, if you had any.
 Following those will be a couple new warnings relating to the system itself:
 
-.. code-block::
+.. code-block:: console
 
     UserWarning: Publisher without subscriber detected on /turtle1/color_sensor.
     UserWarning: Publisher without subscriber detected on /turtle1/pose.
@@ -120,11 +120,11 @@ If you run commands to echo the ``/color_sensor`` and ``/pose`` topics, those wa
 
 You can try this by opening two new terminals while turtlesim is still running, sourcing ROS 2 in each, and running each of the following commands in their own terminal:
 
-.. code-block::
+.. code-block:: console
 
     ros2 topic echo /turtle1/color_sensor
 
-.. code-block::
+.. code-block:: console
 
     ros2 topic echo /turtle1/pose
 
@@ -149,13 +149,13 @@ You can copy and paste the relevant parts of your report into the ticket so the 
 
 To get a full report, enter the following command in the terminal:
 
-.. code-block::
+.. code-block:: console
 
     ros2 doctor --report
 
 Which will return a list of information categorized into five groups:
 
-.. code-block::
+.. code-block:: console
 
   NETWORK CONFIGURATION
   ...
@@ -175,7 +175,7 @@ Which will return a list of information categorized into five groups:
 You can crosscheck the information here against the warnings you get from running ``ros2 doctor``.
 For example, if ``ros2doctor`` returned the warning (mentioned earlier) that your distribution is “not fully supported or tested”, you might take a look at the ``ROS 2 INFORMATION`` section of the report:
 
-.. code-block::
+.. code-block:: console
 
   distribution name      : <distro>
   distribution type      : ros2
@@ -195,7 +195,7 @@ Keep in mind, ``ros2doctor`` is not a debug tool; it won’t help with errors in
 
 
 Related content
-------------------------
+---------------
 
 `ros2doctor’s README <https://github.com/ros2/ros2cli/tree/master/ros2doctor>`__ will tell you more about different arguments.
 You might want to take a look around the ros2doctor repo as well, since it's fairly beginner friendly and a great place to get started with contributing.

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -42,7 +42,7 @@ Tasks
 
 Create a new directory to store your launch file:
 
-.. code-block:: bash
+.. code-block:: console
 
   mkdir launch
 
@@ -52,19 +52,19 @@ Create a launch file named ``turtlesim_mimic_launch.py`` by entering the followi
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         touch turtlesim_mimic_launch.py
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         touch turtlesim_mimic_launch.py
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         type nul > turtlesim_mimic_launch.py
 
@@ -182,7 +182,7 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 
 To launch ``turtlesim_mimic_launch.py``, run the following command:
 
-.. code-block::
+.. code-block:: console
 
   ros2 launch turtlesim_mimic_launch.py
 
@@ -191,7 +191,7 @@ To launch ``turtlesim_mimic_launch.py``, run the following command:
   It is possible to launch a launch file directly (as we do above), or provided by a package.
   When it is provided by a package, the syntax is:
 
-  .. code-block::
+  .. code-block:: console
 
       ros2 launch <package_name> <launch_file_name>
 
@@ -199,7 +199,7 @@ To launch ``turtlesim_mimic_launch.py``, run the following command:
 
 Two turtlesim windows will open, and you will see the following ``[INFO]`` messages telling you which nodes your launch file has started:
 
-.. code-block::
+.. code-block:: console
 
   [INFO] [launch]: Default logging verbosity is set to INFO
   [INFO] [turtlesim_node-1]: process started with pid [11714]
@@ -208,7 +208,7 @@ Two turtlesim windows will open, and you will see the following ``[INFO]`` messa
 
 To see the system in action, run the ``ros2 topic pub`` command on the ``/turtlesim1/turtle1/cmd_vel`` topic to get the first turtle moving:
 
-.. code-block::
+.. code-block:: console
 
   ros2 topic pub -r 1 /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}'
 
@@ -223,7 +223,7 @@ While the system is still running, open a new terminal and run ``rqt_graph`` to 
 
 Run the command:
 
-.. code-block::
+.. code-block:: console
 
   rqt_graph
 

--- a/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
@@ -39,13 +39,13 @@ Start up the two turtlesim nodes, ``/turtlesim`` and ``/teleop_turtle``.
 
 Open a new terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
@@ -55,13 +55,13 @@ Open another terminal and run:
 
 To see the parameters belonging to your nodes, open a new terminal and enter the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 param list
 
 You will see the node subnamespaces, ``/teleop_turtle`` and ``/turtlesim``, followed by each node’s parameters:
 
-.. code-block:: bash
+.. code-block:: console
 
   /teleop_turtle:
     scale_angular
@@ -85,19 +85,19 @@ To be certain of a parameter type, you can use ``ros2 param get``.
 
 To get the current value of a parameter, use the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 param get <node_name> <parameter_name>
 
 Let’s find out the current value of ``/turtlesim``’s parameter ``background_g``:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 param get /turtlesim background_g
 
 Which will return the value:
 
-.. code-block:: bash
+.. code-block:: console
 
     Integer value is: 86
 
@@ -110,19 +110,19 @@ If you run the same command on ``background_r`` and ``background_b``, you will g
 
 To change a parameter's value at runtime, use the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 param set <node_name> <parameter_name> <value>
 
 Let’s change ``/turtlesim``’s background color:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 param set /turtlesim background_r 150
 
 Your terminal should return the message:
 
-.. code-block:: bash
+.. code-block:: console
 
   Set parameter successful
 
@@ -138,26 +138,26 @@ However, you can save your settings changes and reload them next time you start 
 
 You can “dump” all of a node’s current parameter values into a file to save for later using the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 param dump <node_name>
 
 To save your current configuration of ``/turtlesim``’s parameters, enter the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 param dump /turtlesim
 
 Your terminal will return the message:
 
-.. code-block:: bash
+.. code-block:: console
 
   Saving to:  ./turtlesim.yaml
 
 You will find a new file in the directory your workspace is running in.
 If you open this file, you’ll see the following contents:
 
-.. code-block:: bash
+.. code-block:: console
 
   turtlesim:
     ros__parameters:
@@ -173,7 +173,7 @@ Dumping parameters comes in handy if you want to reload the node with the same p
 
 To start the same node using your saved parameter values, use:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run <package_name> <executable_name> --ros-args --params-file <file_name>
 
@@ -181,7 +181,7 @@ This is the same command you always use to start turtlesim, with the added flags
 
 Stop your running turtlesim node so you can try reloading it with your saved parameters, using:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run turtlesim turtlesim_node --ros-args --params-file ./turtlesim.yaml
 

--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -31,7 +31,7 @@ You should have ``ros2 bag`` installed as a part of your regular ROS 2 setup.
 
   If you've installed from Debians on Linux and your system doesn’t recognize the command, install it like so:
 
-  .. code-block::
+  .. code-block:: console
 
     sudo apt-get install ros-<ros-distro>-ros2bag ros-<ros-distro>-rosbag2*
 
@@ -50,19 +50,19 @@ You'll be recording your keyboard input in the ``turtlesim`` system to save and 
 
 Open a new terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
 Let’s also make a new directory to store our saved recordings, just as good practice:
 
-.. code-block:: bash
+.. code-block:: console
 
   mkdir bag_files
 
@@ -73,13 +73,13 @@ Let’s also make a new directory to store our saved recordings, just as good pr
 ``ros2 bag`` can only record data from topics that are published on.
 To see a list of your system's topics, open a new terminal and run the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 topic list
 
 Which will return:
 
-.. code-block:: bash
+.. code-block:: console
 
   /parameter_events
   /rosout
@@ -91,7 +91,7 @@ In the topics tutorial, you learned that the ``/turtle_teleop`` node publishes c
 
 To see the data that ``/turtle1/cmd_vel`` is publishing, run the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 topic echo /turtle1/cmd_vel
 
@@ -99,7 +99,7 @@ Nothing will show up at first because no data is being published by the teleop.
 Return to the terminal where you ran the teleop and select it so it's active.
 Use the arrow keys to move the turtle around, and you will see data being published on the terminal running ``ros2 topic echo``.
 
-.. code-block:: bash
+.. code-block:: console
 
   linear:
     x: 2.0
@@ -118,7 +118,7 @@ Use the arrow keys to move the turtle around, and you will see data being publis
 
 To record the data published to a topic use the command syntax:
 
-.. code-block::
+.. code-block:: console
 
     ros2 bag record <topic_name>
 
@@ -126,13 +126,13 @@ Before running this command on your chosen topic, open a new terminal and move i
 
 Run the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 bag record /turtle1/cmd_vel
 
 You will see the following messages in the terminal (the date and time will be different):
 
-.. code-block::
+.. code-block:: console
 
     [INFO] [rosbag2_storage]: Opened database 'rosbag2_2019_10_11-05_18_45'.
     [INFO] [rosbag2_transport]: Listening for topics...
@@ -156,7 +156,7 @@ You can also record multiple topics, as well as change the name of the file ``ro
 
 Run the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 bag record -o subset /turtle1/cmd_vel /turtle1
 
@@ -186,13 +186,13 @@ You can move the turtle around and press ``Ctrl+C`` when you’re finished.
 
 You can see details about your recording by running:
 
-.. code-block::
+.. code-block:: console
 
     ros2 bag info <bag_file_name>
 
 Running this command on the ``subset`` bag file will return a list of information on the file:
 
-.. code-block::
+.. code-block:: console
 
   Files:             subset.db3
   Bag size:          228.5 KiB
@@ -214,13 +214,13 @@ Then make sure your turtlesim window is visible so you can see the bag file in a
 
 Enter the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 bag play subset
 
 The terminal will return the message:
 
-.. code-block:: bash
+.. code-block:: console
 
     [INFO] [rosbag2_storage]: Opened database 'subset'.
 
@@ -237,7 +237,7 @@ Notice that ``/turtle1/pose`` has a ``Count`` value of over 3000; while we were 
 
 To get an idea of how often position data is published, you can run the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic echo /turtle1/pose
 

--- a/source/Tutorials/Rqt-Console/Using-Rqt-Console.rst
+++ b/source/Tutorials/Rqt-Console/Using-Rqt-Console.rst
@@ -40,7 +40,7 @@ Tasks
 
 Start ``rqt_console`` in a new terminal with the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run rqt_console rqt_console
 
@@ -58,7 +58,7 @@ You can add more filters to this section as well.
 
 Now start ``turtlesim`` with the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
@@ -68,7 +68,7 @@ Now start ``turtlesim`` with the following command:
 To produce log messages for ``rqt_console`` to display, let’s have the turtle run into the wall.
 In a new terminal, enter the ``ros2 topic pub`` command (discussed in detail in the :ref:`topics tutorial <ROS2Topics>`) below:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic pub -r 1 /turtle1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0,y: 0.0,z: 0.0}}'
 
@@ -84,7 +84,7 @@ Press ``Ctrl+C`` in the terminal where you ran the ``ros2 topic pub`` command to
 
 ROS 2’s logger levels are ordered by severity:
 
-.. code-block:: bash
+.. code-block:: console
 
     Fatal
     Error
@@ -112,7 +112,7 @@ For example, if you set the default level to ``Warn``, you would only see messag
 You can set the default logger level when you first run the ``/turtlesim`` node using remapping.
 Enter the following command in your terminal:
 
-.. code-block:: bash
+.. code-block:: console
 
         ros2 run turtlesim turtlesim_node --ros-args --remap __log_level:=WARN
 

--- a/source/Tutorials/Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Services/Understanding-ROS2-Services.rst
@@ -38,13 +38,13 @@ Start up the two turtlesim nodes, ``/turtlesim`` and ``/teleop_turtle``.
 
 Open a new terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
@@ -53,7 +53,7 @@ Open another terminal and run:
 
 Running the ``ros2 service list`` command in a new terminal will return a list of all the topics currently active in the system:
 
-.. code-block:: bash
+.. code-block:: console
 
   /clear
   /kill
@@ -92,20 +92,20 @@ Service types are defined similarly to topic types, except service types have tw
 
 To find out the type of a service, use the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service type <service_name>
 
 Let’s take a look at turtlesim’s ``/clear`` service.
 In a new terminal, enter the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service type /clear
 
 Which should return:
 
-.. code-block:: bash
+.. code-block:: console
 
   std_srvs/srv/Empty
 
@@ -116,13 +116,13 @@ The ``Empty`` type means the service call sends no data when making a request an
 
 To see the types of all the active services at the same time, you can append the ``--show-types`` option, abbreviated as ``-t``, to the ``list`` command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service list -t
 
 Which will return:
 
-.. code-block:: bash
+.. code-block:: console
 
   /clear [std_srvs/srv/Empty]
   /kill [turtlesim/srv/Kill]
@@ -139,19 +139,19 @@ Which will return:
 
 If you want to find all the services of a specific type, you can use the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service find <type_name>
 
 For example, you can find all the ``Empty`` typed services like this:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service find std_srvs/srv/Empty
 
 Which will return:
 
-.. code-block:: bash
+.. code-block:: console
 
   /clear
   /reset
@@ -161,19 +161,19 @@ Which will return:
 
 You can call services from the command line, but first you need to know the structure of the input arguments.
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 interface show <type_name>.srv
 
 To run this command on the ``/clear`` service’s type, ``Empty``:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 interface show std_srvs/srv/Empty.srv
 
 Which will return:
 
-.. code-block:: bash
+.. code-block:: console
 
   ---
 
@@ -186,13 +186,13 @@ From the results of ``ros2 service list -t``, we know ``/spawn``’s type is ``t
 
 To see the arguments in a ``/spawn`` call-and-request, run the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 interface show turtlesim/srv/Spawn.srv
 
 Which will return:
 
-.. code-block:: bash
+.. code-block:: console
 
   float32 x
   float32 y
@@ -211,14 +211,14 @@ The information below the line isn’t something you need to know in this case, 
 
 Now that you know what a service type is, how to find a service’s type, and how to find the structure of that type’s arguments, you can call a service using:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service call <service_name> <service_type> <arguments>
 
 The ``<arguments>`` part is optional.
 For example, you know that ``Empty`` typed services don’t have any arguments:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service call /clear std_srvs/srv/Empty
 
@@ -231,13 +231,13 @@ Input ``<arguments>`` in a service call from the command-line need to be in YAML
 
 Enter the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 service call /spawn turtlesim/srv/Spawn "{x: 2, y: 2, theta: 0.2, name: ''}"
 
 You will get this method-style view of what’s happening, and then the service response:
 
-.. code-block:: bash
+.. code-block:: console
 
   waiting for service to become available...
   requester: making request: turtlesim.srv.Spawn_Request(x=2.0, y=2.0, theta=0.2, name='None')

--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -39,13 +39,13 @@ By now you should be comfortable starting up turtlesim.
 
 Open a new terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
@@ -61,7 +61,7 @@ The :ref:`turtlesim tutorial <Turtlesim>` tells you how to install rqt and all i
 
 To run rqt_graph, open a new terminal and enter the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     rqt_graph
 
@@ -93,7 +93,7 @@ Now we’ll look at some command line tools for introspecting topics.
 
 Running the ``ros2 topic list`` command in a new terminal will return a list of all the topics currently active in the system:
 
-.. code-block:: bash
+.. code-block:: console
 
   /parameter_events
   /rosout
@@ -103,7 +103,7 @@ Running the ``ros2 topic list`` command in a new terminal will return a list of 
 
 ``ros2 topic list -t`` will return the same list of topics, this time with the topic type appended in brackets after each:
 
-.. code-block:: bash
+.. code-block:: console
 
   /parameter_events [rcl_interfaces/msg/ParameterEvent]
   /rosout [rcl_interfaces/msg/Log]
@@ -125,13 +125,13 @@ For now, though, leave those options checked to avoid confusion.
 
 To see the data being published on a topic, use:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic echo <topic_name>
 
 Since we know that ``/teleop_turtle`` publishes data to ``/turtlesim`` over the ``/turtle1/cmd_vel`` topic, let's use ``echo`` to introspect on that topic:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic echo /turtle1/cmd_vel
 
@@ -141,7 +141,7 @@ That’s because it’s waiting for ``/teleop_turtle`` to publish something.
 Return to the terminal where ``turtle_teleop_key`` is running and use the arrows to move the turtle around.
 Watch the terminal where your ``echo`` is running at the same time, and you’ll see position data being published for every movement you make:
 
-.. code-block:: bash
+.. code-block:: console
 
   linear:
     x: 2.0
@@ -167,7 +167,7 @@ Topics don’t have to only be point-to-point communication; it can be one-to-ma
 
 Another way to look at this is running:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic info /turtle1/cmd_vel
 
@@ -177,7 +177,7 @@ Which will return:
 
   .. group-tab:: Eloquent
 
-    .. code-block:: bash
+    .. code-block:: console
 
       Type: geometry_msgs/msg/Twist
       Publisher count: 1
@@ -200,7 +200,7 @@ Publishers and subscribers must send and receive the same type of message to com
 The topic types we saw earlier after running ``ros2 topic list -t`` let us know what type of messages each topic can send.
 Recall that the ``cmd_vel`` topic has the type:
 
-.. code-block:: bash
+.. code-block:: console
 
     geometry_msgs/msg/Twist
 
@@ -208,11 +208,11 @@ This means that in the package ``geometry_msgs`` there is a ``msg`` called ``Twi
 
 Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the details, specifically, what structure of data the message expects.
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 interface show geometry_msgs/msg/Twist.msg
 
-.. code-block:: bash
+.. code-block:: console
 
   # This expresses velocity in free space broken into its linear and angular parts.
 
@@ -222,7 +222,7 @@ Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the 
 This tells you that the ``/turtlesim`` node is expecting a message with two vectors, ``linear`` and ``angular``, of three elements each.
 If you recall the data we saw ``/teleop_turtle`` passing to ``/turtlesim`` with the ``echo`` command, it’s in the same structure:
 
-.. code-block:: bash
+.. code-block:: console
 
   linear:
     x: 2.0
@@ -239,7 +239,7 @@ If you recall the data we saw ``/teleop_turtle`` passing to ``/turtlesim`` with 
 
 Now that you have the message structure, you can publish data onto a topic directly from the command line using:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic pub <topic_name> <msg_type> '<args>'
 
@@ -248,7 +248,7 @@ The ``'<args>'`` argument is the actual data you’ll pass to the topic, in the 
 It’s important to note that this argument needs to be input in YAML syntax.
 Input the full command like so:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 topic pub --once /turtle1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}'
 
@@ -256,7 +256,7 @@ Input the full command like so:
 
 You will receive the following message in the terminal:
 
-.. code-block:: bash
+.. code-block:: console
 
   publisher: beginning loop
   publishing #1: geometry_msgs.msg.Twist(linear=geometry_msgs.msg.Vector3(x=2.0, y=0.0, z=0.0), angular=geometry_msgs.msg.Vector3(x=0.0, y=0.0, z=1.8))
@@ -268,7 +268,7 @@ And you will see your turtle move like so:
 The turtle (and commonly the real robots which it is meant to emulate) require a steady stream of commands to operate continuously.
 So, to get the turtle to keep moving, you can run:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 topic pub --rate 1 /turtle1/cmd_vel geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}'
 
@@ -283,7 +283,7 @@ You will see the ``ros 2 topic pub ...`` node (``/_ros2cli_publisher_…``) is p
 
 Finally, you can run ``echo`` on the ``pose`` topic and recheck rqt_graph:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 topic echo /turtle1/pose
 
@@ -296,13 +296,13 @@ In this case, ``/turtlesim`` is now publishing to the ``pose`` topic, and a new 
 
 For one last introspection on this process, you can report the rate at which data is published using:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 topic hz /turtle1/pose
 
 It will return data on the rate at which the ``/turtlesim`` node is publishing data to the ``pose`` topic.
 
-.. code-block:: bash
+.. code-block:: console
 
   average rate: 59.354
     min: 0.005s max: 0.027s std dev: 0.00284s window: 58

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -44,7 +44,7 @@ Install the turtlesim package for your ROS 2 distro:
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         sudo apt update
 
@@ -60,13 +60,13 @@ Install the turtlesim package for your ROS 2 distro:
 
 Check that the package installed:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 pkg executables turtlesim
 
 The above command should return a list of turtlesim's executables:
 
-.. code-block:: bash
+.. code-block:: console
 
   turtlesim draw_square
   turtlesim mimic
@@ -78,7 +78,7 @@ The above command should return a list of turtlesim's executables:
 
 To start turtlesim, enter the following command in your terminal:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run turtlesim turtlesim_node
 
@@ -88,7 +88,7 @@ The simulator window should appear, with a random turtle in the center.
 
 In the terminal under the command, you will see messages from the node:
 
-.. code-block:: bash
+.. code-block:: console
 
   [INFO] [turtlesim]: Starting turtlesim with node name /turtlesim
 
@@ -103,7 +103,7 @@ Open a new terminal and source ROS 2 again.
 
 Now you will run a new node to control the turtle in the first node:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run turtlesim turtle_teleop_key
 
@@ -120,7 +120,7 @@ It will move around the screen, using its attached "pen" to draw the path it fol
 
 You can see the nodes and their associated services, topics, and actions using the ``list`` command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 node list
   ros2 topic list
@@ -139,7 +139,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       sudo apt update
 
@@ -155,7 +155,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
 To run rqt:
 
-.. code-block:: bash
+.. code-block:: console
 
   rqt
 
@@ -193,7 +193,7 @@ Enter new coordinates for the turtle to spawn at, like ``x = 1.0`` and ``y = 1.0
 
   If you try to spawn a new turtle with the same name as an existing turtle, like your default ``turtle1``, you will get an error message in the terminal running ``turtlesim_node``:
 
-  .. code-block:: bash
+  .. code-block:: console
 
     [ERROR] [turtlesim]: A turtle named [turtle1] already exists
 
@@ -231,13 +231,13 @@ In a new terminal, source ROS 2, and run:
 
    .. group-tab:: Eloquent
 
-      .. code-block::
+      .. code-block:: console
 
         ros2 run turtlesim turtle_teleop_key --ros-args --remap turtle1/cmd_vel:=turtle2/cmd_vel
 
    .. group-tab:: Dashing
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ros2 run turtlesim turtle_teleop_key turtle1/cmd_vel:=turtle2/cmd_vel
 

--- a/source/Tutorials/Understanding-ROS2-Actions.rst
+++ b/source/Tutorials/Understanding-ROS2-Actions.rst
@@ -45,13 +45,13 @@ Start up the two turtlesim nodes, ``/turtlesim`` and ``/teleop_turtle``.
 
 Open a new terminal and run:
 
-.. code-block::
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
-.. code-block::
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
@@ -61,7 +61,7 @@ Open another terminal and run:
 
 When you launch the ``/teleop_turtle`` node, you will see the following message in your terminal:
 
-.. code-block::
+.. code-block:: console
 
     Use arrow keys to move the turtle.
     Use G|B|V|C|D|E|R|T keys to rotate to absolute orientations. 'F' to cancel a rotation.
@@ -78,7 +78,7 @@ Each time you press one of these keys, you are sending a goal to an action serve
 The goal is to rotate the turtle to face a particular direction.
 A message relaying the result of the goal should display once the turtle completes its rotation:
 
-.. code-block::
+.. code-block:: console
 
     [INFO] [turtlesim]: Rotation goal completed successfully
 
@@ -87,7 +87,7 @@ The ``F`` key will cancel a goal mid-execution, demonstrating the preemptable fe
 Try pressing the ``C`` key, and then pressing the ``F`` key before the turtle can complete its rotation.
 In the terminal where the ``/turtlesim`` node is running, you will see the message:
 
-.. code-block::
+.. code-block:: console
 
   [INFO] [turtlesim]: Rotation goal canceled
 
@@ -97,7 +97,7 @@ When the server-side preempts an action, it “aborts” the goal.
 Try hitting the ``D`` key, then the ``G`` key before the first rotation can complete.
 In the terminal where the ``/turtlesim`` node is running, you will see the message:
 
-.. code-block::
+.. code-block:: console
 
   [WARN] [turtlesim]: Rotation goal received before a previous goal finished. Aborting previous goal
 
@@ -108,13 +108,13 @@ The server-side aborted the first goal because it was interrupted.
 
 To see the ``/turtlesim`` node’s actions, open a new terminal and run the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 node info /turtlesim
 
 Which will return a list of ``/turtlesim``’s subscribers, publishers, services, action servers and action clients:
 
-.. code-block::
+.. code-block:: console
 
   /turtlesim
     Subscribers:
@@ -148,13 +148,13 @@ This means ``/turtlesim`` responds to and provides feedback for the ``/turtle1/r
 
 The ``/teleop_turtle`` node has the name ``/turtle1/rotate_absolute`` under ``Action Clients`` meaning that it sends goals for that action name.
 
-.. code-block::
+.. code-block:: console
 
     ros2 node info /teleop_turtle
 
 Which will return:
 
-.. code-block::
+.. code-block:: console
 
   /teleop_turtle
     Subscribers:
@@ -181,13 +181,13 @@ Which will return:
 
 To identify all the actions in the ROS graph, run the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 action list
 
 Which will return:
 
-.. code-block::
+.. code-block:: console
 
     /turtle1/rotate_absolute
 
@@ -201,13 +201,13 @@ You also already know that there is one action client (part of ``/teleop_turtle`
 Actions have types, similar to topics and services.
 To find ``/turtle1/rotate_absolute``'s type, run the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 action list -t
 
 Which will return:
 
-.. code-block::
+.. code-block:: console
 
     /turtle1/rotate_absolute [turtlesim/action/RotateAbsolute]
 
@@ -219,13 +219,13 @@ You will need this when you want to execute an action from the command line or f
 
 You can further introspect the ``/turtle1/rotate_absolute`` action with the command:
 
-.. code-block::
+.. code-block:: console
 
     ros2 action info /turtle1/rotate_absolute
 
 Which will return
 
-.. code-block::
+.. code-block:: console
 
   Action: /turtle1/rotate_absolute
   Action clients: 1
@@ -245,13 +245,13 @@ One more piece of information you will need before sending or executing an actio
 Recall that you identified ``/turtle1/rotate_absolute``’s type when running the command ``ros2 action list -t``.
 Enter the following command with the action type in your terminal:
 
-.. code-block::
+.. code-block:: console
 
     ros2 interface show turtlesim/action/RotateAbsolute.action
 
 Which will return:
 
-.. code-block::
+.. code-block:: console
 
   # The desired heading in radians
   float32 theta
@@ -271,7 +271,7 @@ The last section is the structure of the feedback.
 
 Now let’s send an action goal from the command line with the following syntax:
 
-.. code-block::
+.. code-block:: console
 
     ros2 action send_goal <action_name> <action_type> <values>
 
@@ -279,13 +279,13 @@ Now let’s send an action goal from the command line with the following syntax:
 
 Keep an eye on the turtlesim window, and enter the following command into your terminal:
 
-.. code-block::
+.. code-block:: console
 
     ros2 action send_goal /turtle1/rotate_absolute turtlesim/action/RotateAbsolute {'theta: 1.57'}
 
 You should see the turtle rotating, as well as the following message in your terminal:
 
-.. code-block::
+.. code-block:: console
 
   Waiting for an action server to become available...
   Sending goal:
@@ -305,13 +305,13 @@ To see the feedback of this goal, add ``--feedback`` to the last command you ran
 First, make sure you change the value of ``theta``.
 After running the previous command, the turtle will already be at the orientation of ``1.57`` radians, so it won’t move unless you pass a new ``theta``.
 
-.. code-block::
+.. code-block:: console
 
     ros2 action send_goal /turtle1/rotate_absolute turtlesim/action/RotateAbsolute {'theta: -1.57'} --feedback
 
 Your terminal will return the message:
 
-.. code-block::
+.. code-block:: console
 
   Sending goal:
      theta: -1.57

--- a/source/Tutorials/Understanding-ROS2-Nodes.rst
+++ b/source/Tutorials/Understanding-ROS2-Nodes.rst
@@ -47,13 +47,13 @@ Tasks
 
 The command ``ros2 run`` launches an executable from a package.
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run <package_name> <executable_name>
 
 To run turtlesim, open a new terminal, and enter the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtlesim_node
 
@@ -72,19 +72,19 @@ This is especially useful when you want to interact with a node, or when you hav
 
 Open a new terminal while turtlesim is still running in the other one, and enter the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 node list
 
 The terminal will return the node name:
 
-.. code-block:: bash
+.. code-block:: console
 
   /turtlesim
 
 Open another new terminal and start the teleop node with the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 run turtlesim turtle_teleop_key
 
@@ -93,7 +93,7 @@ Here, we are searching the ``turtlesim`` package again, this time for the execut
 Return to the terminal where you ran ``ros2 node list`` and run it again.
 You will now see the names of two active nodes:
 
-.. code-block:: bash
+.. code-block:: console
 
   /turtlesim
   /teleop_turtle
@@ -107,14 +107,14 @@ In the last tutorial, you used remapping on ``turtle_teleop_key`` to change the 
 Now, lets reassign the name of our ``/turtlesim`` node.
 In a new terminal, run the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run turtlesim turtlesim_node --ros-args --remap __node:=my_turtle
 
 Since you’re calling ``ros2 run`` on turtlesim again, another turtlesim window will open.
 However, now if you return to the terminal where you ran ``ros2 node list``, and run it again, you will see three node names:
 
-.. code-block:: bash
+.. code-block:: console
 
     /turtlesim
     /teleop_turtle
@@ -125,20 +125,20 @@ However, now if you return to the terminal where you ran ``ros2 node list``, and
 
 Now that you know the names of your nodes, you can access more information about them with:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 node info <node_name>
 
 To examine your latest node, ``my_turtle``, run the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 node info /my_turtle
 
 ``ros2 node info`` returns a list of subscribers, publishers, services, and actions (the ROS graph connections) that interact with that node.
 The output should look like this:
 
-.. code-block:: bash
+.. code-block:: console
 
   /my_turtle
     Subscribers:

--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -51,25 +51,25 @@ Depending on how you installed ROS 2 (from source or binaries), and which platfo
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         source /opt/ros/<distro>/setup.bash
 
       For example, if you installed ROS 2 Eloquent:
 
-      .. code-block:: bash
+      .. code-block:: console
 
         source /opt/ros/eloquent/setup.bash
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         . ~/ros2_install/ros2-osx/setup.bash
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         call C:\dev\ros2\local_setup.bat
 
@@ -83,7 +83,7 @@ Best practice is to create a new directory for every new workspace.
 The name doesn’t matter, but it is helpful to have it indicate the purpose of the workspace.
 Let’s choose the directory name ``dev_ws``, for “development workspace”:
 
-.. code-block:: bash
+.. code-block:: console
 
   mkdir dev_ws
   mkdir dev_ws/src
@@ -110,7 +110,7 @@ When you clone this repo, add the ``-b`` argument followed by the branch that co
 
 In the ``dev_ws/src`` directory, if your distro is Dashing for example, run the command:
 
-.. code-block:: bash
+.. code-block:: console
 
   git clone https://github.com/ros/ros_tutorials.git -b dashing-devel
 
@@ -123,26 +123,26 @@ To see the packages inside ``ros_tutorials``, enter the command:
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ls ros_tutorials
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         ls ros_tutorials
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         dir ros_tutorials
 
 
 Which will list the contents of the repo you just cloned, like so:
 
-.. code-block::
+.. code-block:: console
 
     roscpp_tutorials  rospy_tutorials  ros_tutorials  turtlesim
 
@@ -162,19 +162,19 @@ You wouldn’t want a build to fail after a long wait because of missing depende
 From the root of your workspace (``~/dev_ws``):
 Run the following command, replacing ``<distro>`` with your distro:
 
-.. code-block:: bash
+.. code-block:: console
 
   sudo rosdep install -i --from-path src --rosdistro <distro> -y
 
 For example, if you're using Eloquent, you would run:
 
-.. code-block:: bash
+.. code-block:: console
 
   sudo rosdep install -i --from-path src --rosdistro eloquent -y
 
 If you already have all your dependencies, the console will return:
 
-.. code-block:: bash
+.. code-block:: console
 
   #All required rosdeps installed successfully
 
@@ -191,19 +191,19 @@ From the root of your workspace (``~/dev_ws``), you can now build your packages 
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       colcon build
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       colcon build
 
   .. group-tab:: Windows
 
-    .. code-block:: bash
+    .. code-block:: console
 
       colcon build --merge-install
 
@@ -211,7 +211,7 @@ From the root of your workspace (``~/dev_ws``), you can now build your packages 
 
 The console will return the following message:
 
-.. code-block:: bash
+.. code-block:: console
 
   Starting >>> turtlesim
   Finished <<< turtlesim [5.49s]
@@ -227,7 +227,7 @@ The console will return the following message:
 
 Once the build is finished, enter ``ls`` in the workspace root (``~/dev_ws``) and you will see that colcon has created new directories:
 
-.. code-block:: bash
+.. code-block:: console
 
   build  install  log  src
 
@@ -246,25 +246,25 @@ In the new terminal, source your main ROS 2 environment as the “underlay”, s
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
+      .. code-block:: console
 
         source /opt/ros/<distro>/setup.bash
 
    .. group-tab:: macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         . ~/ros2_install/ros2-osx/setup.bash
 
    .. group-tab:: Windows
 
-      .. code-block:: bash
+      .. code-block:: console
 
         call C:\dev\ros2\setup.bat
 
 Go into the root of your workspace:
 
-.. code-block:: bash
+.. code-block:: console
 
   cd dev_ws
 
@@ -274,19 +274,19 @@ In the root, source your overlay:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       . install/local_setup.bash
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       . install/local_setup.bash
 
   .. group-tab:: Windows
 
-    .. code-block:: bash
+    .. code-block:: console
 
       . install/local_setup.bat
 
@@ -300,7 +300,7 @@ In the root, source your overlay:
 
 Now you can run the ``turtlesim`` package from the overlay:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run turtlesim turtlesim_node
 
@@ -326,7 +326,7 @@ Return to first terminal where you ran ``colcon build`` earlier and run it again
 
 Return to the second terminal (where the overlay is sourced) and run turtlesim again:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run turtlesim turtlesim_node
 
@@ -339,7 +339,7 @@ Even though your main ROS 2 environment was sourced in this terminal earlier, th
 To see that your underlay is still intact, open a brand new terminal and source only your ROS 2 installation.
 Run turtlesim again:
 
-.. code-block::
+.. code-block:: console
 
   ros2 run turtlesim turtlesim_node
 

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -39,7 +39,7 @@ Navigate into the ``dev_ws`` directory created in a previous tutorial.
 Recall that packages should be created in the ``src`` directory, not the root of the workspace.
 So, navigate into ``dev_ws/src``, and run the package creation command:
 
-.. code-block:: bash
+.. code-block:: console
 
     ros2 pkg create --build-type ament_cmake cpp_pubsub
 
@@ -58,7 +58,7 @@ Download the example talker code by entering the following command:
 
    .. group-tab:: Linux/macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
             wget -O publisher_member_function.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/minimal_publisher/member_function.cpp
 
@@ -225,21 +225,21 @@ Make sure to save the file.
 Now open the ``CMakeLists.txt`` file.
 Below the existing dependency ``find_package(ament_cmake REQUIRED)``, add the lines:
 
-.. code-block::
+.. code-block:: console
 
     find_package(rclcpp REQUIRED)
     find_package(std_msgs REQUIRED)
 
 After that, add the executable and name it ``talker`` so you can run your node using ``ros2 run``:
 
-.. code-block::
+.. code-block:: console
 
     add_executable(talker src/publisher_member_function.cpp)
     ament_target_dependencies(talker rclcpp std_msgs)
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
 
-.. code-block::
+.. code-block:: console
 
   install(TARGETS
     talker
@@ -247,7 +247,7 @@ Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your e
 
 You can clean up your ``CMakeLists.txt`` by removing some unnecessary sections and comments, so it looks like this:
 
-.. code-block::
+.. code-block:: console
 
   cmake_minimum_required(VERSION 3.5)
   project(cpp_pubsub)
@@ -286,7 +286,7 @@ Enter the following code in your terminal:
 
    .. group-tab:: Linux/macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
             wget -O subscriber_member_function.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/minimal_subscriber/member_function.cpp
 
@@ -298,7 +298,7 @@ Enter the following code in your terminal:
 
 Entering ``ls`` in the console will now return:
 
-.. code-block:: bash
+.. code-block:: console
 
     publisher_member_function.cpp  subscriber_member_function.cpp
 
@@ -381,7 +381,7 @@ Since this node has the same dependencies as the publisher node, there’s nothi
 
 Reopen ``CMakeLists.txt`` and add the executable and target for the subscriber node below the publisher’s entries.
 
-.. code-block::
+.. code-block:: console
 
   add_executable(listener src/subscriber_member_function.cpp)
   ament_target_dependencies(listener rclcpp std_msgs)
@@ -398,31 +398,31 @@ Make sure to save the file, and then your pub/sub system should be ready for use
 You likely already have the ``rclpp`` and ``std_msgs`` packages installed as part of your ROS 2 system.
 In any case, it's good practice to run ``rosdep`` in the root of your workspace to check for missing dependencies before building:
 
-.. code-block:: bash
+.. code-block:: console
 
     sudo rosdep install -i --from-path src --rosdistro <distro> -y
 
 Navigate back to the root of your workspace, ``dev_ws``, and build your new package:
 
-.. code-block:: bash
+.. code-block:: console
 
     colcon build --packages-select cpp_pubsub
 
 Open a new terminal, navigate to ``dev_ws``, and source the setup files:
 
-.. code-block:: bash
+.. code-block:: console
 
     . install/setup.bash
 
 Now run the talker node:
 
-.. code-block:: bash
+.. code-block:: console
 
      ros2 run cpp_pubsub talker
 
 The terminal should start publishing info messages every 0.5 seconds, like so:
 
-.. code-block:: bash
+.. code-block:: console
 
     [INFO] [minimal_publisher]: Publishing: "Hello World: 0"
     [INFO] [minimal_publisher]: Publishing: "Hello World: 1"
@@ -432,13 +432,13 @@ The terminal should start publishing info messages every 0.5 seconds, like so:
 
 Open another terminal, source the setup files from inside ``dev_ws`` again, and then start the listener node:
 
-.. code-block:: bash
+.. code-block:: console
 
      ros2 run cpp_pubsub listener
 
 The listener will start printing messages to the console, starting at whatever message count the publisher is on at that time, like so:
 
-.. code-block:: bash
+.. code-block:: console
 
   [INFO] [minimal_subscriber]: I heard: "Hello World: 10"
   [INFO] [minimal_subscriber]: I heard: "Hello World: 11"

--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -40,7 +40,7 @@ Navigate into the ``dev_ws`` directory created in a previous tutorial.
 Recall that packages should be created in the ``src`` directory, not the root of the workspace.
 Navigate into ``dev_ws/src`` and create a new package:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 pkg create --build-type ament_cmake cpp_srvcli --dependencies rclcpp example_interfaces
 
@@ -49,7 +49,7 @@ Your terminal will return a message verifying the creation of your package ``cpp
 The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml`` and ``CMakeLists.txt``.
 ``example_interfaces`` is the package that includes `the .srv file <https://github.com/ros2/example_interfaces/blob/master/srv/AddTwoInts.srv>`__ you will need to structure your requests and responses:
 
-.. code-block::
+.. code-block:: console
 
     int64 a
     int64 b
@@ -77,7 +77,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
 Inside the ``dev_ws/src/cpp_srvcli/src`` directory, create a new file called ``add_two_ints_server.cpp`` and paste the following code within:
 
-.. code-block:: c++
+.. code-block:: C++
 
       #include "rclcpp/rclcpp.hpp"
       #include "example_interfaces/srv/add_two_ints.hpp"
@@ -115,7 +115,7 @@ The first two ``#include`` statements are your package dependencies.
 
 The ``add`` function adds two integers from the request and gives the sum to the response, while notifying the console of its status using logs.
 
-.. code-block:: c++
+.. code-block:: C++
 
     void add(const std::shared_ptr<example_interfaces::srv::AddTwoInts::Request> request,
              std::shared_ptr<example_interfaces::srv::AddTwoInts::Response>      response)
@@ -165,7 +165,7 @@ The ``main`` function accomplishes the following, line by line:
 The ``add_executable`` macro generates an executable you can run using ``ros2 run``.
 Add the following code block to create an executable named ``server``:
 
-.. code-block::
+.. code-block:: console
 
     add_executable(server src/add_two_ints_server.cpp)
     ament_target_dependencies(server
@@ -173,7 +173,7 @@ Add the following code block to create an executable named ``server``:
 
 So ``ros2 run`` can find the executable, add the following lines to the end of the file, right before ``ament_package()``:
 
-.. code-block::
+.. code-block:: console
 
     install(TARGETS
       server
@@ -276,7 +276,7 @@ Then the client sends its request, and the node spins until it receives its resp
 Return to ``CMakeLists.txt`` to add the executable and target for the new node.
 After removing some unnecessary boilerplate from the automatically generated file, your ``CMakeLists.txt`` should look like this:
 
-.. code-block::
+.. code-block:: console
 
   cmake_minimum_required(VERSION 3.5)
   project(cpp_srvcli)
@@ -306,45 +306,45 @@ After removing some unnecessary boilerplate from the automatically generated fil
 
 Navigate back to the root of your workspace, ``dev_ws``, and build your new package:
 
-.. code-block:: bash
+.. code-block:: console
 
     colcon build --packages-select cpp_srvcli
 
 Open a new terminal, navigate to ``dev_ws``, and source the setup files:
 
-.. code-block:: bash
+.. code-block:: console
 
     . install/setup.bash
 
 Now run the service node:
 
-.. code-block:: bash
+.. code-block:: console
 
      ros2 run cpp_srvcli server
 
 The terminal should return the following message, and then wait:
 
-.. code-block::
+.. code-block:: console
 
     [INFO] [rclcpp]: Ready to add two ints.
 
 Open another terminal, source the setup files from inside ``dev_ws`` again.
 Start the client node, followed by any two integers separated by a space:
 
-.. code-block:: bash
+.. code-block:: console
 
      ros2 run cpp_srvcli client 2 3
 
 If you chose ``2`` and ``3``, for example, the client would receive a response like this:
 
-.. code-block::
+.. code-block:: console
 
     [INFO] [rclcpp]: Sum: 5
 
 Return to the terminal where your service node is running.
 You will see that it published log messages when it received the request and the data it received, and the response it sent back:
 
-.. code-block::
+.. code-block:: console
 
     [INFO] [rclcpp]: Incoming request
     a: 2 b: 3

--- a/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -40,7 +40,7 @@ Navigate into the ``dev_ws`` directory created in a previous tutorial.
 Recall that packages should be created in the ``src`` directory, not the root of the workspace.
 So, navigate into ``dev_ws/src``, and run the package creation command:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 pkg create --build-type ament_python py_pubsub
 
@@ -58,7 +58,7 @@ Download the example talker code by entering the following command:
 
    .. group-tab:: Linux/macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         wget https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
 
@@ -246,7 +246,7 @@ Don’t forget to save.
 
 The contents of the ``setup.cfg`` file should be correctly populated automatically, like so:
 
-.. code-block::
+.. code-block:: console
 
   [develop]
   script-dir=$base/lib/py_pubsub
@@ -267,7 +267,7 @@ Enter the following code in your terminal:
 
    .. group-tab:: Linux/macOS
 
-      .. code-block:: bash
+      .. code-block:: console
 
         wget https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
 
@@ -280,7 +280,7 @@ Enter the following code in your terminal:
 
 Now the directory should have these files:
 
-.. code-block:: bash
+.. code-block:: console
 
   __init__.py  publisher_member_function.py  subscriber_member_function.py
 
@@ -390,7 +390,7 @@ In any case, it's good practice to run ``rosdep`` in the root of your workspace 
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       sudo rosdep install -i --from-paths ./src -y
 
@@ -404,25 +404,25 @@ In any case, it's good practice to run ``rosdep`` in the root of your workspace 
 
 Still in the root of your workspace, ``dev_ws``, build your new package:
 
-.. code-block:: bash
+.. code-block:: console
 
   colcon build --packages-select py_pubsub
 
 Open a new terminal, navigate to ``dev_ws``, and source the setup files:
 
-.. code-block:: bash
+.. code-block:: console
 
   . install/setup.bash
 
 Now run the talker node:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run py_pubsub talker
 
 The terminal should start publishing info messages every 0.5 seconds, like so:
 
-.. code-block:: bash
+.. code-block:: console
 
   [INFO] [minimal_publisher]: Publishing: "Hello World: 0"
   [INFO] [minimal_publisher]: Publishing: "Hello World: 1"
@@ -433,13 +433,13 @@ The terminal should start publishing info messages every 0.5 seconds, like so:
 
 Open another terminal, source the setup files from inside ``dev_ws`` again, and then start the listener node:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run py_pubsub listener
 
 The listener will start printing messages to the console, starting at whatever message count the publisher is on at that time, like so:
 
-.. code-block:: bash
+.. code-block:: console
 
   [INFO] [minimal_subscriber]: I heard: "Hello World: 10"
   [INFO] [minimal_subscriber]: I heard: "Hello World: 11"

--- a/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
@@ -39,7 +39,7 @@ Navigate into the ``dev_ws`` directory created in a previous tutorial.
 Recall that packages should be created in the ``src`` directory, not the root of the workspace.
 Navigate into ``dev_ws/src`` and create a new package:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 pkg create --build-type ament_python py_srvcli --dependencies rclpy example_interfaces
 
@@ -48,7 +48,7 @@ Your terminal will return a message verifying the creation of your package ``py_
 The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml``.
 ``example_interfaces`` is the package that includes `the .srv file <https://github.com/ros2/example_interfaces/blob/master/srv/AddTwoInts.srv>`__ you will need to structure your requests and responses:
 
-.. code-block::
+.. code-block:: console
 
     int64 a
     int64 b
@@ -262,19 +262,19 @@ The ``entry_points`` field of your ``setup.py`` file should look like this:
 
 Navigate back to the root of your workspace, ``dev_ws``, and build your new package:
 
-.. code-block:: bash
+.. code-block:: console
 
   colcon build --packages-select py_srvcli
 
 Open a new terminal, navigate to ``dev_ws``, and source the setup files:
 
-.. code-block:: bash
+.. code-block:: console
 
   . install/setup.bash
 
 Now run the service node:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run py_srvcli service
 
@@ -283,20 +283,20 @@ The node will wait for the client’s request.
 Open another terminal and source the setup files from inside ``dev_ws`` again.
 Start the client node, followed by any two integers separated by a space:
 
-.. code-block:: bash
+.. code-block:: console
 
   ros2 run py_srvcli client 2 3
 
 If you chose ``2`` and ``3``, for example, the client would receive a response like this:
 
-.. code-block::
+.. code-block:: console
 
   [INFO] [minimal_client_async]: Result of add_two_ints: for 2 + 3 = 5
 
 Return to the terminal where your service node is running.
 You will see that it published log messages when it received the request:
 
-.. code-block::
+.. code-block:: console
 
   [INFO] [minimal_service]: Incoming request
   a: 2 b: 3


### PR DESCRIPTION
Apparently the `bash` argument for the `.. code-block::` directive is meant for shell _scripts_, while the `console` argument is for shell sessions. Changing every `bash` to `console` will eliminate meaningless keyword highlighting in some of the code-blocks. Also, the readthedocs theme/builder requires that every `code-block` have an argument, so this PR also adds `console` to those without any distinction.

Signed-off-by: maryaB-osr <marya@openrobotics.org>