### PR TITLE
Update package dependencies for msg tutorial

### DIFF
--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -373,9 +373,19 @@ Add the following lines (C++ only):
 
 package.xml:
 
-Add the following line (same for C++ and Python):
+Add the following line:
 
-.. code-block:: xml
+.. tabs::
+
+  .. group-tab:: C++
+
+    .. code-block:: c++
+
+      <depend>tutorial_interfaces</depend>
+
+  .. group-tab:: Python
+
+    .. code-block:: python
 
       <exec_depend>tutorial_interfaces</exec_depend>
 
@@ -648,9 +658,19 @@ Add the following lines (C++ only):
 
 package.xml:
 
-Add the following line (same for C++ and Python):
+Add the following line:
 
-.. code-block:: xml
+.. tabs::
+
+  .. group-tab:: C++
+
+    .. code-block:: c++
+
+      <depend>tutorial_interfaces</depend>
+
+  .. group-tab:: Python
+
+    .. code-block:: python
 
       <exec_depend>tutorial_interfaces</exec_depend>
 


### PR DESCRIPTION
The C++ package dependencies listed in the tutorial for custom `msg`/`srv` files should be `depend` instead of `exec_depend`. A similar change was made in #574