### PR TITLE
Updated rosdep to use python3

### DIFF
--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -57,7 +57,7 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-pip \
-     python-rosdep \
+     python3-rosdep \
      python3-vcstool \
      wget
    # install some pip packages needed for testing


### PR DESCRIPTION
Tested on Ubuntu20.04.

`python-rosdep` does not exist anymore.