### PR TITLE
Install Python from self-installer on Windows.

### DIFF
--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -29,11 +29,15 @@ You'll use Chocolatey to install some other developer tools.
 Install Python
 ^^^^^^^^^^^^^^
 
-Open a Command Prompt and type the following to install Python via Chocolatey:
+Download Python 3.7.6 from python.org: https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe
+
+Open a Command Prompt and type the following to install Python:
 
 .. code-block:: bash
 
-   > choco install -y python --version 3.7.5
+   > C:\<PATH\TO\DOWNLOADS>\python-3.7.6-amd64.exe /quiet TargetDir=C:\Python37 PrependPath=1 Include_debug=1 Include_symbols=1
+
+Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 
 Install Visual C++ Redistributables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -29,11 +29,15 @@ You'll use Chocolatey to install some other developer tools.
 Install Python
 ^^^^^^^^^^^^^^
 
-Open a Command Prompt and type the following to install Python via Chocolatey:
+Download Python 3.7.6 from python.org: https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe
+
+Open a Command Prompt and type the following to install Python:
 
 .. code-block:: bash
 
-   > choco install -y python --version 3.7.5
+   > C:\<PATH\TO\DOWNLOADS>\python-3.7.6-amd64.exe /quiet TargetDir=C:\Python37 PrependPath=1 Include_debug=1 Include_symbols=1
+
+Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 
 Install Visual C++ Redistributables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -29,11 +29,15 @@ You'll use Chocolatey to install some other developer tools.
 Install Python
 ^^^^^^^^^^^^^^
 
-Open a Command Prompt and type the following to install Python via Chocolatey:
+Download Python 3.7.6 from python.org: https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe
+
+Open a Command Prompt and type the following to install Python:
 
 .. code-block:: bash
 
-   > choco install -y python --version 3.7.5
+   > C:\<PATH\TO\DOWNLOADS>\python-3.7.6-amd64.exe /quiet TargetDir=C:\Python37 PrependPath=1 Include_debug=1 Include_symbols=1
+
+Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 
 Install Visual C++ Redistributables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This replaces the chocolatey installed python with one that includes
the debug interpreter and symbols and matches what we are now doing on
ci.ros2.org.

This also bumps the installed python version to 3.7.6 which our
container builds are running but our HQ hosts are not.