### PR TITLE
Increase python version on Windows install

### DIFF
--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -33,7 +33,7 @@ Open a Command Prompt and type the following to install Python via Chocolatey:
 
 .. code-block:: bash
 
-   > choco install -y python --version 3.7.5
+   > choco install -y python --version 3.8.3
 
 Install Visual C++ Redistributables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The packaging builds use 3.8.3 now as per
https://github.com/ros2/ci/blob/bfbf01b93606feb4f1a882d07aefbc3c0b7f63cd/windows_docker_resources/Dockerfile.foxy#L32

Update the instructions to match

Fixes https://github.com/ros2/ros2_documentation/issues/728