### PR TITLE
Titles in sentence case

### DIFF
--- a/source/Concepts/About-Quality-of-Service-Settings.rst
+++ b/source/Concepts/About-Quality-of-Service-Settings.rst
@@ -2,7 +2,7 @@
 
     About-Quality-of-Service-Settings
 
-About Quality of Service Settings
+About Quality of Service settings
 =================================
 
 Overview

--- a/source/Concepts/Overview-of-ROS-2-concepts.rst
+++ b/source/Concepts/Overview-of-ROS-2-concepts.rst
@@ -4,7 +4,7 @@
 
 .. _Concepts:
 
-Overview of ROS 2 Concepts
+Overview of ROS 2 concepts
 ==========================
 
 .. contents:: Table of Contents

--- a/source/Contributing/Build-Cop-and-Build-Farmer-Guide.rst
+++ b/source/Contributing/Build-Cop-and-Build-Farmer-Guide.rst
@@ -2,7 +2,7 @@
 
     Build-Cop-and-Build-Farmer-Guide
 
-Build Cop and Build Farmer Guide
+Build cop and build farmer guide
 ================================
 
 .. contents:: Table of Contents
@@ -294,5 +294,3 @@ Resources
    Set-up-a-new-Linux-CI-node
    Set-up-a-new-macOS-CI-node
    Set-up-a-new-Windows-CI-node
-
-

--- a/source/Contributing/Code-Style-Language-Versions.rst
+++ b/source/Contributing/Code-Style-Language-Versions.rst
@@ -1,6 +1,6 @@
 .. _CodeStyle:
 
-Code Style and Language Versions
+Code style and language versions
 ================================
 
 .. contents:: Table of Contents

--- a/source/Contributing/Design-Guide.rst
+++ b/source/Contributing/Design-Guide.rst
@@ -3,7 +3,7 @@
     Design-Guide
 
 
-Design Guide: Common patterns in ROS 2
+Design guide: common patterns in ROS 2
 ======================================
 
 Composable nodes as shared libraries

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -2,7 +2,7 @@
 
     Developer-Guide
 
-ROS 2 Developer Guide
+ROS 2 developer guide
 =====================
 
 .. contents:: Table of Contents

--- a/source/Contributing/Examples-and-Tools-for-ROS1----ROS2-Migrations.rst
+++ b/source/Contributing/Examples-and-Tools-for-ROS1----ROS2-Migrations.rst
@@ -2,7 +2,7 @@
 
     Examples-and-Tools-for-ROS1----ROS2-Migrations
 
-Examples and tools for ROS1-to-ROS2 Migration
+Examples and tools for ROS1-to-ROS2 migration
 =============================================
 
 Examples of node/component level migrations

--- a/source/Contributing/Migration-Guide-Python.rst
+++ b/source/Contributing/Migration-Guide-Python.rst
@@ -2,7 +2,7 @@
 
     Migration-Guide-Python
 
-Python Migration guide from ROS 1
+Python migration guide from ROS 1
 =================================
 
 Node Initialization

--- a/source/Contributing/Quality-Guide.rst
+++ b/source/Contributing/Quality-Guide.rst
@@ -2,7 +2,7 @@
 
     Quality-Guide
 
-Quality Guide: Ensuring code quality
+Quality guide: ensuring code quality
 ====================================
 
 This section tries to give guidance about how to improve the software quality of ROS 2 packages. The guide uses a pattern language based approach to improve the readers experience ("read little, understand fast, understand much, apply easily").

--- a/source/Contributing/ROS-2-On-boarding-Guide.rst
+++ b/source/Contributing/ROS-2-On-boarding-Guide.rst
@@ -2,7 +2,7 @@
 
    ROS-2-On-boarding-Guide
 
-ROS 2 On-boarding Guide
+ROS 2 on-boarding guide
 =======================
 
 The purpose of this guide is supplement the on-boarding of new developers when they join the ROS 2 team.

--- a/source/Installation/Install-Connext-University-Eval.rst
+++ b/source/Installation/Install-Connext-University-Eval.rst
@@ -1,4 +1,4 @@
-Installing University or Evaluation Versions of RTI Connext DDS
+Installing University or Evaluation versions of RTI Connext DDS
 ===============================================================
 
 A libraries-only version of RTI Connext DDS 5.3.1 may be installed per the `installation instructions <../Installation>` for

--- a/source/Installation/Latest-Development-Setup.rst
+++ b/source/Installation/Latest-Development-Setup.rst
@@ -1,4 +1,4 @@
-Installing the Latest ROS 2 Development
+Installing the latest ROS 2 development
 =======================================
 
 If you plan to contribute directly to the latest ROS 2 development, you can install ROS 2 by building it from source.

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -1,4 +1,4 @@
-Maintaining a Source Checkout of ROS 2
+Maintaining a source checkout of ROS 2
 ======================================
 
 .. contents::

--- a/source/ROSCon-Content.rst
+++ b/source/ROSCon-Content.rst
@@ -1,6 +1,6 @@
 .. _ROSCon:
 
-ROSCon content
+ROSCon Content
 ==============
 
 The following `ROSCon <http://roscon.ros.org>`__ talks have been given on ROS 2 and provide information about the workings of ROS 2 and various demos:

--- a/source/Releases/Release-Howto.rst
+++ b/source/Releases/Release-Howto.rst
@@ -2,7 +2,7 @@
 
     Release-Howto
 
