### PR TITLE
Patch 1 domain

### DIFF
--- a/source/Contributing/ROS-2-On-boarding-Guide.rst
+++ b/source/Contributing/ROS-2-On-boarding-Guide.rst
@@ -46,8 +46,8 @@ To request access send an email to ros@osrfoundation.org (anybody on the mailing
 Choose a DDS domain ID
 ----------------------
 
-ROS2 uses DDS as the underlying transport and DDS supports a physical segmentation of the network based on the "domain ID" (it is used to calculate the multicast port.
-We use a unique value for this on each machine to keep our ROS2 nodes from interfering from each other.
+ROS2 uses DDS as the underlying transport and DDS supports a physical segmentation of the network based on the "domain ID" (it is used to calculate the multicast port).
+We use a unique value for this on each machine (or group of machines) to keep each group's ROS2 nodes from interfering with other developers' testing.
 We expose this setting via the ``ROS_DOMAIN_ID`` environment variable and use a document to ensure we don't accidentally choose the same one as someone else.
 This is, however, only important for people who will be working on the OSRF network, but it isn't a bad idea to set up at any organization with multiple ROS 2 users on the same network.
 

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -143,10 +143,13 @@ If you need more specific help (because environment setup files can come from di
 3.1 The ``ROS_DOMAIN_ID`` variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your lab or office has multiple computers running ROS 2, it is important that each system sets a unique integer for the environment variable ``ROS_DOMAIN_ID``.
+If your lab or office has multiple, different groups of computers running ROS 2, and you want to avoid cross-talk between the groups, choose a single integer and set it as the environment variable ``ROS_DOMAIN_ID`` on all the computers in a group. Choose a different, unique integer for each subgroup. (For the default RMW on eProsima Fast RTPS, as of ROS 2 Eloquent, this integer must be between 0-232 for the ROS 2 daemon to successfully start.)
 
-The domain ID is used to segment the network in order to avoid interference between ROS 2 programs.
-Once you have determined a unique integer for yourself, you can set the environment variable with the following command:
+The domain ID is used to segment the network in order to avoid interference between different groups of computers running ROS 2 on the same local area network. Machines with different domain id's will not talk, nor interfere, with each other.
+
+If you run into issues having multiple computers talk to each other check Troubleshooting (https://index.ros.org/doc/ros2/Troubleshooting/). Additionally, there are multiple answers at discouse.ros.org and answers.ros.org with more in-depth information.
+
+Once you have determined a unique integer for your group of ROS 2 agents, you can set the environment variable with the following command:
 
 .. tabs::
 


### PR DESCRIPTION
Fixes Issue #535 
The Contributors guide was also confusing, so I included a small change to it. Though any contributors likely already know how to use the domain id properly, if a random user happens upon that file first, it could be confusing.

I included the 0-232 limit for two reasons:
1) https://answers.ros.org/question/318386/ros2-max-domain-id/
2) I tested on a fresh install of Ubuntu and ROS2 Eloquent. `ros2 daemon start` fails when `ROS_DOMAIN_ID` is above 232.