### PR TITLE
Update docs which reference deleted repo

### DIFF
--- a/source/Tutorials/RQt-Port-Plugin-Windows.rst
+++ b/source/Tutorials/RQt-Port-Plugin-Windows.rst
@@ -17,7 +17,7 @@ RQt Porting examples
 Microsoft pushed an effort to port much of ROS to Windows, their pull request is a good resource for necessary changes.
 For example: https://github.com/ros-visualization/qt_gui_core/pull/188
 
-Here is the ROS 2 port of `qt_gui_core <https://github.com/ros-visualization/qt_gui_core/pull/146/commits/c3a9630de6fed3c46684925e7688b6d4c7b8baf8>`__.
+Here is the ROS 2 port of `qt_gui_core <https://github.com/ros-visualization/qt_gui_core/commit/6fb9624033a849f56d1bc1aad0e40d252bf99c2b>`_.
 
 Here is the ROS 2 port of `python_qt_binding <https://github.com/ros-visualization/python_qt_binding/pull/56>`__.
 

--- a/source/Tutorials/RQt-Port-Plugin-Windows.rst
+++ b/source/Tutorials/RQt-Port-Plugin-Windows.rst
@@ -14,9 +14,8 @@ RQt has not been historically supported on Windows, but compatibility is happeni
 RQt Porting examples
 --------------------
 
-Microsoft pushed an effort to port much of ROS to Windows, their repos are a good resource for necessary changes.
-They live at the ms-iot organization with branches called init-windows.
-For example: https://github.com/ms-iot/qt_gui_core/tree/init_windows
+Microsoft pushed an effort to port much of ROS to Windows, their pull request is a good resource for necessary changes.
+For example: https://github.com/ros-visualization/qt_gui_core/pull/188
 
 Here is the ROS 2 port of `qt_gui_core <https://github.com/ros-visualization/qt_gui_core/pull/146/commits/c3a9630de6fed3c46684925e7688b6d4c7b8baf8>`__.
 


### PR DESCRIPTION
This page contained a link to a repo which no longer exists. It has been up-streamed into the main repo. 