### PR TITLE
Add installation docs for Rolling Ridley

### DIFF
--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -11,6 +11,7 @@ Installation
    Installation/Dashing
    Installation/Eloquent
    Installation/Foxy
+   Installation/Rolling
    Installation/Latest-Development-Setup
    Installation/Maintaining-a-Source-Checkout
    Installation/Prerelease-Testing

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -1,5 +1,3 @@
-.. _linux-latest:
-
 Building ROS 2 on Linux
 =======================
 

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -1,5 +1,3 @@
-.. _windows-latest:
-
 Building ROS 2 on Windows
 =========================
 

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -2,8 +2,6 @@
 
   Installation/Foxy/OSX-Development-Setup
 
-.. _macOS-latest:
-
 Building ROS 2 on macOS
 =======================
 

--- a/source/Installation/Prerelease-Testing.rst
+++ b/source/Installation/Prerelease-Testing.rst
@@ -53,6 +53,8 @@ For Debian-based operating systems, you can install binary packages from the **r
       sudo apt update
       sudo apt dist-upgrade
 
+.. _Prerelease_binaries:
+
 Fat binaries
 ------------
 

--- a/source/Installation/Rolling.rst
+++ b/source/Installation/Rolling.rst
@@ -1,0 +1,38 @@
+.. _FoxyInstall:
+
+Installing ROS 2 Foxy Fitzroy
+=============================
+
+.. toctree::
+   :hidden:
+   :glob:
+
+   Foxy/*
+
+Binary packages
+---------------
+
+We provide ROS 2 binary packages for the following platforms:
+
+* Linux (Ubuntu Focal(20.04))
+
+  * `Debian packages <Foxy/Linux-Install-Debians>`
+  * `"fat" archive <Foxy/Linux-Install-Binary>`
+
+* `macOS <Foxy/macOS-Install-Binary>`
+* `Windows <Foxy/Windows-Install-Binary>`
+
+
+.. _Foxy_building-from-source:
+
+Building from source
+--------------------
+
+We support building ROS 2 from source on the following platforms:
+
+
+* `Linux <Foxy/Linux-Development-Setup>`
+* `macOS <Foxy/macOS-Development-Setup>`
+* `Windows <Foxy/Windows-Development-Setup>`
+
+.. include:: _Install-Types.rst

--- a/source/Installation/Rolling.rst
+++ b/source/Installation/Rolling.rst
@@ -1,29 +1,31 @@
-.. _FoxyInstall:
+.. _RollingInstall:
 
-Installing ROS 2 Foxy Fitzroy
-=============================
+Installing ROS 2 Rolling Ridley
+===============================
 
 .. toctree::
    :hidden:
    :glob:
 
-   Foxy/*
+   Rolling/*
 
 Binary packages
 ---------------
 
-We provide ROS 2 binary packages for the following platforms:
+We currently provide ROS 2 binary packages for the following platforms:
 
 * Linux (Ubuntu Focal(20.04))
 
-  * `Debian packages <Foxy/Linux-Install-Debians>`
-  * `"fat" archive <Foxy/Linux-Install-Binary>`
+  * `Debian packages <Rolling/Linux-Install-Debians>`
+  * `"fat" archive <Rolling/Linux-Install-Binary>`
 
-* `macOS <Foxy/macOS-Install-Binary>`
-* `Windows <Foxy/Windows-Install-Binary>`
+* `macOS <Rolling/macOS-Install-Binary>`
+* `Windows <Rolling/Windows-Install-Binary>`
+
+As defined in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`_
 
 
-.. _Foxy_building-from-source:
+.. _Rolling_building-from-source:
 
 Building from source
 --------------------
@@ -31,8 +33,8 @@ Building from source
 We support building ROS 2 from source on the following platforms:
 
 
-* `Linux <Foxy/Linux-Development-Setup>`
-* `macOS <Foxy/macOS-Development-Setup>`
-* `Windows <Foxy/Windows-Development-Setup>`
+* `Linux <Rolling/Linux-Development-Setup>`
+* `macOS <Rolling/macOS-Development-Setup>`
+* `Windows <Rolling/Windows-Development-Setup>`
 
 .. include:: _Install-Types.rst

--- a/source/Installation/Rolling/Fedora-Development-Setup.rst
+++ b/source/Installation/Rolling/Fedora-Development-Setup.rst
@@ -54,5 +54,5 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      wget
 
 
-With this done, you can follow the rest of the `instructions <Foxy_linux-dev-get-ros2-code>` to fetch and build ROS 2.
+With this done, you can follow the rest of the `instructions <Rolling_linux-dev-get-ros2-code>` to fetch and build ROS 2.
 

--- a/source/Installation/Rolling/Fedora-Development-Setup.rst
+++ b/source/Installation/Rolling/Fedora-Development-Setup.rst
@@ -1,0 +1,58 @@
+Building ROS 2 on Fedora Linux
+==============================
+
+How to setup the development environment?
+-----------------------------------------
+
+The following system dependencies are required to build ROS 2 on Fedora. They can be installed with ``dnf`` as follows:
+
+.. code-block:: bash
+
+   $ sudo dnf install \
+     asio-devel \
+     cmake \
+     cppcheck \
+     eigen3-devel \
+     gcc-c++ \
+     liblsan \
+     libXaw-devel \
+     libyaml-devel \
+     make \
+     opencv-devel \
+     patch \
+     python3-argcomplete \
+     python3-colcon-common-extensions \
+     python3-coverage \
+     python3-devel \
+     python3-empy \
+     python3-lark-parser \
+     python3-lxml \
+     python3-mock \
+     python3-mypy \
+     python3-nose \
+     python3-pep8 \
+     python3-pip \
+     python3-pydocstyle \
+     python3-pyflakes \
+     python3-pyparsing \
+     python3-pytest \
+     python3-pytest-cov \
+     python3-pytest-mock \
+     python3-pytest-runner \
+     python3-rosdep \
+     python3-setuptools \
+     python3-vcstool \
+     python3-yaml \
+     poco-devel \
+     poco-foundation \
+     python3-flake8 \
+     python3-flake8-import-order \
+     redhat-rpm-config \
+     tinyxml-devel \
+     tinyxml2-devel \
+     uncrustify \
+     wget
+
+
+With this done, you can follow the rest of the `instructions <Foxy_linux-dev-get-ros2-code>` to fetch and build ROS 2.
+

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -1,0 +1,229 @@
+.. _linux-latest:
+
+Building ROS 2 on Linux
+=======================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+
+System requirements
+-------------------
+Target platforms for Foxy Fitzroy are (see `REP 2000 <http://www.ros.org/reps/rep-2000.html>`__):
+
+- Tier 1: Ubuntu Linux - Focal Fossa (20.04) 64-bit
+
+Tier 3 platforms (not actively tested or supported) include:
+
+- Debian Linux - Buster (10)
+- Fedora 32, see `alternate instructions <Fedora-Development-Setup>`
+- Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/ROS#ROS_2>`__
+- OpenEmbedded / webOS OSE, see `alternate instructions <https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions>`__
+
+System setup
+------------
+
+Set locale
+^^^^^^^^^^
+Make sure to set a locale that supports UTF-8.
+If you are in a minimal environment such as a Docker container, the locale may be set to something minimal like POSIX.
+
+The following is an example for setting locale.
+However, it should be fine if you're using a different UTF-8 supported locale.
+
+.. code-block:: bash
+
+   sudo locale-gen en_US en_US.UTF-8
+   sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+   export LANG=en_US.UTF-8
+
+Add the ROS 2 apt repository
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. include:: ../_Apt-Repositories.rst
+
+Install development tools and ROS tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   sudo apt update && sudo apt install -y \
+     build-essential \
+     cmake \
+     git \
+     libbullet-dev \
+     python3-colcon-common-extensions \
+     python3-flake8 \
+     python3-pip \
+     python3-pytest-cov \
+     python3-rosdep \
+     python3-setuptools \
+     python3-vcstool \
+     wget
+   # install some pip packages needed for testing
+   python3 -m pip install -U \
+     argcomplete \
+     flake8-blind-except \
+     flake8-builtins \
+     flake8-class-newline \
+     flake8-comprehensions \
+     flake8-deprecated \
+     flake8-docstrings \
+     flake8-import-order \
+     flake8-quotes \
+     pytest-repeat \
+     pytest-rerunfailures \
+     pytest
+   # install Fast-RTPS dependencies
+   sudo apt install --no-install-recommends -y \
+     libasio-dev \
+     libtinyxml2-dev
+   # install Cyclone DDS dependencies
+   sudo apt install --no-install-recommends -y \
+     libcunit1-dev
+
+.. _Foxy_linux-dev-get-ros2-code:
+
+Get ROS 2 code
+--------------
+
+Create a workspace and clone all repos:
+
+.. code-block:: bash
+
+   mkdir -p ~/ros2_foxy/src
+   cd ~/ros2_foxy
+   wget https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
+   vcs import src < ros2.repos
+
+Install dependencies using rosdep
+---------------------------------
+
+.. code-block:: bash
+
+   sudo rosdep init
+   rosdep update
+   rosdep install --from-paths src --ignore-src --rosdistro foxy -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"
+
+Install additional DDS implementations (optional)
+-------------------------------------------------
+
+If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <../DDS-Implementations>`.
+
+Build the code in the workspace
+-------------------------------
+
+Note: to build the ROS 1 bridge, read the `ros1_bridge instructions <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__.
+
+More info on working with a ROS workspace can be found in `this tutorial </Tutorials/Colcon-Tutorial>`.
+
+.. code-block:: bash
+
+   cd ~/ros2_foxy/
+   colcon build --symlink-install
+
+Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
+Take for instance: you would like to avoid installing the large OpenCV library.
+Well then simply ``$ touch AMENT_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
+
+Optionally install all packages into a combined directory (rather than each package in a separate subdirectory).
+On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
+
+Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
+You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
+
+
+.. code-block:: bash
+
+   colcon build --symlink-install --merge-install
+
+Afterwards source the ``local_setup.*`` from the ``install`` folder.
+
+Environment setup
+-----------------
+
+Source the setup script
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/install/setup.bash
+
+Install argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete to autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
+.. _latest-examples:
+
+Try some examples
+-----------------
+
+In one terminal, source the setup file and then run a C++ ``talker``\ :
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/install/local_setup.bash
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a Python ``listener``\ :
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/install/local_setup.bash
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+Alternate compilers
+-------------------
+
+Using a different compiler besides gcc to compile ROS 2 is easy. If you set the environment variables ``CC`` and ``CXX`` to executables for a working C and C++ compiler, respectively, and retrigger CMake configuration (by using ``--force-cmake-config`` or by deleting the packages you want to be affected), CMake will reconfigure and use the different compiler.
+
+Clang
+^^^^^
+
+To configure CMake to detect and use Clang:
+
+.. code-block:: bash
+
+   sudo apt install clang
+   export CC=clang
+   export CXX=clang++
+   colcon build --cmake-force-configure
+
+TODO: using ThreadSanitizer, MemorySanitizer
+
+Stay up to date
+---------------
+
+See :ref:`MaintainingSource` to periodically refresh your source installation.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found :ref:`here <linux-troubleshooting>`.
+
+Uninstall
+---------
+
+1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
+   This way, your environment will behave as though there is no Foxy install on your system.
+
+2. If you're also trying to free up space, you can delete the entire workspace directory with:
+
+   .. code-block:: bash
+
+    rm -rf ~/ros2_foxy

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -10,7 +10,7 @@ Building ROS 2 on Linux
 
 System requirements
 -------------------
-Target platforms for Foxy Fitzroy are (see `REP 2000 <http://www.ros.org/reps/rep-2000.html>`__):
+The current target platforms for Rolling Ridley are
 
 - Tier 1: Ubuntu Linux - Focal Fossa (20.04) 64-bit
 
@@ -20,6 +20,8 @@ Tier 3 platforms (not actively tested or supported) include:
 - Fedora 32, see `alternate instructions <Fedora-Development-Setup>`
 - Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/ROS#ROS_2>`__
 - OpenEmbedded / webOS OSE, see `alternate instructions <https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions>`__
+
+As defined in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`_
 
 System setup
 ------------
@@ -83,7 +85,7 @@ Install development tools and ROS tools
    sudo apt install --no-install-recommends -y \
      libcunit1-dev
 
-.. _Foxy_linux-dev-get-ros2-code:
+.. _Rolling_linux-dev-get-ros2-code:
 
 Get ROS 2 code
 --------------
@@ -92,9 +94,9 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_foxy/src
-   cd ~/ros2_foxy
-   wget https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
+   mkdir -p ~/ros2_rolling/src
+   cd ~/ros2_rolling
+   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
    vcs import src < ros2.repos
 
 Install dependencies using rosdep
@@ -104,7 +106,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src --rosdistro foxy -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"
 
 Install additional DDS implementations (optional)
 -------------------------------------------------
@@ -120,7 +122,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 
 .. code-block:: bash
 
-   cd ~/ros2_foxy/
+   cd ~/ros2_rolling/
    colcon build --symlink-install
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``AMENT_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
@@ -150,7 +152,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/install/setup.bash
+   . ~/ros2_rolling/install/setup.bash
 
 Install argcomplete (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,8 +164,6 @@ So if you want autocompletion, installing argcomplete is necessary.
 
    sudo apt install python3-argcomplete
 
-.. _latest-examples:
-
 Try some examples
 -----------------
 
@@ -171,14 +171,14 @@ In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/install/local_setup.bash
+   . ~/ros2_rolling/install/local_setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/install/local_setup.bash
+   . ~/ros2_rolling/install/local_setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -220,10 +220,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Foxy install on your system.
+   This way, your environment will behave as though there is no Rolling install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_foxy
+    rm -rf ~/ros2_rolling

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -1,0 +1,165 @@
+Installing ROS 2 on Linux
+=========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This page explains how to install ROS 2 on Linux from a pre-built binary package.
+
+As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+
+System Requirements
+-------------------
+
+We support Ubuntu Linux Focal Fossa (20.04) 64-bit x86 and 64-bit ARM.
+
+Add the ROS 2 apt repository
+----------------------------
+
+.. include:: ../_Apt-Repositories.rst
+
+Downloading ROS 2
+-----------------
+
+
+* Go `the releases page <https://github.com/ros2/ros2/releases>`_
+* Download the latest package for Linux; let's assume that it ends up at ``~/Downloads/ros2-foxy-linux-x86_64.tar.bz2``.
+
+  * Note: there may be more than one binary download option which might cause the file name to differ.
+
+*
+  Unpack it:
+
+  .. code-block:: bash
+
+       mkdir -p ~/ros2_foxy
+       cd ~/ros2_foxy
+       tar xf ~/Downloads/ros2-foxy-linux-x86_64.tar.bz2
+
+Installing and initializing rosdep
+----------------------------------
+
+.. code-block:: bash
+
+       sudo apt update
+       sudo apt install -y python3-rosdep
+       sudo rosdep init
+       rosdep update
+
+
+Installing the missing dependencies
+-----------------------------------
+
+Set your rosdistro according to the release you downloaded.
+
+.. code-block:: bash
+
+       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro foxy -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+
+#. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
+   Follow the normal install instructions: http://wiki.ros.org/melodic/Installation/Ubuntu
+
+Installing the python3 libraries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+       sudo apt install -y libpython3-dev
+
+Install additional DDS implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <../DDS-Implementations>`.
+
+Environment setup
+-----------------
+
+Sourcing the setup script
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+  . ~/ros2_foxy/ros2-linux/setup.bash
+
+Installing python3 argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete for autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
+
+Try some examples
+-----------------
+
+In one terminal, source the setup file and then run a C++ ``talker``:
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/ros2-linux/setup.bash
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a Python ``listener``:
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/ros2-linux/setup.bash
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+Using the ROS 1 bridge
+----------------------
+
+If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
+We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
+
+If you haven't already, start a roscore:
+
+.. code-block:: bash
+
+   . /opt/ros/melodic/setup.bash
+   roscore
+
+
+In another terminal, start the bridge:
+
+.. code-block:: bash
+
+   . /opt/ros/melodic/setup.bash
+   . ~/ros2_foxy/ros2-linux/setup.bash
+   ros2 run ros1_bridge dynamic_bridge
+
+For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found `here </Troubleshooting>`.
+
+Uninstall
+---------
+
+1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
+   This way, your environment will behave as though there is no Foxy install on your system.
+
+2. If you're also trying to free up space, you can delete the entire workspace directory with:
+
+   .. code-block:: bash
+
+    rm -rf ~/ros2_foxy

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -7,12 +7,14 @@ Installing ROS 2 on Linux
 
 This page explains how to install ROS 2 on Linux from a pre-built binary package.
 
-As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+There are also `Debian packages <Linux-Install-Debians>` available.
 
 System Requirements
 -------------------
 
-We support Ubuntu Linux Focal Fossa (20.04) 64-bit x86 and 64-bit ARM.
+We currently support Ubuntu Linux Focal Fossa (20.04) 64-bit x86 and 64-bit ARM.
+The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
+Most people will want to use a stable ROS distribution.
 
 Add the ROS 2 apt repository
 ----------------------------
@@ -22,9 +24,10 @@ Add the ROS 2 apt repository
 Downloading ROS 2
 -----------------
 
+Binary releases of Rolling Ridley are not provided.
+Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
 
-* Go `the releases page <https://github.com/ros2/ros2/releases>`_
-* Download the latest package for Linux; let's assume that it ends up at ``~/Downloads/ros2-foxy-linux-x86_64.tar.bz2``.
+* Download the latest package for Linux; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
 
@@ -33,9 +36,9 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_foxy
-       cd ~/ros2_foxy
-       tar xf ~/Downloads/ros2-foxy-linux-x86_64.tar.bz2
+       mkdir -p ~/ros2_rolling
+       cd ~/ros2_rolling
+       tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
 ----------------------------------
@@ -55,10 +58,10 @@ Set your rosdistro according to the release you downloaded.
 
 .. code-block:: bash
 
-       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro foxy -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+       rosdep install --from-paths ros2-linux/share --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
 
 #. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
-   Follow the normal install instructions: http://wiki.ros.org/melodic/Installation/Ubuntu
+   Follow the normal install instructions: http://wiki.ros.org/noetic/Installation/Ubuntu
 
 Installing the python3 libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -82,7 +85,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-  . ~/ros2_foxy/ros2-linux/setup.bash
+  . ~/ros2_rolling/ros2-linux/setup.bash
 
 Installing python3 argcomplete (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,14 +105,14 @@ In one terminal, source the setup file and then run a C++ ``talker``:
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/ros2-linux/setup.bash
+   . ~/ros2_rolling/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/ros2-linux/setup.bash
+   . ~/ros2_rolling/ros2-linux/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -122,13 +125,13 @@ Using the ROS 1 bridge
 ----------------------
 
 If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
+We'll assume that it is ``/opt/ros/noetic/setup.bash`` in the following.
 
 If you haven't already, start a roscore:
 
 .. code-block:: bash
 
-   . /opt/ros/melodic/setup.bash
+   . /opt/ros/noetic/setup.bash
    roscore
 
 
@@ -136,8 +139,8 @@ In another terminal, start the bridge:
 
 .. code-block:: bash
 
-   . /opt/ros/melodic/setup.bash
-   . ~/ros2_foxy/ros2-linux/setup.bash
+   . /opt/ros/noetic/setup.bash
+   . ~/ros2_rolling/ros2-linux/setup.bash
    ros2 run ros1_bridge dynamic_bridge
 
 For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
@@ -156,10 +159,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Foxy install on your system.
+   This way, your environment will behave as though there is no Rolling install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_foxy
+    rm -rf ~/ros2_rolling

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -1,0 +1,168 @@
+Installing ROS 2 via Debian Packages
+====================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Debian packages for ROS 2 Foxy Fitzroy are available for Ubuntu Focal.
+
+Resources
+---------
+
+* Status Page:
+
+  * ROS 2 Foxy (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_foxy_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_foxy_ubv8.html>`__
+* `Jenkins Instance <http://build.ros2.org/>`__
+* `Repositories <http://repo.ros2.org>`__
+
+
+Setup Locale
+------------
+Make sure you have a locale which supports ``UTF-8``.
+If you are in a minimal environment, such as a docker container, the locale may be something minimal like POSIX.
+We test with the following settings.
+It should be fine if you're using a different UTF-8 supported locale.
+
+.. code-block:: bash
+
+   sudo locale-gen en_US en_US.UTF-8
+   sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+   export LANG=en_US.UTF-8
+
+Setup Sources
+-------------
+
+.. include:: ../_Apt-Repositories.rst
+
+.. _Foxy_linux-install-debians-install-ros-2-packages:
+
+Install ROS 2 packages
+----------------------
+
+Update your apt repository caches after setting up the repositories.
+
+.. code-block:: bash
+
+   sudo apt update
+
+Desktop Install (Recommended): ROS, RViz, demos, tutorials.
+
+.. code-block:: bash
+
+   sudo apt install ros-foxy-desktop
+
+ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools.
+No GUI tools.
+
+.. code-block:: bash
+
+   sudo apt install ros-foxy-ros-base
+
+See specific sections below for how to also install the :ref:`ros1_bridge <Foxy_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Foxy_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Foxy_linux-install-additional-rmw-implementations>`.
+
+Environment setup
+-----------------
+
+Sourcing the setup script
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set up your environment by sourcing the following file.
+
+.. code-block:: bash
+
+   source /opt/ros/foxy/setup.bash
+
+Install argcomplete (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 command line tools use argcomplete to autocompletion.
+So if you want autocompletion, installing argcomplete is necessary.
+
+.. code-block:: bash
+
+   sudo apt install python3-argcomplete
+
+Try some examples
+-----------------
+
+If you installed ``ros-foxy-desktop`` above you can try some examples.
+
+In one terminal, source the setup file and then run a C++ ``talker``\ :
+
+.. code-block:: bash
+
+   source /opt/ros/foxy/setup.bash
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a Python ``listener``\ :
+
+.. code-block:: bash
+
+   source /opt/ros/foxy/setup.bash
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+.. _Foxy_linux-install-additional-rmw-implementations:
+
+Install additional RMW implementations (optional)
+-------------------------------------------------
+
+By default the RMW implementation ``Fast RTPS`` is used.
+``Cyclone DDS`` is also installed.
+
+To install support for ``RTI Connext``:
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install ros-foxy-rmw-connext-cpp # for RTI Connext (requires license agreement)
+
+By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext instead.
+
+You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
+
+.. _Foxy_linux-ros1-add-pkgs:
+
+Install additional packages using ROS 1 packages
+------------------------------------------------
+
+The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
+To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
+
+If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
+This will also avoid the need to setup the ROS sources as they will already be integrated.
+
+Now you can install the remaining packages:
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install ros-foxy-ros1-bridge
+
+The turtlebot2 packages are not currently available in Foxy.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found `here </Troubleshooting>`.
+
+Uninstall
+---------
+
+If you need to uninstall ROS 2 or switch to a source-based install once you
+have already installed from binaries, run the following command:
+
+.. code-block:: bash
+
+  sudo apt remove ros-foxy-* && sudo apt autoremove

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -5,14 +5,17 @@ Installing ROS 2 via Debian Packages
    :depth: 2
    :local:
 
-Debian packages for ROS 2 Foxy Fitzroy are available for Ubuntu Focal.
+Debian packages for ROS 2 Rolling Ridley are currently available for Ubuntu Focal.
+The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
+The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
+Most people will want to use a stable ROS distribution.
 
 Resources
 ---------
 
 * Status Page:
 
-  * ROS 2 Foxy (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_foxy_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_foxy_ubv8.html>`__
+  * ROS 2 Rolling (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_rolling_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_rolling_ubv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
@@ -35,7 +38,7 @@ Setup Sources
 
 .. include:: ../_Apt-Repositories.rst
 
-.. _Foxy_linux-install-debians-install-ros-2-packages:
+.. _Rolling_linux-install-debians-install-ros-2-packages:
 
 Install ROS 2 packages
 ----------------------
@@ -50,16 +53,16 @@ Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash
 
-   sudo apt install ros-foxy-desktop
+   sudo apt install ros-rolling-desktop
 
 ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools.
 No GUI tools.
 
 .. code-block:: bash
 
-   sudo apt install ros-foxy-ros-base
+   sudo apt install ros-rolling-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Foxy_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Foxy_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Foxy_linux-install-additional-rmw-implementations>`.
+See specific sections below for how to also install the :ref:`ros1_bridge <Rolling_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Rolling_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Rolling_linux-install-additional-rmw-implementations>`.
 
 Environment setup
 -----------------
@@ -71,7 +74,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   source /opt/ros/foxy/setup.bash
+   source /opt/ros/rolling/setup.bash
 
 Install argcomplete (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -86,20 +89,20 @@ So if you want autocompletion, installing argcomplete is necessary.
 Try some examples
 -----------------
 
-If you installed ``ros-foxy-desktop`` above you can try some examples.
+If you installed ``ros-rolling-desktop`` above you can try some examples.
 
 In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   source /opt/ros/foxy/setup.bash
+   source /opt/ros/rolling/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   source /opt/ros/foxy/setup.bash
+   source /opt/ros/rolling/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -108,7 +111,7 @@ Hooray!
 
 See the `tutorials and demos </Tutorials>` for other things to try.
 
-.. _Foxy_linux-install-additional-rmw-implementations:
+.. _Rolling_linux-install-additional-rmw-implementations:
 
 Install additional RMW implementations (optional)
 -------------------------------------------------
@@ -121,13 +124,13 @@ To install support for ``RTI Connext``:
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install ros-foxy-rmw-connext-cpp # for RTI Connext (requires license agreement)
+   sudo apt install ros-rolling-rmw-connext-cpp # for RTI Connext (requires license agreement)
 
 By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext instead.
 
 You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
 
-.. _Foxy_linux-ros1-add-pkgs:
+.. _Rolling_linux-ros1-add-pkgs:
 
 Install additional packages using ROS 1 packages
 ------------------------------------------------
@@ -135,7 +138,7 @@ Install additional packages using ROS 1 packages
 The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
 To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
 
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
+If you're using Docker for isolation you can start with the image ``ros:noetic`` or ``osrf/ros:noetic-desktop``.
 This will also avoid the need to setup the ROS sources as they will already be integrated.
 
 Now you can install the remaining packages:
@@ -143,9 +146,9 @@ Now you can install the remaining packages:
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install ros-foxy-ros1-bridge
+   sudo apt install ros-rolling-ros1-bridge
 
-The turtlebot2 packages are not currently available in Foxy.
+The turtlebot2 packages are not currently available in Rolling.
 
 Build your own packages
 -----------------------
@@ -165,4 +168,4 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo apt remove ros-foxy-* && sudo apt autoremove
+  sudo apt remove ros-rolling-* && sudo apt autoremove

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -1,0 +1,373 @@
+.. _windows-latest:
+
+Building ROS 2 on Windows
+=========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This guide is about how to setup a development environment for ROS 2 on Windows.
+
+Prerequisites
+-------------
+
+First follow the steps for `Installing Prerequisites <Foxy_windows-install-binary-installing-prerequisites>` on the Binary Installation page.
+
+Stop and return here when you reach the "Downloading ROS 2" section.
+
+Additional prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When building from source you'll need a few additional prerequisites installed.
+
+Install additional prerequisites from Chocolatey
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First install git:
+
+.. code-block:: bash
+
+   > choco install -y git
+
+You will need to append the Git cmd folder ``C:\Program Files\Git\cmd`` to the PATH (you can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".
+In the resulting dialog, click "Environment Variables", the click "Path" on the bottom pane, then click "Edit" and add the path).
+
+
+Install developer tools
+-----------------------
+
+Now we are ready to install some our tools that we use to help in developing ROS 2.
+
+Let's start with ``vcstool``:
+
+.. code-block:: bash
+
+   > pip install -U vcstool
+
+You can test it out by just running ``vcs`` (you should be able to do this in the same cmd prompt).
+
+Next, install ``colcon``:
+
+.. code-block:: bash
+
+   > pip install -U colcon-common-extensions
+
+You can test it out by just running ``colcon`` (you should be able to do this in the same cmd prompt).
+
+Also, you should install ``curl``:
+
+.. code-block:: bash
+
+   > choco install -y curl
+
+Install dependencies
+--------------------
+
+Next install the latest version of ``setuptools`` and ``pip``:
+
+.. code-block:: bash
+
+   > <PATH_TO_PYTHON_EXECUTABLE> -m pip install -U setuptools pip
+
+Where ``PATH_TO_PYTHON_EXECUTABLE`` looks like: ``c:\python38\python.exe``
+
+Then you can continue installing other Python dependencies:
+
+.. code-block:: bash
+
+   > pip install -U catkin_pkg cryptography EmPy ifcfg lark-parser lxml numpy pyparsing pyyaml
+
+Next install testing tools like ``pytest`` and others:
+
+.. code-block:: bash
+
+   > pip install -U pytest pytest-mock coverage mock
+
+Next install linters and checkers like ``flake8`` and others:
+
+.. code-block:: bash
+
+   > pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mypy pep8 pydocstyle
+
+Next install cppcheck:
+
+.. code-block:: bash
+
+   > choco install -y cppcheck
+
+Next install xmllint:
+
+* Download the `64 bit binary archives <https://www.zlatkovic.com/pub/libxml/64bit/>`__ of ``libxml2`` (and its dependencies ``iconv`` and ``zlib``) from https://www.zlatkovic.com/projects/libxml/
+* Unpack all archives into e.g. ``C:\xmllint``
+* Add ``C:\xmllint\bin`` to the ``PATH``.
+
+Install Qt5
+^^^^^^^^^^^
+
+This section is only required if you are building rviz, but it comes with our default set of sources, so if you don't know, then assume you are building it.
+
+First get the installer from Qt's website:
+
+https://www.qt.io/download
+
+Select the Open Source version and then the ``Qt Online Installer for Windows``.
+
+Run the installer and install Qt5.
+
+We recommend you install it to the default location of ``C:\Qt``, but if you choose somewhere else, make sure to update the paths below accordingly.
+When selecting components to install, the only thing you absolutely need for Foxy and later is the appropriate MSVC 64-bit component under the ``Qt`` -> ``Qt 5.15.0`` tree.
+We're using ``5.15.0`` as of the writing of this document and that's what we recommend since that's all we test on Windows, but later version will probably work too.
+For Foxy and later, be sure to select ``MSVC 2019 64-bit``.
+After that, the default settings are fine.
+
+Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` where you intend to build so that CMake can find it:
+
+.. code-block:: bash
+
+   > set Qt5_DIR=C:\Qt\5.15.0\msvc2019_64
+
+You could set it permanently with ``setx -m Qt5_DIR C:\Qt\5.15.0\msvc2019_64`` instead, but that requires Administrator.
+
+.. note::
+
+   This path might change based on which MSVC version you're using or if you installed it to a different directory.
+
+RQt dependencies
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   > pip install -U pydot PyQt5
+
+Follow the steps for `Installing Graphviz <Foxy_windows-install-binary-installing-rqt-dependencies>` on the Binary Installation page.
+
+Get the ROS 2 code
+------------------
+
+Now that we have the development tools we can get the ROS 2 source code.
+
+First setup a development folder, for example ``C:\dev\ros2_foxy``:
+
+.. code-block:: bash
+
+   > md \dev\ros2_foxy\src
+   > cd \dev\ros2_foxy
+
+Get the ``ros2.repos`` file which defines the repositories to clone from:
+
+.. code-block:: bash
+
+   # CMD
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos -o ros2.repos
+
+   # PowerShell
+   > curl https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos -o ros2.repos
+
+Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
+
+.. code-block:: bash
+
+   # CMD
+   > vcs import src < ros2.repos
+
+   # PowerShell
+   > vcs import --input ros2.repos src
+
+Install additional DDS implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <../DDS-Implementations>`.
+
+Build the ROS 2 code
+--------------------
+
+.. _windows-dev-build-ros2:
+
+To build ROS 2 you will need a Visual Studio Command Prompt ("x64 Native Tools Command Prompt for VS 2019") running as Administrator.
+
+Fast RTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
+
+To build the ``\dev\ros2_foxy`` folder tree:
+
+.. code-block:: bash
+
+   > colcon build --merge-install
+
+.. note::
+
+   We're using ``--merge-install`` here to avoid a ``PATH`` variable that is too long at the end of the build.
+   If you're adapting these instructions to build a smaller workspace then you might be able to use the default behavior which is isolated install, i.e. where each package is installed to a different folder.
+
+.. note::
+
+   If you are doing a debug build use ``python_d path\to\colcon_executable`` ``colcon``.
+   See `Extra stuff for debug mode`_ for more info on running Python code in debug builds on Windows.
+
+Environment setup
+-----------------
+
+Start a command shell and source the ROS 2 setup file to set up the workspace:
+
+.. code-block:: bash
+
+   > call C:\dev\ros2_foxy\install\local_setup.bat
+
+This will automatically set up the environment for any DDS vendors that support was built for.
+
+It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
+
+Test and run
+------------
+
+Note that the first time you run any executable you will have to allow access to the network through a Windows Firewall popup.
+
+You can run the tests using this command:
+
+.. code-block:: bash
+
+   > colcon test --merge-install
+
+.. note::
+
+   ``--merge-install`` should only be used if it was also used in the build step.
+
+Afterwards you can get a summary of the tests using this command:
+
+.. code-block:: bash
+
+   > colcon test-result
+
+To run the examples, first open a clean new ``cmd.exe`` and set up the workspace by sourcing the ``local_setup.bat`` file.
+Then, run a C++ ``talker``\ :
+
+.. code-block:: bash
+
+   > call install\local_setup.bat
+   > ros2 run demo_nodes_cpp talker
+
+In a separate shell you can do the same, but instead run a Python ``listener``\ :
+
+.. code-block:: bash
+
+   > call install\local_setup.bat
+   > ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+.. note::
+
+   It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+
+Extra stuff for Debug mode
+--------------------------
+
+If you want to be able to run all the tests in Debug mode, you'll need to install a few more things:
+
+
+* To be able to extract the Python source tarball, you can use PeaZip:
+
+.. code-block:: bash
+
+   > choco install -y peazip
+
+
+* You'll also need SVN, since some of the Python source-build dependencies are checked out via SVN:
+
+.. code-block:: bash
+
+   > choco install -y svn hg
+
+
+* You'll need to quit and restart the command prompt after installing the above.
+* Get and extract the Python 3.8.3 source from the ``tgz``:
+
+  * https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tgz
+  * To keep these instructions concise, please extract it to ``C:\dev\Python-3.8.3``
+
+* Now, build the Python source in debug mode from a Visual Studio command prompt:
+
+.. code-block:: bash
+
+   > cd C:\dev\Python-3.8.3\PCbuild
+   > get_externals.bat
+   > build.bat -p x64 -d
+
+
+* Finally, copy the build products into the Python38 installation directories, next to the Release-mode Python executable and DLL's:
+
+.. code-block:: bash
+
+   > cd C:\dev\Python-3.8.3\PCbuild\amd64
+   > copy python_d.exe C:\Python38 /Y
+   > copy python38_d.dll C:\Python38 /Y
+   > copy python3_d.dll C:\Python38 /Y
+   > copy python38_d.lib C:\Python38\libs /Y
+   > copy python3_d.lib C:\Python38\libs /Y
+   > for %I in (*_d.pyd) do copy %I C:\Python38\DLLs /Y
+
+
+* Now, from a fresh command prompt, make sure that ``python_d`` works:
+
+.. code-block:: bash
+
+   > python_d
+   > import _ctypes
+
+* Once you have verified the operation of ``python_d``, it is necessary to reinstall a few dependencies with the debug-enabled libraries:
+
+.. code-block:: bash
+
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.18.4-cp38-cp38d-win_amd64.whl
+   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.5.1-cp38-cp38d-win_amd64.whl
+
+* To verify the installation of these dependencies:
+
+.. code-block:: bash
+
+   > python_d
+   # No import errors should appear when executing the following lines
+   > from lxml import etree
+   > import numpy
+
+* When you wish to return to building release binaries, it is necessary to uninstall the debug variants and use the release variants:
+
+.. code-block:: bash
+
+   > python -m pip uninstall numpy lxml
+   > python -m pip install numpy lxml
+
+* To create executables python scripts(.exe), python_d should be used to invoke colcon
+
+.. code-block:: bash
+
+   > python_d path\to\colcon_executable build
+
+* Hooray, you're done!
+
+Stay up to date
+---------------
+
+See :ref:`MaintainingSource` to periodically refresh your source installation.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found :ref:`here <windows-troubleshooting>`.
+
+Uninstall
+---------
+
+1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
+   This way, your environment will behave as though there is no Foxy install on your system.
+
+2. If you're also trying to free up space, you can delete the entire workspace directory with:
+
+   .. code-block:: bash
+
+    rmdir /s /q \ros2_foxy

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -12,7 +12,7 @@ This guide is about how to setup a development environment for ROS 2 on Windows.
 Prerequisites
 -------------
 
-First follow the steps for `Installing Prerequisites <Foxy_windows-install-binary-installing-prerequisites>` on the Binary Installation page.
+First follow the steps for `Installing Prerequisites <Rolling_windows-install-binary-installing-prerequisites>` on the Binary Installation page.
 
 Stop and return here when you reach the "Downloading ROS 2" section.
 
@@ -140,29 +140,29 @@ RQt dependencies
 
    > pip install -U pydot PyQt5
 
-Follow the steps for `Installing Graphviz <Foxy_windows-install-binary-installing-rqt-dependencies>` on the Binary Installation page.
+Follow the steps for `Installing Graphviz <Rolling_windows-install-binary-installing-rqt-dependencies>` on the Binary Installation page.
 
 Get the ROS 2 code
 ------------------
 
 Now that we have the development tools we can get the ROS 2 source code.
 
-First setup a development folder, for example ``C:\dev\ros2_foxy``:
+First setup a development folder, for example ``C:\dev\ros2_rolling``:
 
 .. code-block:: bash
 
-   > md \dev\ros2_foxy\src
-   > cd \dev\ros2_foxy
+   > md \dev\ros2_rolling\src
+   > cd \dev\ros2_rolling
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
 .. code-block:: bash
 
    # CMD
-   > curl -sk https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos -o ros2.repos
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
 
    # PowerShell
-   > curl https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos -o ros2.repos
+   > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
 
@@ -188,7 +188,7 @@ To build ROS 2 you will need a Visual Studio Command Prompt ("x64 Native Tools C
 
 Fast RTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
 
-To build the ``\dev\ros2_foxy`` folder tree:
+To build the ``\dev\ros2_rolling`` folder tree:
 
 .. code-block:: bash
 
@@ -211,7 +211,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2_foxy\install\local_setup.bat
+   > call C:\dev\ros2_rolling\install\local_setup.bat
 
 This will automatically set up the environment for any DDS vendors that support was built for.
 
@@ -364,10 +364,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Foxy install on your system.
+   This way, your environment will behave as though there is no Rolling install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_foxy
+    rmdir /s /q \ros2_rolling

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -1,0 +1,234 @@
+Installing ROS 2 on Windows
+===========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This page explains how to install ROS 2 on Windows from a pre-built binary package.
+
+System requirements
+-------------------
+
+As of beta-2 only Windows 10 is supported.
+
+.. _Foxy_windows-install-binary-installing-prerequisites:
+
+Installing prerequisites
+------------------------
+
+Install Chocolatey
+^^^^^^^^^^^^^^^^^^
+
+Chocolatey is a package manager for Windows, install it by following their installation instructions:
+
+https://chocolatey.org/
+
+You'll use Chocolatey to install some other developer tools.
+
+Install Python
+^^^^^^^^^^^^^^
+
+Open a Command Prompt and type the following to install Python via Chocolatey:
+
+.. code-block:: bash
+
+   > choco install -y python --version 3.8.3
+
+Install Visual C++ Redistributables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open a Command Prompt and type the following to install them via Chocolatey:
+
+.. code-block:: bash
+
+   > choco install -y vcredist2013 vcredist140
+
+Install OpenSSL
+^^^^^^^^^^^^^^^
+
+Download the *Win64 OpenSSL v1.1.1g* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
+Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1g*.
+Don't download the Win32 or Light versions.
+
+Run the installer with default parameters.
+The following commands assume you used the default installation directory:
+
+* ``setx -m OPENSSL_CONF C:\OpenSSL-Win64\bin\openssl.cfg``
+
+You will need to append the OpenSSL-Win64 bin folder to your PATH.
+You can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".
+In the resulting dialog, click "Environment Variables", then click "Path" on the bottom pane, finally click "Edit" and add the path below.
+
+* ``C:\OpenSSL-Win64\bin\``
+
+Install Visual Studio
+^^^^^^^^^^^^^^^^^^^^^
+
+Install Visual Studio 2019.
+
+If you already have a paid version of Visual Studio 2019 (Professional, Enterprise), skip this step.
+
+Microsoft provides a free of charge version of Visual Studio 2019, named Community, which can be used to build applications that use ROS 2:
+
+   https://visualstudio.microsoft.com/downloads/
+
+Make sure that the Visual C++ features are installed.
+
+An easy way to make sure they're installed is to select the ``Desktop development with C++`` workflow during the install.
+
+   .. image:: https://i.imgur.com/2h0IxCk.png
+
+Make sure that no C++ CMake tools are installed by unselecting them in the list of components to be installed.
+
+Install additional DDS implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <../DDS-Implementations>`.
+
+Install OpenCV
+^^^^^^^^^^^^^^
+
+Some of the examples require OpenCV to be installed.
+
+You can download a precompiled version of OpenCV 3.4.6 from https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip .
+
+Assuming you unpacked it to ``C:\opencv``\ , type the following on a Command Prompt (requires Admin privileges):
+
+.. code-block:: bash
+
+   setx -m OpenCV_DIR C:\opencv
+
+Since you are using a precompiled ROS version, we have to tell it where to find the OpenCV libraries.
+You have to extend the ``PATH`` variable to ``C:\opencv\x64\vc16\bin``.
+
+Install dependencies
+^^^^^^^^^^^^^^^^^^^^
+
+There are a few dependencies not available in the Chocolatey package database.
+In order to ease the manual installation process, we provide the necessary Chocolatey packages.
+
+As some chocolatey packages rely on it, we start by installing CMake
+
+.. code-block:: bash
+
+   > choco install -y cmake
+
+You will need to append the CMake bin folder ``C:\Program Files\CMake\bin`` to your PATH.
+
+Please download these packages from `this <https://github.com/ros2/choco-packages/releases/latest>`__ GitHub repository.
+
+* asio.1.12.1.nupkg
+* bullet.2.89.0.nupkg
+* cunit.2.1.3.nupkg
+* eigen-3.3.4.nupkg
+* tinyxml-usestl.2.6.2.nupkg
+* tinyxml2.6.0.0.nupkg
+* log4cxx.0.10.0.nupkg
+
+Once these packages are downloaded, open an administrative shell and execute the following command:
+
+.. code-block:: bash
+
+   > choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
+
+Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
+
+You must also install some python dependencies for command-line tools:
+
+.. code-block:: bash
+
+   python -m pip install -U catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools
+
+RQt dependencies
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   python -m pip install -U pydot PyQt5
+
+.. _Foxy_windows-install-binary-installing-rqt-dependencies:
+
+To run rqt_graph you need to `download <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install `Graphviz <https://graphviz.gitlab.io/>`__.
+
+* The default installation path will be C:\Program Files (x86)\GraphvizX.XX\bin (Example: GraphvizX.XX → Graphviz2.38)
+* Open cmd window as administrator and go the location C:\Program Files (x86)\GraphvizX.XX\bin and run the below command:
+
+.. code-block:: bash
+
+  dot.exe
+
+* Go to the Control Panel →  System and Security → System, and on the right side navigation panel, you will see the link Advanced systems settings.
+* Once there in advance settings, a dialogue box will open which will show the button Environment Variables. Click on the button Environment Variables.
+* Select the entry "Path" on the system variables section and add C:\Program Files (x86)\GraphvizX.XX\bin to the existing path.
+* Click on Ok Button.
+
+Downloading ROS 2
+-----------------
+
+* Go the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for Windows, e.g., ``ros2-foxy-*-windows-AMD64.zip``.
+
+.. note::
+
+    There may be more than one binary download option which might cause the file name to differ.
+
+.. note::
+
+    To download the ROS 2 debug libraries you'll need to download ``ros2-foxy-*-windows-debug-AMD64.zip``
+
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_foxy``\ ).
+
+Environment setup
+-----------------
+
+Start a command shell and source the ROS 2 setup file to set up the workspace:
+
+.. code-block:: bash
+
+   > call C:\dev\ros2_foxy\local_setup.bat
+
+It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
+
+Try some examples
+-----------------
+
+In a command shell, set up the ROS 2 environment as described above and then run a C++ ``talker``\ :
+
+.. code-block:: bash
+
+   > ros2 run demo_nodes_cpp talker
+
+Start another command shell and run a Python ``listener``\ :
+
+.. code-block:: bash
+
+   > ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found :ref:`here <windows-troubleshooting>`.
+
+Uninstall
+---------
+
+1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
+   This way, your environment will behave as though there is no Foxy install on your system.
+
+2. If you're also trying to free up space, you can delete the entire workspace directory with:
+
+   .. code-block:: bash
+
+    rmdir /s /q \ros2_foxy

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -10,9 +10,9 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-As of beta-2 only Windows 10 is supported.
+Only Windows 10 is supported.
 
-.. _Foxy_windows-install-binary-installing-prerequisites:
+.. _Rolling_windows-install-binary-installing-prerequisites:
 
 Installing prerequisites
 ------------------------
@@ -147,7 +147,7 @@ RQt dependencies
 
    python -m pip install -U pydot PyQt5
 
-.. _Foxy_windows-install-binary-installing-rqt-dependencies:
+.. _Rolling_windows-install-binary-installing-rqt-dependencies:
 
 To run rqt_graph you need to `download <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install `Graphviz <https://graphviz.gitlab.io/>`__.
 
@@ -166,8 +166,10 @@ To run rqt_graph you need to `download <https://graphviz.gitlab.io/_pages/Downlo
 Downloading ROS 2
 -----------------
 
-* Go the releases page: https://github.com/ros2/ros2/releases
-* Download the latest package for Windows, e.g., ``ros2-foxy-*-windows-AMD64.zip``.
+Binary releases of Rolling Ridley are not provided.
+Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
+
+* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
 
 .. note::
 
@@ -175,9 +177,9 @@ Downloading ROS 2
 
 .. note::
 
-    To download the ROS 2 debug libraries you'll need to download ``ros2-foxy-*-windows-debug-AMD64.zip``
+    To download the ROS 2 debug libraries you'll need to download ``ros2-package-windows-debug-AMD64.zip``
 
-* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_foxy``\ ).
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_rolling``\ ).
 
 Environment setup
 -----------------
@@ -186,7 +188,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2_foxy\local_setup.bat
+   > call C:\dev\ros2_rolling\local_setup.bat
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 
@@ -225,10 +227,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Foxy install on your system.
+   This way, your environment will behave as though there is no Rolling install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_foxy
+    rmdir /s /q \ros2_rolling

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -1,6 +1,6 @@
 .. redirect-from::
 
-  Installation/Foxy/OSX-Development-Setup
+  Installation/Rolling/OSX-Development-Setup
 
 .. _macOS-latest:
 
@@ -14,9 +14,9 @@ Building ROS 2 on macOS
 System requirements
 -------------------
 
-We support macOS 10.14 (Mojave).
-
-However, some new versions like 10.13.x and some older versions like 10.11.x and 10.10.x are known to work as well.
+We currently support macOS Mojave (10.14).
+The Rolling Ridley distribution will change target platforms from time to time as new platforms become available.
+Most people will want to use a stable ROS distribution.
 
 Install prerequisites
 ---------------------
@@ -140,9 +140,9 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_foxy/src
-   cd ~/ros2_foxy
-   wget https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
+   mkdir -p ~/ros2_rolling/src
+   cd ~/ros2_rolling
+   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
    vcs import src < ros2.repos
 
 Install additional DDS vendors (optional)
@@ -159,7 +159,7 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this t
 
 .. code-block:: bash
 
-   cd ~/ros2_foxy/
+   cd ~/ros2_rolling/
    colcon build --symlink-install
 
 Environment setup
@@ -169,7 +169,7 @@ Source the ROS 2 setup file:
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/install/setup.bash
+   . ~/ros2_rolling/install/setup.bash
 
 This will automatically set up the environment for any DDS vendors that support was built for.
 
@@ -208,10 +208,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Foxy install on your system.
+   This way, your environment will behave as though there is no Rolling install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_foxy
+    rm -rf ~/ros2_rolling

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -1,0 +1,217 @@
+.. redirect-from::
+
+  Installation/Foxy/OSX-Development-Setup
+
+.. _macOS-latest:
+
+Building ROS 2 on macOS
+=======================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+System requirements
+-------------------
+
+We support macOS 10.14 (Mojave).
+
+However, some new versions like 10.13.x and some older versions like 10.11.x and 10.10.x are known to work as well.
+
+Install prerequisites
+---------------------
+
+You need the following things installed to build ROS 2:
+
+
+#.
+   **Xcode**
+
+
+   *
+     If you don't already have it installed, install Xcode and the Command Line Tools:
+
+     .. code-block:: bash
+
+        xcode-select --install
+        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+
+#.
+   **brew** *(needed to install more stuff; you probably already have this)*:
+
+
+   * Follow installation instructions at http://brew.sh/
+   *
+     *Optional*: Check that ``brew`` is happy with your system configuration by running:
+
+     .. code-block:: bash
+
+        brew doctor
+
+     Fix any problems that it identifies.
+
+#.
+   Use ``brew`` to install more stuff:
+
+   .. code-block:: bash
+
+       brew install cmake cppcheck eigen pcre poco tinyxml wget bullet
+
+       brew install python@3.8
+       brew unlink python
+       # Make the python command be Python 3.8
+       brew link --force python@3.8
+
+       # install dependencies for Fast-RTPS if you are using it
+       brew install asio tinyxml2
+
+       brew install opencv
+
+       # install console_bridge for rosbag2
+       brew install console_bridge
+
+       # install OpenSSL for DDS-Security
+       brew install openssl
+       # if you are using ZSH, then replace '.bashrc' with '.zshrc'
+       echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
+
+       # install dependencies for rcl_logging
+       brew install log4cxx spdlog
+
+       # install CUnit for Cyclone DDS
+       brew install cunit
+
+#.
+   Install rviz dependencies
+
+   .. code-block:: bash
+
+       # install dependencies for Rviz
+       brew install qt freetype assimp
+
+       # Add the Qt directory to the PATH and CMAKE_PREFIX_PATH
+       export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/usr/local/opt/qt
+       export PATH=$PATH:/usr/local/opt/qt/bin
+
+#.
+   Install rqt dependencies
+
+  ``brew install graphviz pyqt5 sip``
+
+  Fix some path names when looking for sip stuff during install (see `ROS 1 wiki <http://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source#Qt_naming_issue>`__):
+
+  ``ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5``
+
+#.
+   Use ``python3 -m pip`` (just ``pip`` may install Python3 or Python2) to install more stuff:
+
+   .. code-block:: bash
+
+       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg lark-parser lxml mock mypy netifaces nose pep8 pydocstyle pydot pygraphviz pyparsing pytest-mock rosdep setuptools vcstool
+
+   Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
+
+#.
+   *Optional*: if you want to build the ROS 1<->2 bridge, then you must also install ROS 1:
+
+
+   * Start with the normal install instructions: http://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source
+   *
+     When you get to the step where you call ``rosinstall_generator`` to get the source code, here's an alternate invocation that brings in just the minimum required to produce a useful bridge:
+
+     .. code-block:: bash
+
+          rosinstall_generator catkin common_msgs roscpp rosmsg --rosdistro kinetic --deps --wet-only --tar > kinetic-ros2-bridge-deps.rosinstall
+          wstool init -j8 src kinetic-ros2-bridge-deps.rosinstall
+
+
+     Otherwise, just follow the normal instructions, then source the resulting ``install_isolated/setup.bash`` before proceeding here to build ROS 2.
+
+Disable System Integrity Protection (SIP)
+-----------------------------------------
+
+macOS/OS X versions >=10.11 have System Integrity Protection enabled by default.
+So that SIP doesn't prevent processes from inheriting dynamic linker environment variables, such as ``DYLD_LIBRARY_PATH``, you'll need to disable it `following these instructions <https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html>`__.
+
+Get the ROS 2 code
+------------------
+
+Create a workspace and clone all repos:
+
+.. code-block:: bash
+
+   mkdir -p ~/ros2_foxy/src
+   cd ~/ros2_foxy
+   wget https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
+   vcs import src < ros2.repos
+
+Install additional DDS vendors (optional)
+-----------------------------------------
+
+If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <../DDS-Implementations>`.
+
+Build the ROS 2 code
+--------------------
+
+**Note**\ : if you are trying to build the ROS 1 <-> ROS 2 bridge, follow instead these `modified instructions <https://github.com/ros2/ros1_bridge/blob/master/README#build-the-bridge-from-source>`__.
+
+Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this tutorial </Tutorials/Colcon-Tutorial>`):
+
+.. code-block:: bash
+
+   cd ~/ros2_foxy/
+   colcon build --symlink-install
+
+Environment setup
+-----------------
+
+Source the ROS 2 setup file:
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/install/setup.bash
+
+This will automatically set up the environment for any DDS vendors that support was built for.
+
+Try some examples
+-----------------
+
+In one terminal, set up the ROS 2 environment as described above and then run a C++ ``talker``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp talker
+
+In another terminal source the setup file and then run a Python ``listener``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+Stay up to date
+---------------
+
+See :ref:`MaintainingSource` to periodically refresh your source installation.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found :ref:`here <macOS-troubleshooting>`.
+
+Uninstall
+---------
+
+1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
+   This way, your environment will behave as though there is no Foxy install on your system.
+
+2. If you're also trying to free up space, you can delete the entire workspace directory with:
+
+   .. code-block:: bash
+
+    rm -rf ~/ros2_foxy

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -1,0 +1,191 @@
+.. redirect-from::
+
+  Installation/Foxy/OSX-Install-Binary
+
+Installing ROS 2 on macOS
+=========================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+This page explains how to install ROS 2 on macOS from a pre-built binary package.
+
+System requirements
+-------------------
+
+We support macOS Mojave (10.14).
+
+.. _Foxy_osx-install-binary-installling-prerequisites:
+
+Installing prerequisites
+------------------------
+
+You need the following things installed before installing ROS 2.
+
+
+*
+  **brew** *(needed to install more stuff; you probably already have this)*:
+
+
+  * Follow installation instructions at http://brew.sh/
+  *
+    *Optional*: Check that ``brew`` is happy with your system configuration by running:
+
+    .. code-block:: bash
+
+        brew doctor
+
+
+      Fix any problems that it identifies.
+
+*
+  Use ``brew`` to install more stuff:
+
+  .. code-block:: bash
+
+       brew install python@3.8
+       # Unlink in case you have python@3.7 installed already
+       brew unlink python
+       # Make the python command be Python 3.8
+       brew link --force python@3.8
+
+       # install asio and tinyxml2 for Fast-RTPS
+       brew install asio tinyxml2
+
+       # install dependencies for robot state publisher
+       brew install tinyxml eigen pcre poco
+
+       # OpenCV isn't a dependency of ROS 2, but it is used by some demos.
+       brew install opencv
+
+       # install OpenSSL for DDS-Security
+       brew install openssl
+       # if you are using ZSH, then replace '.bashrc' with '.zshrc'
+       echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
+
+       # install Qt for RViz
+       brew install qt freetype assimp
+
+       # install console_bridge for rosbag2
+       brew install console_bridge
+
+       # install dependencies for rcl_logging_log4cxx
+       brew install log4cxx spdlog
+
+       # install CUnit for Cyclone DDS
+       brew install cunit
+
+*
+  Install rqt dependencies
+
+  ``brew install sip pyqt5``
+
+  Fix some path names when looking for sip stuff during install (see `ROS 1 wiki <http://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source#Qt_naming_issue>`__):
+
+  ``ln -s /usr/local/share/sip/Qt5 /usr/local/share/sip/PyQt5``
+
+  ``brew install graphviz``
+
+  ``python3 -m pip install pygraphviz pydot``
+
+  .. note::
+
+      You may run into an issue installing ``pygraphviz``, "error: Error locating graphviz".
+      Try the following install command instead:
+
+      .. code-block:: bash
+
+         python3 -m pip install --install-option="--include-path=/usr/local/include/" --install-option="--library-path=/usr/local/lib/" pygraphviz
+
+*
+  Install SROS2 dependencies
+
+  ``python3 -m pip install lxml``
+
+*
+  Install additional runtime dependencies for command-line tools:
+
+  .. code-block:: bash
+
+       python3 -m pip install catkin_pkg empy ifcfg lark-parser lxml netifaces numpy pyparsing pyyaml setuptools argcomplete
+
+Disable System Integrity Protection (SIP)
+-----------------------------------------
+
+macOS/OS X versions >=10.11 have System Integrity Protection enabled by default.
+So that SIP doesn't prevent processes from inheriting dynamic linker environment variables, such as ``DYLD_LIBRARY_PATH``, you'll need to disable it `following these instructions <https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html>`__.
+
+Downloading ROS 2
+-----------------
+
+* Go to the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for macOS; let's assume that it ends up at ``~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2``.
+
+  * Note: there may be more than one binary download option which might cause the file name to differ.
+
+*
+  Unpack it:
+
+  .. code-block:: bash
+
+       mkdir -p ~/ros2_foxy
+       cd ~/ros2_foxy
+       tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
+
+Install additional DDS implementations (optional)
+-------------------------------------------------
+
+If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <../DDS-Implementations>`.
+
+Environment setup
+-----------------
+
+Source the ROS 2 setup file:
+
+.. code-block:: bash
+
+   . ~/ros2_foxy/ros2-osx/setup.bash
+
+Try some examples
+-----------------
+
+In one terminal, set up the ROS 2 environment as described above and then run a C++ ``talker``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp talker
+
+In another terminal, set up the ROS 2 environment and then run a Python ``listener``:
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_py listener
+
+You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
+This verifies both the C++ and Python APIs are working properly.
+Hooray!
+
+See the `tutorials and demos </Tutorials>` for other things to try.
+
+Build your own packages
+-----------------------
+
+If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+
+Troubleshooting
+---------------
+
+Troubleshooting techniques can be found :ref:`here <macOS-troubleshooting>`.
+
+Uninstall
+---------
+
+1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
+   This way, your environment will behave as though there is no Foxy install on your system.
+
+2. If you're also trying to free up space, you can delete the entire workspace directory with:
+
+   .. code-block:: bash
+
+    rm -rf ~/ros2_foxy

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -1,6 +1,6 @@
 .. redirect-from::
 
-  Installation/Foxy/OSX-Install-Binary
+  Installation/Rolling/OSX-Install-Binary
 
 Installing ROS 2 on macOS
 =========================
@@ -14,9 +14,11 @@ This page explains how to install ROS 2 on macOS from a pre-built binary package
 System requirements
 -------------------
 
-We support macOS Mojave (10.14).
+We currently support macOS Mojave (10.14).
+The Rolling Ridley distribution will change target platforms from time to time as new platforms become available.
+Most people will want to use a stable ROS distribution.
 
-.. _Foxy_osx-install-binary-installling-prerequisites:
+.. _Rolling_osx-install-binary-installling-prerequisites:
 
 Installing prerequisites
 ------------------------
@@ -119,8 +121,10 @@ So that SIP doesn't prevent processes from inheriting dynamic linker environment
 Downloading ROS 2
 -----------------
 
-* Go to the releases page: https://github.com/ros2/ros2/releases
-* Download the latest package for macOS; let's assume that it ends up at ``~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2``.
+Binary releases of Rolling Ridley are not provided.
+Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
+
+* Download the latest package for macOS; let's assume that it ends up at ``~/Downloads/ros2-package-osx-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
 
@@ -129,9 +133,9 @@ Downloading ROS 2
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_foxy
-       cd ~/ros2_foxy
-       tar xf ~/Downloads/ros2-release-distro-date-macos-amd64.tar.bz2
+       mkdir -p ~/ros2_rolling
+       cd ~/ros2_rolling
+       tar xf ~/Downloads/ros2-package-osx-x86_64.tar.bz2
 
 Install additional DDS implementations (optional)
 -------------------------------------------------
@@ -145,7 +149,7 @@ Source the ROS 2 setup file:
 
 .. code-block:: bash
 
-   . ~/ros2_foxy/ros2-osx/setup.bash
+   . ~/ros2_rolling/ros2-osx/setup.bash
 
 Try some examples
 -----------------
@@ -182,10 +186,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Foxy install on your system.
+   This way, your environment will behave as though there is no Rolling install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_foxy
+    rm -rf ~/ros2_rolling


### PR DESCRIPTION
This adds installation documentation for Rolling Ridley, copied from Foxy Fitzroy.

:warning: Instead of using the Squash Merge this PR should be Fast-forwarded onto `master` in order to preserve the initial commit (currently 9f59ecf) which will preserve file history when used with `git log --follow`.

The following commits may be rebased above it as many times as needed and squashed into one or more as it makes sense. I have currently broken the changes up into several commits for easier reviewing.

* The second commit is mostly a global replacement of `F|foxy` for `R|rolling` and applies changes similar to #775 for the Rolling instructions.

* The third and fourth commits modify the standard binary installation instructions pointing readers to the Prerelease Testing page for instructions on how to get nightly packages from ci.ros2.org.