### PR TITLE
Rewrite of old rosidl tutorial

### DIFF
--- a/source/Concepts/About-ROS-Interfaces.rst
+++ b/source/Concepts/About-ROS-Interfaces.rst
@@ -1,3 +1,5 @@
+.. _InterfaceConcept:
+
 .. redirect-from::
 
     About-ROS-Interfaces

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -50,7 +50,7 @@ Beginner: Client Libraries
    Tutorials/Writing-A-Simple-Cpp-Service-And-Client
    Tutorials/Writing-A-Simple-Py-Service-And-Client
    Tutorials/Custom-ROS2-Interfaces
-   Tutorials/More-interfaces.rst
+   Tutorials/Single-Package-Define-And-Use-Interface
    Tutorials/Using-Parameters-In-A-Class-CPP
    Tutorials/Getting-Started-With-Ros2doctor
 

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -65,7 +65,7 @@ Working With Your First Package & Workspace
    Tutorials/Developing-a-ROS-2-Package
    Tutorials/Colcon-Tutorial
    Tutorials/Ament-CMake-Documentation
-   Tutorials/Rosidl-Tutorial.rst
+   Tutorials/More-interfaces.rst
 
 Learning the ROS 2 Toolset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials.rst
+++ b/source/Tutorials.rst
@@ -50,6 +50,7 @@ Beginner: Client Libraries
    Tutorials/Writing-A-Simple-Cpp-Service-And-Client
    Tutorials/Writing-A-Simple-Py-Service-And-Client
    Tutorials/Custom-ROS2-Interfaces
+   Tutorials/More-interfaces.rst
    Tutorials/Using-Parameters-In-A-Class-CPP
    Tutorials/Getting-Started-With-Ros2doctor
 
@@ -65,7 +66,6 @@ Working With Your First Package & Workspace
    Tutorials/Developing-a-ROS-2-Package
    Tutorials/Colcon-Tutorial
    Tutorials/Ament-CMake-Documentation
-   Tutorials/More-interfaces.rst
 
 Learning the ROS 2 Toolset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -710,4 +710,4 @@ You can learn about action interfaces :ref:`here <Actions>`.
 Next steps
 ----------
 
-The :ref:`next tutorial <more-interfaces>` covers more ways to use interfaces in ROS 2.
+The :ref:`next tutorial <SinglePkgInterface>` covers more ways to use interfaces in ROS 2.

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -710,5 +710,4 @@ You can learn about action interfaces :ref:`here <Actions>`.
 Next steps
 ----------
 
-Next you will create a simple ROS 2 package with a custom parameter that you will learn to set from a launch file.
-This tutorial is available in :ref:`C++ <CppParamNode>`.
+The :ref:`next tutorial <more-interfaces>` covers more ways to use interfaces in ROS 2.

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -702,7 +702,7 @@ Summary
 In this tutorial, you learned how to create custom interfaces in their own package and how to utilize those interfaces from within other packages.
 
 This is a simple method of interface creation and utilization.
-ROS 2 encourages use of the ``rosidl`` tools, which you can learn about :ref:`here <ros-idl>`.
+You can learn more about interfaces :ref:`here <InterfaceConcept>`.
 
 ``.action`` files are another ROS 2 interface you can customize.
 You can learn about action interfaces :ref:`here <Actions>`.

--- a/source/Tutorials/More-interfaces.rst
+++ b/source/Tutorials/More-interfaces.rst
@@ -4,10 +4,10 @@
 
     Rosidl-Tutorial
 
-Expanding on rosidl interfaces
-==============================
+Expanding on ROS 2 interfaces
+=============================
 
-**Goal:** Learn more about custom interfaces and using rosidl
+**Goal:** Learn more ways to implement custom interfaces in ROS 2
 
 **Tutorial level:** Intermediate
 
@@ -49,18 +49,18 @@ Tasks
 1 Create a package
 ^^^^^^^^^^^^^^^^^^
 
