### PR TITLE
Update package dependencies for pub/sub tutorial

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -212,8 +212,8 @@ Add a new line after the ``ament_cmake`` buildtool dependency and paste the foll
 
 .. code-block:: xml
 
-    <exec_depend>rclcpp</exec_depend>
-    <exec_depend>std_msgs</exec_depend>
+    <depend>rclcpp</depend>
+    <depend>std_msgs</depend>
 
 This declares the package needs ``rclpp`` and ``std_msgs`` when its code is executed.
 


### PR DESCRIPTION
The package dependencies given in the tutorial should be both build and execution dependencies, so I change the dependency tags to just 'depend'. See discussion here: https://github.com/ros2/ros2_documentation/pull/366/files#r397961159