### PR TITLE
Add Dashing 'interface show' syntax back to tutorials

### DIFF
--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -129,25 +129,14 @@ If you ever have problems finding or using your ROS 2 packages, make sure that y
 
         set | findstr -i ROS
 
-Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set:
+Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set.
+For example, if you're using Foxy, you would see:
 
-.. tabs::
+::
 
-   .. group-tab:: Eloquent
-
-      .. code-block:: console
-
-        ROS_VERSION=2
-        ROS_PYTHON_VERSION=3
-        ROS_DISTRO=eloquent
-
-   .. group-tab:: Foxy
-
-      .. code-block:: console
-
-        ROS_VERSION=2
-        ROS_PYTHON_VERSION=3
-        ROS_DISTRO=foxy
+  ROS_VERSION=2
+  ROS_PYTHON_VERSION=3
+  ROS_DISTRO=foxy
 
 If the environment variables are not set correctly, return to the ROS 2 package installation section of the installation guide you followed.
 If you need more specific help (because environment setup files can come from different places), you can `get answers <https://answers.ros.org>`__ from the community.

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -139,17 +139,17 @@ Now you can confirm that your interface creation worked by using the ``ros2 inte
 
 .. tabs::
 
-  .. group-tab:: Dashing
-
-    .. code-block:: console
-
-      ros2 msg show tutorial_interfaces/msg/Num
-
   .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
       ros2 interface show tutorial_interfaces/msg/Num
+
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 msg show tutorial_interfaces/msg/Num
 
 should return:
 
@@ -161,17 +161,17 @@ And
 
 .. tabs::
 
-  .. group-tab:: Dashing
-
-    .. code-block:: console
-
-      ros2 srv show tutorial_interfaces/srv/AddThreeInts
-
   .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
       ros2 interface show tutorial_interfaces/srv/AddThreeInts
+
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 srv show tutorial_interfaces/srv/AddThreeInts
 
 should return:
 

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -137,9 +137,19 @@ In a new terminal, run the following command from within your workspace (``dev_w
 
 Now you can confirm that your interface creation worked by using the ``ros2 interface show`` command:
 
-.. code-block:: console
+.. tabs::
 
-    ros2 interface show tutorial_interfaces/msg/Num
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 msg show tutorial_interfaces/msg/Num
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show tutorial_interfaces/msg/Num
 
 should return:
 
@@ -149,9 +159,19 @@ should return:
 
 And
 
-.. code-block:: console
+.. tabs::
 
-  ros2 interface show tutorial_interfaces/srv/AddThreeInts
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 srv show tutorial_interfaces/msg/Num
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show tutorial_interfaces/srv/AddThreeInts
 
 should return:
 

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -165,7 +165,7 @@ And
 
     .. code-block:: console
 
-      ros2 srv show tutorial_interfaces/msg/Num
+      ros2 srv show tutorial_interfaces/srv/AddThreeInts
 
   .. group-tab:: Eloquent and newer
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -81,7 +81,7 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
 
 .. tabs::
 
-  .. group-tab:: Foxy
+  .. group-tab:: Foxy and newer
 
     .. code-block:: python
 
@@ -113,7 +113,7 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
                 )
             ])
 
-  .. group-tab:: Eloquent/Dashing
+  .. group-tab:: Eloquent and older
 
     .. code-block:: python
 
@@ -172,7 +172,7 @@ The first two actions in the launch description launch two turtlesim windows:
 
 .. tabs::
 
-  .. group-tab:: Foxy
+  .. group-tab:: Foxy and newer
 
     .. code-block:: python
 
@@ -189,7 +189,7 @@ The first two actions in the launch description launch two turtlesim windows:
                name='sim'
            ),
 
-  .. group-tab:: Eloquent/Dashing
+  .. group-tab:: Eloquent and older
 
     .. code-block:: python
 
@@ -217,7 +217,7 @@ The final node is also from the ``turtlesim`` package, but a different executabl
 .. tabs::
 
 
-  .. group-tab:: Foxy
+  .. group-tab:: Foxy and newer
 
     .. code-block:: python
 
@@ -231,7 +231,7 @@ The final node is also from the ``turtlesim`` package, but a different executabl
               ]
           )
 
