### PR TITLE
Remove license expectation from readme

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -140,7 +140,6 @@ All packages should have these documentation elements present in their README or
 * How to build and run tests
 * How to build documentation
 * How to develop (useful for describing things like ``python setup.py develop``)
-* License and copyright statements
 
 Each source file must have a license and copyright statement, checked with an automated linter.
 


### PR DESCRIPTION
It is redundant for the README to contain licensing information, when this is expected in the LICENSE file and/or license header. It also sets an expectation that no current project follows.

Legal notices are according to license. e.g. if using Apache 2, these belong in the NOTICE file.