### PR TITLE
Re-write "Contact" page

### DIFF
--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -12,7 +12,7 @@ Support
 Need help troubleshooting your system?
 First, search `ROS Answers <https://answers.ros.org>`__ to see if others have had similar issues, and if their solution works for you.
 
-If not, ask a new question on ROS Answers.
+If not, ask a new question on `ROS Answers <https://answers.ros.org>`__.
 Make sure to add tags, at the very least the ``ros2`` tag and the distro version you are running, e.g. ``eloquent``.
 If your question is related to the documentation here, add a tag like ``docs``, or more specifically, ``tutorials``.
 

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -1,37 +1,75 @@
 .. _Help:
 
-Contact us
-==========
+Contact
+=======
 
-If you try out ROS 2 and have feedback or questions, please get in touch with us.
+Different types of questions or discussions correspond to different avenues of communication;
+check the descriptions below to ensure you choose the right method.
 
-General/design discussion
--------------------------
+Support
+-------
 
-Discussions about ROS 2 development and plans are happening on the `“Next Generation ROS” Discourse category <http://discourse.ros.org/c/ng-ros>`__ (previously on the `sig-ng-ros (Special Interest Group on Next-Generation ROS) mailing list <https://groups.google.com/forum/?fromgroups#!forum/ros-sig-ng-ros>`__).
-Join us there and participate in the conversation.
+Need help troubleshooting your system?
+First, search `ROS Answers <https://answers.ros.org>`__ to see if others have had similar issues, and if their solution works for you.
 
-If you'd like to contact us privately (e.g., if your question contains information sensitive to your organization or project), you can email us directly at ``ros@osrfoundation.org``.
+If not, ask a new question on ROS Answers.
+Make sure to add tags, at the very least the ``ros2`` tag and the distro version you are running, e.g. ``eloquent``.
+If your question is related to the documentation here, add a tag like ``docs``, or more specifically, ``tutorials``.
 
-Troubleshooting
----------------
+Contributing support
+^^^^^^^^^^^^^^^^^^^^
 
-If you need help with troubleshooting your system, please first check `ROS Answers <https://answers.ros.org>`__ to see if others have come across similar issues, otherwise ask a new questions on ROS Answers making sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``ardent``.
+ROS 2 users come from a wide range of technical backgrounds, use a variety of different operating systems, and don’t necessarily have any prior experience with ROS (1 or 2).
+So, it's important for users with any amount of experience to contribute support.
 
-Opening issues
---------------
+If you see an issue on `ROS Answers <http://answers.ros.org/questions/tags:ros2/>`__ that is similar to something you’ve run into yourself, please consider providing some pointers to what helped in your situation.
+Don’t worry if you aren't sure if your response is correct.
+Simply say so, and other community members will jump in if necessary.
 
-If you identify bugs, you can open an issue to notify the ROS team.
-Before opening an issue, check if other users have reported similar issues by searching across the ros2 and ament Github organizations: `example search query <https://github.com/search?type=Issues&q=user%3Aros2+user%3Aament+my+error+output>`__.
+Issues
+------
+
+If you identify bugs, have suggestions for improvements, or a question specific to one package, you can open an issue on GitHub to notify the ROS 2 team.
+
+For example, if you are following the :ref:`tutorials here <Tutorials>` and come across an instruction that doesn't work on your system,
+you can open an issue in the `ros2_documentation <https://github.com/ros2/ros2_documentation>`__ repo.
+
+You can search for individual ROS 2 repositories on `ROS 2's GitHub <https://github.com/ros2>`__.
+
+Before opening an issue, check if other users have reported similar issues by searching across the ros2 and ament Github organizations: `example search query <https://github.com/search?q=user%3Aros2+user%3Aament+turtlesim&type=Issues>`__.
 
 If it has not been reported, feel free to open an issue in the appropriate repository tracker.
 If it's not clear which tracker to use for a particular issue, file it in the `ros2/ros2 repository <https://github.com/ros2/ros2/issues>`__ and we'll have a look at it.
+
 When filing an issue, please make sure to:
 
-
 * Include enough information for another person to understand the issue.
-* Include information about the exact platform, software, versions, and environment relevant to the problem. This includes how you installed the software (from binaries or from source) and which ROS middleware/DDS vendor you are using (if you know it).
+* Include information about the exact platform, software, versions, and environment relevant to the problem.
+  This includes how you installed the software (from binaries or from source) and which ROS middleware/DDS vendor you are using (if you know it).
 * In case of a bug consider providing a `short, self contained, correct (compilable), example <http://sscce.org/>`__.
 
