### PR TITLE
small fixes for new overview setup

### DIFF
--- a/source/Tutorials/Understanding-ROS2-Nodes.rst
+++ b/source/Tutorials/Understanding-ROS2-Nodes.rst
@@ -190,4 +190,4 @@ Topics are one of the communication types that connects nodes.
 Related content
 ---------------
 
-The :ref:`Concepts` page adds some more detail to the concept of nodes.
+The :ref:`ConceptsHome` page adds some more detail to the concept of nodes.

--- a/source/index.rst
+++ b/source/index.rst
@@ -58,6 +58,9 @@ Newcomers and experienced ROS users should consult this overview of our user-cen
 Learn more
 ^^^^^^^^^^
 
+There are plenty of resources available online to learn more about ROS 2.
+Here's a few to start with:
+
 * `design.ros2.org <http://design.ros2.org>`__ contains various articles on the design decisions behind ROS 2, like:
    * `Why ROS 2? <http://design.ros2.org/articles/why_ros2.html>`__
    * `ROS on DDS <http://design.ros2.org/articles/ros_on_dds.html>`__


### PR DESCRIPTION
The first bullet under the `Learn more` heading is bold for some reason. I think it's because it's the first thing after the heading? It doesn't show up in a local build so adding a sentence between the heading and list.

Also fixed a `:ref:` thing

Signed-off-by: maryaB-osr <marya@openrobotics.org>