### PR TITLE
A newline is missing in section 'Build and Run'

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -308,6 +308,7 @@ After removing some unnecessary boilerplate from the automatically generated fil
 ^^^^^^^^^^^^^^^
 
 It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
+
 .. tabs::
 
    .. group-tab:: Linux


### PR DESCRIPTION
A newline is missing section 'Build and Run' between the group tab causing it not to work when seen. I added a screenshot of how it currently looks.

![image](https://user-images.githubusercontent.com/6756670/81844909-caf70d00-951d-11ea-91cc-acb37cf7b631.png)
