### PR TITLE
Reword disclaimer on Rolling release page.

### DIFF
--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -1,3 +1,4 @@
+.. _latest_release:
 
 ROS 2 Foxy Fitzroy (codename 'foxy'; June 5th, 2020)
 ====================================================

--- a/source/Releases/Release-Rolling-Ridley.rst
+++ b/source/Releases/Release-Rolling-Ridley.rst
@@ -9,8 +9,9 @@ ROS 2 Rolling Ridley (codename 'rolling'; June 2020)
 
 .. warning::
 
-  Rolling Ridley is unstable and is not meant for general ROS 2 use.
-  It is meant for maintainers who want their packages released and ready for the next stable distribution.
+  Rolling Ridley is continuously updated and is subject to in-place updates which will at times include breaking changes.
+  It is used for ROS 2 development and by maintainers who want their packages released and ready for the next stable distribution.
+  We recommend that most users of ROS 2 use the latest `stable distribution <latest-release>`.
 
 For more information see `REP-2002 <https://www.ros.org/reps/rep-2002.html>`_
 

--- a/source/Releases/Release-Rolling-Ridley.rst
+++ b/source/Releases/Release-Rolling-Ridley.rst
@@ -11,7 +11,7 @@ ROS 2 Rolling Ridley (codename 'rolling'; June 2020)
 
   Rolling Ridley is continuously updated and is subject to in-place updates which will at times include breaking changes.
   It is used for ROS 2 development and by maintainers who want their packages released and ready for the next stable distribution.
-  We recommend that most users of ROS 2 use the latest `stable distribution <latest-release>`.
+  We recommend that most users of ROS 2 use the latest `stable distribution <latest_release>`.
 
 For more information see `REP-2002 <https://www.ros.org/reps/rep-2002.html>`_
 


### PR DESCRIPTION
I've reworded the suggested disclaimer in #785 to accomplish a couple aims:

* Use a positive recommendation ("we recommend stable" rather than "we
  do not recommend rolling").

* Adapt the same in-place updates and breaking changes phrase from the
  general description rather than "unstable". This change is a bit more
  subjective. "unstable" seems scarier which maybe we want in a warning
  but this text feels more precise to me.

* Expand the single sentence description of the rolling distribution to
  include "development". I'm torn between this change and removing the
  sentence from the disclaimer entirely and letting people follow the
  REP link.

There's another commit here which adds the anchor to the latest stable release which we'll have to manually update for future releases (such has when Galactic is released next May).