### PR TITLE
set QT_QPA_PLATFORM_PLUGIN_PATH in windows dev to tun turtle examples

### DIFF
--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -138,6 +138,14 @@ Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` where you i
 
    This path might change based on which MSVC version you're using or if you installed it to a different directory.
 
+Set the environment variable QT_QPA_PLATFORM_PLUGIN_PATH to run some of the Qt examples:
+
+.. code-block:: bash
+
+  set QT_QPA_PLATFORM_PLUGIN_PATH=C:\Qt\5.12.2\msvc2017_64\plugins\platforms
+
+You can also do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables". In the resulting dialog, click "Environment Variables", the click "Path" on the bottom pane, then click "Edit" and add the path).
+
 RQt dependencies
 ~~~~~~~~~~~~~~~~
 

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -142,7 +142,8 @@ Set the environment variable QT_QPA_PLATFORM_PLUGIN_PATH to run some of the Qt e
 
 .. code-block:: bash
 
-  set QT_QPA_PLATFORM_PLUGIN_PATH=C:\Qt\5.12.2\msvc2017_64\plugins\platforms
+  > set QT_QPA_PLATFORM_PLUGIN_PATH=C:\Qt\5.12.2\msvc2017_64\plugins\platforms
+  : You could set it permanently with ``setx -m QT_QPA_PLATFORM_PLUGIN_PATH C:\Qt\5.12.2\msvc2017_64\plugins\platforms`` instead, but that requires Administrator.
 
 You can also do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables". In the resulting dialog, click "Environment Variables", the click "Path" on the bottom pane, then click "Edit" and add the path).
 


### PR DESCRIPTION
I was getting this error when I was trying to execute `turtlesim_node`

```
qt.qpa.plugin: Could not find the Qt platform plugin "windows" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

Fixed when QT_QPA_PLATFORM_PLUGIN_PATH is set