### PR TITLE
Updating the ROS 2 roadmap

### DIFF
--- a/source/Feature-Ideas.rst
+++ b/source/Feature-Ideas.rst
@@ -1,0 +1,194 @@
+.. _Roadmap:
+
+Roadmap
+=======
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Please see the page of the :ref:`upcoming distribution <upcoming-release>` for more information what is planned to be part of that release.
+
+Please see the :ref:`Distributions page <Releases>` for the timeline of and information about future distributions.
+
+For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
+The core code for ROS 2 is on the `ros2 GitHub organization <https://github.com/ros2>`__.
+The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
+Questions should be asked on `ROS answers <https://answers.ros.org>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``ardent``.
+
+Feature ideas in no specific order
+----------------------------------
+
+Design / Concept
+~~~~~~~~~~~~~~~~
+
+* IDL format
+
+  * Leverage new features like grouping constants into enums
+  * Extend usage to ``.idl`` files with just constants and/or declare parameters with ranges
+  * Revisit constraints of IDL interface naming, see `ros2/design#220 <https://github.com/ros2/design/pull/220>`_
+
+* Progress on migration plan
+* Uniqueness of node names, see `ros2/design#187 <https://github.com/ros2/design/issues/187>`_
+* Specific "API" of a node in terms of topics / services / etc. in a descriptive format, see `ros2/design#266 <https://github.com/ros2/design/pull/266>`_
+
+Infrastructure and tools
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Building
+
+  * Consolidate build.ros2.org and ci.ros2.org
+  * Provision macOS
+  * Windows and Mac OS packages
+  * Support profiles in ``colcon``
+
+* Documentation
+
+  * Improve documentation platform
+  * Support for ``doc`` jobs on the `ROS 2 buildfarm <https://build.ros2.org>`__
+  * Consider consolidating with design.ros2.org
+  * Provide three different kinds of content:
+
+    * "demos" to show features and cover them with tests
+    * "examples" to show a simple/minimalistic usage which might have multiple ways to do something
+    * "tutorials" which contain more comments and anchors for the wiki (teaching one recommended way)
+
+New features
+~~~~~~~~~~~~
+
+The trailing stars indicate the rough effort: 1 star for small, 2 stars for medium, 3 stars for large.
+
+
+* Logging improvements [\* / \*\*]
+
+  * Configuration specified in a file
+  * Per-logger configuration (enabling e.g. ``rqt_logger_level``)
+
+* Time related
+
+  * Support rate and sleep based on clock
+
+* Parameters
+
+  * enforce type
+
+* Additional Graph API features [\*\* / \*\*\*]
+
+  * Introspect QoS setting for all (especially remote) topics
+  * a la ROS 1 Master API: https://wiki.ros.org/ROS/Master_API
+  * Event-based notification
+  * Requires knowledge of the rmw interface which needs to be extended
+
+* Executor
+
+  * Performance improvements (mostly around the waitset)
+  * Deterministic ordering (fair scheduling)
+  * Work with callback groups
+  * Decouple waitables
+
+* Message generation
+
+  * Catch-up message generation for languages not support out-of-the-box
+  * Mangle field names in message to avoid language specific keywords
+  * Improve generator performance by running them in the same Python interpreter
+
+* Launch
+
+  * Support use case of using ``xacro`` to perform substitutions before passing the result containing parameters
+  * Use pytest for launch testing
+  * Support for launching multi-node executables (i.e. manual composition)
+  * Extend launch XML/YAML support: events and event handlers, tag namespaces and aliasing
+
+* Rosbag
+
+  * Support recording services (and actions)
+
+* ros1_bridge
+
+  * Support bridging actions
+
+* RMW configuration
+
+  * Unified standard way of configuring the middleware
+
+* Remapping [\*\* / \*\*\*]
+
+  * Dynamic remapping and aliasing through a Service interface
+
+* Type masquerading [\*\*\*]
+
+  * a la ROS 1's message traits: https://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes
+  * Requires knowledge of the typesupport system
+
+* Expand on real-time safety [\*\*\*]
+
+  * With Fast RTPS
+  * For services, clients, and parameters
+  * Expose more quality of service parameters related to real-time performance
+  * Real-time-safe intra-process messaging
+
+* Multi-robot supporting features and demos [\*\*\*]
+
+  * Undesired that all nodes across all robots share the same domain (and discover each other)
+  * Design how to “partition” the system
+
+* Implement C client library ``rclc`` [\*\*]
+* Support more DDS / RTPS implementations:
+
+  * Connext 6, see `ros2/rmw_connext#375 <https://github.com/ros2/rmw_connext/issues/375>`_
+  * Connext dynamic [\*]
+  * RTI's micro implementation [\*]
+
+* security improvements:
+
+  * more granularity in security configuration (allow authentication only, authentication and encryption, etc.) [\*]
+  * integrate DDS-Security logging plugin (unified way to aggregate security events and report them to the users through a ROS interface) [\*\*]
+  * key storage security (right now, keys are just stored in the filesystem) [\*\*]
+  * more user friendly interface (make it easier to specify security config). Maybe a Qt GUI? This GUI could also assist in distributing keys somehow. [\*\*\*]
+  * A way to say "please secure this running system" with some UI that would auto-generate keys and policies for everything that is currently running. [\*\*\*]
+  * If there are hardware-specific features for securing keys or accelerating encryption/signing messages, that could be interesting to add to DDS/RTPS implementations that don't use it already. [\*\*\*]
+
+Port of existing ROS 1 functionality
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Perception metapackage
+
+  * Image pipeline
+  * Perception PCL
+
+* MoveIt
+
+  * MoveIt Maintainers are tracking: https://discourse.ros.org/t/moveit-maintainer-meeting-recap-july-25th-2018/5504
+
+* RQt
+
+  * convert more plugins [\* each when dependencies are available]
+
+Reducing Technical Debt
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Extend testing and resolve bugs in the current code base
+
+  * Waitset inconsistency
+  * Multi-threading problems with components
+
+* Fix flaky tests.
+* Ability to run (all) unit tests with tools e.g. valgrind
+* API review, specifically user-facing APIs in rclcpp and rclpy
+* Refactor the rclcpp API into separate packages focused on a single aspect, rclcpp should afterward still provide the combined user-facing API
+* Revisit message allocators, consider using std::polymorphic_allocator to address problems
+
+* Modernization
+
+  * Support/use exporting CMake targets (rather than using CMake variables like ``*_INCLUDE_DIRS``, ``*_LIBRARIES``)
+  * Use C++17 filesystem features rather than custom code
+  * Use pybind11 for rclpy
+  * Move to f-strings in Python code
+  * Use setup.cfg files for Python packages
+
+* Synchronize / reconcile design docs with the implementation.
+
+  * Pre-release retrospective review (APIs, docs, etc.)
+
+* Address / classify pending tickets
+* Address TODOs in code / docs

