### PR TITLE
[foxy] Install dependencies with apt instead of pip where possible

### DIFF
--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -54,14 +54,15 @@ Install development tools and ROS tools
      git \
      libbullet-dev \
      python3-colcon-common-extensions \
+     python3-flake8 \
      python3-pip \
+     python3-pytest-cov \
      python3-rosdep \
      python3-vcstool \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
      argcomplete \
-     flake8 \
      flake8-blind-except \
      flake8-builtins \
      flake8-class-newline \
@@ -73,7 +74,6 @@ Install development tools and ROS tools
      pytest-repeat \
      pytest-rerunfailures \
      pytest \
-     pytest-cov \
      pytest-runner \
      setuptools
    # install Fast-RTPS dependencies

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -58,6 +58,7 @@ Install development tools and ROS tools
      python3-pip \
      python3-pytest-cov \
      python3-rosdep \
+     python3-setuptools \
      python3-vcstool \
      wget
    # install some pip packages needed for testing
@@ -74,8 +75,7 @@ Install development tools and ROS tools
      pytest-repeat \
      pytest-rerunfailures \
      pytest \
-     pytest-runner \
-     setuptools
+     pytest-runner
    # install Fast-RTPS dependencies
    sudo apt install --no-install-recommends -y \
      libasio-dev \

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -74,8 +74,7 @@ Install development tools and ROS tools
      flake8-quotes \
      pytest-repeat \
      pytest-rerunfailures \
-     pytest \
-     pytest-runner
+     pytest
    # install Fast-RTPS dependencies
    sudo apt install --no-install-recommends -y \
      libasio-dev \


### PR DESCRIPTION
pytest-cov and flake8 have the same versions in Ubuntu Focal as if they were installed with pip.

For setuptools, the version in Focal is 45.2.0. The previous version in Bionic is 39.0.1 and the version we get from pip is 46.1.1. Although the version from pip is newer, it doesn't look like we are effected by any changes.