### PR TITLE
Adding TF2 timer interface migration information

### DIFF
--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -166,6 +166,21 @@ Here is the related pull request:
 
 `https://github.com/ros2/rviz/pull/455 <https://github.com/ros2/rviz/pull/455>`_
 
+TF2 Buffer
+^^^^^^^^^^
+
+TF2 buffers have to be given a timer interface, ei
+
+.. code-block:: cpp
+
+    tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+    /* New addition */
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+      this->get_node_base_interface(),
+      this->get_node_timers_interface());
+    tf_->setCreateTimerInterface(timer_interface);
+    transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_);
+
 Timeline before the release
 ---------------------------
 

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -169,7 +169,9 @@ Here is the related pull request:
 TF2 Buffer
 ^^^^^^^^^^
 
-TF2 buffers now have to be given a timer interface. If a timer interface is not given, an exception will be thrown.
+TF2 buffers now have to be given a timer interface.
+
+If a timer interface is not given, an exception will be thrown.
 
 For example:
 

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -169,17 +169,20 @@ Here is the related pull request:
 TF2 Buffer
 ^^^^^^^^^^
 
-TF2 buffers have to be given a timer interface, ei
+TF2 buffers now have to be given a timer interface. If a timer interface is not given, an exception will be thrown.
+
+For example:
 
 .. code-block:: cpp
 
-    tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
-    /* New addition */
+    tf = std::make_shared<tf2_ros::Buffer>(get_clock());
+    // The next two lines are new in Eloquent
     auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
       this->get_node_base_interface(),
       this->get_node_timers_interface());
-    tf_->setCreateTimerInterface(timer_interface);
-    transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_);
+    tf->setCreateTimerInterface(timer_interface);
+    // Pass the Buffer to the TransformListener as before
+    transform_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
 
 Timeline before the release
 ---------------------------


### PR DESCRIPTION
Eloquent is missing this for TF2 which I think is important enough to be noted in the migration guide. 