### PR TITLE
Add header file rule in Code-Style-Language-Versions.rst

### DIFF
--- a/source/Contributing/Code-Style-Language-Versions.rst
+++ b/source/Contributing/Code-Style-Language-Versions.rst
@@ -70,9 +70,13 @@ Line Length
 File Extensions
 ~~~~~~~~~~~~~~~
 
-* Header files should use the .hpp extension.  Implementation files should use the .cpp extension.
+* Header files should use the .hpp extension.
 
-  * rationale: consistency. ROS2 auto-generated code and example code uses .hpp and .cpp extensions.
+  * rationale: Allow tools to determine content of files, C++ or C.
+
+* Implementation files should use the .cpp extension.
+
+  * rationale: Allow tools to determine content of files, C++ or C.
 
 Variable Naming
 ~~~~~~~~~~~~~~~

--- a/source/Contributing/Code-Style-Language-Versions.rst
+++ b/source/Contributing/Code-Style-Language-Versions.rst
@@ -67,6 +67,13 @@ Line Length
 
 * Our maximum line length is 100 characters.
 
+File Extensions
+~~~~~~~~~~~~~~~
+
+* Header files should use the .hpp extension.  Implementation files should use the .cpp extension.
+
+  * rationale: consistency. ROS2 auto-generated code and example code uses .hpp and .cpp extensions.
+
 Variable Naming
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When I was starting to work on my own ROS2 project, I noticed that all the auto-generated (IDL) header files and the header files in the example code use the .hpp suffix.  I checked the Google Style Guide and it mandates the use of .h suffix for header files and implicitly expects developers to use the .cc suffix for implementation files.  This pull request adds a new rule for file naming to prefer the use of the .hpp and .cpp suffixes.  I deliberately used "should" rather than "shall" to allow some freedom, but I leave the final decision of wording to those people how know the code base better than me. 

The changes build without error and I spell checked them!