### PR TITLE
Use new syntax for configuring log level from command line

### DIFF
--- a/source/Concepts/Logging.rst
+++ b/source/Concepts/Logging.rst
@@ -70,8 +70,6 @@ Command line configuration of the default severity level
 
 As of the Bouncy ROS 2 release, the default severity level for loggers can be configured from the command line with the following, for example (the level string is not case sensitive):
 
-.. code-block:: bash
-
 .. tabs::
 
   .. group-tab:: Bouncy+

--- a/source/Concepts/Logging.rst
+++ b/source/Concepts/Logging.rst
@@ -72,7 +72,19 @@ As of the Bouncy ROS 2 release, the default severity level for loggers can be co
 
 .. code-block:: bash
 
-   ros2 run demo_nodes_cpp listener --ros-args --log-level DEBUG
+.. tabs::
+
+  .. group-tab:: Bouncy+
+
+    .. code-block:: bash
+
+      ros2 run demo_nodes_cpp listener __log_level:=debug
+
+  .. group-tab:: Eloquent+
+
+    .. code-block:: bash
+
+      ros2 run demo_nodes_cpp listener --ros-args --log-level DEBUG
 
 This will affect all loggers that have not explicitly been configured to use a particular severity level.
 Configuration of specific loggers from the command line is forthcoming.

--- a/source/Concepts/Logging.rst
+++ b/source/Concepts/Logging.rst
@@ -72,7 +72,7 @@ As of the Bouncy ROS 2 release, the default severity level for loggers can be co
 
 .. code-block:: bash
 
-   ros2 run demo_nodes_cpp listener __log_level:=debug
+   ros2 run demo_nodes_cpp listener --ros-args --log-level DEBUG
 
 This will affect all loggers that have not explicitly been configured to use a particular severity level.
 Configuration of specific loggers from the command line is forthcoming.


### PR DESCRIPTION
In the example, I fixed the deprecated syntax according to the warning displayed by rcl:

`[rcl]: Found log level rule '__log_level:=debug'. This syntax is deprecated. Use '--ros-args --log-level DEBUG' instead.`