### PR TITLE
Add setuptools to the list of pip-installed packages for Linux.

### DIFF
--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -76,7 +76,8 @@ Install development tools and ROS tools
      flake8-quotes \
      pytest-repeat \
      pytest-rerunfailures \
-     pytest
+     pytest \
+     setuptools
    # install Fast-RTPS dependencies
    sudo apt install --no-install-recommends -y \
      libasio-dev \


### PR DESCRIPTION
This is so we can get at least setuptools 47.3.0, which will
use importlib_metadata instead of pkg_resources when possible.
In turn, this makes it so that the command-line tools are
more snappy.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This will solve the Linux from-source issue as discussed in https://github.com/ros2/ros2/issues/919#issuecomment-650278328