### PR TITLE
Install python3-rosdep instead of python-rosdep

### DIFF
--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -53,7 +53,7 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-pip \
-     python-rosdep \
+     python3-rosdep \
      python3-vcstool \
      wget
    # install some pip packages needed for testing


### PR DESCRIPTION
Python-rosdep is no longer available.