### PR TITLE
Change coverage script path to point to ros2/ci repo

### DIFF
--- a/source/Contributing/ROS-2-On-boarding-Guide.rst
+++ b/source/Contributing/ROS-2-On-boarding-Guide.rst
@@ -272,8 +272,8 @@ How to calculate the coverage rate from the buildfarm report
 Get the combined unit coverage rate using the automatic script:
 
  * From the ci_linux_coverage Jenkins build copy the URL of the build
- * Download the `get_coverage_ros2_pkg <https://github.com/j-rivero/ros2_coverage_jenkins_params/blob/coverage_checker/get_coverage_results/get_coverage_ros2_pkg.py>`__ script
- * Execute the script: ``./get_coverage_ros2_pkg.py <jenkins_build_url> <ros2_package_name>`` (`README <https://github.com/j-rivero/ros2_coverage_jenkins_params/blob/coverage_checker/get_coverage_results/README.md>`__)
+ * Download the `get_coverage_ros2_pkg <https://raw.githubusercontent.com/ros2/ci/master/tools/get_coverage_ros2_pkg.py>`__ script
+ * Execute the script: ``./get_coverage_ros2_pkg.py <jenkins_build_url> <ros2_package_name>`` (`README <https://github.com/ros2/ci/blob/master/tools/README.md>`__)
  * Grab the results from the "Combined unit testing" final line in the output of the script
 
 Alternative: get the combined unit coverage rate from coverage report (require manual calculation):


### PR DESCRIPTION
After merging https://github.com/ros2/ci/pull/476 , update the location of the script and README file.