### PR TITLE
Reorder environment setup sections for Eloquent

### DIFF
--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -231,6 +231,34 @@ You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/s
 
 Afterwards source the ``local_setup.*`` from the ``install`` folder.
 
+Environment setup
+-----------------
+
+Sourcing the setup script
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+   . ~/ros2_eloquent/install/setup.bash
+
+You may want to add this to your ``.bashrc``.
+
+.. code-block:: bash
+
+   echo ". ~/ros2_eloquent/install/setup.bash" >> ~/.bashrc
+
+Install argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete to autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
 Try some examples
 -----------------
 

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -243,12 +243,6 @@ Set up your environment by sourcing the following file.
 
    . ~/ros2_eloquent/install/setup.bash
 
-You may want to add this to your ``.bashrc``.
-
-.. code-block:: bash
-
-   echo ". ~/ros2_eloquent/install/setup.bash" >> ~/.bashrc
-
 Install argcomplete (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -69,19 +69,6 @@ Installing the python3 libraries
 
        sudo apt install -y libpython3-dev
 
-Environment setup
------------------
-
-Installing python3 argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete for autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 Install additional DDS implementations (optional)
 -------------------------------------------------
 
@@ -133,6 +120,35 @@ Note: the above may need modification to match your RTI installation location
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <../Install-Connext-Security-Plugins>`.
 
+
+Environment setup
+-----------------
+
+Sourcing the setup script
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+  . ~/ros2_eloquent/ros2-linux/setup.bash
+
+You may want to add this to your ``.bashrc``.
+
+.. code-block:: bash
+
+   echo ". ~/ros2_eloquent/ros2-linux/setup.bash" >> ~/.bashrc
+
+Installing python3 argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete for autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
 Try some examples
 -----------------
 
@@ -157,8 +173,9 @@ If you have installed support for an optional vendor, see `this page </Tutorials
 
 See the `demos </Tutorials>` for other things to try, including how to `run the talker-listener example in Python </Tutorials/Python-Programming>`.
 
+
 Using the ROS 1 bridge
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
 We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -133,12 +133,6 @@ Set up your environment by sourcing the following file.
 
   . ~/ros2_eloquent/ros2-linux/setup.bash
 
-You may want to add this to your ``.bashrc``.
-
-.. code-block:: bash
-
-   echo ". ~/ros2_eloquent/ros2-linux/setup.bash" >> ~/.bashrc
-
 Installing python3 argcomplete (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -73,12 +73,6 @@ Set up your environment by sourcing the following file.
 
    source /opt/ros/eloquent/setup.bash
 
-You may want to add this to your ``.bashrc``.
-
-.. code-block:: bash
-
-   echo "source /opt/ros/eloquent/setup.bash" >> ~/.bashrc
-
 Install argcomplete (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -1,5 +1,5 @@
-Installing ROS2 via Debian Packages
-===================================
+Installing ROS 2 via Debian Packages
+====================================
 
 .. contents:: Table of Contents
    :depth: 2
@@ -61,6 +61,34 @@ No GUI tools.
 
 See specific sections below for how to also install the :ref:`ros1_bridge <Eloquent_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Eloquent_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Eloquent_linux-install-additional-rmw-implementations>`.
 
+Environment setup
+-----------------
+
+Sourcing the setup script
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+   source /opt/ros/eloquent/setup.bash
+
+You may want to add this to your ``.bashrc``.
+
+.. code-block:: bash
+
+   echo "source /opt/ros/eloquent/setup.bash" >> ~/.bashrc
+
+Install argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete to autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
 Try some examples
 -----------------
 
@@ -84,35 +112,6 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 Hooray!
 
 See the `demos </Tutorials>` for other things to try.
-
-Environment setup
------------------
-
-(optional) Install argcomplete
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
-
-Sourcing the setup script
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Set up your environment by sourcing the following file.
-
-.. code-block:: bash
-
-   source /opt/ros/eloquent/setup.bash
-
-You may want to add this to your ``.bashrc``.
-
-.. code-block:: bash
-
-   echo "source /opt/ros/eloquent/setup.bash" >> ~/.bashrc
 
 .. _Eloquent_linux-install-additional-rmw-implementations:
 

--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -150,25 +150,31 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this t
    cd ~/ros2_eloquent/
    colcon build --symlink-install
 
-
-Try some examples
+Environment setup
 -----------------
 
-In a clean new terminal, source the setup file (this will automatically set up the environment for any DDS vendors that support was built for) and then run a ``talker``:
+Source the ROS 2 setup file:
 
 .. code-block:: bash
 
    . ~/ros2_eloquent/install/setup.bash
-   ros2 run demo_nodes_cpp talker
 
+This will automatically set up the environment for any DDS vendors that support was built for.
+
+Try some examples
+-----------------
+
+In one terminal, set up the ROS 2 environment as described above and then run a ``talker``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_eloquent/install/setup.bash
    ros2 run demo_nodes_cpp listener
-
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
 Hooray!
@@ -342,4 +348,3 @@ When building qt_gui_cpp there may be errors look like the following:
    Failed   <<< qt_gui_cpp [ Exited with code 1 ]
 
 To fix this issue, follow `these steps <../../Tutorials/RQt-Source-Install-MacOS>` to install dependencies for RQt.
-

--- a/source/Installation/Eloquent/OSX-Install-Binary.rst
+++ b/source/Installation/Eloquent/OSX-Install-Binary.rst
@@ -111,7 +111,6 @@ So that SIP doesn't prevent processes from inheriting dynamic linker environment
 Downloading ROS 2
 -----------------
 
-
 * Go to the releases page: https://github.com/ros2/ros2/releases
 * Download the latest package for OS X; let's assume that it ends up at ``~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2``.
 
@@ -158,24 +157,14 @@ Set the ``NDDSHOME`` environment variable:
 
 If you want to install the Connext DDS-Security plugins please refer to `this page <../Install-Connext-Security-Plugins>`.
 
-Set up the ROS 2 environment
-----------------------------
+Environment setup
+-----------------
 
 Source the ROS 2 setup file:
 
 .. code-block:: bash
 
    . ~/ros2_eloquent/ros2-osx/setup.bash
-
-
-For ROS 2 releases up to and including Ardent, if you downloaded a release with OpenSplice support you must additionally source the OpenSplice setup file manually (this is done automatically for ROS 2 releases later than Ardent).
-Only do this **after** you have sourced the ROS 2 one:
-
-.. code-block:: bash
-
-   . <path_to_opensplice>/x86_64.darwin10_clang/release.com
-
-
 
 Try some examples
 -----------------
@@ -185,7 +174,6 @@ In one terminal, set up the ROS 2 environment as described above and then run a 
 .. code-block:: bash
 
    ros2 run demo_nodes_cpp talker
-
 
 In another terminal, set up the ROS 2 environment and then run a ``listener``:
 

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -241,6 +241,19 @@ To build the ``\dev\ros2_eloquent`` folder tree:
    If you are doing a debug build use ``python_d path\to\colcon_executable`` ``colcon``.
    See `Extra stuff for debug mode`_ for more info on running Python code in debug builds on Windows.
 
+Environment setup
+-----------------
+
+Start a command shell and source the ROS 2 setup file to set up the workspace:
+
+.. code-block:: bash
+
+   > call C:\dev\ros2_eloquent\local_setup.bat
+
+This will automatically set up the environment for any DDS vendors that support was built for.
+
+It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
+
 Testing and Running
 -------------------
 
@@ -262,8 +275,7 @@ Afterwards you can get a summary of the tests using this command:
 
    > colcon test-result
 
-To run the examples, first open a clean new ``cmd.exe`` and set up the workspace.
-This is done by sourcing the ``local_setup.bat`` file, which will automatically set up the environment for any DDS vendors that support was built for.
+To run the examples, first open a clean new ``cmd.exe`` and set up the workspace by sourcing the ``local_setup.bat`` file.
 Then execute the examples, e.g.:
 
 .. code-block:: bash

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -190,9 +190,8 @@ Downloading ROS 2
 
 * Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_eloquent``\ ).
 
-
-Set up the ROS 2 environment
-----------------------------
+Environment setup
+-----------------
 
 Start a command shell and source the ROS 2 setup file to set up the workspace:
 


### PR DESCRIPTION
Debians install page had the examples before the environment setup instructions.
Other pages (from-source on all platforms) were missing environment setup sections.
I just copied the environment setup sections across for like-platforms, but need a check that they make sense.

Signed-off-by: maryaB-osr <marya@openrobotics.org>