### PR TITLE
Remove '.msg' from ros2 interface show.

### DIFF
--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -207,7 +207,7 @@ Now we can run ``ros2 interface show <type>.msg`` on this type to learn its the 
 
     .. code-block:: console
 
-        ros2 interface show geometry_msgs/msg/Twist.msg
+        ros2 interface show geometry_msgs/msg/Twist
 
   .. group-tab:: Dashing
 


### PR DESCRIPTION
While it works, it isn't the typical way we do things; usually
it is just 'geometry_msgs/msg/Twist'.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>