--- a/source/Feature-Ideas.rst
+++ b/source/Feature-Ideas.rst
@@ -1,26 +1,17 @@
-.. _Roadmap:
+.. _FeatureIdeas:
 
-Roadmap
-=======
+Feature Ideas
+==========
 
 .. contents:: Table of Contents
    :depth: 2
    :local:
 
-Please see the page of the :ref:`upcoming distribution <upcoming-release>` for more information what is planned to be part of that release.
-
-Please see the :ref:`Distributions page <Releases>` for the timeline of and information about future distributions.
-
-For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
-The core code for ROS 2 is on the `ros2 GitHub organization <https://github.com/ros2>`__.
-The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
-Questions should be asked on `ROS answers <https://answers.ros.org>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``ardent``.
-
-Feature ideas in no specific order
-----------------------------------
+The following are feature ideas in no specific order. This list contains
+features that we think are important and can make for good contributions to ROS 2. :ref:`Please get in touch with us <Help>` before digging to a new feature. We can offer guidance, and connect you with other developers.
 
 Design / Concept
-~~~~~~~~~~~~~~~~
+----------------
 
 * IDL format
 
@@ -28,12 +19,12 @@ Design / Concept
   * Extend usage to ``.idl`` files with just constants and/or declare parameters with ranges
   * Revisit constraints of IDL interface naming, see `ros2/design#220 <https://github.com/ros2/design/pull/220>`_
 
-* Progress on migration plan
+* Create migration plan for ROS 1 -> ROS 2 transition
 * Uniqueness of node names, see `ros2/design#187 <https://github.com/ros2/design/issues/187>`_
 * Specific "API" of a node in terms of topics / services / etc. in a descriptive format, see `ros2/design#266 <https://github.com/ros2/design/pull/266>`_
 
 Infrastructure and tools
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 * Building
 
