### PR TITLE
Update installation redirect from Crystal

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -205,5 +205,5 @@ def make_router(origin, destination):
 def setup(app):
     RedirectFrom.register(app)
     app.connect('missing-reference', make_router(
-        'Installation', 'Installation/Crystal'
+        'Installation', 'Installation/Eloquent'
     ))


### PR DESCRIPTION
Which release should installation pages be redirected to if no distro is mentioned?
I say Eloquent, because it's the most recent release. There's also Foxy (upcoming) or Dashing (most recent LTS)

Signed-off-by: maryaB-osr <marya@openrobotics.org>