### PR TITLE
Update Introducing-Turtlesim.rst

### DIFF
--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -146,6 +146,15 @@ Open a new terminal to install ``rqt`` and its plugins:
       sudo apt update
 
       sudo apt install ros-<distro>-rqt-*
+      
+    For ROS2 foxy: 
+
+    .. code-block:: console
+
+      sudo apt update
+
+      sudo apt install ros-foxy-rqt
+
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
Command sudo apt install ros-<distro>-rqt-* did not work for foxy on Ubuntu 20.04 --- used sudo apt install ros-<distro>-rqt instead.