### PR TITLE
Document wstring

### DIFF
--- a/source/Concepts/About-ROS-Interfaces.rst
+++ b/source/Concepts/About-ROS-Interfaces.rst
@@ -121,6 +121,10 @@ Field types can be:
      - std::string
      - builtins.str
      - string
+   * - wstring
+     - std::u16string
+     - builtins.str
+     - wstring
 
 
 *Every built-in-type can be used to define arrays:*


### PR DESCRIPTION
fixes #620 

From the [design doc](http://design.ros2.org/articles/wide_strings.html):
Pyton "In Python the `str` type will be used for both strings and wide strings"
C++ "Instead ROS 2 will use ... `std::u16string` for wide strings themselves."

not sure if this is accurate :/

Signed-off-by: maryaB-osr <marya@openrobotics.org>