### PR TITLE
Specify the packages involved in the Foxy release timeline

### DIFF
--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -62,7 +62,8 @@ Timeline before the release
 A few milestones leading up to the release:
 
     Wed. April 8th, 2020
-        API and feature freeze for ``ros_core`` [1]_ packages
+        API and feature freeze for ``ros_core`` [1]_ packages.
+        Note that this includes ``rmw``, which is a recursive dependency of ``ros_core``.
         Only bug fix releases should be made after this point.
         New packages can be released independently.
 

--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -62,17 +62,20 @@ Timeline before the release
 A few milestones leading up to the release:
 
     Wed. April 8th, 2020
-        API and feature freeze for core packages
+        API and feature freeze for ``ros_core`` [1]_ packages
         Only bug fix releases should be made after this point.
         New packages can be released independently.
 
     Mon. April 13th, 2020 (beta)
-        Updated releases of core packages available.
+        Updated releases of ``desktop`` [2]_ packages available.
         Testing of the new features.
 
     Wed. May 13th, 2020 (release candidate)
-        Updated releases of core packages available.
+        Updated releases of ``desktop`` [2]_ packages available.
 
     Wed. May 20, 2020
         Freeze rosdistro.
         No PRs for Foxy on the `rosdistro` repo will be merged (reopens after the release announcement).
+
+.. [1] The ``ros_core`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.
+.. [2] The ``desktop`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.


### PR DESCRIPTION
For intermediate releases, people can expect the desktop variants which I believe is consistent with our release history. Regarding the early API and feature freeze deadline, I've restricted it to a smaller set of packages, leaving out more leafy packages.