### PR TITLE
Adds Package-BuildType-Tutorial

### DIFF
--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -91,6 +91,7 @@ Advanced
    Tutorials/Cross-compilation
    Tutorials/Allocator-Template-Tutorial
    Tutorials/Releasing-a-ROS-2-package-with-bloom
+   Tutorials/Package-BuildType-Tutorial
 
 Windows Tutorials
 -----------------

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -279,8 +279,8 @@ Add the ``package_data`` snippet to setup.py just below the entry_points.
      ],
    },
 
-Rebuild ament_x package
-^^^^^^^^^^^^^^^^^^^^^^^
+9. Rebuild ament_x package
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We need to rebuild the ament_x package to pick up our recent changes. From the root folder of the package enter the following on the commandline:
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -238,7 +238,7 @@ Add the following content to main.x.em and save the file. Note that template var
 
 *Hang in there we are almost done!*
 
-Add the ``populate()`` method to the end of ament_x.py. This code translates the main.x.em template file into a new package's 'src/main.x' file.
+Add the ``populate()`` method to the `AmentXBuildType` class in `ament_x.py` file. This code translates the main.x.em template file into a new package's 'src/main.x' file.
 
 .. code-block:: python
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -199,8 +199,8 @@ A package implemented using our fictitious programming language X requires all c
 
 While you could use general Python programming api for this task, we will use utilities from the ros2pkg.create Python module.
 
-5 - Create 'src' Directory
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+7. Create src Directory
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Returning to the ament_x.py file, implement the ``create_source_folders()`` method inside `AmentXBuildType` class as shown below.
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -316,4 +316,7 @@ The my_x_project directory should appear as follows:
      src/
        main.x
 
-Congrats! You've successfully created a ROS 2 package build-type that can serve as a working example for more sophisticated custom build-types. The next step is to create a build-type plugin for the colcon build-tool. You can start that journey by getting familiar with the colcon `TaskExtensionPoint <https://github.com/colcon/colcon-core/blob/master/colcon_core/task/__init__.py>`_ and explore implementations such as the python build-type found in the same directory.
+Congrats! 
+You've successfully created a ROS 2 package build-type that can serve as a working example for more sophisticated custom build-types. 
+The next step is to create a build-type plugin for the colcon build-tool. 
+You can start that journey by getting familiar with the colcon `TaskExtensionPoint <https://github.com/colcon/colcon-core/blob/master/colcon_core/task/__init__.py>`_ and explore implementations such as the Python build-type found in the same directory.

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -60,7 +60,11 @@ From a command shell enter the following commands:
 2. Implement ament_x Build-Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We have 2 options for how we create the ament_x build-type. The first is we can subclass the BuildTypeExtension, an interface, and implement its ``create_package()`` method. Doing this gives us fine grained control over how the package files structure and content are created. The second option is to extend the BaseBuildType class and customize the parts of its implementation needed for the ament_x build-type. BaseBuildType implements a workflow and common package creation functionality.
+We have two options for how we create the ament_x build-type. 
+The first is we can subclass the BuildTypeExtension, an interface, and implement its ``create_package()`` method.
+Doing this gives us fine grained control over how the package files' structure and content are created. 
+The second option is to extend the BaseBuildType class and customize the parts of its implementation needed for the ament_x build-type. 
+BaseBuildType implements a workflow and common package creation functionality.
 
 Both approaches have their merits but for simplicity we will pursue option-2 and subclass our ament_x build-type from BaseBuildType.
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -220,8 +220,8 @@ The create_folder() utility function simplifies directory creation. You will als
 
    from ros2pkg.api.create import create_folder
 
-6 - Create main.x Using An EmPy Template File
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+8. Create main.x Using an EmPy Template File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We will use the `EmPy <http://www.alcyone.com/software/empy/>`_ template engine to generate the ``main.x`` file. To do this we need to create a template file for main.x and provide it to the EmPy interpreter along with a set of values for replacing template parameters and the location to output translated content.
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -192,8 +192,8 @@ The ``my_x_project/package.xml`` will look similar to this:
 
 YOU'RE DOING MARVELOUS!
 
