### PR TITLE
Fix non-pointer type error by accessing the message object directly

### DIFF
--- a/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
@@ -195,16 +195,16 @@ In ``more_interfaces/src`` create a file called ``publish_address_book.cpp`` and
       auto publish_msg = [this]() -> void {
           auto message = more_interfaces::msg::AddressBook();
 
-          message->first_name = "John";
-          message->last_name = "Doe";
-          message->age = 30;
-          message->gender = message->MALE;
-          message->address = "unknown";
+          message.first_name = "John";
+          message.last_name = "Doe";
+          message.age = 30;
+          message.gender = message.MALE;
+          message.address = "unknown";
 
-          std::cout << "Publishing Contact\nFirst:" << message->first_name <<
-            "  Last:" << message->last_name << std::endl;
+          std::cout << "Publishing Contact\nFirst:" << message.first_name <<
+            "  Last:" << message.last_name << std::endl;
 
-          this->address_book_publisher_->publish(*message);
+          this->address_book_publisher_->publish(message);
         };
       timer_ = this->create_wall_timer(1s, publish_msg);
     }


### PR DESCRIPTION
I wasn't able to build the C++ example in `publish_address_book.cpp` because the message in the file was being accessed like it was a pointer to the message.  The result was non-pointer type errors: `error: base operand of ‘->’ has non-pointer type ‘more_interfaces::msg::AddressBook_<std::allocator<void> >’`

I changed the code to treat the message variable as an object, not a pointer to an object, and was able to build and run the example successfully.