### PR TITLE
Switch to tabbed interface for nodes tutorial.

### DIFF
--- a/source/Tutorials/Understanding-ROS2-Nodes.rst
+++ b/source/Tutorials/Understanding-ROS2-Nodes.rst
@@ -107,9 +107,19 @@ In the last tutorial, you used remapping on ``turtle_teleop_key`` to change the 
 Now, lets reassign the name of our ``/turtlesim`` node.
 In a new terminal, run the following command:
 
-.. code-block:: console
+.. tabs::
 
-  ros2 run turtlesim turtlesim_node --ros-args --remap __node:=my_turtle
+   .. group-tab:: Eloquent and newer
+
+      .. code-block:: console
+
+        ros2 run turtlesim turtlesim_node --ros-args --remap __node:=my_turtle
+
+   .. group-tag:: Dashing
+
+      .. code-block:: console
+
+        ros2 run turtlesim turtlesim_node __node:=my_turtle
 
 Since you’re calling ``ros2 run`` on turtlesim again, another turtlesim window will open.
 However, now if you return to the terminal where you ran ``ros2 node list``, and run it again, you will see three node names:

--- a/source/Tutorials/Understanding-ROS2-Nodes.rst
+++ b/source/Tutorials/Understanding-ROS2-Nodes.rst
@@ -115,7 +115,7 @@ In a new terminal, run the following command:
 
         ros2 run turtlesim turtlesim_node --ros-args --remap __node:=my_turtle
 
-   .. group-tag:: Dashing
+   .. group-tab:: Dashing
 
       .. code-block:: console
 


### PR DESCRIPTION
While the remapping syntax happens to work for Dashing, it is
actually incorrect; the `--ros-args --remap` portions are
ignored.  Make a tabbed interface to be consistent with what
we do elsewhere.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>