-Populating The ament_x Package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6. Populating the ament_x Package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A package implemented using our fictitious programming language X requires all code reside in a folder named ``src`` and the initial entry point must be a file named ``main.x``. So let's look at how we can create this src directory and file.
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -288,8 +288,8 @@ We need to rebuild the ament_x package to pick up our recent changes. From the r
 
    colcon build
 
-Test ament_x Build-type
-^^^^^^^^^^^^^^^^^^^^^^^
+10. Test ament_x Build-type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To test this last change to the ament_x build-type will recreate the my_x_project from `step-5 <5-create-src-directory>`_. If you haven't done so already remove the former my_x_project directory and its content.
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -1,0 +1,313 @@
+
+ROS 2 Package Build-Type Tutorial
+=================================
+
+This tutorial demonstrates how to create a custom ROS 2 package build-type plugin. A ROS 2 package build-type indicates to the ROS 2 tooling the type of programming and build technology (e.g., C++ and Python) required by the package's implementation. The package build-type is specified during the package creation process. Thereafter it can be found in the package.xml file of the package root directory. Here's an example package creation command line:
+
+.. code-block::
+
+   ros2 pkg create --build-type <build-type> newPkgName
+
+Beginning with the ROS 2 Foxy Fitzroy release, build-types are implemented as plugins. This design enhancement enables ROS 2 to support build-types beyond the classic ament_cmake, cmake and ament_python build-types.
+
+Build-type plugins are responsible for creating the package directory, the package.xml file and other directories and files specific to the each build-type. All build-type plugins must implement the small interface defined by ros2pkg.build_type.BuildTypeExtension.
+
+.. code-block:: python
+
+   class BuildTypeExtension():
+       """The interface for build-type extensions (plugins)."""
+
+       def create_package(self, args):
+           """
+           Create the package structure and content.
+
+           :param args: Command Line args wrapped in a package_create_args object.
+           """
+           raise NotImplementedError
+
+Build-types are "plugged in" to the ros2cli via the ``ros2pkg.build_type`` entry-point. See how the ament_cmake, cmake and ament_python build-types are defined below.
+
+.. code-block:: python
+
+   entry_points={
+     'ros2pkg.build_type': [
+       'ament_cmake = ros2pkg.build_type.ament_cmake:AmentCMakeBuildType',
+       'ament_python = ros2pkg.build_type.ament_python:AmentPythonBuildType',
+       'cmake = ros2pkg.build_type.cmake:CMakeBuildType',
+     ],
+   },...
+
+Creating a Custom Build-Type
+----------------------------
+
+Let's walk through the steps for creating a build-type plugin. We will name our build-type **ament_x** and it will create ROS 2 packages structured for a fictitious programming language known as X.
+
+The source code for this tutorial is available `here <https://github.com/wayneparrott/ament_x_buildtype>`_.
+
+1. Create the ROS 2 python package, ament_x
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We will implement the ament_x build-type as a ROS 2 package and code it in Python. The first step is to create the ament_x package.
+
+From a command shell enter the following commands:
+
+.. code-block::
+
+   ros2 pkg create --build-type ament_python ament_x
+   cd ament_x
+
+2. Implement ament_x Build-Type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We have 2 options for how we create the ament_x build-type. The first is we can subclass the BuildTypeExtension, an interface, and implement its ``create_package()`` method. Doing this gives us fine grained control over how the package files structure and content are created. The second option is to extend the BaseBuildType class and customize the parts of its implementation needed for the ament_x build-type. BaseBuildType implements a workflow and common package creation functionality.
+
+Both approaches have their merits but for simplicity we will pursue option-2 and subclass our ament_x build-type from BaseBuildType.
+
+In the ament_x subdirectory, create a file named **ament_x.py** with the following content.
+
+.. code-block:: python
+
+   from ros2pkg.api.build_type import BaseBuildType
+
+   class AmentXBuildType(BaseBuildType):
+
+       def __init__(self):
+           super(AmentXBuildType, self).__init__()
+
+This initial version of the ament_x build-type uses BaseBuildType's default create_package() functionality to create a package directory and a configured package.xml file. But before we can test it out we have a bit more work.
+
+3. Register ament_x Built-Type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Next we need to contribute our AmentXBuildType plugin. Open the setup.py file in your editor and change the entry_point as follows:
+
+.. code-block:: python
+
+   entry_points={
+     'ros2pkg.build_type': [
+         'ament_x = ament_x.ament_x:AmentXBuildType',
+     ],
+   },
+
+4. Build ament_x Package and Update ROS 2 Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the plugin created and registered, we need to build it using the ``colcon`` build tool. From your command shell enter the following:
+
+.. code-block:: sh
+
+   cd <ament_x package root directory>
+   colcon build
+
+Now let's make the ament_x build-type visible to the ros2 command line tool. Execute the command that best applies to your shell environment. For Linux and Mac users choose one of the following commands:
+
+.. code-block:: sh
+
+   source install/local_setup.bash
+   source install/local_setup.sh
+   source install/local_setup.zsh
+
+For Windows users use this command:
+
+.. code-block:: sh
+
+   install/local_setup.ps1
+
+5. Test Initial Version of ament_x Build-Type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We can confirm that the ros2 cli should now know about our ament_x build type by inspecting the ros package creation command line flags:
+
+.. code-block::
+
+   ros2 pkg create -h
+
+Notice that the --build-type description includes 'ament_x' in the list of available build-types.
+
+.. code-block::
+
+   ros2 pkg create -h
+
+   usage: ros2 pkg create [-h] [--package-format {2,3}]
+                          [--description DESCRIPTION] [--license LICENSE]
+                          [--destination-directory DESTINATION_DIRECTORY]
+                    >>>>  [--build-type {ament_cmake,ament_python,ament_x,cmake}]
+                          [--dependencies DEPENDENCIES [DEPENDENCIES ...]]
+                          [--maintainer-email MAINTAINER_EMAIL]
+                          [--maintainer-name MAINTAINER_NAME]
+                          [--node-name NODE_NAME] [--library-name LIBRARY_NAME]
+                          package_name
+
+Now, let's create a ROS 2 package with the ament_x build-type. Note: the current ament_x build-type implementation doesn't do much yet. It is limited to creation of a new package directory and it's package.xml file.
+
+From the command line, enter the ``ros2 pkg create ...`` command shown below and observe the output.
+
+.. code-block:: sh
+
+   ros2 pkg create --build-type ament_x my_x_project
+
+Output from the package creation process appears below.
+
+.. code-block:: sh
+
+   ros2 pkg create --build-type ament_x my_x_project
+   create package
+     package name: my_x_package
+     destination directory: /dev
+     package format: 3
+     version: 0.0.0
+     description: TODO: Package description
+     maintainer: ['']
+     licenses: ['TODO: License declaration']
+     build type: ament_x
+     dependencies: []
+   creating folder ./my_x_package
+   creating ./my_x_package/package.xml
+
+The ``my_x_project/package.xml`` will look similar to this:
+
+.. code-block:: xml
+
+   <?xml version="1.0"?>
+   <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/200
+   1/XMLSchema"?>
+   <package format="3">
+     <name>my_x_package</name>
+     <version>0.0.0</version>
+     <description>TODO: Package description</description>
+     <maintainer email="nobody@nowhere.com">nobody</maintainer>
+     <license>TODO: License declaration</license>
+
+     <buildtool_depend>ament_x</buildtool_depend>
+
+     <export>
+       <build_type>ament_x</build_type>
+     </export>
+   </package>
+
+YOU'RE DOING MARVELOUS!
+
+Populating The ament_x Package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A package implemented using our fictitious programming language X requires all code reside in a folder named ``src`` and the initial entry point must be a file named ``main.x``. So let's look at how we can create this src directory and file.
+
+While you could use general Python programming api for this task, we will use utilities from the ros2pkg.create Python module.
+
+5 - Create 'src' Directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Returning to the ament_x.py file, implement the ``create_source_folders()`` method as shown below.
+
+.. code-block:: python
+
+   def create_source_folders(self):
+     super(AmentXBuildType, self).create_source_folders()
+
+     print('creating source folder')
+     self.source_directory = create_folder('src', self.package_directory)
+     if not self.source_directory:
+       return 'unable to create source folder in ' + self.package_directory
+
+The create_folder() utility function simplifies directory creation. You will also need to add an import for the create_folder() function at the top of the file.
+
+.. code-block:: python
+
+   from ros2pkg.api.create import create_folder
+
+6 - Create main.x Using An EmPy Template File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We will use the `EmPy <http://www.alcyone.com/software/empy/>`_ template engine to generate the ``main.x`` file. To do this we need to create a template file for main.x and provide it to the EmPy interpreter along with a set of values for replacing template parameters and the location to output translated content.
+
+Create the file ``main.x.em`` at the path shown below:
+
+.. code-block:: sh
+
+   cd <package_root_dir>/ament_x/
+   mkdir -p resource/ament_x
+   touch resource/ament_x/main.x.em
+
+Add the following content to main.x.em and save the file. Note that template variables are preceded with a @ character.
+
+.. code-block:: javascript
+
+   main() {
+     print('Hi from @package_name.')
+   }
+
+*Hang in there we are almost done!*
+
+Add the ``populate()`` method to the end of ament_x.py. This code translates the main.x.em template file into a new package's 'src/main.x' file.
+
+.. code-block:: python
+
+   def populate(self):
+     super(AmentXBuildType, self).populate()
+
+     params = {
+       'package_name': self.package.name
+     }
+     create_template_file(
+       'ament_x',
+       'ament_x/main.x.em',
+       self.source_directory,
+       'main.x',
+       params)
+
+Our final step is to inform the Python `setuptools <https://pythonhosted.org/an_example_pypi_project/setuptools.html>`_ installation system to copy the ``ament_x/resource/main.x.em`` file.
+
+Add the ``package_data`` snippet to setup.py just below the entry_points.
+
+.. code-block::
+
+   entry_points={
+     'console_scripts': [
+     ],
+     'ros2pkg.build_type': [
+       'ament_x = ament_x.ament_x:AmentXBuildType',
+     ],
+   },
+   package_data={
+     'ament_x': [
+       'resource/**/*',
+     ],
+   },
+
+Rebuild ament_x package
+^^^^^^^^^^^^^^^^^^^^^^^
+
+We need to rebuild the ament_x package to pick up our recent changes. From the root folder of the package enter the following on the commandline:
+
+.. code-block:: sh
+
+   colcon build
+
+Test ament_x Build-type
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To test this last change to the ament_x build-type will recreate the my_x_project from `step-5 <5-create-src-directory>`_. If you haven't done so already remove the former my_x_project directory and its content.
+
+.. code-block::
+
+   cd <path>/my_x_project/..
+   rm -rf my_x_project
+
+Now using ros2 cli tools, create a new version of my_x_project.
+
+.. code-block:: sh
+
+   ros2 pkg create --build-type ament_x my_x_project
+   cd my_x_project
+   ls src
+
+The my_x_project directory should appear as follows:
+
+.. code-block:: sh
+
+   my_x_project/
+     package.xml
+     src/
+       main.x
+
+Congrats! You've successfully created a ROS 2 package build-type that can serve as a working example for more sophisticated custom build-types. The next step is to create a build-type plugin for the colcon build-tool. You can start that journey by getting familiar with the colcon `TaskExtensionPoint <https://github.com/colcon/colcon-core/blob/master/colcon_core/task/__init__.py>`_ and explore implementations such as the python build-type found in the same directory.

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -291,7 +291,8 @@ We need to rebuild the ament_x package to pick up our recent changes. From the r
 10. Test ament_x Build-type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To test this last change to the ament_x build-type will recreate the my_x_project from `step-5 <5-create-src-directory>`_. If you haven't done so already remove the former my_x_project directory and its content.
