### PR TITLE
Update ros1_bridge installation instructions for Foxy to use Noetic.

### DIFF
--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -58,7 +58,7 @@ Set your rosdistro according to the release you downloaded.
        rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro foxy -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
 
 #. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
-   Follow the normal install instructions: http://wiki.ros.org/melodic/Installation/Ubuntu
+   Follow the normal install instructions: http://wiki.ros.org/noetic/Installation/Ubuntu
 
 Installing the python3 libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,13 +122,13 @@ Using the ROS 1 bridge
 ----------------------
 
 If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
+We'll assume that it is ``/opt/ros/noetic/setup.bash`` in the following.
 
 If you haven't already, start a roscore:
 
 .. code-block:: bash
 
-   . /opt/ros/melodic/setup.bash
+   . /opt/ros/noetic/setup.bash
    roscore
 
 
@@ -136,7 +136,7 @@ In another terminal, start the bridge:
 
 .. code-block:: bash
 
-   . /opt/ros/melodic/setup.bash
+   . /opt/ros/noetic/setup.bash
    . ~/ros2_foxy/ros2-linux/setup.bash
    ros2 run ros1_bridge dynamic_bridge
 

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -133,9 +133,9 @@ Install additional packages using ROS 1 packages
 ------------------------------------------------
 
 The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
+To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=noetic>`__.
 
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
+If you're using Docker for isolation you can start with the image ``ros:noetic`` or ``osrf/ros:noetic-desktop``.
 This will also avoid the need to setup the ROS sources as they will already be integrated.
 
 Now you can install the remaining packages:


### PR DESCRIPTION
Foxy on Ubuntu Focal should use Noetic for the ros1_bridge.

I spotted this while working on the Install docs for Rolling Ridley.
