### PR TITLE
Bump the minimum required version of bloom

### DIFF
--- a/source/Tutorials/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/Tutorials/Releasing-a-ROS-2-package-with-bloom.rst
@@ -17,7 +17,7 @@ This page describes how to prepare a repository for release on the public ROS 2 
 Required Tools
 --------------
 
-* ``bloom`` >= 0.8.0
+* ``bloom`` >= 0.9.7
 * ``catkin_pkg`` >= 0.4.10
 
 Ensure that you have the latest version of bloom and catkin_pkg


### PR DESCRIPTION
This is the minimum version required for Foxy Fitzroy, and should still work for older distros.