### PR TITLE
Change mentions of beginner tutorial sections to match new titles

### DIFF
--- a/source/Tutorials/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Creating-Your-First-ROS2-Package.rst
@@ -390,7 +390,7 @@ Then, edit the description on line 6 to summarize the package:
 
 .. code-block:: xml
 
-  <description>Beginner developer tutorials practice package</description>
+  <description>Beginner client libraries tutorials practice package</description>
 
 Then, update the license on line 8.
 You can read more about open source licenses `here <https://opensource.org/licenses/alphabetical>`__.

--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -250,8 +250,8 @@ Whether you’re sharing your work with others or introspecting on your own expe
 Next steps
 ----------
 
-You’ve completed the "Beginner User" tutorials!
-The next step is tackling the "Beginner Developer" tutorials, starting with :ref:`ROS2Workspace`.
+You’ve completed the "Beginner: CLI Tools" tutorials!
+The next step is tackling the "Beginner: Client Libraries" tutorials, starting with :ref:`ROS2Workspace`.
 
 Related content
 ---------------

--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -102,7 +102,7 @@ Ensure you’re still in the ``dev_ws/src`` directory before you clone.
 In the rest of the beginner developer tutorials, you will create your own packages, but for now you will practice putting a workspace together using existing packages.
 
 The existing packages you will use are from the ``ros_tutorials`` repository (repo).
-If you went through the beginner user tutorials, you'll be familiar with ``turtlesim``, one of the packages in this repo.
+If you went through the "Beginner: CLI Tools" tutorials, you'll be familiar with ``turtlesim``, one of the packages in this repo.
 
 You can see the repo `on github <https://github.com/ros/ros_tutorials/>`__.
 


### PR DESCRIPTION
The beginner tutorial sections changed to "CLI Tools" and "Client Libraries" but we forgot to update a few places in the tutorials where we mentioned the sections by name (previously "User" and "Developer")

Signed-off-by: maryaB-osr <marya@openrobotics.org>