@@ -54,7 +45,7 @@ Infrastructure and tools
     * "tutorials" which contain more comments and anchors for the wiki (teaching one recommended way)
 
 New features
-~~~~~~~~~~~~
+------------
 
 The trailing stars indicate the rough effort: 1 star for small, 2 stars for medium, 3 stars for large.
 
@@ -88,7 +79,7 @@ The trailing stars indicate the rough effort: 1 star for small, 2 stars for medi
 
 * Message generation
 
-  * Catch-up message generation for languages not support out-of-the-box
+  * Catch-up message generation for languages not supported out-of-the-box
   * Mangle field names in message to avoid language specific keywords
   * Improve generator performance by running them in the same Python interpreter
 
@@ -122,7 +113,6 @@ The trailing stars indicate the rough effort: 1 star for small, 2 stars for medi
 
 * Expand on real-time safety [\*\*\*]
 
-  * With Fast RTPS
   * For services, clients, and parameters
   * Expose more quality of service parameters related to real-time performance
   * Real-time-safe intra-process messaging
@@ -149,11 +139,10 @@ The trailing stars indicate the rough effort: 1 star for small, 2 stars for medi
   * If there are hardware-specific features for securing keys or accelerating encryption/signing messages, that could be interesting to add to DDS/RTPS implementations that don't use it already. [\*\*\*]
 
 Port of existing ROS 1 functionality
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 
 * Perception metapackage
 
-  * Image pipeline
   * Perception PCL
 
 * MoveIt
@@ -165,7 +154,7 @@ Port of existing ROS 1 functionality
   * convert more plugins [\* each when dependencies are available]
 
 Reducing Technical Debt
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 * Extend testing and resolve bugs in the current code base
 

--- a/source/Roadmap.rst
+++ b/source/Roadmap.rst
@@ -9,6 +9,7 @@ Roadmap
 
 This page describes planned work for ROS 2.
 The set of planned features and development efforts should provide insight into the overall direction of ROS 2.
+Please refer to the meta tickets listed in the :ref:`Planned releases<Planned releases>` section for information about additional development efforts for each release.
 If you would like to see other features on the roadmap, then please get in touch with us at info@openrobotics.org.
 
 Quarterly Roadmap
@@ -38,6 +39,12 @@ Planned releases
 ----------------
 
 Please see the :ref:`Distributions page <Releases>` for the timeline of and information about future distributions.
+
+Addtional features and tasks for each ROS 2 release can be found at following locations:
+* `Galactic Geochelone <Releases/Release-Galactic-Geochelone>`
+    * See the `Galatic Geochelone meta ticket <https://github.com/ros2/ros2/issues/954>`.
+* `Foxy Fitzroy <Releases/Release-Foxy-Fitzroy>`
+    * See the `Foxy Fitzroy meta ticket <https://github.com/ros2/ros2/issues/830>`.
 
 Contributing to ROS 2
 ---------------------

--- a/source/Roadmap.rst
+++ b/source/Roadmap.rst
@@ -7,199 +7,46 @@ Roadmap
    :depth: 2
    :local:
 
-Please see the page of the :ref:`upcoming distribution <upcoming-release>` for more information what is planned to be part of that release.
+This page describes planned work for ROS 2.
+The set of planned features and development efforts should provide insight into the overall direction of ROS 2.
+If you would like to see other features on the roadmap, then please get in touch with us at info@openrobotics.org.
+
+Quarterly Roadmap
+-----------------
+
+**Product Readiness** is the current focus topic for ROS 2.
+Over the next two quarters we will concentrate development efforts on topics that make ROS 2 more suitable for use in production scenarios.
+This includes improving the out-of-box experience for common use cases, documentation improvements, and addressing disparities between ROS 1 and ROS 2.
+
+## 2020 Q3(Jul - Sep)
+
+* **Transport Documentation and Configurations**: Describe and document the
+  ROS 2 transport system.
+  Provide default configurations for common uses cases along with documentation.
+
+## 2020 Q4(Oct - Dec)
+
+* **Performance Improvements**: Analyze `rcl*-level` performance and resource
+  usage.
+  Develop a strategy to improve performance and reduce resource usage based on data from the analysis.
+
+* **Launch**: Address current shortcoming in launch, and improve launch testing.
+
+* **Documentation Infrastructure**: Develop package-level documentation generation infrastructure, deploy documentation, and consolidate existing documentation.
+
+Planned releases
+----------------
 
 Please see the :ref:`Distributions page <Releases>` for the timeline of and information about future distributions.
 
