### PR TITLE
Add empty Galactic release page

### DIFF
--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -1,7 +1,3 @@
-.. _upcoming-release:
-
-.. move this directive when next release page is created
-
 ROS 2 Foxy Fitzroy (codename 'foxy'; June 5th, 2020)
 ====================================================
 

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -1,0 +1,33 @@
+.. _upcoming-release:
+
+.. move this directive when next release page is created
+
+ROS 2 Galactic Geochelone (codename 'galactic'; May 2021?)
+====================================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+*Galactic Geochelone* is the seventh release of ROS 2.
+
+Supported Platforms
+-------------------
+
+TBD
+
+
+New features in this ROS 2 release
+----------------------------------
+
+TBD
+
+
+Changes since the Foxy release
+----------------------------------
+
+
+Timeline before the release
+---------------------------
+
+TBD


### PR DESCRIPTION
We need this to have a place to list all breaking API changes.
e.g. https://github.com/ros2/rclcpp/pull/1160