### PR TITLE
Update Introducing-Turtlesim.rst

### DIFF
--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -139,13 +139,21 @@ Open a new terminal to install ``rqt`` and its plugins:
 
 .. tabs::
 
+  .. group-tab:: Linux (with Apt 2.0 and newer, such as Ubuntu 20.04)
+
+    .. code-block:: console
+
+      sudo apt update
+      
+      sudo apt install ~nros-foxy-rqt*
+
   .. group-tab:: Linux
 
     .. code-block:: console
 
       sudo apt update
 
-      sudo apt install ros-<distro>-rqt-*
+      sudo apt install ros-<distro>-rqt*
 
   .. group-tab:: macOS
 

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -145,7 +145,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt update
       
-      sudo apt install ~nros-foxy-rqt*
+      sudo apt install ~nros-<distro>-rqt*
 
   .. group-tab:: Linux
 

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -139,7 +139,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
 .. tabs::
 
-  .. group-tab:: Linux (with Apt 2.0 and newer, such as Ubuntu 20.04)
+  .. group-tab:: Linux (apt 2.0/Ubuntu 20.04 and newer)
 
     .. code-block:: console
 

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -144,7 +144,7 @@ Open a new terminal to install ``rqt`` and its plugins:
     .. code-block:: console
 
       sudo apt update
-      
+
       sudo apt install ~nros-<distro>-rqt*
 
   .. group-tab:: Linux


### PR DESCRIPTION
Add a tab under '4 Install rqt' for Ubuntu 20.04 (focal), because Apt 2.0 doesn't recognize the  "*"  in the end to represent many strings at once.