-For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
-The core code for ROS 2 is on the `ros2 GitHub organization <https://github.com/ros2>`__.
-The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
-Questions should be asked on `ROS answers <https://answers.ros.org>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``ardent``.
+Contributing to ROS 2
+---------------------
 
-Feature ideas in no specific order
-----------------------------------
+Looking for something to work on, or just want to help out? Here are a few resources to get you going.
 
-Design / Concept
-~~~~~~~~~~~~~~~~
-
-* IDL format
-
-  * Leverage new features like grouping constants into enums
-  * Extend usage to ``.idl`` files with just constants and/or declare parameters with ranges
-  * Revisit constraints of IDL interface naming, see `ros2/design#220 <https://github.com/ros2/design/pull/220>`_
-
-* Progress on migration plan
-* Uniqueness of node names, see `ros2/design#187 <https://github.com/ros2/design/issues/187>`_
-* Specific "API" of a node in terms of topics / services / etc. in a descriptive format, see `ros2/design#266 <https://github.com/ros2/design/pull/266>`_
-
-Infrastructure and tools
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-* Building
-
-  * Consolidate build.ros2.org and ci.ros2.org
-  * Provision macOS
-  * Windows and Mac OS packages
-  * Support profiles in ``colcon``
-
-* Documentation
-
-  * Improve documentation platform
-  * Support for ``doc`` jobs on the `ROS 2 buildfarm <https://build.ros2.org>`__
-  * Consider consolidating with design.ros2.org
-  * Provide three different kinds of content:
-
-    * "demos" to show features and cover them with tests
-    * "examples" to show a simple/minimalistic usage which might have multiple ways to do something
-    * "tutorials" which contain more comments and anchors for the wiki (teaching one recommended way)
-
-New features
-~~~~~~~~~~~~
-
-The trailing stars indicate the rough effort: 1 star for small, 2 stars for medium, 3 stars for large.
-
-
-* Logging improvements [\* / \*\*]
-
-  * Configuration specified in a file
-  * Per-logger configuration (enabling e.g. ``rqt_logger_level``)
-
-* Time related
-
-  * Support rate and sleep based on clock
-
-* Parameters
-
-  * enforce type
-
-* Additional Graph API features [\*\* / \*\*\*]
-
-  * Introspect QoS setting for all (especially remote) topics
-  * a la ROS 1 Master API: https://wiki.ros.org/ROS/Master_API
-  * Event-based notification
-  * Requires knowledge of the rmw interface which needs to be extended
-
-* Executor
-
-  * Performance improvements (mostly around the waitset)
-  * Deterministic ordering (fair scheduling)
-  * Work with callback groups
-  * Decouple waitables
-
-* Message generation
-
-  * Catch-up message generation for languages not support out-of-the-box
-  * Mangle field names in message to avoid language specific keywords
-  * Improve generator performance by running them in the same Python interpreter
-
-* Launch
-
-  * Support use case of using ``xacro`` to perform substitutions before passing the result containing parameters
-  * Use pytest for launch testing
-  * Support for launching multi-node executables (i.e. manual composition)
-  * Extend launch XML/YAML support: events and event handlers, tag namespaces and aliasing
-
-* Rosbag
-
-  * Support recording services (and actions)
-
-* ros1_bridge
-
-  * Support bridging actions
-
-* RMW configuration
-
-  * Unified standard way of configuring the middleware
-
-* Remapping [\*\* / \*\*\*]
-
-  * Dynamic remapping and aliasing through a Service interface
-
-* Type masquerading [\*\*\*]
-
-  * a la ROS 1's message traits: https://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes
-  * Requires knowledge of the typesupport system
-
-* Expand on real-time safety [\*\*\*]
-
-  * With Fast RTPS
-  * For services, clients, and parameters
-  * Expose more quality of service parameters related to real-time performance
-  * Real-time-safe intra-process messaging
-
-* Multi-robot supporting features and demos [\*\*\*]
-
-  * Undesired that all nodes across all robots share the same domain (and discover each other)
-  * Design how to “partition” the system
-
-* Implement C client library ``rclc`` [\*\*]
-* Support more DDS / RTPS implementations:
-
-  * Connext 6, see `ros2/rmw_connext#375 <https://github.com/ros2/rmw_connext/issues/375>`_
-  * Connext dynamic [\*]
-  * RTI's micro implementation [\*]
-
-* security improvements:
-
-  * more granularity in security configuration (allow authentication only, authentication and encryption, etc.) [\*]
-  * integrate DDS-Security logging plugin (unified way to aggregate security events and report them to the users through a ROS interface) [\*\*]
-  * key storage security (right now, keys are just stored in the filesystem) [\*\*]
-  * more user friendly interface (make it easier to specify security config). Maybe a Qt GUI? This GUI could also assist in distributing keys somehow. [\*\*\*]
-  * A way to say "please secure this running system" with some UI that would auto-generate keys and policies for everything that is currently running. [\*\*\*]
-  * If there are hardware-specific features for securing keys or accelerating encryption/signing messages, that could be interesting to add to DDS/RTPS implementations that don't use it already. [\*\*\*]
-
-Port of existing ROS 1 functionality
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* Perception metapackage
-
-  * Image pipeline
-  * Perception PCL
-
-* MoveIt
-
-  * MoveIt Maintainers are tracking: https://discourse.ros.org/t/moveit-maintainer-meeting-recap-july-25th-2018/5504
-
-* RQt
-
-  * convert more plugins [\* each when dependencies are available]
-
-Reducing Technical Debt
-~~~~~~~~~~~~~~~~~~~~~~~
-
-* Extend testing and resolve bugs in the current code base
-
-  * Waitset inconsistency
-  * Multi-threading problems with components
-
-* Fix flaky tests.
-* Ability to run (all) unit tests with tools e.g. valgrind
-* API review, specifically user-facing APIs in rclcpp and rclpy
-* Refactor the rclcpp API into separate packages focused on a single aspect, rclcpp should afterward still provide the combined user-facing API
-* Revisit message allocators, consider using std::polymorphic_allocator to address problems
-
-* Modernization
-
-  * Support/use exporting CMake targets (rather than using CMake variables like ``*_INCLUDE_DIRS``, ``*_LIBRARIES``)
-  * Use C++17 filesystem features rather than custom code
-  * Use pybind11 for rclpy
-  * Move to f-strings in Python code
-  * Use setup.cfg files for Python packages
-
-* Synchronize / reconcile design docs with the implementation.
-
-  * Pre-release retrospective review (APIs, docs, etc.)
-
-<<<<<<< HEAD
-* Address / classify pending tickets
-* Address TODOs in code / docs
-=======
-1. The :ref:`Contributing <Contributing>` guide describes how to make
-   a contribution to ROS 2.
-2. Check out the list of :ref:`Feature Ideas <Feature Ideas>` for
-   inspiration.
+1. The :ref:`Contributing <Contributing>` guide describes how to make a contribution to ROS 2.
+2. Check out the list of :ref:`Feature Ideas <Feature Ideas>` for inspiration.
 3. For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
 4. The core code for ROS 2 is in the `ros2 GitHub organization <https://github.com/ros2>`__.
 5. The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
 6. Questions should be asked on `ROS answers <https://answers.ros.org>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``ardent``.
->>>>>>> dfa9aae... Update source/Roadmap.rst

--- a/source/Roadmap.rst
+++ b/source/Roadmap.rst
@@ -190,5 +190,16 @@ Reducing Technical Debt
 
   * Pre-release retrospective review (APIs, docs, etc.)
 
+<<<<<<< HEAD
 * Address / classify pending tickets
 * Address TODOs in code / docs
+=======
+1. The :ref:`Contributing <Contributing>` guide describes how to make
+   a contribution to ROS 2.
+2. Check out the list of :ref:`Feature Ideas <Feature Ideas>` for
+   inspiration.
+3. For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
+4. The core code for ROS 2 is in the `ros2 GitHub organization <https://github.com/ros2>`__.
+5. The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
+6. Questions should be asked on `ROS answers <https://answers.ros.org>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``ardent``.
+>>>>>>> dfa9aae... Update source/Roadmap.rst

--- a/source/index.rst
+++ b/source/index.rst
@@ -17,6 +17,7 @@ ROS 2 Documentation
    Releases
    Features
    Roadmap
+   Feature-Ideas
    Governance
    Marketing
    Related-Projects


### PR DESCRIPTION
This PR updates the ROS 2 roadmap to be a list of quarter goals. The list of feature ideas has been move to `Feature-Ideas`.

This is my first time contributing here, and using RST. Please point out all of my mistakes.

Signed-off-by: Nate Koenig <nate@openrobotics.org>