### PR TITLE
Make arm32 a Tier 3 platform for Foxy.

### DIFF
--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -19,12 +19,9 @@ Tier 1 platforms:
 * Mac macOS 10.14 (Mojave)
 * Windows 10 (Visual Studio 2019)
 
-Tier 2 platforms:
-
-* Ubuntu 20.04 (Focal): ``arm32``
-
 Tier 3 platforms:
 
+* Ubuntu 20.04 (Focal): ``arm32``
 * Debian Buster (10): ``amd64``, ``arm64`` and ``arm32``
 * OpenEmbedded Thud (2.6) / webOS OSE: ``arm32`` and ``x86``
 


### PR DESCRIPTION
See https://discourse.ros.org/t/potential-downgrade-of-arm32-support-to-tier-3/14136
for details.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>