### PR TITLE
Add link to ROS2 launch file migrator

### DIFF
--- a/source/Contributing/Examples-and-Tools-for-ROS1----ROS2-Migrations.rst
+++ b/source/Contributing/Examples-and-Tools-for-ROS1----ROS2-Migrations.rst
@@ -22,5 +22,6 @@ Examples of system level migrations
 Useful tools
 ------------
 
+- Launch File migrator that converts a ROS1 XML launch file to a ROS2 Python launch file: https://github.com/aws-robotics/ros2-launch-file-migrator
 -  Amazon has exposed their tools for porting ROS1 robots to ROS2
-   https://github.com/awslabs/ros2-migration-tools/tree/master/ros2\_migration/porting\_tools
+   https://github.com/awslabs/ros2-migration-tools/tree/master/porting\_tools


### PR DESCRIPTION
- Add link to ROS2 launch file migrator in Useful tools section
- Fix link to porting_tools directory inside ros2-migration-tools repository