+To test this last change to the ament_x build-type we will recreate the my_x_project from step ` 7. Create src directory`_. 
+If you haven't done so already remove the former my_x_project directory and its content.
 
 .. code-block::
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -10,7 +10,8 @@ This tutorial demonstrates how to create a custom ROS 2 package build-type plugi
 
 Beginning with the ROS 2 Foxy Fitzroy release, build-types are implemented as plugins. This design enhancement enables ROS 2 to support build-types beyond the classic ament_cmake, cmake and ament_python build-types.
 
-Build-type plugins are responsible for creating the package directory, the package.xml file and other directories and files specific to the each build-type. All build-type plugins must implement the small interface defined by ros2pkg.build_type.BuildTypeExtension.
+Build-type plugins are responsible for creating the package directory, the package.xml file and other directories and files specific to each build-type. 
+All build-type plugins must implement the small interface defined by ros2pkg.build_type.BuildTypeExtension.
 
 .. code-block:: python
 

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -2,16 +2,15 @@
 ROS 2 Package Build-Type Tutorial
 =================================
 
-This tutorial demonstrates how to create a custom ROS 2 package build-type plugin. A ROS 2 package build-type indicates to the ROS 2 tooling the type of programming and build technology (e.g., C++ and Python) required by the package's implementation. The package build-type is specified during the package creation process. Thereafter it can be found in the package.xml file of the package root directory. Here's an example package creation command line:
+This tutorial demonstrates how to create a custom ROS 2 package build-type plugin. You may already be familiar with package build-types as the ROS 2 distributions have supported creation and building of packages with the build-types: ``ament_cmake``, ``ament_python`` and ``cmake``. Beginning with the ROS 2 Foxy Fitzroy release, ROS 2 can be extended to support additional build-types developed by the community for popular programming languages such as Java, JavaScript, and Go.  
 
