### PR TITLE
Fix indent in run-time composition using dlopen

### DIFF
--- a/source/Tutorials/Composition.rst
+++ b/source/Tutorials/Composition.rst
@@ -211,11 +211,11 @@ The process will open each library and create one instance of each "rclcpp::Node
 
        ros2 pkg prefix composition
 
-to get the path to where composition is installed. Then call
+    to get the path to where composition is installed. Then call
 
-.. code-block:: bash
+    .. code-block:: bash
 
-   ros2 run composition dlopen_composition <path_to_composition_install>\bin\talker_component.dll <path_to_composition_install>\bin\listener_component.dll
+       ros2 run composition dlopen_composition <path_to_composition_install>\bin\talker_component.dll <path_to_composition_install>\bin\listener_component.dll
 
 Now the shell should show repeated output for each sent and received message.
 


### PR DESCRIPTION
In the composition tutorial, in the section [Run-time composition using dlopen](https://index.ros.org/doc/ros2/Tutorials/Composition/#run-time-composition-using-dlopen), there is a windows command following the first code block (uses `.dll` files).  From looking at the raw file, it is clear that this section is meant to be in the Windows group above it.  I've adjusted the formatting to include this text in the Windows group and tested that it builds and displays correctly on my local machine.