### PR TITLE
Update ros::Time migration, existing was out of date

### DIFF
--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -333,12 +333,11 @@ For usages of ``ros::Time``:
 
 * If your messages or code makes use of std_msgs::Time:
 
-  * Convert all instances of std_msgs::Time to builtin_interfaces::msg::Time 
+  * Convert all instances of std_msgs::Time to builtin_interfaces::msg::Time
   
   * Convert all ``#include "std_msgs/time.h`` to ``#include "builtin_interfaces/msg/time.hpp"``
   
   * Convert all instances using the std_msgs::Time field ``nsec`` to the builtin_interfaces::msg::Time field ``nanosec``
-  
 
 Usages of ros::Rate
 ~~~~~~~~~~~~~~~~~~~

--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -334,9 +334,9 @@ For usages of ``ros::Time``:
 * If your messages or code makes use of std_msgs::Time:
 
   * Convert all instances of std_msgs::Time to builtin_interfaces::msg::Time
-  
+
   * Convert all ``#include "std_msgs/time.h`` to ``#include "builtin_interfaces/msg/time.hpp"``
-  
+
   * Convert all instances using the std_msgs::Time field ``nsec`` to the builtin_interfaces::msg::Time field ``nanosec``
 
 Usages of ros::Rate

--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -330,10 +330,15 @@ Usages of ros::Time
 For usages of ``ros::Time``:
 
 * Replace all instances of ``ros::Time`` with ``rclcpp::Time``
+
 * If your messages or code makes use of std_msgs::Time:
-** Convert all instances of std_msgs::Time to builtin_interfaces::msg::Time 
-** Convert all ``#include "std_msgs/time.h`` to ``#include "builtin_interfaces/msg/time.hpp"``
-** Convert all instances using the std_msgs::Time field ``nsec`` to the builtin_interfaces::msg::Time field ``nanosec``
+
+  * Convert all instances of std_msgs::Time to builtin_interfaces::msg::Time 
+  
+  * Convert all ``#include "std_msgs/time.h`` to ``#include "builtin_interfaces/msg/time.hpp"``
+  
+  * Convert all instances using the std_msgs::Time field ``nsec`` to the builtin_interfaces::msg::Time field ``nanosec``
+  
 
 Usages of ros::Rate
 ~~~~~~~~~~~~~~~~~~~

--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -327,21 +327,13 @@ Instead of returning false on failures, throwing exceptions is recommended.
 Usages of ros::Time
 ~~~~~~~~~~~~~~~~~~~
 
-**TODO There is no direct replacement for ros::Time yet we expect to have one in the future.**
+For usages of ``ros::Time``:
 
-Under the hood we expect to leverage the cross platform ``std::chrono`` library.
-
-Currently for usages of ``ros::Time``:
-
-
-* Replace all instances of ``ros::Time`` with ``builtin_interfaces::msg::Time``
-* Convert all instances of ``nsec`` to ``nanosec``
-* Convert all single argument double constructors to bare constructor plus assignment
-
-Field values do not get initialized to zero when constructed.
-You must make sure to set all values instead of relying on them to be zero.
-
-Alternatively you can switch to an internal proxy datatype temporarily while waiting for an rclcpp::Time
+* Replace all instances of ``ros::Time`` with ``rclcpp::Time``
+* If your messages or code makes use of std_msgs::Time:
+** Convert all instances of std_msgs::Time to builtin_interfaces::msg::Time 
+** Convert all ``#include "std_msgs/time.h`` to ``#include "builtin_interfaces/msg/time.hpp"``
+** Convert all instances using the std_msgs::Time field ``nsec`` to the builtin_interfaces::msg::Time field ``nanosec``
 
 Usages of ros::Rate
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The existing documentation made the out of date claim that there is no rclcpp::Time implementation yet. Since there is, I've attempted to provide some basic pointers on how to migrate.