### PR TITLE
Add Rolling Ridley release page.

### DIFF
--- a/source/Releases/Release-Rolling-Ridley.rst
+++ b/source/Releases/Release-Rolling-Ridley.rst
@@ -1,0 +1,35 @@
+ROS 2 Rolling Ridley (codename 'rolling'; June 2020)
+==========================================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+*Rolling Ridley* is a rolling development release of ROS 2.
+
+For more information see `REP-2002 <https://www.ros.org/reps/rep-2002.html>`_
+
+Currently Supported Platforms
+-----------------------------
+
+Rolling Ridley is currently supported on the following platforms:
+
+Tier 1 platforms:
+
+* Ubuntu 20.04 (Focal): ``amd64`` and ``arm64``
+* Mac macOS 10.14 (Mojave)
+* Windows 10 (Visual Studio 2019)
+
+Tier 3 platforms:
+
+* Ubuntu 20.04 (Focal): ``arm32``
+* Debian Buster (10): ``amd64``, ``arm64`` and ``arm32``
+* OpenEmbedded Thud (2.6) / webOS OSE: ``arm32`` and ``x86``
+
+
+New features and changes in this release
+----------------------------------------
+
+Rolling Ridley is an ongoing development distribution.
+Changes between the current stable release and the upcoming one can be found on the page for the `upcoming release <upcoming-release>`.
+


### PR DESCRIPTION
Adapted from the Galactic release page but rather than keep separate new
features and changes, I consolidated the final section with a link to
the `upcoming_release` anchor, currently pointing to Galactic.

I started this off quite minimal. Does anyone have suggestions about additional information we should add to this page specifically?