### PR TITLE
Add spdlog to dependencies

### DIFF
--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -67,7 +67,7 @@ You need the following things installed before installing ROS 2.
        brew install console_bridge
 
        # install dependencies for rcl_logging_log4cxx
-       brew install log4cxx
+       brew install log4cxx spdlog
 
        # install CUnit for CycloneDDS
        brew install cunit


### PR DESCRIPTION
`ros_tutorials` needs `spdlog` to be built with colcon as directed in https://index.ros.org/doc/ros2/Tutorials/Workspace/Creating-A-Workspace/