### PR TITLE
FutureReturnCode deprecated in Foxy

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -229,7 +229,7 @@ Inside the ``dev_ws/src/cpp_srvcli/src`` directory, create a new file called ``a
         auto result = client->async_send_request(request);
         // Wait for the result.
         if (rclcpp::spin_until_future_complete(node, result) ==
-          rclcpp::FutureReturnCode)
+          rclcpp::FutureReturnCode::SUCCESS)
         {
           RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);
         } else {

--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -186,55 +186,114 @@ You could build your package now, source the local setup files, and run it, but 
 
 Inside the ``dev_ws/src/cpp_srvcli/src`` directory, create a new file called ``add_two_ints_client.cpp`` and paste the following code within:
 
-.. code-block:: C++
+.. tabs::
 
-    #include "rclcpp/rclcpp.hpp"
-    #include "example_interfaces/srv/add_two_ints.hpp"
+  .. group-tab:: Foxy and newer
 
-    #include <chrono>
-    #include <cstdlib>
-    #include <memory>
+    .. code-block:: C++
 
-    using namespace std::chrono_literals;
+      #include "rclcpp/rclcpp.hpp"
+      #include "example_interfaces/srv/add_two_ints.hpp"
 
-    int main(int argc, char **argv)
-    {
-      rclcpp::init(argc, argv);
+      #include <chrono>
+      #include <cstdlib>
+      #include <memory>
 
-      if (argc != 3) {
-          RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: add_two_ints_client X Y");
-          return 1;
+      using namespace std::chrono_literals;
+
+      int main(int argc, char **argv)
+      {
+        rclcpp::init(argc, argv);
+
+        if (argc != 3) {
+            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: add_two_ints_client X Y");
+            return 1;
+        }
+
+        std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_client");
+        rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client =
+          node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+
+        auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+        request->a = atoll(argv[1]);
+        request->b = atoll(argv[2]);
+
+        while (!client->wait_for_service(1s)) {
+          if (!rclcpp::ok()) {
+            RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Interrupted while waiting for the service. Exiting.");
+            return 0;
+          }
+          RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service not available, waiting again...");
+        }
+
+        auto result = client->async_send_request(request);
+        // Wait for the result.
+        if (rclcpp::spin_until_future_complete(node, result) ==
+          rclcpp::FutureReturnCode)
+        {
+          RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);
+        } else {
+          RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service add_two_ints");
+        }
+
+        rclcpp::shutdown();
+        return 0;
       }
 
-      std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_client");
-      rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client =
-        node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+  .. group-tab:: Eloquent and older
 
-      auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
-      request->a = atoll(argv[1]);
-      request->b = atoll(argv[2]);
+      .. code-block:: C++
 
-      while (!client->wait_for_service(1s)) {
-        if (!rclcpp::ok()) {
-          RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Interrupted while waiting for the service. Exiting.");
+        #include "rclcpp/rclcpp.hpp"
+        #include "example_interfaces/srv/add_two_ints.hpp"
+
+        #include <chrono>
+        #include <cstdlib>
+        #include <memory>
+
+        using namespace std::chrono_literals;
+
+        int main(int argc, char **argv)
+        {
+          rclcpp::init(argc, argv);
+
+          if (argc != 3) {
+              RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: add_two_ints_client X Y");
+              return 1;
+          }
+
+          std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_client");
+          rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client =
+            node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+
+          auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+          request->a = atoll(argv[1]);
+          request->b = atoll(argv[2]);
+
+          while (!client->wait_for_service(1s)) {
+            if (!rclcpp::ok()) {
+              RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Interrupted while waiting for the service. Exiting.");
+              return 0;
+            }
+            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service not available, waiting again...");
+          }
+
+          auto result = client->async_send_request(request);
+          // Wait for the result.
+          if (rclcpp::spin_until_future_complete(node, result) ==
+            rclcpp::executor::FutureReturnCode::SUCCESS)
+          {
+            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);
+          } else {
+            RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service add_two_ints");
+          }
+
+          rclcpp::shutdown();
           return 0;
         }
-        RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service not available, waiting again...");
-      }
 
-      auto result = client->async_send_request(request);
-      // Wait for the result.
-      if (rclcpp::spin_until_future_complete(node, result) ==
-        rclcpp::executor::FutureReturnCode::SUCCESS)
-      {
-        RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);
-      } else {
-        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service add_two_ints");
-      }
 
-      rclcpp::shutdown();
-      return 0;
-    }
+
 
 
 3.1 Examine the code


### PR DESCRIPTION
`FutureReturnCode` is deprecated in Foxy [according to this](https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/future_return_code.hpp#L48)

But the deprecation warning is only showing up on macOS, @wjwwood?

Signed-off-by: maryaB-osr <marya@openrobotics.org>