### PR TITLE
Specifically install Python 3.7.5 on Windows

### DIFF
--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -33,7 +33,7 @@ Open a Command Prompt and type the following to install Python via Chocolatey:
 
 .. code-block:: bash
 
-   > choco install -y python
+   > choco install -y python --version 3.7.5
 
 Install OpenSSL
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
choco will currently install 3.8.0 without specifying the version.

Signed-off-by: Michael Carroll <michael@openrobotics.org>