### PR TITLE
Update links to 5.3.1 download page

### DIFF
--- a/source/Installation/Install-Connext-Security-Plugins.rst
+++ b/source/Installation/Install-Connext-Security-Plugins.rst
@@ -8,6 +8,9 @@ university and research license versions of RTI Connext DDS Pro, which
 is bundled with tools for system debugging, monitoring, record/replay,
 etc.
 
+The Connext DDS Evaluation Version (5.3.1) includes the security plugins, and can be dowloaded via options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
+
+
 A video walk-thru of this installation (tools and security plug-ins) is
 available
 `here <https://www.rti.com/gettingstarted/installwindows_secure>`__ at

--- a/source/Installation/Install-Connext-Security-Plugins.rst
+++ b/source/Installation/Install-Connext-Security-Plugins.rst
@@ -8,8 +8,7 @@ university and research license versions of RTI Connext DDS Pro, which
 is bundled with tools for system debugging, monitoring, record/replay,
 etc.
 
-The Connext DDS Evaluation Version (5.3.1) includes the security plugins, and can be dowloaded via options available for `university, purchase or evaluation <Install-Connext-University-Eval>`
-
+The Connext DDS Evaluation Version (5.3.1) includes the security plugins, and can be downloaded via options available for `university, purchase or evaluation <Install-Connext-University-Eval>`.
 
 A video walk-thru of this installation (tools and security plug-ins) is
 available

--- a/source/Installation/Install-Connext-University-Eval.rst
+++ b/source/Installation/Install-Connext-University-Eval.rst
@@ -8,9 +8,9 @@ A full-suite installation of RTI Connext DDS is available for many additional pl
 This installation includes diagnostic tools, layered services, and security.  See below for installation details.
 
 .. note::
-    As of the ROS 2 'Dashing' release, the Connext RMW layer in ROS 2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.0).
+    The Connext RMW layer in ROS 2 is compatible with version 5.3.x of RTI Connext DDS, but not with the most-recent version (6.0.x).
 
-    The Connext RMW layer is being modified for 6.0.x compatibility and will be available prior to the next release of ROS 2.
+    The Connext RMW layer is undergoing updates to support newer versions of RTI Connext DDS.
 
 RTI University Program
 ----------------------
@@ -24,8 +24,8 @@ RTI Connext DDS Evaluation
 --------------------------
 
 To install RTI Connext DDS **version 5.3.1** Evalution:
- * Visit the `RTI Free Trial (5.3.1) site <https://www.rti.com/free-trial-5.3.1>`__.
- * Register using the online form.
- * When directed to the download page, choose the **version 5.3.1** installer for your platform.
+ * Visit the `RTI Free Trial (5.3.1) site <https://www.rti.com/free-trial/dds-files-5.3.1>`__.
+ * Download the version(s) to match your environment.
+ * Contact license@rti.com for an evaluation license.
  * Install RTI Connext 5.3.1 by running the installation program.  When finished, it will run the RTI Launcher.
  * Use the RTI Launcher to install the license file (rti_license.dat) if needed.  The launcher may also be used to launch the diagnostic tools and services.


### PR DESCRIPTION
The links now point to a 5.3.1 eval direct-download page.
Updated descriptions to match.