### PR TITLE
Update Using-Rqt-Console.rst

### DIFF
--- a/source/Tutorials/Rqt-Console/Using-Rqt-Console.rst
+++ b/source/Tutorials/Rqt-Console/Using-Rqt-Console.rst
@@ -114,7 +114,7 @@ Enter the following command in your terminal:
 
 .. code-block:: console
 
-        ros2 run turtlesim turtlesim_node --ros-args --remap __log_level:=WARN
+        ros2 run turtlesim turtlesim_node --ros-args --log-level WARN
 
 Now you won’t see the initial ``Info`` level warnings that came up in the console last time you started ``turtlesim``.
 That’s because ``Info`` messages are lower priority than the new default severity, ``Warn``.


### PR DESCRIPTION
Running the old command to set the log-level gives the following error: 
[ERROR] [rcl]: Failed to parse global arguments

The proposed command (partially from: [link](https://index.ros.org/doc/ros2/Tutorials/Logging-and-logger-configuration/#logger-level-configuration-command-line) ) works.