-  .. group-tab:: Eloquent/Dashing
+  .. group-tab:: Eloquent and older
 
     .. code-block:: python
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -81,11 +81,43 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
 
 .. tabs::
 
-   .. group-tab:: Dashing or Eloquent
+  .. group-tab:: Foxy
 
-      .. code-block:: python
+    .. code-block:: python
 
-         from  launch import LaunchDescription
+        from launch import LaunchDescription
+        from launch_ros.actions import Node
+
+        def generate_launch_description():
+            return LaunchDescription([
+                Node(
+                    package='turtlesim',
+                    namespace='turtlesim1',
+                    executable='turtlesim_node',
+                    name='sim'
+                ),
+                Node(
+                    package='turtlesim',
+                    namespace='turtlesim2',
+                    executable='turtlesim_node',
+                    name='sim'
+                ),
+                Node(
+                    package='turtlesim',
+                    executable='mimic',
+                    name='mimic',
+                    remappings=[
+                        ('/input/pose', '/turtlesim1/turtle1/pose'),
+                        ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+                    ]
+                )
+            ])
+
+  .. group-tab:: Eloquent/Dashing
+
+    .. code-block:: python
+
+         from launch import LaunchDescription
          from launch_ros.actions import Node
 
          def generate_launch_description():
@@ -113,37 +145,6 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
                  )
              ])
 
-   .. group-tab:: Foxy or newer
-
-      .. code-block:: python
-
-         from  launch import LaunchDescription
-         from launch_ros.actions import Node
-
-         def generate_launch_description():
-             return LaunchDescription([
-                 Node(
-                     package='turtlesim',
-                     namespace='turtlesim1',
-                     executable='turtlesim_node',
-                     name='sim'
-                 ),
-                 Node(
-                     package='turtlesim',
-                     namespace='turtlesim2',
-                     executable='turtlesim_node',
-                     name='sim'
-                 ),
-                 Node(
-                     package='turtlesim',
-                     executable='mimic',
-                     name='mimic',
-                     remappings=[
-                         ('/input/pose', '/turtlesim1/turtle1/pose'),
-                         ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                     ]
-                 )
-             ])
 
 2.1 Examine the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -171,9 +172,26 @@ The first two actions in the launch description launch two turtlesim windows:
 
 .. tabs::
 
-   .. group-tab:: Dashing or Eloquent
+  .. group-tab:: Foxy
 
-      .. code-block:: python
+    .. code-block:: python
+
+           Node(
+               package='turtlesim',
+               namespace='turtlesim1',
+               executable='turtlesim_node',
+               name='sim'
+           ),
+           Node(
+               package='turtlesim',
+               namespace='turtlesim2',
+               executable='turtlesim_node',
+               name='sim'
+           ),
+
+  .. group-tab:: Eloquent/Dashing
+
+    .. code-block:: python
 
             Node(
                 package='turtlesim',
@@ -188,23 +206,6 @@ The first two actions in the launch description launch two turtlesim windows:
                 node_name='sim'
             ),
 
-   .. group-tab:: Foxy or newer
-
-      .. code-block:: python
-
-            Node(
-                package='turtlesim',
-                namespace='turtlesim1',
-                executable='turtlesim_node',
-                name='sim'
-            ),
-            Node(
-                package='turtlesim',
-                namespace='turtlesim2',
-                executable='turtlesim_node',
-                name='sim'
-            ),
-
 Note the only difference between the two nodes is their namespace values.
 Unique namespaces allow the system to start two simulators without node name nor topic name conflicts.
 
@@ -215,9 +216,24 @@ The final node is also from the ``turtlesim`` package, but a different executabl
 
 .. tabs::
 
-   .. group-tab:: Dashing or Eloquent
 
-      .. code-block:: python
+  .. group-tab:: Foxy
+
+    .. code-block:: python
+
+          Node(
+              package='turtlesim',
+              executable='mimic',
+              name='mimic',
+              remappings=[
+                ('/input/pose', '/turtlesim1/turtle1/pose'),
+                ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+              ]
+          )
+
+  .. group-tab:: Eloquent/Dashing
+
+    .. code-block:: python
 
             Node(
                 package='turtlesim',
@@ -229,19 +245,6 @@ The final node is also from the ``turtlesim`` package, but a different executabl
                 ]
             )
 
