### PR TITLE
Update eloquent debian docs to source eloquent debian setup files

### DIFF
--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -68,14 +68,14 @@ In one terminal, source the setup file and then run a ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_dashing/install/local_setup.bash
+   source /opt/ros/eloquent/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_dashing/install/local_setup.bash
+   source /opt/ros/eloquent/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.


### PR DESCRIPTION
This makes the eloquent tutorials work and self consistent.