### PR TITLE
Document memory leak caused by reference cycle between rclcpp::Context and rclcpp::GraphListener

### DIFF
--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -779,7 +779,7 @@ Known Issues
 * `[ros2/rclcpp#912] <https://github.com/ros2/rclcpp/issues/912>`_ Inter-process communication forces a message copy when intra-process communication takes place between an ``std::unique_ptr`` publisher and a single ``std::unique_ptr`` subscription (published ``std::unique_ptr`` is internally being promoted to an ``std::shared_ptr``).
 * `[ros2/rosbag2#125] <https://github.com/ros2/rosbag2/issues/125>`_ Topics with unreliable QOS are not recorded.
 * `[ros2/rclcpp#715] <https://github.com/ros2/rclcpp/issues/715>`_ Composable nodes cannot receive parameters via remapping. Supplying parameters to composable nodes can be accomplished using the methods described in `[this comment] <https://github.com/ros2/rclcpp/issues/715#issuecomment-497392626>`_.
-* `[ros2/rclcpp#893] <https://github.com/ros2/rclcpp/issues/893>`_ `rclcpp::Context` is not destroyed because of a reference cycle with `rclcpp::GraphListener`. This causes a memory leak. A fix hasn't been backported because of the risk of breaking ABI.
+* `[ros2/rclcpp#893] <https://github.com/ros2/rclcpp/issues/893>`_ ``rclcpp::Context`` is not destroyed because of a reference cycle with ``rclcpp::GraphListener``. This causes a memory leak. A fix has not been backported because of the risk of breaking ABI.
 
 Timeline before the release
 ---------------------------

--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -779,6 +779,7 @@ Known Issues
 * `[ros2/rclcpp#912] <https://github.com/ros2/rclcpp/issues/912>`_ Inter-process communication forces a message copy when intra-process communication takes place between an ``std::unique_ptr`` publisher and a single ``std::unique_ptr`` subscription (published ``std::unique_ptr`` is internally being promoted to an ``std::shared_ptr``).
 * `[ros2/rosbag2#125] <https://github.com/ros2/rosbag2/issues/125>`_ Topics with unreliable QOS are not recorded.
 * `[ros2/rclcpp#715] <https://github.com/ros2/rclcpp/issues/715>`_ Composable nodes cannot receive parameters via remapping. Supplying parameters to composable nodes can be accomplished using the methods described in `[this comment] <https://github.com/ros2/rclcpp/issues/715#issuecomment-497392626>`_.
+* `[ros2/rclcpp#893] <https://github.com/ros2/rclcpp/issues/893>`_ `rclcpp::Context` is not destroyed because of a reference cycle with `rclcpp::GraphListener`. This causes a memory leak. A fix hasn't been backported because of the risk of breaking ABI.
 
 Timeline before the release
 ---------------------------

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -221,7 +221,7 @@ Known Issues
 
 * `[ros2/rosidl#402] <https://github.com/ros2/rosidl/issues/402>`_ ``find_package(PCL)`` interferes with ROS interface generation.
   Workaround: invoke ``find_package(PCL)`` *after* ``rosidl_generate_interfaces()``.
-* `[ros2/rclcpp#893] <https://github.com/ros2/rclcpp/issues/893>`_ `rclcpp::Context` is not destroyed because of a reference cycle with `rclcpp::GraphListener`. This causes a memory leak. A fix hasn't been backported because of the risk of breaking ABI.
+* `[ros2/rclcpp#893] <https://github.com/ros2/rclcpp/issues/893>`_ ``rclcpp::Context`` is not destroyed because of a reference cycle with ``rclcpp::GraphListener``. This causes a memory leak. A fix has not been backported because of the risk of breaking ABI.
 
 Timeline before the release
 ---------------------------

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -221,6 +221,7 @@ Known Issues
 
 * `[ros2/rosidl#402] <https://github.com/ros2/rosidl/issues/402>`_ ``find_package(PCL)`` interferes with ROS interface generation.
   Workaround: invoke ``find_package(PCL)`` *after* ``rosidl_generate_interfaces()``.
+* `[ros2/rclcpp#893] <https://github.com/ros2/rclcpp/issues/893>`_ `rclcpp::Context` is not destroyed because of a reference cycle with `rclcpp::GraphListener`. This causes a memory leak. A fix hasn't been backported because of the risk of breaking ABI.
 
 Timeline before the release
 ---------------------------


### PR DESCRIPTION
See https://github.com/ros2/rclcpp/pull/1233#issuecomment-661240280.