### PR TITLE
Add troubleshooting details when changing between RMWs

### DIFF
--- a/source/Tutorials/Working-with-multiple-RMW-implementations.rst
+++ b/source/Tutorials/Working-with-multiple-RMW-implementations.rst
@@ -107,6 +107,27 @@ If you have support for multiple RMW implementations installed and you request u
 
 If this occurs, double check that your ROS 2 installation includes support for the RMW implementation that you have specified in the ``RMW_IMPLEMENTATION`` environment variable.
 
+If you want to switch between RMW implementations, verify that the ROS2 daemon process is not running with the previous RMW implementation to avoid any issues between nodes and command line tools such as ``ros2 node``. For example, if you run:
+
+.. code-block:: bash
+
+   RMW_IMPLEMENTATION=rmw_connext_cpp ros2 run demo_nodes_cpp talker
+
+and
+
+.. code-block:: bash
+
+   ros2 node list
+
+it will generate a daemon with a Fast RTPS implementation:
+
+.. code-block:: bash
+
+   21318 22.0  0.6 535896 55044 pts/8    Sl   16:14   0:00 /usr/bin/python3 /opt/ros/foxy/bin/_ros2_daemon --rmw-implementation rmw_fastrtps_cpp --ros-domain-id 22
+
+Even if you run the command line tool again with the correct RMW implementation, the daemon's RMW implementation will not change and the ROS2 command line tools will fail. To solve this, simply kill the daemon process and rerun the ROS2 command line tool with the correct RMW implementation.
+
+
 RTI Connext on OSX: Failure due to insufficient shared memory kernel settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Working-with-multiple-RMW-implementations.rst
+++ b/source/Tutorials/Working-with-multiple-RMW-implementations.rst
@@ -107,7 +107,8 @@ If you have support for multiple RMW implementations installed and you request u
 
 If this occurs, double check that your ROS 2 installation includes support for the RMW implementation that you have specified in the ``RMW_IMPLEMENTATION`` environment variable.
 
-If you want to switch between RMW implementations, verify that the ROS2 daemon process is not running with the previous RMW implementation to avoid any issues between nodes and command line tools such as ``ros2 node``. For example, if you run:
+If you want to switch between RMW implementations, verify that the ROS2 daemon process is not running with the previous RMW implementation to avoid any issues between nodes and command line tools such as ``ros2 node``.
+For example, if you run:
 
 .. code-block:: bash
 

--- a/source/Tutorials/Working-with-multiple-RMW-implementations.rst
+++ b/source/Tutorials/Working-with-multiple-RMW-implementations.rst
@@ -107,7 +107,7 @@ If you have support for multiple RMW implementations installed and you request u
 
 If this occurs, double check that your ROS 2 installation includes support for the RMW implementation that you have specified in the ``RMW_IMPLEMENTATION`` environment variable.
 
-If you want to switch between RMW implementations, verify that the ROS2 daemon process is not running with the previous RMW implementation to avoid any issues between nodes and command line tools such as ``ros2 node``.
+If you want to switch between RMW implementations, verify that the ROS 2 daemon process is not running with the previous RMW implementation to avoid any issues between nodes and command line tools such as ``ros2 node``.
 For example, if you run:
 
 .. code-block:: bash
@@ -126,8 +126,15 @@ it will generate a daemon with a Fast RTPS implementation:
 
    21318 22.0  0.6 535896 55044 pts/8    Sl   16:14   0:00 /usr/bin/python3 /opt/ros/foxy/bin/_ros2_daemon --rmw-implementation rmw_fastrtps_cpp --ros-domain-id 22
 
-Even if you run the command line tool again with the correct RMW implementation, the daemon's RMW implementation will not change and the ROS2 command line tools will fail. To solve this, simply kill the daemon process and rerun the ROS2 command line tool with the correct RMW implementation.
+Even if you run the command line tool again with the correct RMW implementation, the daemon's RMW implementation will not change and the ROS 2 command line tools will fail.
 
+To solve this, simply stop the daemon process:
+
+.. code-block:: bash
+
+   ros2 daemon stop
+
+and rerun the ROS 2 command line tool with the correct RMW implementation.
 
 RTI Connext on OSX: Failure due to insufficient shared memory kernel settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently, if you run with a specific RMW implementation and then you run a ROS2 command line tool with another one, the daemon will run with the RMW implementation given by the ROS2 command line tool.  In the case where you run an RMW implementation A for your nodes and then you use RMW implementation B to run a ROS2 command line tool, the RMW implementation for the daemon is B.

In the troubleshoot section of `Tutorials/Working-with-multiple-RMW-implementations.rst`, I made the suggestion of killing the daemon process and rerun the command line tool with the correct RMW implementation.