### PR TITLE
Remove duplicate shared memory info 

### DIFF
--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -217,8 +217,6 @@ The setup file and path will depend on your macOS version.
    # macOS 10.13 High Sierra
    source /Applications/rti_connext_dds-5.3.1/resource/scripts/rtisetenv_x64Darwin17clang9.0.bash
 
-You may need to increase shared memory resources following https://community.rti.com/kb/osx510.
-
 If you want to install the Connext DDS-Security plugins please refer to `this page <../Install-Connext-Security-Plugins>`.
 
 .. _Eloquent_osx-development-setup-troubleshooting:

--- a/source/Installation/Eloquent/OSX-Install-Binary.rst
+++ b/source/Installation/Eloquent/OSX-Install-Binary.rst
@@ -156,8 +156,6 @@ Set the ``NDDSHOME`` environment variable:
 
    export NDDSHOME=/Applications/rti_connext_dds-5.3.1
 
-You may need to increase shared memory resources following https://community.rti.com/kb/osx510.
-
 If you want to install the Connext DDS-Security plugins please refer to `this page <../Install-Connext-Security-Plugins>`.
 
 Set up the ROS 2 environment


### PR DESCRIPTION
Remove duplicate from #419 . Reasons being:
1. this issue doesn't affect build process
2. only some osx users encounter it
3. ``Troubleshooting`` section in tutorials allows more details to help users understand the problem