### PR TITLE
Make the macOS Eloquent and Foxy instructions point to full Xcode.

### DIFF
--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -38,6 +38,7 @@ You need the following things installed to build ROS 2:
      .. code-block:: bash
 
         xcode-select --install
+        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 
 #.
    **brew** *(needed to install more stuff; you probably already have this)*:

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -34,7 +34,7 @@ You need the following things installed to build ROS 2:
      .. code-block:: bash
 
         xcode-select --install
-        sudo xcode-select --switch /Library/Developer/CommandLineTools # Enable Command Line Tools
+        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 
 #.
    **brew** *(needed to install more stuff; you probably already have this)*:


### PR DESCRIPTION
On macOS it is *not* enough to point to the command-line tools;
in particular, you won't be able to build GUI stuff with those.
Update the from-source instructions to point to the full
install of Xcode at /Applications/Xcode.app/Contents/Developer.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@Karsten1987 FYI