### PR TITLE
Instructions to install Graphviz on Windows

### DIFF
--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -145,6 +145,8 @@ RQt dependencies
 
    > pip install -U pydot PyQt5
 
+Follow the steps for `Installing Graphviz <Foxy_windows-install-binary-installing-rqt-dependencies>` on the Binary Installation page.
+
 Get the ROS 2 code
 ------------------
 

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -147,6 +147,8 @@ RQt dependencies
 
    python -m pip install -U pydot PyQt5
 
+.. _Foxy_windows-install-binary-installing-rqt-dependencies:
+
 To run rqt_graph you need to `download <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install `Graphviz <https://graphviz.gitlab.io/>`__.
 
 * The default installation path will be C:\Program Files (x86)\GraphvizX.XX\bin (Example: GraphvizX.XX → Graphviz2.38)

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -147,6 +147,20 @@ RQt dependencies
 
    python -m pip install -U pydot PyQt5
 
+To run rqt_graph you need to `download <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install `Graphviz <https://graphviz.gitlab.io/>`__.
+
+* The default installation path will be C:\Program Files (x86)\GraphvizX.XX\bin (Example: GraphvizX.XX → Graphviz2.38)
+* Open cmd window as administrator and go the location C:\Program Files (x86)\GraphvizX.XX\bin and run the below command:
+
+.. code-block:: bash
+
+  dot.exe
+
+* Go to the Control Panel →  System and Security → System, and on the right side navigation panel, you will see the link Advanced systems settings.
+* Once there in advance settings, a dialogue box will open which will show the button Environment Variables. Click on the button Environment Variables.
+* Select the entry "Path" on the system variables section and add C:\Program Files (x86)\GraphvizX.XX\bin to the existing path.
+* Click on Ok Button.
+
 Downloading ROS 2
 -----------------
 


### PR DESCRIPTION
There is no mention in the tutorial about how to install Graphviz. This dependency is needed for rqt_graph. The `dot.exe` needs to be available in the path too.

Signed-off-by: ahcorde <ahcorde@gmail.com>