### PR TITLE
Update image name and tag in docker examples

### DIFF
--- a/source/Tutorials/Run-2-nodes-in-a-single-docker-container.rst
+++ b/source/Tutorials/Run-2-nodes-in-a-single-docker-container.rst
@@ -5,18 +5,18 @@
 Running 2 nodes in a single docker container [community-contributed]
 ====================================================================
 
-Pull the ROS2 docker image with tag "ardent-basic".
+Pull the ROS docker image with tag "eloquent-desktop".
 
 .. code-block:: bash
 
-   docker pull osrf/ros2:ardent-basic
+   docker pull osrf/ros:eloquent-desktop
 
 
 Run the image in a container in interactive mode.
 
 .. code-block:: bash
 
-   $ docker run -it osrf/ros2:ardent-basic
+   $ docker run -it osrf/ros:eloquent-desktop
    root@<container-id>:/#
 
 

--- a/source/Tutorials/Run-2-nodes-in-two-separate-docker-containers.rst
+++ b/source/Tutorials/Run-2-nodes-in-two-separate-docker-containers.rst
@@ -9,13 +9,13 @@ Open a terminal. Run the image in a container in interactive mode and launch a t
 
 .. code-block:: bash
 
-   docker run -it --rm osrf/ros2:ardent-basic ros2 run demo_nodes_cpp talker
+   docker run -it --rm osrf/ros:eloquent-desktop ros2 run demo_nodes_cpp talker
 
 Open a second terminal. Run the image in a container in interactive mode and launch a topic subscriber (executable ``listener`` from the package ``demo_nodes_cpp``)  with ``ros2 run``:
 
 .. code-block:: bash
 
-   docker run -it --rm osrf/ros2:ardent-basic ros2 run demo_nodes_cpp listener
+   docker run -it --rm osrf/ros:eloquent-desktop ros2 run demo_nodes_cpp listener
 
 As an alternative to the command line invocation, you can create a ``docker-compose.yml`` file (here version 2) with the following (minimal) content:
 
@@ -25,10 +25,10 @@ As an alternative to the command line invocation, you can create a ``docker-comp
 
    services:
      talker:
-       image: osrf/ros2:ardent-basic
+       image: osrf/ros:eloquent-desktop
        command: ros2 run demo_nodes_cpp talker
      listener:
-       image: osrf/ros2:ardent-basic
+       image: osrf/ros:eloquent-desktop
        command: ros2 run demo_nodes_cpp listener
        depends_on:
          - talker


### PR DESCRIPTION
Current docker examples are no longer working because the `osrf/ros2` image does not have the `ardent-basic` tag anymore. 
Updated the example to use `osrf/ros` image and `eloquent-desktop` tag.