### PR TITLE
Clarify OpenSSL version to install

### DIFF
--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -38,9 +38,9 @@ Open a Command Prompt and type the following to install Python via Chocolatey:
 Install OpenSSL
 ^^^^^^^^^^^^^^^
 
-Download an OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
-Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2*.
-Don't download the Win32 or Light versions.
+Download the *Win64 OpenSSL v1.0.2u* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
+Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2u*.
+Don't download the Win32 or Light versions or version 1.1.0 or newer.
 
 Run the installer with default parameters.
 The following commands assume you used the default installation directory:

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -47,9 +47,9 @@ Open a Command Prompt and type the following to install them via Chocolatey:
 Install OpenSSL
 ^^^^^^^^^^^^^^^
 
-Download an OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
-Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2*.
-Don't download the Win32 or Light versions.
+Download the *Win64 OpenSSL v1.0.2u* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
+Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2u*.
+Don't download the Win32 or Light versions or version 1.1.0 or newer.
 
 Run the installer with default parameters.
 The following commands assume you used the default installation directory:

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -47,9 +47,9 @@ Open a Command Prompt and type the following to install them via Chocolatey:
 Install OpenSSL
 ^^^^^^^^^^^^^^^
 
-Download an OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
-Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2*.
-Don't download the Win32 or Light versions.
+Download the *Win64 OpenSSL v1.0.2u* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
+Scroll to the bottom of the page and download *Win64 OpenSSL v1.0.2u*.
+Don't download the Win32 or Light versions or version 1.1.0 or newer.
 
 Run the installer with default parameters.
 The following commands assume you used the default installation directory:


### PR DESCRIPTION
Added clarity that v1.0.2u should be installed

Using a newer version may cause issues per https://github.com/ros2/ros2_documentation/issues/488

From OpenSSL website:
- "OpenSSL 1.1.0 and later are quite different from previous releases"
- "Version 1.0.2 is no longer supported"
- long term we will need to address why v1.1.0 results in the issue linked above