### PR TITLE
[foxy] Use master ros2.repos file

### DIFF
--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -95,7 +95,7 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_foxy/src
    cd ~/ros2_foxy
-   wget https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
    vcs import src < ros2.repos
 
 Install dependencies using rosdep


### PR DESCRIPTION
This file will be the one updated regularly between now and the release.
We should update that this once we branch for Foxy.

This is so that users coming from https://index.ros.org/doc/ros2/Installation/Latest-Development-Setup/ will get the correct source code.