### PR TITLE
Update Linux-Development-Setup.rst

### DIFF
--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -57,7 +57,7 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-pip \
-     python-rosdep \
+     python3-rosdep \
      python3-vcstool \
      wget
    # install some pip packages needed for testing


### PR DESCRIPTION
Python 2 is not available in Ubuntu Focal, so instead of python-rosdep it's necessary to install python3-rosdep. It aligns the Python version with colcon, pip and vcstool packages.