### PR TITLE
param load and dump don't work in dashing

### DIFF
--- a/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
@@ -161,7 +161,7 @@ However, you can save your settings changes and reload them next time you start 
     You will find a new file in the directory your workspace is running in.
     If you open this file, you’ll see the following contents:
 
-    .. code-block:: console
+    .. code-block:: YAML
 
       turtlesim:
         ros__parameters:
@@ -218,7 +218,7 @@ However, you can save your settings changes and reload them next time you start 
 
     .. code-block:: console
 
-      ros2 run turtlesim turtlesim_node __params:./turtlesim.yaml
+      ros2 run turtlesim turtlesim_node __params:=./turtlesim.yaml
 
     Where ``__params:`` is the path to your parameter file.
 

--- a/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
@@ -174,8 +174,20 @@ However, you can save your settings changes and reload them next time you start 
 
   .. group-tab:: Dashing
 
-    This command isn't available in Dashing.
-    You're all done!
+    Dashing does not have the ``param dump`` command.
+    However, it is possible to run a node with saved parameters.
+    The equivalent to ``param dump`` would be manually recording your current parameter values into a YAML file.
+
+    Save the following in a file named ``./turtlesim.yaml``:
+
+    .. code-block:: YAML
+
+      turtlesim:
+        ros__parameters:
+          background_b: 255
+          background_g: 86
+          background_r: 150
+          use_sim_time: false
 
 6 Load parameter file
 ^^^^^^^^^^^^^^^^^^^^^
@@ -202,8 +214,13 @@ However, you can save your settings changes and reload them next time you start 
 
   .. group-tab:: Dashing
 
-    This command isn't available in Dashing.
-    You're all done!
+    To start a node using the parameter settings you manually "dumped" in the last section, run the command
+
+    .. code-block:: console
+
+      ros2 run turtlesim turtlesim_node __params:./turtlesim.yaml
+
+    Where ``__params:`` is the path to your parameter file.
 
 Summary
 -------

--- a/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
@@ -136,56 +136,74 @@ However, you can save your settings changes and reload them next time you start 
 5 ros2 param dump
 ^^^^^^^^^^^^^^^^^
 
-You can “dump” all of a node’s current parameter values into a file to save for later using the command:
+.. tabs::
 
-.. code-block:: console
+  .. group-tab:: Eloquent and newer
 
-  ros2 param dump <node_name>
+    You can “dump” all of a node’s current parameter values into a file to save for later using the command:
 
-To save your current configuration of ``/turtlesim``’s parameters, enter the command:
+    .. code-block:: console
 
-.. code-block:: console
+      ros2 param dump <node_name>
 
-  ros2 param dump /turtlesim
+    To save your current configuration of ``/turtlesim``’s parameters, enter the command:
 
-Your terminal will return the message:
+    .. code-block:: console
 
-.. code-block:: console
+      ros2 param dump /turtlesim
 
-  Saving to:  ./turtlesim.yaml
+    Your terminal will return the message:
 
-You will find a new file in the directory your workspace is running in.
-If you open this file, you’ll see the following contents:
+    .. code-block:: console
 
-.. code-block:: console
+      Saving to:  ./turtlesim.yaml
 
-  turtlesim:
-    ros__parameters:
-      background_b: 255
-      background_g: 86
-      background_r: 150
-      use_sim_time: false
+    You will find a new file in the directory your workspace is running in.
+    If you open this file, you’ll see the following contents:
 
-Dumping parameters comes in handy if you want to reload the node with the same parameters in the future.
+    .. code-block:: console
+
+      turtlesim:
+        ros__parameters:
+          background_b: 255
+          background_g: 86
+          background_r: 150
+          use_sim_time: false
+
+    Dumping parameters comes in handy if you want to reload the node with the same parameters in the future.
+
+  .. group-tab:: Dashing
+
+    This command isn't available in Dashing.
+    You're all done!
 
 6 Load parameter file
 ^^^^^^^^^^^^^^^^^^^^^
 
-To start the same node using your saved parameter values, use:
+.. tabs::
 
-.. code-block:: console
+  .. group-tab:: Eloquent and newer
 
-  ros2 run <package_name> <executable_name> --ros-args --params-file <file_name>
+    To start the same node using your saved parameter values, use:
 
-This is the same command you always use to start turtlesim, with the added flags ``--ros-args`` and ``--params-file``, followed by the file you want to load.
+    .. code-block:: console
 
-Stop your running turtlesim node so you can try reloading it with your saved parameters, using:
+      ros2 run <package_name> <executable_name> --ros-args --params-file <file_name>
 
-.. code-block:: console
+    This is the same command you always use to start turtlesim, with the added flags ``--ros-args`` and ``--params-file``, followed by the file you want to load.
 
-  ros2 run turtlesim turtlesim_node --ros-args --params-file ./turtlesim.yaml
+    Stop your running turtlesim node so you can try reloading it with your saved parameters, using:
 
-The turtlesim window should appear as usual, but with the purple background you set earlier.
+    .. code-block:: console
+
+      ros2 run turtlesim turtlesim_node --ros-args --params-file ./turtlesim.yaml
+
+    The turtlesim window should appear as usual, but with the purple background you set earlier.
+
+  .. group-tab:: Dashing
+
+    This command isn't available in Dashing.
+    You're all done!
 
 Summary
 -------


### PR DESCRIPTION
I put each section's content in tabs (it wouldn't let me put section headers under tabs though)

Signed-off-by: maryaB-osr <marya@openrobotics.org>