### PR TITLE
Fix typos in the Ros2Bag Overriding QoS Policy tutorial

### DIFF
--- a/source/Tutorials/Ros2bag/Overriding-QoS-Policies-For-Recording-And-Playback.rst
+++ b/source/Tutorials/Ros2bag/Overriding-QoS-Policies-For-Recording-And-Playback.rst
@@ -84,7 +84,7 @@ And call it from the CLI:
 
 .. code-block:: console
 
-    ros2 bag record -a -b my_bag --qos-profile-overrides-path durability_override.yaml
+    ros2 bag record -a -o my_bag --qos-profile-overrides-path durability_override.yaml
 
 If we want to playback the bag file but with a different Reliability policy, we can specify one as such;
 
@@ -92,7 +92,7 @@ If we want to playback the bag file but with a different Reliability policy, we 
 
     # reliability_override.yaml
     /talker:
-      realiability: best_effort
+      reliability: best_effort
 
 And call it from the CLI:
 


### PR DESCRIPTION
I noticed two errors in commands when going through this tutorial:

1. In calling `ros2 bag`, the `-b` flag was called with `my_bag` following.  `-b` is used to set the max bag size, and has a default arguement.  I assume that the intention is to save the bag in a directory named `my_bag`, so I changed `-b` to `-o`, which sets the output directory.
2. The second override YAML file spelled 'reliability' as 'realiability'.

This pull request corrects both of these typos.