### PR TITLE
Remove mention of beta 2 from install instructions

### DIFF
--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -7,7 +7,7 @@ Installing ROS 2 on Linux
 
 This page explains how to install ROS 2 on Linux from a pre-built binary package.
 
-As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+There are also `Debian packages <Linux-Install-Debians>` available.
 
 System Requirements
 -------------------

--- a/source/Installation/Crystal/Windows-Install-Binary.rst
+++ b/source/Installation/Crystal/Windows-Install-Binary.rst
@@ -10,7 +10,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-As of beta-2 only Windows 10 is supported.
+Only Windows 10 is supported.
 
 .. _windows-install-binary-installing-prerequisites:
 

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -7,7 +7,7 @@ Installing ROS 2 on Linux
 
 This page explains how to install ROS 2 on Linux from a pre-built binary package.
 
-As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+There are also `Debian packages <Linux-Install-Debians>` available.
 
 System Requirements
 -------------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -10,7 +10,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-As of beta-2 only Windows 10 is supported.
+Only Windows 10 is supported.
 
 .. _Dashing_windows-install-binary-installing-prerequisites:
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -12,7 +12,7 @@ Installing ROS 2 on Linux
 
 This page explains how to install ROS 2 on Linux from a pre-built binary package.
 
-As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+There are also `Debian packages <Linux-Install-Debians>` available.
 
 System Requirements
 -------------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -15,7 +15,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-As of beta-2 only Windows 10 is supported.
+Only Windows 10 is supported.
 
 .. _Eloquent_windows-install-binary-installing-prerequisites:
 

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -7,7 +7,7 @@ Installing ROS 2 on Linux
 
 This page explains how to install ROS 2 on Linux from a pre-built binary package.
 
-As of Beta 2 there are also `Debian packages <Linux-Install-Debians>` available.
+There are also `Debian packages <Linux-Install-Debians>` available.
 
 System Requirements
 -------------------

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -10,7 +10,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-As of beta-2 only Windows 10 is supported.
+Only Windows 10 is supported.
 
 .. _Foxy_windows-install-binary-installing-prerequisites:
 


### PR DESCRIPTION
Beta 2 is quite old and I don't think mentioning it in these install instructions adds much value.