### PR TITLE
Remove references to waffle.io

### DIFF
--- a/source/Contributing.rst
+++ b/source/Contributing.rst
@@ -73,10 +73,10 @@ Development Guides
 What to work on
 ^^^^^^^^^^^^^^^
 
-We have identified a number of tasks that could be worked on by community members: they can be listed by `searching across the ROS 2 repositories for issues labeled as "help wanted" <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A"help+wanted"&type=Issues>`__ or filtering the items on `the ROS 2 waffle.io board <https://waffle.io/ros2/ros2?label=help%20wanted>`__.
+We have identified a number of tasks that could be worked on by community members: they can be listed by `searching across the ROS 2 repositories for issues labeled as "help wanted" <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A"help+wanted"&type=Issues>`__.
 If you see something on that list that you would like to work on, please comment on the item to let others know that you are looking into it.
 
-We also have a label for issues that we think should be more accessible for first-time contributors, `labelled “good first issue” <https://waffle.io/ros2/ros2?label=good%20first%20issue>`__.
+We also have a label for issues that we think should be more accessible for first-time contributors, `labelled “good first issue” <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A%22good+first+issue%22&type=Issues>`__.
 If you are interested in contributing to the ROS 2 project, we encourage you to take a look at those issues first.
 If you’d like to cast a wider net, we welcome contributions on any open issue (or others that you might propose), particularly tasks that have a milestone signifying they’re targeted for the next ROS 2 release (the milestone will be the next release's codename e.g. 'crystal').
 

--- a/source/Contributing.rst
+++ b/source/Contributing.rst
@@ -76,7 +76,7 @@ What to work on
 We have identified a number of tasks that could be worked on by community members: they can be listed by `searching across the ROS 2 repositories for issues labeled as "help wanted" <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A"help+wanted"&type=Issues>`__.
 If you see something on that list that you would like to work on, please comment on the item to let others know that you are looking into it.
 
-We also have a label for issues that we think should be more accessible for first-time contributors, `labelled “good first issue” <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A%22good+first+issue%22&type=Issues>`__.
+We also have a label for issues that we think should be more accessible for first-time contributors, `labeled “good first issue” <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A%22good+first+issue%22&type=Issues>`__.
 If you are interested in contributing to the ROS 2 project, we encourage you to take a look at those issues first.
 If you’d like to cast a wider net, we welcome contributions on any open issue (or others that you might propose), particularly tasks that have a milestone signifying they’re targeted for the next ROS 2 release (the milestone will be the next release's codename e.g. 'crystal').
 

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -288,6 +288,27 @@ For example, a new function ``rmw_foo()`` introduced to the RMW API must be impl
 Updates for non-Tier 1 middleware libraries should also be considered if feasible (e.g. depending on the size of the change).
 See `REP-2000 <http://www.ros.org/reps/rep-2000.html#crystal-clemmys-december-2018-december-2019>`__ for the list of middleware libraries and their tiers.
 
+Tracking tasks
+^^^^^^^^^^^^^^
+
+To help organize work on ROS 2, the core ROS 2 development team uses kanban-style `GitHub project boards <https://github.com/orgs/ros2/projects>`_.
+
+Not all issues and pull requests are tracked on the project boards, however.
+A board usually represents an upcoming release or specific project.
+Tickets can be browsed on a per-repo basis by browsing the `ROS 2 repositories' <https://github.com/ros2>`_ individual issue pages.
+
+The names and purposes of columns in any given ROS 2 project board vary, but typically follow the same general structure:
+
+* **To do**: Issues that are relevant to the project, ready to be assigned
+* **In progress**: Active pull requests on which work is currently in progress
+* **In review**: Pull requests where work is complete and ready for review, and for those currently under active review
+* **Done**: Pull requests and related issues are merged/closed (for informational purposes)
+
+To request permission to make changes, simply comment on the tickets you're interested in.
+Depending on the complexity, it might be useful to describe how you plan to address it.
+We will update the status (if you don't have the permission) and you can start working on a pull request.
+If you contribute regularly we will likely just grant you permission to manage the labels etc. yourself.
+
 Programming conventions
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Contributing/ROS-2-On-boarding-Guide.rst
+++ b/source/Contributing/ROS-2-On-boarding-Guide.rst
@@ -94,10 +94,11 @@ We try to spread our responsibilities out across the team and so we ask everyone
 Developer Workflow
 ------------------
 
+We track open tickets and active PRs related to upcoming releases and larger projects using `GitHub project boards <https://github.com/orgs/ros2/projects>`_.
+
 Higher level tasks are tracked on the internal (private) Jira: https://osrfoundation.atlassian.net/projects/ROS2
 
 The usual workflow is (this list is a work in progress):
-
 
 * Discuss design (GitHub ticket, and a meeting if needed)
 * Assign implementation to a team member
@@ -123,11 +124,15 @@ The usual workflow is (this list is a work in progress):
 
 * To get the PR reviewed, you need to put the label "in review":
 
-  * Through github interface:
+  * Through GitHub interface:
 
     * Click on "" next to labels
     * Remove "in progress" label if applicable
     * Add "in review" label
+
+  * If the PR is part of a project board:
+
+    * Drag the card from "In progress" to "In review"
 
 * When the PR has been approved:
 
@@ -138,6 +143,15 @@ The usual workflow is (this list is a work in progress):
       * Note: each PR should target a specific feature so Squash and Merge should make sense 99% of the time
 
 * Delete the branch once merged
+
+GitHub tips
+^^^^^^^^^^^
+
+Link PRs to the issues they address using `keywords <https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>`_ and the ticket number.
+This will close the issue once the pull request is merged.
+
+* In the same repo: "fixes #216"
+* In another repo: "fixes ros2/rosidl#216"
 
 Build Farm Introduction
 -----------------------

--- a/source/Contributing/ROS-2-On-boarding-Guide.rst
+++ b/source/Contributing/ROS-2-On-boarding-Guide.rst
@@ -94,8 +94,6 @@ We try to spread our responsibilities out across the team and so we ask everyone
 Developer Workflow
 ------------------
 
-We track all open tickets and current PRs using waffle.io: https://waffle.io/ros2/ros2
-
 Higher level tasks are tracked on the internal (private) Jira: https://osrfoundation.atlassian.net/projects/ROS2
 
 The usual workflow is (this list is a work in progress):
@@ -131,10 +129,6 @@ The usual workflow is (this list is a work in progress):
     * Remove "in progress" label if applicable
     * Add "in review" label
 
-  * Through waffle:
-
-    * Drag your PR to the "in review" column
-
 * When the PR has been approved:
 
   * the person who submitted the PR merges it using "Squash and Merge" option so that we keep a clean history
@@ -144,27 +138,6 @@ The usual workflow is (this list is a work in progress):
       * Note: each PR should target a specific feature so Squash and Merge should make sense 99% of the time
 
 * Delete the branch once merged
-
-Waffle.io How-to
-----------------
-
-Here are some tips on how to use our Kanban board on waffle.io:
-
-
-* Assigning labels: drag and drop cards to the column with the label you want to assign
-* Connecting Issues/PR: Waffle allows to connect cards together using keywords
-
-  * Note1: The keywords need to be placed in the 1st comment of the GitHub ticket
-  * Note2: Waffle uses the "simplified" GitHub reference and not the full URL to connect card.
-
-    * Does not work:
-
-      * "connects to https://github.com/ros2/rosidl/issues/216"
-
-    * Works:
-
-      * In the same repo: "connects to #216"
-      * In another repo: "connects to ros2/rosidl#216"
 
 Build Farm Introduction
 -----------------------


### PR DESCRIPTION
AFAIU waffles.io is not a service anymore. 
This PR is for removing the references to this service.

I do not know if you have a replacement tool that you keep track of tasks. If there is one, feel free to add it to this PR.