### PR TITLE
Update required Linux and rosdep versions for Foxy

### DIFF
--- a/source/Installation/Foxy.rst
+++ b/source/Installation/Foxy.rst
@@ -14,7 +14,7 @@ Binary packages
 
 We provide ROS 2 binary packages for the following platforms:
 
-* Linux (Ubuntu Bionic(18.04))
+* Linux (Ubuntu Focal(20.04))
 
   * `Debian packages <Foxy/Linux-Install-Debians>`
   * `"fat" archive <Foxy/Linux-Install-Binary>`

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -12,12 +12,12 @@ System Requirements
 -------------------
 Target platforms for Foxy Fitzroy are (see `REP 2000 <http://www.ros.org/reps/rep-2000.html>`__):
 
-- Tier 1: Ubuntu Linux - Bionic Beaver (18.04) 64-bit
+- Tier 1: Ubuntu Linux - Focal Fossa (20.04) 64-bit
 
 Tier 3 platforms (not actively tested or supported) include:
 
-- Debian Linux - Stretch (9)
-- Fedora 30, see `alternate instructions <Fedora-Development-Setup>`
+- Debian Linux - Buster (10)
+- Fedora 31, see `alternate instructions <Fedora-Development-Setup>`
 - Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/ROS#ROS_2>`__
 - OpenEmbedded / webOS OSE, see `alternate instructions <https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions>`__
 
@@ -54,7 +54,7 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-pip \
-     python-rosdep \
+     python3-rosdep \
      python3-vcstool \
      wget
    # install some pip packages needed for testing

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -17,7 +17,7 @@ Target platforms for Foxy Fitzroy are (see `REP 2000 <http://www.ros.org/reps/re
 Tier 3 platforms (not actively tested or supported) include:
 
 - Debian Linux - Buster (10)
-- Fedora 31, see `alternate instructions <Fedora-Development-Setup>`
+- Fedora 32, see `alternate instructions <Fedora-Development-Setup>`
 - Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/ROS#ROS_2>`__
 - OpenEmbedded / webOS OSE, see `alternate instructions <https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions>`__
 

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -12,9 +12,7 @@ As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
 System Requirements
 -------------------
 
-We support Ubuntu Linux Bionic Beaver (18.04) and Ubuntu Xenial Xerus (16.04) on 64-bit x86 and 64-bit ARM.
-
-Note: Ardent and beta versions supported Ubuntu Xenial Xerus 16.04.
+We support Ubuntu Linux Focal Fossa (20.04) 64-bit x86 and 64-bit ARM.
 
 Add the ROS 2 apt repository
 ----------------------------
@@ -45,7 +43,7 @@ Installing and initializing rosdep
 .. code-block:: bash
 
        sudo apt update
-       sudo apt install -y python-rosdep
+       sudo apt install -y python3-rosdep
        sudo rosdep init
        rosdep update
 

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -5,14 +5,14 @@ Installing ROS 2 via Debian Packages
    :depth: 2
    :local:
 
-Debian packages for ROS 2 Foxy Fitzroy are available for Ubuntu Bionic.
+Debian packages for ROS 2 Foxy Fitzroy are available for Ubuntu Focal.
 
 Resources
 ---------
 
 * Status Page:
 
-  * ROS 2 Foxy (Ubuntu Bionic): `amd64 <http://repo.ros2.org/status_page/ros_foxy_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_foxy_ubv8.html>`__
+  * ROS 2 Foxy (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_foxy_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_foxy_ubv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 


### PR DESCRIPTION
Addressing some of the comments from #445:

https://github.com/ros2/ros2_documentation/pull/445#discussion_r362993122

https://github.com/ros2/ros2_documentation/pull/445#discussion_r362993384

https://github.com/ros2/ros2_documentation/pull/445#discussion_r362993483