### PR TITLE
ament_lint_common link

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -183,11 +183,10 @@ We will also require justification for merging a change or making a release that
 Linters and static analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We will use :ref:`ROS code style <CodeStyle>` and enforce it with linters from `ament_lint_common <https://github.com/ament/ament_lint/tree/master/ament_lint_common>`_.
+We will use :ref:`ROS code style <CodeStyle>` and enforce it with linters from `ament_lint_common <https://github.com/ament/ament_lint/tree/master/ament_lint_common/doc/index.rst>`_.
 All linters/static analysis that are part of ``ament_lint_common`` must be used.
 
-.. link to ament_lint_common documentation when it exists
-
+The `ament_lint_auto <https://github.com/ament/ament_lint/blob/master/ament_lint_auto/doc/index.rst>`_ documentation provides information on running ``ament_lint_common``.
 
 General Practices
 -----------------

--- a/source/Tutorials/Ament-CMake-Documentation.rst
+++ b/source/Tutorials/Ament-CMake-Documentation.rst
@@ -271,7 +271,7 @@ It's advised to use the combined call from `ament_lint_auto <https://github.com/
 
 This will run linters as defined in the ``package.xml``.
 It is recommended to use the set of linters defined by the package ``ament_lint_common``.
-The individual linters included there, as well as their functions, can be seen in the `ament_lint_common docs<https://github.com/ament/ament_lint/tree/master/ament_lint_common/doc/index.rst>`_.
+The individual linters included there, as well as their functions, can be seen in the `ament_lint_common docs <https://github.com/ament/ament_lint/blob/master/ament_lint_common/doc/index.rst>`_.
 
 Linters provided by ament can also be added separately, instead of running ``ament_lint_auto``.
 One example of how to do so can be found in the `ament_cmake_lint_cmake documentation <https://github.com/ament/ament_lint/blob/master/ament_cmake_lint_cmake/doc/index.rst>`_.

--- a/source/Tutorials/Ament-CMake-Documentation.rst
+++ b/source/Tutorials/Ament-CMake-Documentation.rst
@@ -262,7 +262,7 @@ In order to separate testing from building the library with colcon, wrap all cal
 Linting
 ^^^^^^^
 
-While all linters provided by ament can be added separately, it is advised to use the combined call:
+It's advised to use the combined call from `ament_lint_auto <https://github.com/ament/ament_lint/blob/master/ament_lint_auto/doc/index.rst#ament_lint_auto>`_:
 
 .. code-block:: cmake
 
@@ -270,29 +270,11 @@ While all linters provided by ament can be added separately, it is advised to us
     ament_lint_auto_find_test_dependencies()
 
 This will run linters as defined in the ``package.xml``.
-It is recommended to use the set of linters defined by the package ``ament_lint_common``, which will result in running all of the following linters:
+It is recommended to use the set of linters defined by the package ``ament_lint_common``.
+The individual linters included there, as well as their functions, can be seen in the `ament_lint_common docs<https://github.com/ament/ament_lint/tree/master/ament_lint_common/doc/index.rst>`_.
 
-- a copyright linter which checks that copyright statements and license headers are present and correct
-
-- cppcheck, a C++ checker which can also find some logic tests
-
-- cpplint, a C++ style checker (e.g. comment style)
-
-- uncrustify, a C++ style checker
-
-- a cmake linter
-
-- an xml linter
-
-- flake8, a style checker for python files
-
-- pep257, a style checker for python docstrings
-
-Note that ``ament_uncrustify`` comes with a command line tool which can automatically reformat the code according to the style guide by calling
-
-.. code-block:: bash
-
-    ament_uncrustify --reformat <path_to_source_folders>
+Linters provided by ament can also be added separately, instead of running ``ament_lint_auto``.
+One example of how to do so can be found in the `ament_cmake_lint_cmake documentation <https://github.com/ament/ament_lint/blob/master/ament_cmake_lint_cmake/doc/index.rst>`_.
 
 Testing
 ^^^^^^^


### PR DESCRIPTION
added documentation to [ament_lint_common](https://github.com/ament/ament_lint/pull/218) so it could be linked to from the dev guide and removed details from the ament cmake guide in favor of the linter's own doc

CI won't pass until the above mentioned PR is merged because the link doesn't exist yet

Signed-off-by: maryaB-osr <marya@openrobotics.org>