### PR TITLE
Fix improper indenting

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -146,7 +146,7 @@ All packages should have these documentation elements present in their README or
 
 Each source file must have a license and copyright statement, checked with an automated linter.
 
-Each package must have a LICENSE file, typically the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
+Each package must have a LICENSE file, typically the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD).
 
 Each package should describe itself and its purpose assuming, as much as possible, that the reader has stumbled onto it without previous knowledge of ROS or other related projects.
 

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -144,8 +144,9 @@ All packages should have these documentation elements present in their README or
 * How to develop (useful for describing things like ``python setup.py develop``)
 * License and copyright statements
 
-  * Each source file must have a license and copyright statement, checked with an automated linter.
-  * Each package must have a LICENSE file, typically the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
+Each source file must have a license and copyright statement, checked with an automated linter.
+
+Each package must have a LICENSE file, typically the Apache 2.0 license, unless the package has an existing permissive license (e.g. rviz uses three-clause BSD)
 
 Each package should describe itself and its purpose assuming, as much as possible, that the reader has stumbled onto it without previous knowledge of ROS or other related projects.
 


### PR DESCRIPTION
The statements are not sub bullets of the README license bullet but top level requirements. 

Followup to the ambiguity noticed in #693 

Alternatively the whole thing could be a bulleted or numbered list.