-   .. group-tab:: Foxy or newer
-
-      .. code-block:: python
-
-            Node(
-                package='turtlesim',
-                executable='mimic',
-                name='mimic',
-                remappings=[
-                  ('/input/pose', '/turtlesim1/turtle1/pose'),
-                  ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                ]
-            )
 
 This node has added configuration details in the form of remappings.
 

--- a/source/Tutorials/Launch-system.rst
+++ b/source/Tutorials/Launch-system.rst
@@ -88,48 +88,47 @@ Your launch file should define the ``generate_launch_description()`` which retur
 
 .. tabs::
 
-   .. group-tab:: Dashing or Eloquent
+  .. group-tab:: Foxy
 
-      .. code-block:: python
+     .. code-block:: python
 
-          import launch
-          import launch.actions
-          import launch.substitutions
-          import launch_ros.actions
-
-
-          def generate_launch_description():
-              return launch.LaunchDescription([
-                  launch.actions.DeclareLaunchArgument(
-                      'node_prefix',
-                      default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
-                      description='Prefix for node names'),
-                  launch_ros.actions.Node(
-                      package='demo_nodes_cpp', node_executable='talker', output='screen',
-                      node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
-              ])
-
-   .. group-tab:: Foxy or newer
-
-      .. code-block:: python
-
-          import launch
-          import launch.actions
-          import launch.substitutions
-          import launch_ros.actions
+         import launch
+         import launch.actions
+         import launch.substitutions
+         import launch_ros.actions
 
 
-          def generate_launch_description():
-              return launch.LaunchDescription([
-                  launch.actions.DeclareLaunchArgument(
-                      'node_prefix',
-                      default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
-                      description='Prefix for node names'),
-                  launch_ros.actions.Node(
-                      package='demo_nodes_cpp', executable='talker', output='screen',
-                      name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
-              ])
+         def generate_launch_description():
+             return launch.LaunchDescription([
+                 launch.actions.DeclareLaunchArgument(
+                     'node_prefix',
+                     default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
+                     description='Prefix for node names'),
+                 launch_ros.actions.Node(
+                     package='demo_nodes_cpp', executable='talker', output='screen',
+                     name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
+             ])
 
+  .. group-tab:: Eloquent/Dashing
+
+    .. code-block:: python
+
+        import launch
+        import launch.actions
+        import launch.substitutions
+        import launch_ros.actions
+
+
+        def generate_launch_description():
+            return launch.LaunchDescription([
+                launch.actions.DeclareLaunchArgument(
+                    'node_prefix',
+                    default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
+                    description='Prefix for node names'),
+                launch_ros.actions.Node(
+                    package='demo_nodes_cpp', node_executable='talker', output='screen',
+                    node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
+            ])
 
 Usage
 ^^^^^

--- a/source/Tutorials/Launch-system.rst
+++ b/source/Tutorials/Launch-system.rst
@@ -88,7 +88,7 @@ Your launch file should define the ``generate_launch_description()`` which retur
 
 .. tabs::
 
-  .. group-tab:: Foxy
+  .. group-tab:: Foxy and newer
 
      .. code-block:: python
 
@@ -109,7 +109,7 @@ Your launch file should define the ``generate_launch_description()`` which retur
                      name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
              ])
 
-  .. group-tab:: Eloquent/Dashing
+  .. group-tab:: Eloquent and older
 
     .. code-block:: python
 

--- a/source/Tutorials/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Logging-and-logger-configuration.rst
@@ -98,13 +98,13 @@ Restart the demo including the following command line argument:
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
        ros2 run logging_demo logging_demo_main --ros-args --log-level debug
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 

--- a/source/Tutorials/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Logging-and-logger-configuration.rst
@@ -98,7 +98,7 @@ Restart the demo including the following command line argument:
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 

--- a/source/Tutorials/Node-arguments.rst
+++ b/source/Tutorials/Node-arguments.rst
@@ -16,7 +16,7 @@ All ros specific arguments have to be specified after a ``--ros-args`` flag:
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 
@@ -35,7 +35,7 @@ Name remapping
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     Names within a node (e.g. topics/services) can be remapped using the syntax ``-r <old name>:=<new name>``.
     The name/namespace of the node itself can be remapped using ``-r __node:=<new node name>`` and ``-r __ns:=<new node namespace>``.
@@ -57,7 +57,7 @@ The namespace, which must start with a forward slash, is set to ``/demo``, which
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 
@@ -77,7 +77,7 @@ For example, the following will pass the remapping arguments to the specified no
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 
@@ -95,7 +95,7 @@ The following example will both change the node name and remap a topic (node and
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 
@@ -115,17 +115,12 @@ See ``--log-level`` argument usage in `the logging page <logging-command-line-co
 Parameters
 ----------
 
-.. note::
-
-   The behavior of parameters changed for Dashing and newer.
-   If you're using Crystal or older, see the :ref:`section below <CrystalOlder>`.
-
 Setting parameters directly in the command line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     You can set parameters directly from the command line using the following syntax:
 
@@ -178,7 +173,7 @@ Then run the following:
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 
@@ -195,45 +190,6 @@ Other nodes will be able to retrieve the parameter values, e.g.:
 .. code-block:: bash
 
   $ ros2 param list parameter_blackboard
-  a_string
-  some_int
-  some_lists.some_doubles
-  some_lists.some_integers
-
-.. _CrystalOlder:
-
-Crystal and older
-^^^^^^^^^^^^^^^^^
-
-*Parameters support for Python nodes was added in Crystal. In Bouncy only C++ nodes are supported.*
-
-Setting parameters from the command-line is currently supported in the form of yaml files.
-
-`See here <https://github.com/ros2/rcl/tree/master/rcl_yaml_param_parser>`__ for examples of the yaml file syntax.
-
-As an example, save the following as ``demo_params.yaml``:
-
-.. code-block:: yaml
-
-  talker:
-      ros__parameters:
-          some_int: 42
-          a_string: "Hello world"
-          some_lists:
-              some_integers: [1, 2, 3, 4]
-              some_doubles : [3.14, 2.718]
-
-Then run the following:
-
-.. code-block:: bash
-
-  ros2 run demo_nodes_cpp talker __params:=demo_params.yaml
-
-Other nodes will be able to retrieve the parameter values, e.g.:
-
-.. code-block:: bash
-
-  $ ros2 param list talker
   a_string
   some_int
   some_lists.some_doubles

--- a/source/Tutorials/Node-arguments.rst
+++ b/source/Tutorials/Node-arguments.rst
@@ -16,13 +16,13 @@ All ros specific arguments have to be specified after a ``--ros-args`` flag:
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
        ros2 run my_package node_executable --ros-args ...
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 
@@ -30,20 +30,17 @@ All ros specific arguments have to be specified after a ``--ros-args`` flag:
 
 For more details, see `this design doc <http://design.ros2.org/articles/ros_command_line_arguments.html>`__.
 
-
-*Note: all features on this page are only available as of the ROS 2 Bouncy release.*
-
 Name remapping
 --------------
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     Names within a node (e.g. topics/services) can be remapped using the syntax ``-r <old name>:=<new name>``.
     The name/namespace of the node itself can be remapped using ``-r __node:=<new node name>`` and ``-r __ns:=<new node namespace>``.
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     Remapping rules were specified directly using ``<old name>:=<new name>``, ``__node:=<new node name>``, ``__ns:=<new node namespace>``.
 
@@ -60,13 +57,13 @@ The namespace, which must start with a forward slash, is set to ``/demo``, which
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
       ros2 run demo_nodes_cpp talker --ros-args -r __ns:=/demo -r __node:=my_talker -r chatter:=my_topic
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 
@@ -80,13 +77,13 @@ For example, the following will pass the remapping arguments to the specified no
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
       ros2 run composition manual_composition --ros-args -r talker:__node:=my_talker -r listener:__node:=my_listener
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 
@@ -98,13 +95,13 @@ The following example will both change the node name and remap a topic (node and
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
       ros2 run composition manual_composition --ros-args -r talker:__node:=my_talker -r my_talker:chatter:=my_topic -r listener:__node:=my_listener -r my_listener:chatter:=my_topic
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 
@@ -128,7 +125,7 @@ Setting parameters directly in the command line
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     You can set parameters directly from the command line using the following syntax:
 
@@ -152,7 +149,7 @@ Setting parameters directly in the command line
       some_lists.some_doubles
       some_lists.some_integers
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     Not supported
 
@@ -181,13 +178,13 @@ Then run the following:
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
       ros2 run demo_nodes_cpp parameter_blackboard --ros-args --params-file demo_params.yaml
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -86,7 +86,7 @@ In case you don't have a camera attached to your computer, there is a commandlin
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 
@@ -141,7 +141,7 @@ In one of your terminals, add a -h flag to the original command:
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: bash
 

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -86,13 +86,13 @@ In case you don't have a camera attached to your computer, there is a commandlin
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
        ros2 run image_tools cam2image --ros-args -p burger_mode:=True
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 
@@ -141,13 +141,13 @@ In one of your terminals, add a -h flag to the original command:
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: bash
 
        ros2 run image_tools showimage -h
 
-  .. group-tab:: Before Eloquent
+  .. group-tab:: Dashing
 
     .. code-block:: bash
 

--- a/source/Tutorials/Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Services/Understanding-ROS2-Services.rst
@@ -161,15 +161,36 @@ Which will return:
 
 You can call services from the command line, but first you need to know the structure of the input arguments.
 
-.. code-block:: console
+.. tabs::
 
-  ros2 interface show <type_name>.srv
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 srv show <type_name>
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show <type_name>.srv
+
 
 To run this command on the ``/clear`` service’s type, ``Empty``:
 
-.. code-block:: console
+.. tabs::
 
-  ros2 interface show std_srvs/srv/Empty.srv
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 srv show std_srvs/srv/Empty
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show std_srvs/srv/Empty.srv
 
 Which will return:
 
@@ -186,9 +207,19 @@ From the results of ``ros2 service list -t``, we know ``/spawn``’s type is ``t
 
 To see the arguments in a ``/spawn`` call-and-request, run the command:
 
-.. code-block:: console
+.. tabs::
 
-  ros2 interface show turtlesim/srv/Spawn.srv
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 srv show turtlesim/srv/Spawn
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show turtlesim/srv/Spawn.srv
 
 Which will return:
 

--- a/source/Tutorials/Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Services/Understanding-ROS2-Services.rst
@@ -163,34 +163,33 @@ You can call services from the command line, but first you need to know the stru
 
 .. tabs::
 
-  .. group-tab:: Dashing
-
-    .. code-block:: console
-
-      ros2 srv show <type_name>
-
   .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
       ros2 interface show <type_name>.srv
 
-
-To run this command on the ``/clear`` service’s type, ``Empty``:
-
-.. tabs::
-
   .. group-tab:: Dashing
 
     .. code-block:: console
 
-      ros2 srv show std_srvs/srv/Empty
+      ros2 srv show <type_name>
+
+To run this command on the ``/clear`` service’s type, ``Empty``:
+
+.. tabs::
 
   .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
       ros2 interface show std_srvs/srv/Empty.srv
+
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 srv show std_srvs/srv/Empty
 
 Which will return:
 
@@ -209,17 +208,19 @@ To see the arguments in a ``/spawn`` call-and-request, run the command:
 
 .. tabs::
 
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show turtlesim/srv/Spawn.srv
+
   .. group-tab:: Dashing
 
     .. code-block:: console
 
       ros2 srv show turtlesim/srv/Spawn
 
-  .. group-tab:: Eloquent and newer
 
-    .. code-block:: console
-
-      ros2 interface show turtlesim/srv/Spawn.srv
 
 Which will return:
 

--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -201,9 +201,19 @@ This means that in the package ``geometry_msgs`` there is a ``msg`` called ``Twi
 
 Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the details, specifically, what structure of data the message expects.
 
-.. code-block:: console
+.. tabs::
 
-    ros2 interface show geometry_msgs/msg/Twist.msg
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 msg show geometry_msgs/msg/Twist
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+        ros2 interface show geometry_msgs/msg/Twist.msg
 
 .. code-block:: console
 

--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -168,7 +168,7 @@ Which will return:
 
 .. tabs::
 
-  .. group-tab:: Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
@@ -176,7 +176,7 @@ Which will return:
       Publisher count: 1
       Subscriber count: 2
 
-  .. group-tab:: Dashing/earlier
+  .. group-tab:: Dashing
 
     .. code-block::
 
@@ -203,17 +203,17 @@ Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the 
 
 .. tabs::
 
-  .. group-tab:: Dashing
-
-    .. code-block:: console
-
-      ros2 msg show geometry_msgs/msg/Twist
-
   .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
         ros2 interface show geometry_msgs/msg/Twist.msg
+
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 msg show geometry_msgs/msg/Twist
 
 .. code-block:: console
 

--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -168,7 +168,7 @@ Which will return:
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 
@@ -203,7 +203,7 @@ Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the 
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 

--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -168,7 +168,7 @@ Which will return:
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: console
 
@@ -203,7 +203,7 @@ Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the 
 
 .. tabs::
 
-  .. group-tab:: Eloquent and newer
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: console
 

--- a/source/Tutorials/Understanding-ROS2-Actions.rst
+++ b/source/Tutorials/Understanding-ROS2-Actions.rst
@@ -245,9 +245,19 @@ One more piece of information you will need before sending or executing an actio
 Recall that you identified ``/turtle1/rotate_absolute``’s type when running the command ``ros2 action list -t``.
 Enter the following command with the action type in your terminal:
 
-.. code-block:: console
+.. tabs::
 
-    ros2 interface show turtlesim/action/RotateAbsolute.action
+  .. group-tab:: Dashing
+
+    .. code-block:: console
+
+      ros2 action show turtlesim/action/RotateAbsolute
+
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show turtlesim/action/RotateAbsolute.action
 
 Which will return:
 

--- a/source/Tutorials/Understanding-ROS2-Actions.rst
+++ b/source/Tutorials/Understanding-ROS2-Actions.rst
@@ -246,6 +246,12 @@ Recall that you identified ``/turtle1/rotate_absolute``’s type when running th
 Enter the following command with the action type in your terminal:
 
 .. tabs::
+  
+  .. group-tab:: Eloquent and newer
+
+    .. code-block:: console
+
+      ros2 interface show turtlesim/action/RotateAbsolute.action
 
   .. group-tab:: Dashing
 
@@ -253,11 +259,6 @@ Enter the following command with the action type in your terminal:
 
       ros2 action show turtlesim/action/RotateAbsolute
 
-  .. group-tab:: Eloquent and newer
-
-    .. code-block:: console
-
-      ros2 interface show turtlesim/action/RotateAbsolute.action
 
 Which will return:
 

--- a/source/Tutorials/Understanding-ROS2-Actions.rst
+++ b/source/Tutorials/Understanding-ROS2-Actions.rst
@@ -247,7 +247,7 @@ Enter the following command with the action type in your terminal:
 
 .. tabs::
 
-  .. group-tab:: Foxy/Eloquent
+  .. group-tab:: Eloquent and newer
 
     .. code-block:: console
 

--- a/source/Tutorials/Understanding-ROS2-Actions.rst
+++ b/source/Tutorials/Understanding-ROS2-Actions.rst
@@ -246,8 +246,8 @@ Recall that you identified ``/turtle1/rotate_absolute``’s type when running th
 Enter the following command with the action type in your terminal:
 
 .. tabs::
-  
-  .. group-tab:: Eloquent and newer
+
+  .. group-tab:: Foxy/Eloquent
 
     .. code-block:: console
 

--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -111,19 +111,15 @@ When you clone this repo, add the ``-b`` argument followed by the branch that co
 
 In the ``dev_ws/src`` directory, run the following command for the distro you're using:
 
-.. tabs::
+.. code-block:: console
 
-   .. group-tab:: Eloquent
+  git clone https://github.com/ros/ros_tutorials.git -b <distro>-devel
 
-      .. code-block:: console
+For example, if you're using Foxy:
 
-        git clone https://github.com/ros/ros_tutorials.git -b eloquent-devel
+.. code-block:: console
 
-   .. group-tab:: Foxy
-
-      .. code-block:: console
-
-        git clone https://github.com/ros/ros_tutorials.git -b foxy-devel
+  git clone https://github.com/ros/ros_tutorials.git -b foxy-devel
 
 Now ``ros_tutorials`` is cloned in your workspace.
 If you view the contents of ``dev_ws/src`` now, you will see the new ``ros_tutorials`` directory.


### PR DESCRIPTION
[People still use Dashing](https://discourse.ros.org/t/ros-2-release-specific-documentation/13992)

Didn't change the Actions tutorials, will do in the open PR for Actions: #594 

Signed-off-by: maryaB-osr <marya@openrobotics.org>