### PR TITLE
update creating a launch

### DIFF
--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -116,7 +116,7 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
    .. group-tab:: Foxy or newer
 
       .. code-block:: python
-      
+
          from  launch import LaunchDescription
          from launch_ros.actions import Node
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -116,7 +116,7 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
    .. group-tab:: Foxy or newer
 
       .. code-block:: python
-
+      
          from  launch import LaunchDescription
          from launch_ros.actions import Node
 
@@ -124,20 +124,20 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
              return LaunchDescription([
                  Node(
                      package='turtlesim',
-                     namespace='turtlesim1',
-                     executable='turtlesim_node',
-                     name='sim'
+                     node_namespace='turtlesim1',
+                     node_executable='turtlesim_node',
+                     node_name='sim'
                  ),
                  Node(
                      package='turtlesim',
-                     namespace='turtlesim2',
-                     executable='turtlesim_node',
-                     name='sim'
+                     node_namespace='turtlesim2',
+                     node_executable='turtlesim_node',
+                     node_name='sim'
                  ),
                  Node(
                      package='turtlesim',
-                     executable='mimic',
-                     name='mimic',
+                     node_executable='mimic',
+                     node_name='mimic',
                      remappings=[
                          ('/input/pose', '/turtlesim1/turtle1/pose'),
                          ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),


### PR DESCRIPTION
the launch file proposed for foxy and newer actually does not work. this proposed change just imitates what was done for dashing and eloquent. 
Received an error: "_init__() missing 1 required keyword-only argument: 'node_executable'" Once swapped it out for the suggested eloquent one it worked