### PR TITLE
Update Linux-Install-Debians.rst

### DIFF
--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -68,14 +68,14 @@ In one terminal, source the setup file and then run a ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_dashing/install/local_setup.bash
+   source /opt/ros/dashing/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_dashing/install/local_setup.bash
+   source /opt/ros/dashing/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.


### PR DESCRIPTION
There is no ~/ros2_dashing/install/local_setup.bash after following the previous instructions.
To run the talker and listener one should source setup.bash as suggested later.