### PR TITLE
Foxy OSX needs numpy

### DIFF
--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -93,7 +93,7 @@ You need the following things installed to build ROS 2:
 
    .. code-block:: bash
 
-       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg lark-parser lxml mock mypy netifaces nose numpy pep8 pydocstyle pyparsing pytest-mock rosdep setuptools vcstool
+       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg lark-parser lxml mock mypy netifaces nose numpy pep8 pydocstyle pyparsing PyQt5 pytest-mock rosdep setuptools vcstool
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
 

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -93,7 +93,7 @@ You need the following things installed to build ROS 2:
 
    .. code-block:: bash
 
-       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg lark-parser lxml mock mypy netifaces nose pep8 pydocstyle pyparsing pytest-mock rosdep setuptools vcstool
+       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg lark-parser lxml mock mypy netifaces nose numpy pep8 pydocstyle pyparsing pytest-mock rosdep setuptools vcstool
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
 


### PR DESCRIPTION
See https://ci.ros2.org/job/test_ci_osx/315/console

```
--- stderr: rosidl_generator_py
11:32:17 Traceback (most recent call last):
11:32:17   File "<string>", line 1, in <module>
11:32:17 ModuleNotFoundError: No module named 'numpy'
11:32:17 CMake Error at cmake/rosidl_generator_py_generate_interfaces.cmake:213 (message):
11:32:17   
11:32:17   execute_process(/Users/osrf/jenkins-agent/workspace/test_ci_osx/venv/bin/python3
11:32:17   -c 'import numpy;print(numpy.get_include())') returned error code 1
11:32:17 Call Stack (most recent call first):
11:32:17   /Users/osrf/jenkins-agent/workspace/test_ci_osx/ws/install/ament_cmake_core/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
11:32:17   /Users/osrf/jenkins-agent/workspace/test_ci_osx/ws/install/rosidl_cmake/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
11:32:17   CMakeLists.txt:48 (rosidl_generate_interfaces)
```

`pip3 freeze` shows `mini2` has numpy installed, while `mini1` does not. I think this went unnoticed because `mini1` has been out of the farm for a while by missing a jenkins label.