### PR TITLE
Updates to macOS install pages for Eloquent

### DIFF
--- a/source/Installation/Eloquent/OSX-Development-Setup.rst
+++ b/source/Installation/Eloquent/OSX-Development-Setup.rst
@@ -9,9 +9,9 @@ Building ROS 2 on OS X
 System requirements
 -------------------
 
-We support OS X 10.12.x.
+We support macOS 10.14 (Mojave).
 
-However, some new versions like 10.13.x and some older versions like 10.11.x and 10.10.x are known to work as well.
+However, some older versions like 10.13.x are known to work as well.
 
 Install prerequisites
 ---------------------

--- a/source/Installation/Eloquent/OSX-Install-Binary.rst
+++ b/source/Installation/Eloquent/OSX-Install-Binary.rst
@@ -10,7 +10,7 @@ This page explains how to install ROS 2 on OS X from a pre-built binary package.
 System requirements
 -------------------
 
-We support OS X Sierra (10.12.x).
+We support macOS 10.14 (Mojave).
 
 .. _Eloquent_osx-install-binary-installling-prerequisites:
 

--- a/source/Installation/Eloquent/OSX-Install-Binary.rst
+++ b/source/Installation/Eloquent/OSX-Install-Binary.rst
@@ -100,7 +100,7 @@ You need the following things installed before installing ROS 2.
 
   .. code-block:: bash
 
-       python3 -m pip install catkin_pkg empy ifcfg lark-parser lxml numpy pyparsing pyyaml setuptools argcomplete
+       python3 -m pip install catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy pyparsing pyyaml setuptools argcomplete
 
 Disable System Integrity Protection (SIP)
 -----------------------------------------


### PR DESCRIPTION
* Update macOS version on Eloquent install pages
Supported version is Mojave.
* Add missing macOS Python dependencies for Eloquent binary install
`cryptography` and `netifaces`