-Pull requests are welcome for any of `the ros2 repositories <https://github.com/ros2>`__ to suggest specific code changes!
-See :ref:`Contributing <Contributing>` for more details on how to contribute.
+Pull requests
+-------------
+
+When you feel comfortable enough to suggest a specific change directly to the code, you can submit a pull request.
+Pull requests are welcome for any of `the ros2 repositories <https://github.com/ros2>`__.
+See the :ref:`Contributing <Contributing>` page for more details and etiquette on how to contribute.
+
+Discussion
+----------
+
+To start a discussion with other ROS 2 community members, visit the official `ROS Discourse <https://discourse.ros.org/>`__.
+Content on the Discourse should be high-level;
+it's not a place to get *questions* about code answered, but it would be suitable to start a conversation about best practices or improving standards.
+
+Discussions about ROS 2 development and plans are happening on the `“Next Generation ROS” Discourse category <http://discourse.ros.org/c/ng-ros>`__.
+Participating in these discussions is an important way to have a say on how different features of ROS 2 will work and be implemented.
+
+The diverse community behind the ROS ecosystem is one of its greatest assets.
+We encourage all members of the ROS community to participate in these design discussions so that we can leverage the experience of community members, and keep the varied use cases of ROS in mind.
+
+Private contact
+---------------
+
+Mail us directly for sensitive information
+If you'd like to contact us privately (e.g., if your question contains information sensitive to your organization or project), you can email us directly at ``ros@osrfoundation.org``.

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -29,7 +29,7 @@ Simply say so, and other community members will jump in if necessary.
 Issues
 ------
 
-If you identify bugs, have suggestions for improvements, or a question specific to one package, you can open an issue on GitHub to notify the ROS 2 team.
+If you identify bugs, have suggestions for improvements, or a question specific to one package, you can open an issue on GitHub.
 
 For example, if you are following the :ref:`tutorials here <Tutorials>` and come across an instruction that doesn't work on your system,
 you can open an issue in the `ros2_documentation <https://github.com/ros2/ros2_documentation>`__ repo.

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -71,4 +71,4 @@ We encourage all members of the ROS community to participate in these design dis
 Private contact
 ---------------
 
-If you'd like to contact us privately (e.g., if your question contains information sensitive to your organization or project), you can email us directly at ``ros@osrfoundation.org``.
+If you'd like to contact us privately (e.g., if your question contains information sensitive to your organization or project, or if it's regarding a security issue), you can email us directly at ``ros@osrfoundation.org``.

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -71,5 +71,4 @@ We encourage all members of the ROS community to participate in these design dis
 Private contact
 ---------------
 
-Mail us directly for sensitive information
 If you'd like to contact us privately (e.g., if your question contains information sensitive to your organization or project), you can email us directly at ``ros@osrfoundation.org``.

--- a/source/Contributing.rst
+++ b/source/Contributing.rst
@@ -39,23 +39,11 @@ Tenets
 
 There are a number of ways you can contribute to the ROS 2 project.
 
-Design discussions
-------------------
+Discussions and support
+-----------------------
 
-Discussions about the design of ROS 2 are ongoing on the `ROS 2 forum <http://discourse.ros.org/c/ng-ros>`__.
-Participating in these discussions is an important way to have a say on how different features of ROS 2 will work and will be implemented.
-
-The diverse community behind the ROS ecosystem is one of its greatest assets.
-We encourage all members of the ROS community to participate in these design discussions so that we can 1) leverage the experience of community members, and 2) keep the varied use cases of ROS in mind.
-
-Support
--------
-
-One of the easiest ways that you can contribute to ROS 2 is by helping other community members troubleshoot their system.
-ROS 2 users come from a range of technical backgrounds, use a variety of different operating systems/platforms, and don’t necessarily have any prior experience with ROS (1 or 2).
-
-If you see an issue on `ROS Answers <http://answers.ros.org/questions/tags:ros2/>`__ that is similar to something you’ve run into yourself, please consider providing some pointers to what helped in your situation.
-+Don’t worry if you are not sure if your response is correct - simply say so, and other community members will jump in if necessary.
+Some of the easiest ways to contribute to ROS 2 involve engaging in community discussions and support.
+You can find more information on how to pitch in on the :ref:`Contact <Help>` page.
 
 Contributing code
 -----------------

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -11,8 +11,7 @@ We recommend following the tutorials in order, from the "Users" set to the "Deve
 
 You're welcome to pick tutorials out of the set if you're looking for something specific, just understand that the tutorials build off of each other and are not meant to be comprehensive documentation.
 These tutorials are under construction, so please share your `feedback <https://github.com/ros2/ros2_documentation/issues/new>`__.
-
-.. Feedback is placeholder for actual feedback solution in development
+The :ref:`Contact <Help>` page includes more ways to get help.
 
 .. note::
 


### PR DESCRIPTION
Includes moving info from Contributing page and linking to Contact instead of repeating.
Also linking on Tutorials page so learners know how to find help.

Signed-off-by: maryaB-osr <marya@openrobotics.org>