-How to Release
+How to release
 ==============
 
 This page tries to capture the process we go through to make a new beta release of ROS 2.

--- a/source/Tutorials/Ament-CMake-Documentation.rst
+++ b/source/Tutorials/Ament-CMake-Documentation.rst
@@ -1,4 +1,4 @@
-Ament_cmake user documentation
+ament_cmake user documentation
 ==============================
 
 ament_cmake is the build system for CMake based packages in ROS 2 (in particular, it will be used for most if not all C/C++ projects).

--- a/source/Tutorials/Ament-CMake-Documentation.rst
+++ b/source/Tutorials/Ament-CMake-Documentation.rst
@@ -1,4 +1,4 @@
-ament_cmake User Documentation
+Ament_cmake user documentation
 ==============================
 
 ament_cmake is the build system for CMake based packages in ROS 2 (in particular, it will be used for most if not all C/C++ projects).

--- a/source/Tutorials/Building-Realtime-rt_preempt-kernel-for-ROS-2.rst
+++ b/source/Tutorials/Building-Realtime-rt_preempt-kernel-for-ROS-2.rst
@@ -2,7 +2,7 @@
 
     Building-Realtime-rt_preempt-kernel-for-ROS-2
 
-Building Realtime Linux for ROS 2 [community-contributed]
+Building realtime Linux for ROS 2 [community-contributed]
 =========================================================
 
 This tutorial begins with a clean Ubuntu 16.04.2 install. Actual kernel is 4.13.0-38-generic, but we will install another one.
@@ -133,4 +133,3 @@ Then we install the kernel to /boot and update grub with
 .. image:: https://i.imgur.com/Y5ihCXd.png
    :target: https://i.imgur.com/Y5ihCXd.png
    :alt: eclipse-1
-

--- a/source/Tutorials/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Creating-Your-First-ROS2-Package.rst
@@ -1,6 +1,6 @@
 .. _CreatePkg:
 
-Creating Your First ROS 2 package
+Creating your first ROS 2 package
 =================================
 
 **Goal:** Create a new package using either CMake or Python, and run its executable.

--- a/source/Tutorials/Cross-compilation.rst
+++ b/source/Tutorials/Cross-compilation.rst
@@ -1,4 +1,4 @@
-Cross-Compilation
+Cross-compilation
 =================
 
 .. contents:: Table of Contents

--- a/source/Tutorials/Developing-a-ROS-2-Package.rst
+++ b/source/Tutorials/Developing-a-ROS-2-Package.rst
@@ -2,7 +2,7 @@
 
     Developing-a-ROS-2-Package
 
-Developing a ROS 2 Package
+Developing a ROS 2 package
 ##########################
 
 .. contents:: Table of Contents

--- a/source/Tutorials/Python-Programming.rst
+++ b/source/Tutorials/Python-Programming.rst
@@ -2,7 +2,7 @@
 
     Python-Programming
 
-Python Programming in ROS 2
+Python programming in ROS 2
 ===========================
 
 .. contents:: Table of Contents

--- a/source/Tutorials/RQt-Overview-Usage.rst
+++ b/source/Tutorials/RQt-Overview-Usage.rst
@@ -2,7 +2,7 @@
 
    RQt-Overview-Usage
 
-Overview and Usage of RQt
+Overview and usage of RQt
 =========================
 
 .. contents:: Table of Contents

--- a/source/Tutorials/RQt-Source-Install-MacOS.rst
+++ b/source/Tutorials/RQt-Source-Install-MacOS.rst
@@ -2,7 +2,7 @@
 
     RQt-Source-Install-MacOS
 
-Building RQt from Source on macOS
+Building RQt from source on macOS
 =================================
 
 This page provides specific information to building RQt from source on macOS.

--- a/source/Tutorials/RQt-Source-Install-Windows10.rst
+++ b/source/Tutorials/RQt-Source-Install-Windows10.rst
@@ -2,7 +2,7 @@
 
     RQt-Source-Install-Windows10
 
-Building RQt from Source on Windows 10
+Building RQt from source on Windows 10
 ======================================
 
 This page provides specific information to building RQt from source on Windows.

--- a/source/Tutorials/RQt-Source-Install.rst
+++ b/source/Tutorials/RQt-Source-Install.rst
@@ -2,7 +2,7 @@
 
     RQt-Source-Install
 
-Building RQt from Source
+Building RQt from source
 ========================
 
 We've provided our development setup here to aid future users in easily extending RQt by creating their own plugins. We encourage you to contribute those plugins back to the ``ros-visualization`` Github repository!

--- a/source/Tutorials/Real-Time-Programming.rst
+++ b/source/Tutorials/Real-Time-Programming.rst
@@ -2,7 +2,7 @@
 
     Real-Time-Programming
 
-Real-Time Programming in ROS 2
+Real-time programming in ROS 2
 ==============================
 
 .. contents:: Table of Contents

--- a/source/Tutorials/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-CPP.rst
@@ -1,6 +1,6 @@
 .. _CppParamNode:
 
-Using Parameters In A Class (C++)
+Using parameters in a class (C++)
 =================================
 
 **Goal:** Create and run a class with ROS parameters using C++.


### PR DESCRIPTION
Change all titles to sentence case (since most already were in sentence case) except top level docs (`source/....rst`), which are in title case.

Signed-off-by: maryaB-osr <marya@openrobotics.org>