### PR TITLE
Update Windows install instructions image from MSVC17 to MSVC19

### DIFF
--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -77,9 +77,10 @@ Make sure that the Visual C++ features are installed.
 
 An easy way to make sure they're installed is to select the ``Desktop development with C++`` workflow during the install.
 
-   .. image:: https://i.imgur.com/2h0IxCk.png
+Make sure that no C++ CMake tools are installed by unselecting them in the list of components to be installed as in the image below.
 
-Make sure that no C++ CMake tools are installed by unselecting them in the list of components to be installed.
+   .. image:: https://i.imgur.com/F2TONuw.png
+
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Previous image was for MSVC17, which does not require deselecting CMake tools - the required version MSVC19 does require deselecting (although, I am not sure deselecting the CMake tools is actually necessary).