### PR TITLE
Update macOS-Development-Setup.rst

### DIFF
--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -34,6 +34,7 @@ You need the following things installed to build ROS 2:
      .. code-block:: bash
 
         xcode-select --install
+        sudo xcode-select --switch /Library/Developer/CommandLineTools # Enable Command Line Tools
 
 #.
    **brew** *(needed to install more stuff; you probably already have this)*:


### PR DESCRIPTION
Add command to enable Command Line Tools to prevent error("xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance").