### PR TITLE
Backport guidelines

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -111,9 +111,12 @@ Guidelines for backport PRs
 
 When changing an older version of ROS:
 
-* Make sure the backported features or fixes are accepted and merged in all [newer, still supported versions](https://index.ros.org/doc/ros2/Releases/) before opening a backport PR.
-* Don't skip a distribution before its EOL, even if it's not an LTS version.
-* If you are backporting a single PR, title the new PR "[Distro] <name of original PR>". If you are backporting a set of PRs, or only some changes from one or more PRs, link to those PRs in the body of the PR.
+* Make sure the features or fixes are accepted and merged in the master branch before opening a PR to backport the changes to older versions.
+* When backporting to older versions, also backport to any [newer, still supported versions](https://index.ros.org/doc/ros2/Releases/), even non-LTS versions.
+* If you are backporting a single PR in its entirety, title the backport PR "[Distro] <name of original PR>".
+  If backporting a subset of changes from one or multiple PRs, the title should be "[Distro] <description of changes>".
+* Link to all PRs whose changes you're backporting from the description of your backport PR.
+  In a Dashing backport of a Foxy change, you do not need to link to the Eloquent backport of the same change.
 
 Documentation
 ^^^^^^^^^^^^^

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -106,6 +106,15 @@ Change control process
 
 * Any required changes to documentation (API documentation, feature documentation, release notes, etc.) must be proposed before merging related changes.
 
+Guidelines for backport PRs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When changing an older version of ROS:
+
+* Make sure the backported features or fixes are accepted and merged in all [newer, still supported versions](https://index.ros.org/doc/ros2/Releases/) before opening a backport PR.
+* Don't skip a distribution before its EOL, even if it's not an LTS version.
+* If you are backporting a single PR, title the new PR "[Distro] <name of original PR>". If you are backporting a set of PRs, or only some changes from one or more PRs, link to those PRs in the body of the PR.
+
 Documentation
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
As per https://github.com/ros2/rcl/pull/595#issuecomment-597759171
@dirk-thomas  there seem to be a few conventions for the name of backport PRs:
https://github.com/ros2/rclcpp/pulls?q=is%3Apr+dashing

I like the brevity of `[Distro]` but I could go with whatever convention. Also, maybe we should be using labels instead or in addition? https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests