### PR TITLE
Fix installation redirects (again)

### DIFF
--- a/source/Installation/Crystal/Fedora-Development-Setup.rst
+++ b/source/Installation/Crystal/Fedora-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Fedora-Development-Setup
-    Installation/Fedora-Development-Setup
-
 Building ROS 2 on Fedora Linux
 ==============================
 

--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Linux-Development-Setup
-    Installation/Linux-Development-Setup
-
 Building ROS 2 on Linux
 =======================
 

--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Linux-Install-Binary
-    Installation/Linux-Install-Binary
-
 Installing ROS 2 on Linux
 =========================
 

--- a/source/Installation/Crystal/Linux-Install-Debians.rst
+++ b/source/Installation/Crystal/Linux-Install-Debians.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Linux-Install-Debians
-    Installation/Linux-Install-Debians
-
 Installing ROS 2 via Debian Packages
 ====================================
 

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Windows-Development-Setup
-    Installation/Windows-Development-Setup
-
 Building ROS 2 on Windows
 =========================
 

--- a/source/Installation/Crystal/Windows-Install-Binary.rst
+++ b/source/Installation/Crystal/Windows-Install-Binary.rst
@@ -1,8 +1,3 @@
-.. redirect-from::
-
-    Windows-Install-Binary
-    Installation/Windows-Install-Binary
-
 Installing ROS 2 on Windows
 ===========================
 

--- a/source/Installation/Eloquent/Fedora-Development-Setup.rst
+++ b/source/Installation/Eloquent/Fedora-Development-Setup.rst
@@ -1,3 +1,10 @@
+.. redirect-from::
+
+    Fedora-Development-Setup
+    Installation/Fedora-Development-Setup
+
+.. move lines 1-6 to most recently released distro
+
 Building ROS 2 on Fedora Linux
 ==============================
 
@@ -55,4 +62,3 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
 
 
 With this done, you can follow the rest of the `instructions <Eloquent_linux-dev-get-ros2-code>` to fetch and build ROS 2.
-

--- a/source/Installation/Eloquent/Fedora-Development-Setup.rst
+++ b/source/Installation/Eloquent/Fedora-Development-Setup.rst
@@ -1,9 +1,3 @@
-.. redirect-from::
-
-    Fedora-Development-Setup
-    Installation/Fedora-Development-Setup
-
-.. move lines 1-6 to most recently released distro
 
 Building ROS 2 on Fedora Linux
 ==============================

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -1,3 +1,9 @@
+.. redirect-from::
+
+    Linux-Development-Setup
+    Installation/Linux-Development-Setup
+
+.. move lines 1-6 to most recently released distro
 
 Building ROS 2 on Linux
 =======================

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -1,10 +1,3 @@
-.. redirect-from::
-
-    Linux-Development-Setup
-    Installation/Linux-Development-Setup
-
-.. move lines 1-6 to most recently released distro
-
 Building ROS 2 on Linux
 =======================
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -1,9 +1,3 @@
-.. redirect-from::
-
-    Linux-Install-Binary
-    Installation/Linux-Install-Binary
-
-.. move lines 1-6 to most recently released distro
 
 Installing ROS 2 on Linux
 =========================

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -1,3 +1,10 @@
+.. redirect-from::
+
+    Linux-Install-Binary
+    Installation/Linux-Install-Binary
+
+.. move lines 1-6 to most recently released distro
+
 Installing ROS 2 on Linux
 =========================
 

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -1,9 +1,3 @@
-.. redirect-from::
-
-    Linux-Install-Debians
-    Installation/Linux-Install-Debians
-
-.. move lines 1-6 to most recently released distro
 
 Installing ROS 2 via Debian Packages
 ====================================

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -1,3 +1,10 @@
+.. redirect-from::
+
+    Linux-Install-Debians
+    Installation/Linux-Install-Debians
+
+.. move lines 1-6 to most recently released distro
+
 Installing ROS 2 via Debian Packages
 ====================================
 

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -1,9 +1,3 @@
-.. redirect-from::
-
-    Windows-Development-Setup
-    Installation/Windows-Development-Setup
-
-.. move lines 1-6 to most recently released distro
 
 Building ROS 2 on Windows
 =========================

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -1,3 +1,9 @@
+.. redirect-from::
+
+    Windows-Development-Setup
+    Installation/Windows-Development-Setup
+
+.. move lines 1-6 to most recently released distro
 
 Building ROS 2 on Windows
 =========================

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -1,9 +1,3 @@
-.. redirect-from::
-
-    Windows-Install-Binary
-    Installation/Windows-Install-Binary
-    
-.. move lines 1-6 to most recently released distro
 
 Installing ROS 2 on Windows
 ===========================

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -1,3 +1,10 @@
+.. redirect-from::
+
+    Windows-Install-Binary
+    Installation/Windows-Install-Binary
+    
+.. move lines 1-6 to most recently released distro
+
 Installing ROS 2 on Windows
 ===========================
 

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -1,10 +1,7 @@
 .. redirect-from::
 
   Eloquent/OSX-Development-Setup
-  macOS-Development-Setup
-  Installation/macOS-Development-Setup
-
-.. move redirects on lines 4 and 5 (and this comment) to most recently released distro
+  Installation/OSX-Development-Setup
 
 Building ROS 2 on macOS
 =======================

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -1,6 +1,10 @@
 .. redirect-from::
 
   Eloquent/OSX-Development-Setup
+  macOS-Development-Setup
+  Installation/macOS-Development-Setup
+
+.. move redirects on lines 4 and 5 (and this comment) to most recently released distro
 
 Building ROS 2 on macOS
 =======================

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -1,10 +1,7 @@
 .. redirect-from::
 
   Eloquent/OSX-Install-Binary
-  macOS-Install-Binary
-  Installation/macOS-Install-Binary
-
-.. move redirects on lines 4 and 5 (and this comment) to most recently released distro
+  Installation/OSX-Install-Binary
 
 Installing ROS 2 on macOS
 =========================

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -1,6 +1,10 @@
 .. redirect-from::
 
   Eloquent/OSX-Install-Binary
+  macOS-Install-Binary
+  Installation/macOS-Install-Binary
+
+.. move redirects on lines 4 and 5 (and this comment) to most recently released distro
 
 Installing ROS 2 on macOS
 =========================


### PR DESCRIPTION
Even with the conf.py changes in #570 ,`Installation/..` was still redirecting to Crystal because of these directives. 

Signed-off-by: maryaB-osr <marya@openrobotics.org>