### PR TITLE
Clarify tutorial prereqs for installing turtlesim/rqt

### DIFF
--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -36,6 +36,7 @@ Before starting these tutorials, install ROS 2 by following the instructions on 
 
 The commands used in this tutorial assume you followed the binary packages installation guide for your operating system (Debian packages for Linux).
 You can still follow along if you built from source, but the path to your setup files will likely be different.
+You also won't be able to use the ``sudo apt install ros-<distro>-<package>`` command (used frequently in the beginner level tutorials) if you install from source.
 
 If you are using Linux or macOS, but are not already familiar with the shell, `this tutorial <http://www.ee.surrey.ac.uk/Teaching/Unix/>`__ will help.
 

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -30,6 +30,8 @@ Prerequisites
 
 The previous tutorial, :ref:`ConfigROS2`, will show you how to set up your environment.
 
+Turtlesim and rqt are only available in ROS 2 from Dashing onward.
+
 Tasks
 -----
 


### PR DESCRIPTION
Adding a couple sentences about what needs to be in place to use `sudo apt install ros-<distro>-turtlesim/rqt*`

Fixes #454 (more like "answers", since it's a question)

Signed-off-by: maryaB-osr <marya@openrobotics.org>