### PR TITLE
Clarify rosdep exceptions in beginner tutorials

### DIFF
--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -96,6 +96,8 @@ Create a workspace and clone all repos:
    wget https://raw.githubusercontent.com/ros2/ros2/eloquent/ros2.repos
    vcs import src < ros2.repos
 
+.. _Eloquent_linux-development-setup-install-dependencies-using-rosdep:
+
 Install dependencies using rosdep
 ---------------------------------
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -49,6 +49,7 @@ Installing and initializing rosdep
        sudo rosdep init
        rosdep update
 
+.. _Eloquent_linux-install-binary-install-missing-dependencies:
 
 Installing the missing dependencies
 -----------------------------------

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -15,8 +15,8 @@ The :ref:`Contact <Help>` page includes more ways to get help.
 
 .. note::
 
-  Currently, the beginner level tutorials target **Eloquent**.
-  Certain features may not be available for older distributions.
+  Currently, the beginner level tutorials target **Eloquent**, installed from `Debians on Linux </Installation/Linux-Install-Debians>`.
+  Certain features and commands may not be available for older distributions/other installation types.
 
 Users
 ^^^^^

--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -159,18 +159,14 @@ Before building the workspace, you need to resolve package dependencies.
 You may have all the dependencies already, but best practice is to check for dependencies every time you clone.
 You wouldn’t want a build to fail after a long wait because of missing dependencies.
 
-From the root of your workspace (``~/dev_ws``):
-Run the following command, replacing ``<distro>`` with your distro:
+From the root of your workspace (``~/dev_ws``), run the following command, replacing ``<distro>`` with your distro:
 
 .. code-block:: console
 
   sudo rosdep install -i --from-path src --rosdistro <distro> -y
 
-For example, if you're using Eloquent, you would run:
-
-.. code-block:: console
-
-  sudo rosdep install -i --from-path src --rosdistro eloquent -y
+If you installed ROS 2 on Linux from source or the "fat" archive, you will need to use the rosdep command from their installation instructions.
+For example, here are the Eloquent :ref:`from-source rosdep section <Eloquent_linux-development-setup-install-dependencies-using-rosdep>` and the :ref:`"fat" archive rosdep section <Eloquent_linux-install-binary-install-missing-dependencies>`.
 
 If you already have all your dependencies, the console will return:
 

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -396,13 +396,13 @@ Make sure to save the file, and then your pub/sub system should be ready for use
 4 Build and run
 ^^^^^^^^^^^^^^^
 You likely already have the ``rclpp`` and ``std_msgs`` packages installed as part of your ROS 2 system.
-In any case, it's good practice to run ``rosdep`` in the root of your workspace to check for missing dependencies before building:
+In any case, it's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
 
 .. code-block:: console
 
     sudo rosdep install -i --from-path src --rosdistro <distro> -y
 
-Navigate back to the root of your workspace, ``dev_ws``, and build your new package:
+Still in the root of your workspace, ``dev_ws``, build your new package:
 
 .. code-block:: console
 

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -396,7 +396,7 @@ Make sure to save the file, and then your pub/sub system should be ready for use
 4 Build and run
 ^^^^^^^^^^^^^^^
 You likely already have the ``rclpp`` and ``std_msgs`` packages installed as part of your ROS 2 system.
-In any case, it's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
+It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
 
 .. code-block:: console
 

--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -307,6 +307,12 @@ After removing some unnecessary boilerplate from the automatically generated fil
 4 Build and run
 ^^^^^^^^^^^^^^^
 
+It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
+
+.. code-block:: console
+
+  sudo rosdep install -i --from-path src --rosdistro <distro> -y
+
 Navigate back to the root of your workspace, ``dev_ws``, and build your new package:
 
 .. code-block:: console

--- a/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -384,7 +384,7 @@ Make sure to save the file, and then your pub/sub system should be ready for use
 4 Build and run
 ^^^^^^^^^^^^^^^
 You likely already have the ``rclpy`` and ``std_msgs`` packages installed as part of your ROS 2 system.
-In any case, it's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
+It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
 
 .. code-block:: console
 

--- a/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -386,21 +386,9 @@ Make sure to save the file, and then your pub/sub system should be ready for use
 You likely already have the ``rclpy`` and ``std_msgs`` packages installed as part of your ROS 2 system.
 In any case, it's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
 
-.. tabs::
+.. code-block:: console
 
-  .. group-tab:: Linux
-
-    .. code-block:: console
-
-      sudo rosdep install -i --from-paths ./src -y
-
-  .. group-tab:: macOS
-
-    You will already have ``rclpy`` and ``std_msgs`` from your installation.
-
-  .. group-tab:: Windows
-
-    You will already have ``rclpy`` and ``std_msgs`` from your installation.
+  sudo rosdep install -i --from-path src --rosdistro <distro> -y
 
 Still in the root of your workspace, ``dev_ws``, build your new package:
 

--- a/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
@@ -260,6 +260,12 @@ The ``entry_points`` field of your ``setup.py`` file should look like this:
 4 Build and run
 ^^^^^^^^^^^^^^^
 
+It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
+
+.. code-block:: console
+
+  sudo rosdep install -i --from-path src --rosdistro <distro> -y
+
 Navigate back to the root of your workspace, ``dev_ws``, and build your new package:
 
 .. code-block:: console


### PR DESCRIPTION
Closes #469 

I'm not crazy about adding a lot of "ifs" to the tutorials. There could be a whole page written about rosdep conditions for different platforms and installation types. Instead I added to the note on the front tutorial page emphasizing that these tutorials target Debian installation (previously only mentioned in the first tutorial, "Configuring your ROS 2 environment")

I also added one note about using the rosdep command relevant to your installation to the "Creating a workspace" tutorial. I think that's fair because the main tutorial page does say that the tutorials build on each other, and that one comes before the others where rosdep is used. 

Signed-off-by: maryaB-osr <marya@openrobotics.org>