### PR TITLE
ros2node API changes

### DIFF
--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -146,6 +146,13 @@ The CLI tools ``ros2msg`` and ``ros2srv`` are deprecated.
 They have been replaced by the tool ``ros2interface``, which also supports action and IDL interfaces.
 You can run ``ros2 interface --help`` for usage.
 
+ros2node
+""""""""""""""""""""""""""""""
+
+Service clients have been added to ros2node info. As part of that change 
+``get_service_info`` has been replaced by ``get_service_server_info`` within
+the API.
+
 Timeline before the release
 ---------------------------
 

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -147,9 +147,9 @@ They have been replaced by the tool ``ros2interface``, which also supports actio
 You can run ``ros2 interface --help`` for usage.
 
 ros2node
-""""""""""""""""""""""""""""""
+""""""""
 
-Service clients have been added to ros2node info. As part of that change 
+Service clients have been added to ros2node info. As part of that change
 ``get_service_info`` has been replaced by ``get_service_server_info`` within
 the API.
 

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -149,9 +149,9 @@ You can run ``ros2 interface --help`` for usage.
 ros2node
 """"""""
 
-Service clients have been added to ros2node info. As part of that change
-``get_service_info`` has been replaced by ``get_service_server_info`` within
-the API.
+Service clients have been added to ros2node info.
+As part of that change the Python function ``ros2node.api.get_service_info``
+has been renamed to ``ros2node.api.get_service_server_info``.
 
 Timeline before the release
 ---------------------------


### PR DESCRIPTION
Detected while using ROS 2 reconnaissance tools. See
https://github.com/aliasrobotics/aztarna/pull/44.

Essentially, when adding service clients to ros2node info, get_service_info function has been renamed causing issues with tools that built on prior versions of the ros2node API

ping @mjcarroll 