-.. code-block::
+Before we begin creating our custom ROS 2 package build-type, let's learn about the role and responsibilities of a build-type.  A ROS 2 package build-type indicates to the ROS 2 tooling the type of programming model and build technology (e.g., C++ and Python) required by a package's implementation. The package build-type is specified during the package creation process as shown below. Thereafter it can be found in the package.xml file of the package root directory.
+
+.. code-block:: console
 
    ros2 pkg create --build-type <build-type> newPkgName
 
-Beginning with the ROS 2 Foxy Fitzroy release, build-types are implemented as plugins. This design enhancement enables ROS 2 to support build-types beyond the classic ament_cmake, cmake and ament_python build-types.
-
-Build-type plugins are responsible for creating the package directory, the package.xml file and other directories and files specific to each build-type. 
-All build-type plugins must implement the small interface defined by ros2pkg.build_type.BuildTypeExtension.
+A build-type plugin is responsible for creating the standard ROS 2 package directory and package.xml file as well as additional directories and files specific to the build-type. The plugin must implement the small interface defined by ``ros2pkg.build_type.BuildTypeExtension``.
 
 .. code-block:: python
 
@@ -26,7 +25,7 @@ All build-type plugins must implement the small interface defined by ros2pkg.bui
            """
            raise NotImplementedError
 
-Build-types are "plugged in" to the ros2cli via the ``ros2pkg.build_type`` entry-point. See how the ament_cmake, cmake and ament_python build-types are defined below.
+Build-types are "plugged in" to the ros2cli via the ``ros2pkg.build_type`` entry-point. Below is the code for the standard ROS 2 build-type plugins.
 
 .. code-block:: python
 
@@ -41,50 +40,51 @@ Build-types are "plugged in" to the ros2cli via the ``ros2pkg.build_type`` entry
 Creating a Custom Build-Type
 ----------------------------
 
-Let's walk through the steps for creating a build-type plugin. We will name our build-type **ament_x** and it will create ROS 2 packages structured for a fictitious programming language known as X.
+Let's walk through the steps for creating a build-type plugin. We will name our build-type ``ament_x`` and it will create a ROS 2 package structured for a fictitious programming language known as ``X``.
 
 The source code for this tutorial is available `here <https://github.com/wayneparrott/ament_x_buildtype>`_.
 
 1. Create the ROS 2 python package, ament_x
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We will implement the ament_x build-type as a ROS 2 package and code it in Python. The first step is to create the ament_x package.
+We will implement the ``ament_x`` build-type as a ROS 2 package and code it in Python. The first step is to create the ``ament_x`` package.
 
 From a command shell enter the following commands:
 
-.. code-block::
+.. code-block:: console
 
-   ros2 pkg create --build-type ament_python ament_x
-   cd ament_x
+   ros2 pkg create --build-type ament_python --destination-directory ament_x_buildtype ament_x
+   cd ament_x_buildtype
 
 2. Implement ament_x Build-Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We have two options for how we create the ament_x build-type. 
-The first is we can subclass the BuildTypeExtension, an interface, and implement its ``create_package()`` method.
-Doing this gives us fine grained control over how the package files' structure and content are created. 
-The second option is to extend the BaseBuildType class and customize the parts of its implementation needed for the ament_x build-type. 
-BaseBuildType implements a workflow and common package creation functionality.
+We have two options for how we create the ``ament_x`` build-type. 
 
-Both approaches have their merits but for simplicity we will pursue option-2 and subclass our ament_x build-type from BaseBuildType.
+1. This option involves subclassing ``ros2pkg.api.build_type.BuildTypeExtension``, an interface, and implementing its ``create_package()`` method. The benefit of this approach is that it gives us fine control over how the package files' structure and content are created. But it can be tedious to implement as it requires us to manage every aspect of the package creation process.
+2. This option involves extending the ``ros2pkg.api.build_type.BaseBuildType`` class and customizing the parts of its implementation needed for our ``ament_x`` build-type. ``BaseBuildType`` is a base class that implements a simple package creation workflow and common package creation functionality. This approach trades off maximum flexibility for implementation simplicity and convenience.
 
-In the ament_x subdirectory, create a file named **ament_x.py** with the following content.
+While both approaches have their merits, this tutorial will pursue option 2 and subclass our ``ament_x`` build-type from ``BaseBuildType``.
+
+In the ``ament_x_buildtype/ament_x/ament_x/`` directory, create a file named ``ament_x.py`` with the following content. Note that the imported ``create_file()`` and ``create_folder()`` functions will be used at a later step in this tutorial.
 
 .. code-block:: python
 
    from ros2pkg.api.build_type import BaseBuildType
+   from ros2pkg.api.create import create_file
+   from ros2pkg.api.create import create_folder
 
    class AmentXBuildType(BaseBuildType):
 
        def __init__(self):
            super(AmentXBuildType, self).__init__()
 
-This initial version of the ament_x build-type uses BaseBuildType's default create_package() functionality to create a package directory and a configured package.xml file. But before we can test it out we have a bit more work.
+This initial version of the ``ament_x`` build-type uses ``BaseBuildType``'s default ``create_package()`` functionality to create a package directory and a configured package.xml file. But before we can test it out we have a bit more work.
 
 3. Register ament_x Built-Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Next we need to contribute our AmentXBuildType plugin. Open the setup.py file in your editor and change the entry_point as follows:
+Next we need to contribute our ``AmentXBuildType`` plugin. Open the ``setup.py`` file in your editor and change the entry_point as follows:
 
 .. code-block:: python
 
@@ -97,39 +97,43 @@ Next we need to contribute our AmentXBuildType plugin. Open the setup.py file in
 4. Build ament_x Package and Update ROS 2 Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-With the plugin created and registered, we need to build it using the ``colcon`` build tool. From your command shell enter the following:
+With the plugin created and registered, we need to build it using the ROS 2 ``colcon`` build tool. From your command shell enter the following:
 
-.. code-block:: sh
+.. code-block:: console
 
-   cd <ament_x package root directory>
+   cd <ament_x_buildtype directory>
    colcon build
 
-Now let's make the ament_x build-type visible to the ros2 command line tool. Execute the command that best applies to your shell environment. For Linux and Mac users choose one of the following commands:
+Now let's make the ``ament_x`` build-type visible to the ros2 command line tool. Execute the command that best applies to your shell environment.
 
-.. code-block:: sh
+.. tags::
 
-   source install/local_setup.bash
-   source install/local_setup.sh
-   source install/local_setup.zsh
+  .. group-tag:: Linux & Mac OSX
 
-For Windows users use this command:
+    .. code-block:: bash
 
-.. code-block:: sh
+      source install/local_setup.bash
+      source install/local_setup.sh
+      source install/local_setup.zsh
 
-   install/local_setup.ps1
+  .. group-tag:: Windows
+
+    .. code-block:: bash
+
+      install\local_setup.ps1
 
 5. Test Initial Version of ament_x Build-Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We can confirm that the ros2 cli should now know about our ament_x build type by inspecting the ros package creation command line flags:
+Let's confirm that the ros2 cli recognizes our ``ament_x`` build-type by running the following command:
 
-.. code-block::
+.. code-block:: console
 
    ros2 pkg create -h
 
-Notice that the --build-type description includes 'ament_x' in the list of available build-types.
+Notice in the console output below that the ``--build-type`` description includes ``ament_x`` in the list of available build-types.
 
-.. code-block::
+.. code-block:: console
 
    ros2 pkg create -h
 
@@ -143,17 +147,17 @@ Notice that the --build-type description includes 'ament_x' in the list of avail
                           [--node-name NODE_NAME] [--library-name LIBRARY_NAME]
                           package_name
 
-Now, let's create a ROS 2 package with the ament_x build-type. Note: the current ament_x build-type implementation doesn't do much yet. It is limited to creation of a new package directory and it's package.xml file.
+Now, let's create a ROS 2 package with the ``ament_x`` build-type. Note: the current ``ament_x`` build-type implementation doesn't do much yet. It is limited to creation of a new package directory and it's package.xml file.
 
 From the command line, enter the ``ros2 pkg create ...`` command shown below and observe the output.
 
-.. code-block:: sh
+.. code-block:: console
 
    ros2 pkg create --build-type ament_x my_x_project
 
 Output from the package creation process appears below.
 
-.. code-block:: sh
+.. code-block:: console
 
    ros2 pkg create --build-type ament_x my_x_project
    create package
@@ -195,14 +199,14 @@ YOU'RE DOING MARVELOUS!
 6. Populating the ament_x Package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A package implemented using our fictitious programming language X requires all code reside in a folder named ``src`` and the initial entry point must be a file named ``main.x``. So let's look at how we can create this src directory and file.
+A ROS 2 package implemented using our fictitious programming language ``X`` requires all code reside in a folder named ``src``. Additionally, the initial entry point for execution of the package must be a file named ``main.x``. So let's look at how we can create a ``src`` directory and file.
 
-While you could use general Python programming api for this task, we will use utilities from the ros2pkg.create Python module.
+While you could use general Python programming api for this task, we will use utilities from the ``ros2pkg.create`` Python module.
 
 7. Create src Directory
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Returning to the ament_x.py file, implement the ``create_source_folders()`` method inside `AmentXBuildType` class as shown below.
+Returning to the ``ament_x.py`` file, implement the ``create_source_folders()`` method inside the ``AmentXBuildType`` class as shown below. The ``create_folder()`` utility function simplifies directory creation.
 
 .. code-block:: python
 
@@ -214,26 +218,32 @@ Returning to the ament_x.py file, implement the ``create_source_folders()`` meth
      if not self.source_directory:
        return 'unable to create source folder in ' + self.package_directory
 
-The create_folder() utility function simplifies directory creation. You will also need to add an import for the create_folder() function at the top of the file.
-
-.. code-block:: python
-
-   from ros2pkg.api.create import create_folder
-
 8. Create main.x Using an EmPy Template File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We will use the `EmPy <http://www.alcyone.com/software/empy/>`_ template engine to generate the ``main.x`` file. To do this we need to create a template file for main.x and provide it to the EmPy interpreter along with a set of values for replacing template parameters and the location to output translated content.
+We will use the `EmPy <http://www.alcyone.com/software/empy/>`_ template engine to generate the ``main.x`` file. To do this we need to create a template file for ``main.x`` and provide it to the EmPy interpreter along with a set of values for replacing template parameters and the file path where intepreter output should be written.
 
-Create the file ``main.x.em`` at the path shown below:
+Create the file ``main.x.em`` as shown below:
 
-.. code-block:: sh
+.. tags::
 
-   cd <package_root_dir>/ament_x/
-   mkdir -p resource/ament_x
-   touch resource/ament_x/main.x.em
+  .. group-tag:: Linux & Mac OSX
 
-Add the following content to main.x.em and save the file. Note that template variables are preceded with a @ character.
+    .. code-block:: console
+
+      cd ament_x_buildtype/ament_x/ament_x
+      mkdir -p resource/ament_x
+      touch resource/ament_x/main.x.em
+
+  .. group-tag:: Windows
+
+    .. code-block:: console
+
+      cd ament_x_buildtype\ament_x\ament_x
+      mkdir resource\ament_x
+      type nul > resource\ament_x\main.x.em
+
+Add the following content to ``main.x.em`` and save the file. Note that template variables are preceded with a ``@`` character.
 
 .. code-block:: javascript
 
@@ -243,7 +253,7 @@ Add the following content to main.x.em and save the file. Note that template var
 
 *Hang in there we are almost done!*
 
-Add the ``populate()`` method to the `AmentXBuildType` class in `ament_x.py` file. This code translates the main.x.em template file into a new package's 'src/main.x' file.
+Add the ``populate()`` method to the ``AmentXBuildType`` class in the ``ament_x.py`` file. This code translates the ``main.x.em`` template file into a new package's ``src/main.x`` file.
 
 .. code-block:: python
 
@@ -253,16 +263,16 @@ Add the ``populate()`` method to the `AmentXBuildType` class in `ament_x.py` fil
      params = {
        'package_name': self.package.name
      }
-     create_template_file(
+     create_file(
        'ament_x',
        'ament_x/main.x.em',
        self.source_directory,
        'main.x',
        params)
 
-Our final step is to inform the Python `setuptools <https://pythonhosted.org/an_example_pypi_project/setuptools.html>`_ installation system to copy the ``ament_x/resource/main.x.em`` file.
+Our final step is to inform the Python `setuptools <https://pythonhosted.org/an_example_pypi_project/setuptools.html>`_ installation system to copy the ``ament_x_buildtype/ament_x/ament_x/resource/main.x.em`` file.
 
-Add the ``package_data`` snippet to setup.py just below the entry_points.
+Add the ``package_data`` snippet to ``setup.py`` just below the entry_points.
 
 .. code-block::
 
@@ -282,34 +292,42 @@ Add the ``package_data`` snippet to setup.py just below the entry_points.
 9. Rebuild ament_x package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We need to rebuild the ament_x package to pick up our recent changes. From the root folder of the package enter the following on the commandline:
+We need to rebuild the ``ament_x`` package to pick up our recent changes. From the ``ament_x_buildtype`` directory enter the following on the command line:
 
-.. code-block:: sh
+.. code-block:: console
 
    colcon build
 
 10. Test ament_x Build-type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To test this last change to the ament_x build-type we will recreate the my_x_project from step ` 7. Create src directory`_. 
-If you haven't done so already remove the former my_x_project directory and its content.
+Our last step is to test our latest changes by recreating the ``my_x_project`` from step `7. Create src directory`_. If you haven't done so already remove the former ``my_x_project`` directory and its content.
 
-.. code-block::
+.. tags::
 
-   cd <path>/my_x_project/..
-   rm -rf my_x_project
+  .. group-tag:: Linux & Mac OSX
 
-Now using ros2 cli tools, create a new version of my_x_project.
+    .. code-block:: console
 
-.. code-block:: sh
+      cd <path>/my_x_project/..
+      rm -rf my_x_project
+
+  .. group-tag:: Windows
+
+    .. code-block:: console
+
+      cd <path>\my_x_project/..
+      rmdir /S my_x_project
+
+Now using ros2 cli tool, create a new version of ``my_x_project``.
+
+.. code-block:: console
 
    ros2 pkg create --build-type ament_x my_x_project
-   cd my_x_project
-   ls src
 
-The my_x_project directory should appear as follows:
+The ``my_x_project`` directory should appear as follows:
 
-.. code-block:: sh
+.. code-block:: console
 
    my_x_project/
      package.xml
@@ -317,6 +335,6 @@ The my_x_project directory should appear as follows:
        main.x
 
 Congrats! 
-You've successfully created a ROS 2 package build-type that can serve as a working example for more sophisticated custom build-types. 
+You've successfully created a ROS 2 package build-type. The ament_x build-type can serve as a working example for creating more sophisticated custom build-types. 
 The next step is to create a build-type plugin for the colcon build-tool. 
 You can start that journey by getting familiar with the colcon `TaskExtensionPoint <https://github.com/colcon/colcon-core/blob/master/colcon_core/task/__init__.py>`_ and explore implementations such as the Python build-type found in the same directory.

--- a/source/Tutorials/Package-BuildType-Tutorial.rst
+++ b/source/Tutorials/Package-BuildType-Tutorial.rst
@@ -197,7 +197,7 @@ While you could use general Python programming api for this task, we will use ut
 5 - Create 'src' Directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Returning to the ament_x.py file, implement the ``create_source_folders()`` method as shown below.
+Returning to the ament_x.py file, implement the ``create_source_folders()`` method inside `AmentXBuildType` class as shown below.
 
 .. code-block:: python
 


### PR DESCRIPTION
A tutorial introducing ROS 2 Package Build-types and how to create a build-type. Accompanies the introduction of [ros2cli pkg build-types](https://github.com/ros2/ros2cli/pull/444).

The 1st draft of this tutorial was create using markdown. As a rst noob, I opted to run the m2r converter to translate it to the current rst format.