-In your workspace, create a package ``rosidl_tutorial`` and make a folder within it for msg files:
+In your workspace, create a package ``more_interfaces`` and make a folder within it for msg files:
 
 .. code-block:: bash
 
    cd ~/dev_ws/src
-   ros2 pkg create --build-type ament_cmake rosidl_tutorial
-   mkdir rosidl_tutorial/msg
+   ros2 pkg create --build-type ament_cmake more_interfaces
+   mkdir more_interfaces/msg
 
 2 Create a msg file
 ^^^^^^^^^^^^^^^^^^^
 
-Inside ``rosidl_tutorials/msg``, create a new file ``AddressBook.msg``
+Inside ``more_interfaces/msg``, create a new file ``AddressBook.msg``
 
 Paste the following code to create a message meant to carry information about an individual:
 
@@ -173,7 +173,7 @@ Now you're ready to generate source files from your msg definition.
 
 Now we can start writing code that uses this message.
 
-In ``rosidl_tutorials/src`` create a file called ``publish_address_book.cpp`` and paste the following code:
+In ``more_interfaces/src`` create a file called ``publish_address_book.cpp`` and paste the following code:
 
 .. code-block:: c++
 
@@ -181,7 +181,7 @@ In ``rosidl_tutorials/src`` create a file called ``publish_address_book.cpp`` an
   #include <memory>
 
   #include "rclcpp/rclcpp.hpp"
-  #include "rosidl_tutorial/msg/address_book.hpp"
+  #include "more_interfaces/msg/address_book.hpp"
 
   using namespace std::chrono_literals;
 
@@ -192,10 +192,10 @@ In ``rosidl_tutorials/src`` create a file called ``publish_address_book.cpp`` an
     : Node("address_book_publisher")
     {
       address_book_publisher_ =
-        this->create_publisher<rosidl_tutorial::msg::AddressBook>("address_book", 10);
+        this->create_publisher<more_interfaces::msg::AddressBook>("address_book", 10);
 
       auto publish_msg = [this]() -> void {
-          auto message = rosidl_tutorial::msg::AddressBook();
+          auto message = more_interfaces::msg::AddressBook();
 
           message->first_name = "John";
           message->last_name = "Doe";
@@ -212,7 +212,7 @@ In ``rosidl_tutorials/src`` create a file called ``publish_address_book.cpp`` an
     }
 
   private:
-    rclcpp::Publisher<rosidl_tutorial::msg::AddressBook>::SharedPtr address_book_publisher_;
+    rclcpp::Publisher<more_interfaces::msg::AddressBook>::SharedPtr address_book_publisher_;
     rclcpp::TimerBase::SharedPtr timer_;
   };
 
@@ -231,7 +231,7 @@ In ``rosidl_tutorials/src`` create a file called ``publish_address_book.cpp`` an
 
 .. code-block:: c++
 
-   #include "rosidl_tutorial/msg/address_book.hpp"
+   #include "more_interfaces/msg/address_book.hpp"
 
 Include the header of our newly created ``AddressBook.msg``.
 
