### PR TITLE
Replace 'ROS2' with 'ROS 2' in plain text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribute
 
-The source files for all the ROS2 documentation are under the /source directory. The sources are in [ReStructuredText](http://docutils.sourceforge.net/rst.html) format (.rst).
+The source files for all the ROS 2 documentation are under the /source directory. The sources are in [ReStructuredText](http://docutils.sourceforge.net/rst.html) format (.rst).
 
 
 ## Building documentation locally
@@ -18,6 +18,6 @@ If you are a Github user, the most effective way to contribute is to submit a pu
 If you don't feel comfortable creating a pull request or you want to make a general suggestion or start a discussion about the documentation, you can create a Github issue on this repository.
 
 
-# Contributing to ROS2
+# Contributing to ROS 2
 
-To contribute to the ROS2 source code project please refer to the [ROS2 contributing guidelines](https://index.ros.org/doc/ros2/Contributing/).
+To contribute to the ROS 2 source code project please refer to the [ROS 2 contributing guidelines](https://index.ros.org/doc/ros2/Contributing/).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ROS Documentation
 =================
 
 
-This is the ROS2 documentation site.
+This is the ROS 2 documentation site.
 
 
 ## Project structure

--- a/source/Concepts/ROS-2-Client-Libraries.rst
+++ b/source/Concepts/ROS-2-Client-Libraries.rst
@@ -2,8 +2,8 @@
 
    ROS-2-Client-Libraries
 
-About ROS2 client libraries
-===========================
+About ROS 2 client libraries
+============================
 
 .. contents:: Table of Contents
    :local:

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -17,7 +17,7 @@ General Principles
 Some principles are common to all ROS 2 development:
 
 
-* **Shared ownership**: Everybody working on ROS2 should feel ownership over all parts of the system.
+* **Shared ownership**: Everybody working on ROS 2 should feel ownership over all parts of the system.
   The original author of a chunk of code does not have any special permission or obligation to control or maintain that chunk of code.
   Everyone is free to propose changes anywhere, to handle any type of ticket, and to review any pull request.
 * **Be willing to work on anything**: As a corollary to shared ownership, everybody should be willing to take on any available task and contribute to any aspect of the system.
@@ -158,7 +158,7 @@ Whether or not a design document is required for your change depends on how big 
   * You should fork the repository and submit a pull request detailing the design.
 
   Mention the related ros2 issue (for example, ``Design doc for task ros2/ros2#<issue id>``) in the pull request or the commit message.
-  Detailed instructions are on the `ROS2 Contribute <http://design.ros2.org/contribute.html>`__ page.
+  Detailed instructions are on the `ROS 2 Contribute <http://design.ros2.org/contribute.html>`__ page.
   Design comments will made directly on the pull request.
 
 If the task is planned to be released with a specific version of ROS, this information should be included in the pull request.

--- a/source/Contributing/Examples-and-Tools-for-ROS1----ROS2-Migrations.rst
+++ b/source/Contributing/Examples-and-Tools-for-ROS1----ROS2-Migrations.rst
@@ -14,7 +14,7 @@ Examples of node/component level migrations
 Examples of system level migrations
 -----------------------------------
 
--  Turtlebot has been ported to ROS2
+-  Turtlebot has been ported to ROS 2
    https://discourse.ros.org/t/tb3-introducing-ros2-tutorials/5959
 -  Toyota's Jaguar 4x4
    https://roscon.ros.org/2018/presentations/ROSCon2018\_supercharging\_the\_jaguar4x4.pdf
@@ -22,6 +22,6 @@ Examples of system level migrations
 Useful tools
 ------------
 
-- Launch File migrator that converts a ROS1 XML launch file to a ROS2 Python launch file: https://github.com/aws-robotics/ros2-launch-file-migrator
--  Amazon has exposed their tools for porting ROS1 robots to ROS2
+- Launch File migrator that converts a ROS1 XML launch file to a ROS 2 Python launch file: https://github.com/aws-robotics/ros2-launch-file-migrator
+-  Amazon has exposed their tools for porting ROS1 robots to ROS 2
    https://github.com/awslabs/ros2-migration-tools/tree/master/porting\_tools

--- a/source/Contributing/Quality-Guide.rst
+++ b/source/Contributing/Quality-Guide.rst
@@ -5,27 +5,27 @@
 Quality Guide: Ensuring code quality
 ====================================
 
-This section tries to give guidance about how to improve the software quality of ROS2 packages. The guide uses a pattern language based approach to improve the readers experience ("read little, understand fast, understand much, apply easily").
+This section tries to give guidance about how to improve the software quality of ROS 2 packages. The guide uses a pattern language based approach to improve the readers experience ("read little, understand fast, understand much, apply easily").
 
 **What this sections is about:**
 
 
-* ROS2 core, application and ecosystem packages.
-* ROS2 core client libraries C++ and Python (right now: mainly C++)
+* ROS 2 core, application and ecosystem packages.
+* ROS 2 core client libraries C++ and Python (right now: mainly C++)
 * Design and implementation considerations to improve quality attributes like "Reliability", "Security", "Maintainability", "Determinism", etc. which relate to non-functional requirements (right now: mainly "Reliability").
 
 **What this section is not about:**
 
 
-* Design and implementation considerations which go beyond a single ROS2 package and a single ROS2 node (means no integration considerations w.r.t. ROS2 graphs, etc.).
+* Design and implementation considerations which go beyond a single ROS 2 package and a single ROS 2 node (means no integration considerations w.r.t. ROS 2 graphs, etc.).
 * Organizational considerations to improve software quality (an organizations structure and processes, etc.).
 * Infrastructural considerations which go beyond a single repository (overall continuous integration infrastructure, etc.)
 
 **Relation to other sections:**
 
 
-* The `Design Guide <Design-Guide>` summarizes design patterns for ROS2 packages. As quality is highly impacted by design it is a good idea to have a look into it before.
-* The `Developer Guide <Developer-Guide>` explains what to consider when contributing to ROS2 packages w.r.t. to contribution workflow (organizational), coding conventions, documentation considerations, etc. All these consideration may have an impact on single or several quality attributes.
+* The `Design Guide <Design-Guide>` summarizes design patterns for ROS 2 packages. As quality is highly impacted by design it is a good idea to have a look into it before.
+* The `Developer Guide <Developer-Guide>` explains what to consider when contributing to ROS 2 packages w.r.t. to contribution workflow (organizational), coding conventions, documentation considerations, etc. All these consideration may have an impact on single or several quality attributes.
 
 Patterns
 --------
@@ -37,14 +37,14 @@ Patterns
   * Static code analysis as part of the ament package build
 
 * Dynamic code analysis
-* ROS2 library test
+* ROS 2 library test
 
   * (referencing of generic unit test patterns like from `xUnitPatterns <http://xunitpatterns.com/Book%20Outline%20Diagrams.html>`__ with references to C++ gtest+gmock/Python unittest implementations)
-  * (ROS2 specific unit test use cases)
+  * (ROS 2 specific unit test use cases)
   * Property based test (C++ `RapidCheck <https://github.com/emil-e/rapidcheck>`__ / Python `hypothesis <https://github.com/HypothesisWorks/hypothesis-python>`__)
   * Code coverage analysis
 
-* ROS2 node unit test
+* ROS 2 node unit test
 
   * (generic use cases of ``launch`` based tests)
 
@@ -55,7 +55,7 @@ Static code analysis as part of the ament package build
 
 
 * You have developed your C++ production code.
-* You have created a ROS2 package with build support with ``ament``.
+* You have created a ROS 2 package with build support with ``ament``.
 
 **Problem**:
 
@@ -140,14 +140,14 @@ Static Thread Safety Analysis via Code Annotation
 **Context For Implementation:**
 
 
-To enable Thread Safety Analysis, code must be annotated to let the compiler know more about the smantics of the code. These annotations are Clang-specific attributes - e.g. ``__atribute__(capability()))``. Instead of using those attributes directly, ROS2 provides preprocessor macros that are erased when using other compilers.
+To enable Thread Safety Analysis, code must be annotated to let the compiler know more about the smantics of the code. These annotations are Clang-specific attributes - e.g. ``__atribute__(capability()))``. Instead of using those attributes directly, ROS 2 provides preprocessor macros that are erased when using other compilers.
 
 These macros can be found in `rcpputils/thread_safety_annotations.h <https://github.com/ros2/rcpputils/blob/master/include/rcpputils/thread_safety_annotations.h>`__
 
 The Thread Safety Analysis documentation states
   Thread safety analysis can be used with any threading library, but it does require that the threading API be wrapped in classes and methods which have the appropriate annotations
 
-We have decided that we want ROS2 developers to be able to use ``std::`` threading primitives directly for their development. We do not want to provide our own wrapped types as is suggested above.
+We have decided that we want ROS 2 developers to be able to use ``std::`` threading primitives directly for their development. We do not want to provide our own wrapped types as is suggested above.
 
 There are three C++ standard libraries to be aware of
 * The GNU standard library ``libstdc++`` - default on Linux, explicitly via the compiler option ``-stdlib=libstdc++``
@@ -233,7 +233,7 @@ The code migration suggestions here are by no means complete - when writing (or 
 
 * How to run the analysis
 
-  * The ROS CI build farm runs a nightly job with ``libcxx``, which will surface any issues in the ROS2 core stack by being marked "Unstable" when Thread Safety Analysis raises warnings
+  * The ROS CI build farm runs a nightly job with ``libcxx``, which will surface any issues in the ROS 2 core stack by being marked "Unstable" when Thread Safety Analysis raises warnings
   * For local runs, you have the following options, all equivalent
 
     * Use the colcon `clang-libcxx mixin <https://github.com/colcon/colcon-mixin-repository/blob/master/clang-libcxx.mixin>`__
@@ -302,7 +302,7 @@ Code coverage analysis
 
 **Context**
 
-You have written tests for the library level production code of a ROS2 package (usually refered to as "unit tests").
+You have written tests for the library level production code of a ROS 2 package (usually refered to as "unit tests").
 
 **Problem**
 

--- a/source/Contributing/ROS-2-On-boarding-Guide.rst
+++ b/source/Contributing/ROS-2-On-boarding-Guide.rst
@@ -37,8 +37,8 @@ How to access the machines running the ci.ros2.org?
 Only do this if you're working at OSRF or if you're asked to log into the machines.
 To be able to ssh into the node hosted on AWS, you need give request access from Tully Foote (tfoote@osrfoundation.org).
 
-Request access to the Google drive ROS2 folder
-----------------------------------------------
+Request access to the Google drive ROS 2 folder
+-----------------------------------------------
 
 Only do this if you're working at OSRF or need access to a particular document.
 To request access send an email to ros@osrfoundation.org (anybody on the mailing list can share it).
@@ -46,8 +46,8 @@ To request access send an email to ros@osrfoundation.org (anybody on the mailing
 Choose a DDS domain ID
 ----------------------
 
-ROS2 uses DDS as the underlying transport and DDS supports a physical segmentation of the network based on the "domain ID" (it is used to calculate the multicast port).
-We use a unique value for this on each machine (or group of machines) to keep each group's ROS2 nodes from interfering with other developers' testing.
+ROS 2 uses DDS as the underlying transport and DDS supports a physical segmentation of the network based on the "domain ID" (it is used to calculate the multicast port).
+We use a unique value for this on each machine (or group of machines) to keep each group's ROS 2 nodes from interfering with other developers' testing.
 We expose this setting via the ``ROS_DOMAIN_ID`` environment variable and use a document to ensure we don't accidentally choose the same one as someone else.
 This is, however, only important for people who will be working on the OSRF network, but it isn't a bad idea to set up at any organization with multiple ROS 2 users on the same network.
 
@@ -236,7 +236,7 @@ There several categories of jobs on the buildfarm:
   * packaging_osx
   * Packaging_windows
 
-Learning ROS2 concepts at a high level
---------------------------------------
+Learning ROS 2 concepts at a high level
+---------------------------------------
 
-All ROS2 design documents are available at http://design.ros2.org/ and there is some generated documentation at http://docs.ros2.org/.
+All ROS 2 design documents are available at http://design.ros2.org/ and there is some generated documentation at http://docs.ros2.org/.

--- a/source/Contributing/Set-up-a-new-Linux-CI-node.rst
+++ b/source/Contributing/Set-up-a-new-Linux-CI-node.rst
@@ -9,7 +9,7 @@ How to setup Linux Jenkins nodes
    :depth: 1
    :local:
 
-This page describes how to set up a linux machine for ROS2 CI jobs using AWS.
+This page describes how to set up a linux machine for ROS 2 CI jobs using AWS.
 
 Creating an AWS instance
 ------------------------
@@ -26,7 +26,7 @@ In short, use the company AWS account to launch an instance running based off th
 
   * Make sure to save it with the other credentials so others can access this machine
 
-Give the instance a descriptive name like ``ROS2 CI (linux 4)``.
+Give the instance a descriptive name like ``ROS 2 CI (linux 4)``.
 Record the ip address `here <https://docs.google.com/spreadsheets/d/1OSwqbE3qPF8v3HSMr8JOaJ6r4QOiQFk6pwgaudXVE-4/edit#gid=0>`__ (private).
 
 Setting up the machine

--- a/source/Installation/Crystal/Fedora-Development-Setup.rst
+++ b/source/Installation/Crystal/Fedora-Development-Setup.rst
@@ -21,4 +21,4 @@ Then install vcstool from pip:
 
    $ pip3 install vcstool
 
-With this done, you can follow the rest of the `instructions <linux-dev-get-ros2-code>` to fetch and build ROS2.
+With this done, you can follow the rest of the `instructions <linux-dev-get-ros2-code>` to fetch and build ROS 2.

--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -141,7 +141,7 @@ Well then simply ``$ touch AMENT_IGNORE`` in the ``cam2image`` demo directory to
 Optionally install all packages into a combined directory (rather than each package in a separate subdirectory).
 On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
 
-Also, if you have already installed ROS2 from Debian make sure that you run the ``build`` command in a fresh environment. You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
+Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment. You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
 
 
 .. code-block:: bash

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -10,7 +10,7 @@ Building ROS 2 on Windows
    :depth: 2
    :local:
 
-This guide is about how to setup a development environment for ROS2 on Windows.
+This guide is about how to setup a development environment for ROS 2 on Windows.
 
 Prerequisites
 -------------

--- a/source/Installation/DDS-Implementations.rst
+++ b/source/Installation/DDS-Implementations.rst
@@ -37,7 +37,7 @@ ADLINK OpenSplice Debian Packages built by OSRF
    Install the packages provided by [OpenSplice](https://github.com/ADLINK-IST/opensplice/releases/tag/OSPL_V6_7_180404OSS_RELEASE%2BVS2017%2Bubuntu1804).
    Remember to replace `@@INSTALLDIR@@` with the path where you unpacked the OpenSplice distribution.
    Then, source the ROS `setup.bash` file, and finally, source the `release.com` file in the root of the OpenSplice distribution to set the `OSPL_HOME` environment variable appropriately.
-   After that, your shell is ready to run ROS2 binaries with the official OpenSplice distribution.
+   After that, your shell is ready to run ROS 2 binaries with the official OpenSplice distribution.
 
    You may also need to add the following line to your `.bashrc` file:
 

--- a/source/Installation/Dashing/Fedora-Development-Setup.rst
+++ b/source/Installation/Dashing/Fedora-Development-Setup.rst
@@ -52,5 +52,5 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      wget
 
 
-With this done, you can follow the rest of the `instructions <Dashing_linux-dev-get-ros2-code>` to fetch and build ROS2.
+With this done, you can follow the rest of the `instructions <Dashing_linux-dev-get-ros2-code>` to fetch and build ROS 2.
 

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -130,7 +130,7 @@ Well then simply ``$ touch AMENT_IGNORE`` in the ``cam2image`` demo directory to
 Optionally install all packages into a combined directory (rather than each package in a separate subdirectory).
 On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
 
-Also, if you have already installed ROS2 from Debian make sure that you run the ``build`` command in a fresh environment.
+Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
 You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
 
 

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -5,7 +5,7 @@ Building ROS 2 on Windows
    :depth: 2
    :local:
 
-This guide is about how to setup a development environment for ROS2 on Windows.
+This guide is about how to setup a development environment for ROS 2 on Windows.
 
 Prerequisites
 -------------

--- a/source/Installation/Eloquent/Fedora-Development-Setup.rst
+++ b/source/Installation/Eloquent/Fedora-Development-Setup.rst
@@ -54,5 +54,5 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      wget
 
 
-With this done, you can follow the rest of the `instructions <Eloquent_linux-dev-get-ros2-code>` to fetch and build ROS2.
+With this done, you can follow the rest of the `instructions <Eloquent_linux-dev-get-ros2-code>` to fetch and build ROS 2.
 

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -133,7 +133,7 @@ Well then simply ``$ touch AMENT_IGNORE`` in the ``cam2image`` demo directory to
 Optionally install all packages into a combined directory (rather than each package in a separate subdirectory).
 On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
 
-Also, if you have already installed ROS2 from Debian make sure that you run the ``build`` command in a fresh environment.
+Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
 You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
 
 

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -6,7 +6,7 @@ Building ROS 2 on Windows
    :depth: 2
    :local:
 
-This guide is about how to setup a development environment for ROS2 on Windows.
+This guide is about how to setup a development environment for ROS 2 on Windows.
 
 Prerequisites
 -------------

--- a/source/Installation/Foxy/Fedora-Development-Setup.rst
+++ b/source/Installation/Foxy/Fedora-Development-Setup.rst
@@ -54,5 +54,5 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      wget
 
 
-With this done, you can follow the rest of the `instructions <Foxy_linux-dev-get-ros2-code>` to fetch and build ROS2.
+With this done, you can follow the rest of the `instructions <Foxy_linux-dev-get-ros2-code>` to fetch and build ROS 2.
 

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -132,7 +132,7 @@ Well then simply ``$ touch AMENT_IGNORE`` in the ``cam2image`` demo directory to
 Optionally install all packages into a combined directory (rather than each package in a separate subdirectory).
 On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
 
-Also, if you have already installed ROS2 from Debian make sure that you run the ``build`` command in a fresh environment.
+Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
 You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
 
 

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -7,7 +7,7 @@ Building ROS 2 on Windows
    :depth: 2
    :local:
 
-This guide is about how to setup a development environment for ROS2 on Windows.
+This guide is about how to setup a development environment for ROS 2 on Windows.
 
 Prerequisites
 -------------

--- a/source/Installation/Install-Connext-Security-Plugins.rst
+++ b/source/Installation/Install-Connext-Security-Plugins.rst
@@ -1,7 +1,7 @@
 Installing Connext security plugins
 ===================================
 
-The Connext DDS Libraries are included with ROS2 under a `non-commercial
+The Connext DDS Libraries are included with ROS 2 under a `non-commercial
 license <https://www.rti.com/ncl>`__ and do not include the security
 plug-in libraries. These libraries are available in the commercial,
 university and research license versions of RTI Connext DDS Pro, which

--- a/source/Installation/Install-Connext-University-Eval.rst
+++ b/source/Installation/Install-Connext-University-Eval.rst
@@ -8,9 +8,9 @@ A full-suite installation of RTI Connext DDS is available for many additional pl
 This installation includes diagnostic tools, layered services, and security.  See below for installation details.
 
 .. note::
-    As of the ROS2 'Dashing' release, the Connext RMW layer in ROS2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
+    As of the ROS 2 'Dashing' release, the Connext RMW layer in ROS 2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
 
-    The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS2.
+    The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS 2.
 
 RTI University Program
 ----------------------

--- a/source/Related-Projects/Intel-ROS2-Projects.rst
+++ b/source/Related-Projects/Intel-ROS2-Projects.rst
@@ -2,30 +2,30 @@
 
   Intel-ROS2-Projects
 
-Intel ROS2 Projects
-===================
+Intel ROS 2 Projects
+====================
 
 Intel® Robotics Open Source Project (Intel® ROS Project) to enable object detection/location/tracking, people detection, vehicle detection, industry robot arm grasp point analysis with kinds of Intel technologies and platforms, including CPU, GPU, `Intel® Movidius™ NCS <https://developer.movidius.com/>`__ optimized deep learning backend, FPGA, `Intel® RealSense™ <http://www.intel.com/realsense>`__ camera, etc.
 
 Key Projects
 ------------
 
-We are working on below ROS2 projects and publish source code through https://github.com/intel/ or ROS2 github repo gradually.
+We are working on below ROS 2 projects and publish source code through https://github.com/intel/ or ROS 2 github repo gradually.
 
-* `ROS2 OpenVINO <https://github.com/intel/ros2_openvino_toolkit>`__: ROS2 package for Intel® Visual Inference and Neural Network Optimization Toolkit to develop multiplatform computer vision solutions.
-* `ROS2 RealSense Camera <https://github.com/intel/ros2_intel_realsense>`__: ROS2 package for Intel® RealSense™ D400 serial cameras
-* `ROS2 Movidius NCS <https://github.com/intel/ros2_intel_movidius_ncs>`__: ROS2 package for object detection with Intel® Movidius™ Neural Computing Stick (NCS).
-* `ROS2 Object Messages <https://github.com/intel/ros2_object_msgs>`__: ROS2 messages for object.
-* `ROS2 Object Analytics <https://github.com/intel/ros2_object_analytics>`__: ROS2 package for object detection, tracking and 2D/3D localization.
-* `ROS2 Message Filters <https://github.com/ros2/message_filters>`__: ROS2 package for message synchronization with time stamp.
-* `ROS2 CV Bridge <https://github.com/ros-perception/vision_opencv/tree/ros2/cv_bridge>`__: ROS2 package to bridge with openCV.
-* `ROS2 Object Map <https://github.com/intel/ros2_object_map>`__: ROS2 package to mark tag of objects on map when SLAM based on information provided by ROS2 object analytics.
-* `ROS2 Moving Object <https://github.com/intel/ros2_moving_object>`__: ROS2 package to provide object motion information (like object velocity on x, y, z axis) based on information provided by ROS2 object analytics.
-* `ROS2 Grasp Library <https://github.com/intel/ros2_grasp_library>`__: ROS2 package for grasp position analysis, and compatible with `MoveIt <https://github.com/ros-planning/moveit.git>`__ grasp interfaces.
-* `ROS2 Navigation <https://github.com/ros-planning/navigation2>`__: ROS2 package for robot navigation, it's already integrated to ROS2 Crystal release.
-* `Robot SDK <https://github.com/intel/robot_sdk>`__: An open source project which enables developers to easily and efficiently create, customize, optimize, and deploy a robot software stack to an Autonomous Mobile Robot (AMR) platform based on the Robot Operating System 2 (ROS2) framework.
+* `ROS2 OpenVINO <https://github.com/intel/ros2_openvino_toolkit>`__: ROS 2 package for Intel® Visual Inference and Neural Network Optimization Toolkit to develop multiplatform computer vision solutions.
+* `ROS2 RealSense Camera <https://github.com/intel/ros2_intel_realsense>`__: ROS 2 package for Intel® RealSense™ D400 serial cameras
+* `ROS2 Movidius NCS <https://github.com/intel/ros2_intel_movidius_ncs>`__: ROS 2 package for object detection with Intel® Movidius™ Neural Computing Stick (NCS).
+* `ROS2 Object Messages <https://github.com/intel/ros2_object_msgs>`__: ROS 2 messages for object.
+* `ROS2 Object Analytics <https://github.com/intel/ros2_object_analytics>`__: ROS 2 package for object detection, tracking and 2D/3D localization.
+* `ROS2 Message Filters <https://github.com/ros2/message_filters>`__: ROS 2 package for message synchronization with time stamp.
+* `ROS2 CV Bridge <https://github.com/ros-perception/vision_opencv/tree/ros2/cv_bridge>`__: ROS 2 package to bridge with openCV.
+* `ROS2 Object Map <https://github.com/intel/ros2_object_map>`__: ROS 2 package to mark tag of objects on map when SLAM based on information provided by ROS 2 object analytics.
+* `ROS2 Moving Object <https://github.com/intel/ros2_moving_object>`__: ROS 2 package to provide object motion information (like object velocity on x, y, z axis) based on information provided by ROS 2 object analytics.
+* `ROS2 Grasp Library <https://github.com/intel/ros2_grasp_library>`__: ROS 2 package for grasp position analysis, and compatible with `MoveIt <https://github.com/ros-planning/moveit.git>`__ grasp interfaces.
+* `ROS2 Navigation <https://github.com/ros-planning/navigation2>`__: ROS 2 package for robot navigation, it's already integrated to ROS 2 Crystal release.
+* `Robot SDK <https://github.com/intel/robot_sdk>`__: An open source project which enables developers to easily and efficiently create, customize, optimize, and deploy a robot software stack to an Autonomous Mobile Robot (AMR) platform based on the Robot Operating System 2 (ROS 2) framework.
 
 Reference
 ---------
 
-ROS components at: http://wiki.ros.org/IntelROSProject shows the relationship among those packages, which also applies to ROS2.
+ROS components at: http://wiki.ros.org/IntelROSProject shows the relationship among those packages, which also applies to ROS 2.

--- a/source/Tutorials/Ament-Tutorial.rst
+++ b/source/Tutorials/Ament-Tutorial.rst
@@ -70,7 +70,7 @@ This is the directory structure of ``~/ros2_ws`` that you can expect at this poi
 Add some sources
 ^^^^^^^^^^^^^^^^
 
-To start off we need to setup an underlay without any of ROS2 installed.
+To start off we need to setup an underlay without any of ROS 2 installed.
 
 Note: if you do not have ``vcs`` installed, instructions are `here <https://github.com/dirk-thomas/vcstool>`__.
 

--- a/source/Tutorials/Building-ROS-2-on-Linux-with-Eclipse-Oxygen.rst
+++ b/source/Tutorials/Building-ROS-2-on-Linux-with-Eclipse-Oxygen.rst
@@ -2,8 +2,8 @@
 
     Building-ROS-2-on-Linux-with-Eclipse-Oxygen
 
-Building ROS2 on Linux with Eclipse Oxygen [community-contributed]
-==================================================================
+Building ROS 2 on Linux with Eclipse Oxygen [community-contributed]
+===================================================================
 
 .. warning::
    **Some people have reported issues about this tutorial.

--- a/source/Tutorials/Cross-compilation.rst
+++ b/source/Tutorials/Cross-compilation.rst
@@ -8,12 +8,12 @@ Cross-Compilation
 Overview
 --------
 
-Open Robotics provides pre-built ROS2 packages for multiple platforms, but a number of developers still rely on `cross-compilation <https://en.wikipedia.org/wiki/Cross_compiler>`__ for different reasons such as:
+Open Robotics provides pre-built ROS 2 packages for multiple platforms, but a number of developers still rely on `cross-compilation <https://en.wikipedia.org/wiki/Cross_compiler>`__ for different reasons such as:
  - The development machine does not match the target system.
  - Tuning the build for specific core architecture (e.g. setting -mcpu=cortex-a53 -mfpu=neon-fp-armv8 when building for Raspberry Pi3).
  - Targeting a different file systems other than the ones supported by the pre-built images released by Open Robotics.
 
-This document provides you with details on how to cross-compile the ROS2 software stack as well as provide examples for cross-compiling to systems based on the Arm cores.
+This document provides you with details on how to cross-compile the ROS 2 software stack as well as provide examples for cross-compiling to systems based on the Arm cores.
 
 How does it work ?
 ------------------
@@ -25,13 +25,13 @@ There are a number of factors which make this process more complex:
  - All dependencies (e.g. libraries) must be present, either as pre-built packages or also cross-compiled before the target software using them is cross-compiled.
  - When building software stacks (as opposed to an standalone software) using build tools (e.g. colcon), it is expected from the build tool a mechanism to allow the developer to enable cross-compilation on the underlying build system used by each of software in the stack.
 
-Cross-compiling ROS2
---------------------
+Cross-compiling ROS 2
+---------------------
 
-The ROS2 cross-compile tool is under shared ownership of Open Robotics and ROS Tooling Working Group.
+The ROS 2 cross-compile tool is under shared ownership of Open Robotics and ROS Tooling Working Group.
 
-It is a Python script that compiles ROS2 source files for supported target architectures using an emulator in a docker container.
-Detailed design of the tool can be found on `ROS2 design <http://design.ros2.org/articles/cc_build_tools.html>`__.
+It is a Python script that compiles ROS 2 source files for supported target architectures using an emulator in a docker container.
+Detailed design of the tool can be found on `ROS 2 design <http://design.ros2.org/articles/cc_build_tools.html>`__.
 Instructions to use the tool are in the `cross_compile package <https://github.com/ros-tooling/cross_compile>`__.
 
 If you are using an older version, please follow the `legacy tool instructions`_.
@@ -41,15 +41,15 @@ Legacy tool instructions
 
 .. note:: Follow the steps below only if you are using the old version (release `0.0.1 <https://github.com/ros-tooling/cross_compile/releases/tag/0.0.1>`__) of the cross-compile tool. For all other purposes, follow the `cross_compile <https://github.com/ros-tooling/cross_compile>`__ package documentation.
 
-Although ROS2 is a rich software stack with a number of dependencies, it primarily uses two different types of packages:
+Although ROS 2 is a rich software stack with a number of dependencies, it primarily uses two different types of packages:
  - Python based software, which requires no cross-compilation.
  - CMake based software, which provides a mechanism to do cross-compilation.
 
-Furthermore, the ROS2 software stack is built with `Colcon <https://github.com/colcon/colcon-core>`__ which provides a mechanism to forward parameters to the CMake instance used for the individual build of each package/library that is part of the ROS2 distribution.
+Furthermore, the ROS 2 software stack is built with `Colcon <https://github.com/colcon/colcon-core>`__ which provides a mechanism to forward parameters to the CMake instance used for the individual build of each package/library that is part of the ROS 2 distribution.
 
-When building ROS2 natively, the developer is required to download all the dependencies (e.g. Python and other libraries) before compiling the packages that are part of the ROS2 distribution. When cross-compiling, the same approach is required. The developer must first have the target system's filesystem with all dependencies already installed.
+When building ROS 2 natively, the developer is required to download all the dependencies (e.g. Python and other libraries) before compiling the packages that are part of the ROS 2 distribution. When cross-compiling, the same approach is required. The developer must first have the target system's filesystem with all dependencies already installed.
 
-The next sections of this document explain in detail the use of `cmake-toolchains <https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html>`__ and the `CMAKE_SYSROOT <https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html>`__ feature to cross-compile ROS2.
+The next sections of this document explain in detail the use of `cmake-toolchains <https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html>`__ and the `CMAKE_SYSROOT <https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html>`__ feature to cross-compile ROS 2.
 
 CMake toolchain-file
 ^^^^^^^^^^^^^^^^^^^^
@@ -63,26 +63,26 @@ A CMake toolchain-file is a file which defines variables to configure CMake for 
  - ``CMAKE_CXX_COMPILER``: the C++ cross-compiler, e.g. ``aarch64-linux-gnu-g++``
  - ``CMAKE_FIND_ROOT_PATH``: an alternative path used by the ``find_*`` command to find the file-system
 
-When cross-compiling ROS2, the following options are required to be set:
+When cross-compiling ROS 2, the following options are required to be set:
 
- - ``CMAKE_FIND_ROOT_PATH``: the alternative path used by the ``find_*`` command, use it to specify the path to ROS2 ``/install`` folder
+ - ``CMAKE_FIND_ROOT_PATH``: the alternative path used by the ``find_*`` command, use it to specify the path to ROS 2 ``/install`` folder
  - ``CMAKE_FIND_ROOT_PATH_MODE_*``: the search strategy for program,package,library, and include, usually: ``NEVER`` (look on the host-fs), ``ONLY`` (look on sysroot), and ``BOTH`` (look on both sysroot and host-fs)
- - ``PYTHON_SOABI``: the index name of the python libraries generated by ROS2, e.g. ``cpython-36m-aarch64-linux-gnu``
+ - ``PYTHON_SOABI``: the index name of the python libraries generated by ROS 2, e.g. ``cpython-36m-aarch64-linux-gnu``
  - ``THREADS_PTHREAD_ARG "0" CACHE STRING "Result from TRY_RUN" FORCE``: Force the result of the ``TRY_RUN`` cmd to 0 (success) because binaries can not run on the host system.
 
 The toolchain-file is provided to CMake with the ``-DCMAKE_TOOLCHAIN_FILE=path/to/file`` parameter. This will also set the ``CMAKE_CROSSCOMPILING`` variable to ``true`` which can be used by the software being built.
 
-The ``CMAKE_SYSROOT`` is particularly important for ROS2 as the packages need many dependencies (e.g. python, openssl, opencv, poco, eigen3, ...).
+The ``CMAKE_SYSROOT`` is particularly important for ROS 2 as the packages need many dependencies (e.g. python, openssl, opencv, poco, eigen3, ...).
 Setting ``CMAKE_SYSROOT`` to a target file-system with all the dependencies installed on it will allow CMake to find them during the cross-compilation.
 
 .. note:: You can find more information on the CMake `documentation <https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html>`__ page.
 
-When downloading the ROS2 source code, a generic toolchain-file is available in the repository `ros-tooling/cross_compile/cmake-toolchains <https://github.com/ros-tooling/cross_compile>`__ which can be downloaded separately. Further examples on using it can be found on the `Cross-compiling examples for Arm`_ section.
+When downloading the ROS 2 source code, a generic toolchain-file is available in the repository `ros-tooling/cross_compile/cmake-toolchains <https://github.com/ros-tooling/cross_compile>`__ which can be downloaded separately. Further examples on using it can be found on the `Cross-compiling examples for Arm`_ section.
 
 Target file-system
 ^^^^^^^^^^^^^^^^^^
 
-As mentioned previously, ROS2 requires different libraries which needs to be provided to cross-compile.
+As mentioned previously, ROS 2 requires different libraries which needs to be provided to cross-compile.
 
 There are a number of ways to obtain the file-system:
  - downloading a pre-built image
@@ -104,11 +104,11 @@ The build process is similar to native compilation. The only difference is an ex
             -DCMAKE_TOOLCHAIN_FILE="<path_to_toolchain/toolchainfile.cmake>"
 
 The ``toolchain-file`` provide to CMake the information of the ``cross-compiler`` and the ``target file-system``.
-``Colcon`` will call CMake with the given toolchain-file on every package of ROS2.
+``Colcon`` will call CMake with the given toolchain-file on every package of ROS 2.
 
 Cross-compiling examples for Arm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-After `downloading the ROS2 source code <../../Installation/Linux-Development-Setup>`__, you can add cross-compilation assets to the workspace via ``git clone https://github.com/ros-tooling/cross_compile.git -b 0.0.1 src/ros2/cross_compile``. These are working examples on how to cross-compile for Arm cores.
+After `downloading the ROS 2 source code <../../Installation/Linux-Development-Setup>`__, you can add cross-compilation assets to the workspace via ``git clone https://github.com/ros-tooling/cross_compile.git -b 0.0.1 src/ros2/cross_compile``. These are working examples on how to cross-compile for Arm cores.
 
 The following targets are supported:
  - Ubuntu-arm64: To be used with any ARMv8-A based system.
@@ -116,10 +116,10 @@ The following targets are supported:
 
 These are the main steps:
  - Installing development tools
- - Downloading ROS2 source code
- - Downloading the ROS2 cross-compilation assets
+ - Downloading ROS 2 source code
+ - Downloading the ROS 2 cross-compilation assets
  - Preparing the sysroot
- - Cross-compiling the ROS2 software stack
+ - Cross-compiling the ROS 2 software stack
 
 The next sections explains in detail each of these steps.
 For a quick-setup, have a look at the `Automated Cross-compilation`_.
@@ -153,10 +153,10 @@ The following packages are required
 
 Docker is used to build the target environment. Follow the official `documentation <https://docs.docker.com/install/linux/docker-ce/ubuntu/>`__ for the installation.
 
-2. Download ROS2 source code
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2. Download ROS 2 source code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Then create a workspace and download the ROS2 source code:
+Then create a workspace and download the ROS 2 source code:
 
 .. code-block:: bash
 
@@ -170,16 +170,16 @@ Then create a workspace and download the ROS2 source code:
 3. Prepare the sysroot
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Build an arm Ubuntu image with all the ROS2 dependencies using Docker and qemu:
+Build an arm Ubuntu image with all the ROS 2 dependencies using Docker and qemu:
 Copy the ``qemu-static`` binary to the workspace.
-It will be used to install the ros2 dependencies on the target file-system with docker.
+It will be used to install the ROS 2 dependencies on the target file-system with docker.
 
 .. code-block:: bash
 
     mkdir qemu-user-static
     cp /usr/bin/qemu-*-static qemu-user-static
 
-The standard `setup <../../Installation/Linux-Development-Setup>`__ process of ROS2 is run inside an arm docker. This is possible thanks to ``qemu-static``, which will emulate an arm machine. The base image used is an Ubuntu Bionic from Docker Hub.
+The standard `setup <../../Installation/Linux-Development-Setup>`__ process of ROS 2 is run inside an arm docker. This is possible thanks to ``qemu-static``, which will emulate an arm machine. The base image used is an Ubuntu Bionic from Docker Hub.
 
 .. code-block:: bash
 
@@ -274,12 +274,12 @@ The result of the build will be inside the ``ros2_ws`` directory, which can be e
 
     docker cp ros2_cc:/root/cc_ws/ros2_ws .
 
-Cross-compiling against a pre-built ROS2
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Cross-compiling against a pre-built ROS 2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is possible to cross-compile your packages against a pre-built ROS2. The steps are similar to the previous `Cross-compiling examples for Arm`_ section, with the following modifications:
+It is possible to cross-compile your packages against a pre-built ROS 2. The steps are similar to the previous `Cross-compiling examples for Arm`_ section, with the following modifications:
 
-Instead of downloading the ROS2 stack, just populate your workspace with your package (ros2 examples on this case) and the cross-compilation assets:
+Instead of downloading the ROS 2 stack, just populate your workspace with your package (ros2 examples on this case) and the cross-compilation assets:
 
 .. code-block:: bash
 
@@ -289,7 +289,7 @@ Instead of downloading the ROS2 stack, just populate your workspace with your pa
     git clone https://github.com/ros-tooling/cross_compile.git -b 0.0.1
     cd ..
 
-Generate and export the file-system as described in `3. Prepare the sysroot`_, but with the provided ``Dockerfile_ubuntu_arm64_prebuilt``. These ``_prebuilt`` Dockerfile will use the `binary packages <https://index.ros.org/doc/ros2/Linux-Install-Debians/>`__ to install ROS2 instead of building from source.
+Generate and export the file-system as described in `3. Prepare the sysroot`_, but with the provided ``Dockerfile_ubuntu_arm64_prebuilt``. These ``_prebuilt`` Dockerfile will use the `binary packages <https://index.ros.org/doc/ros2/Linux-Install-Debians/>`__ to install ROS 2 instead of building from source.
 
 Modify the environment variable ``ROS2_INSTALL_PATH`` to point to the installation directory:
 

--- a/source/Tutorials/Defining-custom-interfaces-(msg-srv).rst
+++ b/source/Tutorials/Defining-custom-interfaces-(msg-srv).rst
@@ -19,4 +19,4 @@ If the interfaces are created in the same package that utilizes them, you'll nee
 
    rosidl_target_interfaces(MY_LIBRARY_NAME ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
-Note that the ``package.xml`` format must equal 3 for this to build, this is because the ``member_of_group`` command requires format 3. ROS2's create package generates the ``package.xml`` with a default format of 2, e.i. ``<member_of_group>rosidl_interface_packages</member_of_group>`` required for packages with custom interfaces.
+Note that the ``package.xml`` format must equal 3 for this to build, this is because the ``member_of_group`` command requires format 3. ROS 2's create package generates the ``package.xml`` with a default format of 2, e.i. ``<member_of_group>rosidl_interface_packages</member_of_group>`` required for packages with custom interfaces.

--- a/source/Tutorials/Developing-a-ROS-2-Package.rst
+++ b/source/Tutorials/Developing-a-ROS-2-Package.rst
@@ -78,11 +78,11 @@ An example for launch files and nodes:
 Python Packages
 ^^^^^^^^^^^^^^^
 
-ROS2 follows Python's standard module distribution process that uses ``setuptools``.
+ROS 2 follows Python's standard module distribution process that uses ``setuptools``.
 For Python packages, the ``setup.py`` file complements a C++ package's ``CMakeLists.txt``.
 More details on distribution can be found in the `official documentation <https://docs.python.org/3/distributing/index.html#distributing-index>`_.
 
-In your ROS2 package, you should have a ``setup.cfg`` file which looks like:
+In your ROS 2 package, you should have a ``setup.cfg`` file which looks like:
 
 .. code-block:: bash
 

--- a/source/Tutorials/Launch-files-migration-guide.rst
+++ b/source/Tutorials/Launch-files-migration-guide.rst
@@ -13,8 +13,8 @@ Background
 A description of the ROS 2 launch system and its Python API can be found in `Launch System tutorial <Launch-system>`.
 
 
-Migrating tags from ROS1 to ROS2
---------------------------------
+Migrating tags from ROS 1 to ROS 2
+----------------------------------
 
 launch
 ^^^^^^

--- a/source/Tutorials/RQt-Overview-Usage.rst
+++ b/source/Tutorials/RQt-Overview-Usage.rst
@@ -85,7 +85,7 @@ From system architecture's perspective:
 Further Reading
 ---------------
 
-* ROS 2 Discourse `announcment of porting to ROS2 <https://discourse.ros.org/t/rqt-in-ros2/6428>`__).
+* ROS 2 Discourse `announcment of porting to ROS 2 <https://discourse.ros.org/t/rqt-in-ros2/6428>`__).
 * `RQt for ROS 1 documentation <http://wiki.ros.org/rqt>`__.
 * Brief overview of RQt (from `a Willow Garage intern blog post <http://web.archive.org/web/20130518142837/http://www.willowgarage.com/blog/2012/10/21/ros-gui>`__).
 

--- a/source/Tutorials/RQt-Source-Install.rst
+++ b/source/Tutorials/RQt-Source-Install.rst
@@ -24,7 +24,7 @@ Other Requirements
 Building From Source
 --------------------
 
-In order to build RQt from source, first create a ROS2 workspace at ``~/ros2_ws/``.
+In order to build RQt from source, first create a ROS 2 workspace at ``~/ros2_ws/``.
 This is step is already covered in `building ROS 2 from source instructions <../Installation>`, so we skip it here.
 
 Download RQt Repositories

--- a/source/Tutorials/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/Tutorials/Releasing-a-ROS-2-package-with-bloom.rst
@@ -58,4 +58,4 @@ Build Status
 ------------
 
 * Individual build details on the build farm `Jenkins <http://build.ros2.org/>`__ frontend.
-* The `ROS2 Package Status Pages <http://repo.ros2.org/status_page/>`__ (e.g. `Bouncy-Default <http://repo.ros2.org/status_page/ros_bouncy_default.html>`__).
+* The `ROS 2 Package Status Pages <http://repo.ros2.org/status_page/>`__ (e.g. `Bouncy-Default <http://repo.ros2.org/status_page/ros_bouncy_default.html>`__).

--- a/source/Tutorials/Rosbag-with-ROS1-Bridge.rst
+++ b/source/Tutorials/Rosbag-with-ROS1-Bridge.rst
@@ -35,7 +35,7 @@ Then we'll run the ROS 1 <=> ROS 2 ``dynamic_bridge`` with the ``--bridge-all-to
    # Or, on OSX, something like:
    # . ~/ros_catkin_ws/install_isolated/setup.bash
    . /opt/ros/ardent/setup.bash
-   # Or, if building ROS2 from source:
+   # Or, if building ROS 2 from source:
    # . <workspace-with-bridge>/install/setup.bash
    export ROS_MASTER_URI=http://localhost:11311
    ros2 run ros1_bridge dynamic_bridge --bridge-all-topics
@@ -51,7 +51,7 @@ First we'll run the ``cam2image`` program with the ``-b`` option so it doesn't r
 
    # Shell C:
    . /opt/ros/ardent/setup.bash
-   # Or, if building ROS2 from source:
+   # Or, if building ROS 2 from source:
    # . <workspace-with-bridge>/install/setup.bash
    ros2 run image_tools cam2image -- -b
 
@@ -108,7 +108,7 @@ You can run this python script in a new ROS 2 shell:
 
    # Shell D:
    . /opt/ros/ardent/setup.bash
-   # Or, if building ROS2 from source:
+   # Or, if building ROS 2 from source:
    # . <workspace-with-bridge>/install/setup.bash
    python3 emulate_kobuki_node.py
 
@@ -179,7 +179,7 @@ Then run the ``dynamic_bridge`` in another shell:
    # Or, on OSX, something like:
    # . ~/ros_catkin_ws/install_isolated/setup.bash
    . /opt/ros/ardent/setup.bash
-   # Or, if building ROS2 from source:
+   # Or, if building ROS 2 from source:
    # . <workspace-with-bridge>/install/setup.bash
    export ROS_MASTER_URI=http://localhost:11311
    ros2 run ros1_bridge dynamic_bridge --bridge-all-topics
@@ -204,7 +204,7 @@ Now that the data is being played back and the bridge is running we can see the 
 
    # Shell S:
    . /opt/ros/ardent/setup.bash
-   # Or, if building ROS2 from source:
+   # Or, if building ROS 2 from source:
    # . <workspace-with-bridge>/install/setup.bash
    ros2 topic list
    ros2 topic echo /odom

--- a/source/Tutorials/catment.rst
+++ b/source/Tutorials/catment.rst
@@ -64,7 +64,7 @@ Postulates
 #.
    **Interoperability is a good thing.**
    Whenever possible (not all combinations will be practical), developers should be able to mix and match meta-build systems, including mixing their different aspects (i.e., use the building tool from one system and the API from another).
-   Such mixing and matching is especially important when developers want to combine a large existing code base using one meta-build system (e.g., ROS with ``catkin``) with new libraries and tools offered by a code base using another meta-build system (e.g., ROS2 with ``ament``).
+   Such mixing and matching is especially important when developers want to combine a large existing code base using one meta-build system (e.g., ROS with ``catkin``) with new libraries and tools offered by a code base using another meta-build system (e.g., ROS 2 with ``ament``).
    Ideally that kind of combination can be done without requiring changes to the API used by either code base and without telling the developer which builder tool to use.
 
 
@@ -77,10 +77,10 @@ Postulates
 Use cases, with experimental implementations
 --------------------------------------------
 
-Adding ROS packages to a ROS2 workspace and building with ``ament build``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding ROS packages to a ROS 2 workspace and building with ``ament build``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Let's say that you want to add some existing ROS packages to your ROS2 workspace and don't want to migrate the ROS packages from ``catkin`` to ``ament`` (or vice versa). Here are two patches that let you do that:
+Let's say that you want to add some existing ROS packages to your ROS 2 workspace and don't want to migrate the ROS packages from ``catkin`` to ``ament`` (or vice versa). Here are two patches that let you do that:
 
 
 * `ament_package <https://github.com/ament/ament_package/compare/catkin?expand=1>`__:
@@ -96,7 +96,7 @@ Let's say that you want to add some existing ROS packages to your ROS2 workspace
 Example usage:
 
 
-#. Get the ROS2 code as usual, using the branches mentioned above.
+#. Get the ROS 2 code as usual, using the branches mentioned above.
 #. Add to your workspace some ``catkin`` ROS packages, ensuring that all of their dependencies are satisfied (either also present in the workspace or installed elsewhere with appropriate setup shell files sourced).
 #. Build as usual (e.g., ``./src/ament/ament_tools/scripts/ament.by build``).
 
@@ -133,10 +133,10 @@ Now build the ROS packages:
 
 Voila: you used the ``ament`` build tool to build your ``catkin`` packages, without having to migrate them.
 
-Variation: Using the ``catkin`` API in a ROS2 package
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Variation: Using the ``catkin`` API in a ROS 2 package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Let's say that you're building on top of ROS2, which internally uses the ``ament`` API, and you want to add a new package using the ``catkin`` API.
+Let's say that you're building on top of ROS 2, which internally uses the ``ament`` API, and you want to add a new package using the ``catkin`` API.
 
 To make this work, we need a Python3 installation of ``catkin`` (the binary debians use Python2.7).
 Here's an example of doing that, installing to ``$HOME/catkin``:
@@ -159,9 +159,9 @@ Here's an example of doing that, installing to ``$HOME/catkin``:
 
 To use that version of catkin, you just need to source the ``$HOME/catkin/setup.bash`` file.
 
-Let's assume that you have the usual ROS2 workspace in ``~/ros2_ws``, and that you're on the ``catkin`` branches in ``ament_package`` and ``ament_tools``.
+Let's assume that you have the usual ROS 2 workspace in ``~/ros2_ws``, and that you're on the ``catkin`` branches in ``ament_package`` and ``ament_tools``.
 Add to that workspace the ``image_tools_catkin`` package from https://github.com/gerkey/catment.
-It's a simple port of the ROS2 ``image_tools`` package, taking it from the ``ament`` API to the ``catkin`` API.
+It's a simple port of the ROS 2 ``image_tools`` package, taking it from the ``ament`` API to the ``catkin`` API.
 To build it:
 
 .. code-block:: bash
@@ -170,7 +170,7 @@ To build it:
    . $HOME/catkin/setup.bash
    ./src/ament/ament_tools/scripts/ament.py build
 
-Voila: when adding new packages atop ROS2, you're free to choose which CMake API you prefer inside your package.
+Voila: when adding new packages atop ROS 2, you're free to choose which CMake API you prefer inside your package.
 
 
 * **Caveat**: I had to comment out the use of ``CATKIN_DEPENDS`` inside ``catkin_package()``, because somewhere somebody was getting upset that things like ``rclcpp`` aren't ``catkin`` packages.
@@ -178,10 +178,10 @@ Voila: when adding new packages atop ROS2, you're free to choose which CMake API
 * **TODO**: The same demo but with a ``ament`` package that depends on a ``catkin`` package (this is easy).
 * **TODO**: The same demo but with a package that has a vanilla ``CMakeLists.txt`` that uses neither ``ament`` nor ``catkin``, and provides a manually generated ``fooConfig.cmake`` file that exports the right stuff to make it look the same to outsiders.
 
-Building ROS2 packages with ``catkin_make_isolated``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Building ROS 2 packages with ``catkin_make_isolated``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Let's say that you're already familiar with ROS and ``catkin`` and that you're excited to try ROS2, but that you're not in the mood to learn about ``ament``.
+Let's say that you're already familiar with ROS and ``catkin`` and that you're excited to try ROS 2, but that you're not in the mood to learn about ``ament``.
 You'd rather stick to what you know, such as using ``catkin_make_isolated`` to build everything.
 Here is a patch that allows you to do that:
 
@@ -230,7 +230,7 @@ Then we need to install the modified version of catkin somewhere:
    PYTHONPATH=$HOME/catkin/lib/python3/dist-packages/ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/catkin -DPYTHON_EXECUTABLE=/usr/bin/python3
    make install
 
-Now build the ROS2 packages:
+Now build the ROS 2 packages:
 
 .. code-block:: bash
 
@@ -240,23 +240,23 @@ Now build the ROS2 packages:
    touch src/eProsima/AMENT_IGNORE
    PYTHONPATH=$PYTHONPATH:/home/gerkey/ros2_ws_catkin/install_isolated/lib/python3.5/site-packages catkin_make_isolated --install
 
-Voila: you've built ROS2 using the tools that you're familiar with.
+Voila: you've built ROS 2 using the tools that you're familiar with.
 
 
 * **Caveat**: we're ignoring the ``eProsima`` packages in the workspace because they lack ``package.xml`` files, which means that ``catkin`` can't see them.
   ``ament`` has some heuristics for handling such packages.
   Options: backport those heuristics to ``catkin``; switch to installing non-``package.xml``-containing packages outside of the workspace; or just add a ``package.xml`` to each of those packages (e.g., in our own fork).
 
-Combining all of ROS and ROS2 in one workspace and building it (TODO)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Combining all of ROS and ROS 2 in one workspace and building it (TODO)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This step will require sorting out some things, including at least:
 
 * Package name conflicts.
-  We currently have ROS2 versions of ROS message packages, as well as some stuff in ``geometry2``.
+  We currently have ROS 2 versions of ROS message packages, as well as some stuff in ``geometry2``.
   Either the functionality needs to be merged into one package that can support both systems, or the new versions need different names.
 * Message generation.
-  ROS and ROS2 have different message generation steps, the output of which might or not might conflict.
+  ROS and ROS 2 have different message generation steps, the output of which might or not might conflict.
   Something sort of sophisticated needs to be done to allow generation of all the right artifacts from a single message package (or, as indicated above, the new message packages need different name).
 
 Using ``bloom`` to release ``ament`` packages (TODO)

--- a/source/Tutorials/dummy-robot-demo.rst
+++ b/source/Tutorials/dummy-robot-demo.rst
@@ -10,7 +10,7 @@ In this demo, we present a simple demo robot with all components from publishing
 Launching the demo
 ------------------
 
-We assume your ROS2 installation dir as ``~/ros2_ws``. Please change the directories according to your platform.
+We assume your ROS 2 installation dir as ``~/ros2_ws``. Please change the directories according to your platform.
 
 To start the demo, we execute the demo bringup launch file, which we are going to explain in more details in the next section.
 


### PR DESCRIPTION
I didn't modify anything that was either an RST reference/file name or a presentation title.