### PR TITLE
[Windows][installation] Add Visual C++ Redistributable Install

### DIFF
--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -33,7 +33,16 @@ Open a Command Prompt and type the following to install Python via Chocolatey:
 
 .. code-block:: bash
 
-   > choco install -y python
+   > choco install -y python --version=3.7.5
+
+Install Visual C++ Redistributables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open a Command Prompt and type the following to install them via Chocolatey:
+
+.. code-block:: bash
+
+   > choco install -y vcredist2013 vcredist140
 
 Install OpenSSL
 ^^^^^^^^^^^^^^^

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -33,7 +33,7 @@ Open a Command Prompt and type the following to install Python via Chocolatey:
 
 .. code-block:: bash
 
-   > choco install -y python --version=3.7.5
+   > choco install -y python
 
 Install Visual C++ Redistributables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
* For clean `Windows` image, `Visual C++ Redistributable` needs to be install manually and I added them for completeness.