### PR TITLE
Fix small travis warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python: 3.6
-sudo: false
+dist: xenial
+os: linux
 install:
   - pip3 install doc8 sphinx
   - pip3 install git+https://github.com/osrf/sphinx-tabs


### PR DESCRIPTION
If you look at the travis job screen, it shows three warnings:

root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing dist, using the default xenial
root: missing os, using the default linux

This fixes all of them by removing sudo and setting the defaults.
We may want to consider updating from xenial to bionic or focal,
but that can be done separately.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>