@@ -246,7 +246,7 @@ Include the header of our newly created ``AddressBook.msg``.
      : Node("address_book_publisher")
      {
        address_book_publisher_ =
-         this->create_publisher<rosidl_tutorials::msg::AddressBook>("address_book");
+         this->create_publisher<more_interfaces::msg::AddressBook>("address_book");
 
 Create a node and an ``AddressBook`` publisher.
 
@@ -258,7 +258,7 @@ Create a callback to publish the messages periodically.
 
 .. code-block:: c++
 
-    auto message = rosidl_tutorials::msg::AddressBook();
+    auto message = more_interfaces::msg::AddressBook();
 
 Create an ``AddressBook`` message instance that we will later publish.
 
@@ -330,7 +330,7 @@ Return to the root of the workspace to build the package:
 .. code-block:: bash
 
   cd ~/dev_ws
-  colcon build --packages-up-to rosidl_tutorial
+  colcon build --packages-up-to more_interfaces
 
 Then source the workspace and run the publisher:
 
@@ -338,7 +338,7 @@ Then source the workspace and run the publisher:
 
   . install/local_setup.bash
 
-  ros2 run rosidl_tutorial publish_address_book
+  ros2 run more_interfaces publish_address_book
 
 You should see the publisher relaying the msg you defined, including the values you set in ``publish_address_book.cpp``.
 
@@ -350,7 +350,7 @@ We won't create a subscriber in this tutorial, but you should try to write one y
 .. note::
 
   You can use an existing interface definition in a new interface definition.
-  For example, in the `rosidl_tutorials_msgs package <https://github.com/ros2/tutorials/blob/rosidl_tutorials/rosidl_tutorials/rosidl_tutorials_msgs/msg/Contact.msg>`_ on GitHub, there is a msg defined in a package called ``Contact.msg``.
+  For example, the `rosidl_tutorials_msgs package <https://github.com/ros2/tutorials/blob/rosidl_tutorials/rosidl_tutorials/rosidl_tutorials_msgs/msg/Contact.msg>`_ on GitHub has a msg named ``Contact.msg``.
   Notice that it's identical to our custom-made ``AddressBook.msg`` interface from earlier.
 
   You could have defined ``AddressBook.msg`` (an interface in the package *with* your nodes) as type ``Contact`` (an interface in a *separate* package).
@@ -390,7 +390,7 @@ We won't create a subscriber in this tutorial, but you should try to write one y
   .. code-block:: c++
 
     auto publish_msg = [this]() -> void {
-       auto msg = std::make_shared<rosidl_tutorial::msg::AddressBook>();
+       auto msg = std::make_shared<more_interfaces::msg::AddressBook>();
        {
          rosidl_tutorials_msgs::msg::Contact contact;
          contact.first_name = "John";

--- a/source/Tutorials/More-interfaces.rst
+++ b/source/Tutorials/More-interfaces.rst
@@ -1,4 +1,4 @@
-.. _ros-idl:
+.. _more-interfaces:
 
 .. redirect-from::
 
@@ -9,7 +9,7 @@ Expanding on ROS 2 interfaces
 
 **Goal:** Learn more ways to implement custom interfaces in ROS 2
 
-**Tutorial level:** Intermediate
+**Tutorial level:** Beginner
 
 **Time:** 15 minutes
 
@@ -428,6 +428,12 @@ Summary
 In this tutorial, you tried out different field types for defining interfaces, then built an interface in the same package where it's being used.
 
 You also learned how to use another interface as a field type, as well as the ``package.xml``, ``CMakeLists.txt``, and ``#include`` statements necessary for utilizing that feature.
+
+Next steps
+----------
+
+Next you will create a simple ROS 2 package with a custom parameter that you will learn to set from a launch file.
+This tutorial is available in :ref:`C++ <CppParamNode>`.
 
 Related content
 ---------------

--- a/source/Tutorials/Rosidl-Tutorial.rst
+++ b/source/Tutorials/Rosidl-Tutorial.rst
@@ -4,28 +4,41 @@
 
     Rosidl-Tutorial
 
-Introduction to msg and srv interfaces
-======================================
+Expanding on msg and srv interfaces
+===================================
 
-**INCOMPLETE: this is a draft of an upcoming tutorial for creating and using custom ROS interfaces.**
+**Goal:** Learn more about custom interfaces, such as
 
-**Disclaimer: The code provided is to support the explanation, it is likely outdated and should not be expected to compile as is**
+**Tutorial level:** Intermediate
 
-Creating a msg package
-----------------------
+**Time:** 15 minutes
 
-**NOTE:** only ament_cmake packages can generate messages currently (not ament_python packages).
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+Background
+----------
+
+Prerequisites
+-------------
+
+Tasks
+-----
+
+1 Creating a msg package
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 For this tutorial we will use the packages stored in the `rosidl_tutorials repository <https://github.com/ros2/tutorials/tree/rosidl_tutorials/rosidl_tutorials>`__.
 
 .. code-block:: bash
 
-   cd ~/ros2_overlway_ws/src
+   cd ~/dev_ws/src
    git clone -b rosidl_tutorials https://github.com/ros2/tutorials.git
    cd rosidl_tutorials/rosidl_tutorials_msgs
 
-Creating a msg file
-^^^^^^^^^^^^^^^^^^^
+1.1 Creating a msg file
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Here we will create a message meant to carry information about an individual.
 

--- a/source/Tutorials/Rosidl-Tutorial.rst
+++ b/source/Tutorials/Rosidl-Tutorial.rst
@@ -20,12 +20,15 @@ Expanding on rosidl interfaces
 Background
 ----------
 
-In a :ref:`previous tutorial <CustomInterfaces>`, you learned how create custom msg and srv interfaces.
+In a :ref:`previous tutorial <CustomInterfaces>`, you learned how to create custom msg and srv interfaces.
 
 .. In previous tutorials, you learned how to create :ref:`custom msg and srv interfaces <CustomInterfaces>` and :ref:`action interfaces <ActionCreate>`. (When actions redo is done)
 
 While best practice is to declare interfaces in dedicated interface packages, sometimes it can be convenient to declare, create and use an interface all in one package.
-Recall that interfaces can currently only be defined in CMake packages, so the node you plan on using the interface with will also need to be written in C++.
+
+Recall that interfaces can currently only be defined in CMake packages.
+It is possible, however, to have Python libraries and nodes in CMake packages (using `ament_cmake_python <https://github.com/ament/ament_cmake/tree/master/ament_cmake_python>`_), so you could define interfaces and Python nodes together in one package.
+We'll use a CMake package and C++ nodes here for the sake of simplicity.
 
 This tutorial will focus on the msg interface type, but the steps here are applicable to all interface types.
 
@@ -135,7 +138,7 @@ Also make sure you export the message runtime dependency:
 Now you're ready to generate source files from your msg definition.
 
 2.2 (Extra) Set multiple interfaces
-"""""""""""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
 
@@ -194,16 +197,16 @@ In ``rosidl_tutorials/src`` create a file called ``publish_address_book.cpp`` an
       auto publish_msg = [this]() -> void {
           auto message = rosidl_tutorial::msg::AddressBook();
 
-          message.first_name = "John";
-          message.last_name = "Doe";
-          message.age = 30;
-          message.gender = message.MALE;
-          message.address = "unknown";
+          message->first_name = "John";
+          message->last_name = "Doe";
+          message->age = 30;
+          message->gender = message->MALE;
+          message->address = "unknown";
 
-          std::cout << "Publishing Contact\nFirst:" << message.first_name <<
-            "  Last:" << message.last_name << std::endl;
+          std::cout << "Publishing Contact\nFirst:" << message->first_name <<
+            "  Last:" << message->last_name << std::endl;
 
-          this->address_book_publisher_->publish(message);
+          this->address_book_publisher_->publish(*message);
         };
       timer_ = this->create_wall_timer(1s, publish_msg);
     }

--- a/source/Tutorials/Rosidl-Tutorial.rst
+++ b/source/Tutorials/Rosidl-Tutorial.rst
@@ -416,7 +416,7 @@ We won't create a subscriber in this tutorial, but you should try to write one y
        address_book_publisher_->publish(*msg);
      };
 
-  Building and running these changes should show the msg defined as expected (matching `Contact.msg <>`_)
+  Building and running these changes should show the msg defined as expected (matching `Contact.msg <https://github.com/ros2/tutorials/blob/rosidl_tutorials/rosidl_tutorials/rosidl_tutorials_msgs/msg/Contact.msg>`_)
   as well as the array of msgs defined above.
 
 Summary

--- a/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
@@ -32,12 +32,10 @@ We'll use a CMake package and C++ nodes here for the sake of simplicity.
 
 This tutorial will focus on the msg interface type, but the steps here are applicable to all interface types.
 
-.. not sure if it's a good idea to reference the `rosidl_tutorials repository <https://github.com/ros2/tutorials/tree/rosidl_tutorials/rosidl_tutorials>`__ here since the code doesn't work.
-
 Prerequisites
 -------------
 
-It might be helpful to review the basics in the :ref:`CustomInterfaces` tutorial before working through this one.
+We assume you've reviewed the basics in the :ref:`CustomInterfaces` tutorial before working through this one.
 
 You should have :ref:`ROS 2 installed <InstallationGuide>`, a :ref:`workspace <ROS2Workspace>`, and an understanding of :ref:`creating packages <CreatePkg>`.
 

--- a/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
@@ -1,4 +1,4 @@
-.. _more-interfaces:
+.. _SinglePkgInterface:
 
 .. redirect-from::
 
@@ -332,7 +332,7 @@ Return to the root of the workspace to build the package:
 
 Then source the workspace and run the publisher:
 
-.. code-block::
+.. code-block:: console
 
   . install/local_setup.bash
 
@@ -340,7 +340,15 @@ Then source the workspace and run the publisher:
 
 You should see the publisher relaying the msg you defined, including the values you set in ``publish_address_book.cpp``.
 
-We won't create a subscriber in this tutorial, but you should try to write one yourself (use :ref:`CppPubSub` to help).
+To confirm the message is being published on the ``address_book`` topic, open another terminal, source the workspace, and call ``topic echo``:
+
+.. code-block:: console
+
+  . install/local_setup.bash
+
+  ros2 topic echo /address_book
+
+We won't create a subscriber in this tutorial, but you can try to write one yourself for practice (use :ref:`CppPubSub` to help).
 
 5 (Extra) Use an existing interface definition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -348,7 +356,7 @@ We won't create a subscriber in this tutorial, but you should try to write one y
 .. note::
 
   You can use an existing interface definition in a new interface definition.
-  For example, the `rosidl_tutorials_msgs package <https://github.com/ros2/tutorials/blob/rosidl_tutorials/rosidl_tutorials/rosidl_tutorials_msgs/msg/Contact.msg>`_ on GitHub has a msg named ``Contact.msg``.
+  For example, let's use `Contact.msg <https://github.com/ros2/tutorials/blob/rosidl_tutorials/rosidl_tutorials/rosidl_tutorials_msgs/msg/Contact.msg>`_, which belongs to an existing ROS 2 package.
   Notice that it's identical to our custom-made ``AddressBook.msg`` interface from earlier.
 
   You could have defined ``AddressBook.msg`` (an interface in the package *with* your nodes) as type ``Contact`` (an interface in a *separate* package).


### PR DESCRIPTION
The [old rosidl tutorial](https://index.ros.org/doc/ros2/Tutorials/Rosidl-Tutorial/) had some concepts in it that I didn't cover in my new ["simple" interface tutorial](https://index.ros.org/doc/ros2/Tutorials/Custom-ROS2-Interfaces/) (because it's already too long) so instead of deleting the old one, I rewrote it and removed all the repeated information between the two.

The code works now but I'm not sure if it's "right".

This bit of code in the original:
```
get_default_rmw_implementation(rmw_implementation)
find_package("${rmw_implementation}" REQUIRED)
get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")

foreach(typesupport_impl ${typesupport_impls})
  rosidl_target_interfaces(publish_address_book
    ${PROJECT_NAME} ${typesupport_impl}
  )
endforeach()
```

works, but I replaced it with this because it's much shorter:
```
  rosidl_target_interfaces(publish_address_book
    ${PROJECT_NAME} "rosidl_typesupport_cpp")
```

Is there a different situation for each of these? If that longer block is meant for a specific purpose, I'd like to include that in the tutorial.

fixes #565 