### PR TITLE
Add importlib-metadata to Rolling macOS and Windows install.

### DIFF
--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -76,7 +76,7 @@ Then you can continue installing other Python dependencies:
 
 .. code-block:: bash
 
-   > pip install -U catkin_pkg cryptography EmPy ifcfg lark-parser lxml numpy pyparsing pyyaml
+   > pip install -U catkin_pkg cryptography EmPy ifcfg importlib-metadata lark-parser lxml numpy pyparsing pyyaml
 
 Next install testing tools like ``pytest`` and others:
 

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -138,7 +138,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy ifcfg lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools
+   python -m pip install -U catkin_pkg cryptography empy ifcfg importlib-metadata lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools
 
 RQt dependencies
 ~~~~~~~~~~~~~~~~

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -107,7 +107,7 @@ You need the following things installed to build ROS 2:
 
    .. code-block:: bash
 
-       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg lark-parser lxml mock mypy netifaces nose pep8 pydocstyle pydot pygraphviz pyparsing pytest-mock rosdep setuptools vcstool
+       python3 -m pip install -U argcomplete catkin_pkg colcon-common-extensions coverage cryptography empy flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes ifcfg importlib-metadata lark-parser lxml mock mypy netifaces nose pep8 pydocstyle pydot pygraphviz pyparsing pytest-mock rosdep setuptools vcstool
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
 

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -110,7 +110,7 @@ You need the following things installed before installing ROS 2.
 
   .. code-block:: bash
 
-       python3 -m pip install catkin_pkg empy ifcfg lark-parser lxml netifaces numpy pyparsing pyyaml setuptools argcomplete
+       python3 -m pip install argcomplete catkin_pkg empy ifcfg importlib-metadata lark-parser lxml netifaces numpy pyparsing pyyaml setuptools
 
 Disable System Integrity Protection (SIP)
 -----------------------------------------


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

As part of https://github.com/ros2/ros2/issues/919 , we need to install importlib-metadata pip package on macOS and Windows.  Add that to the Rolling install instructions here.