### PR TITLE
make argcomplete a dependency for ros-distro-desktop

### DIFF
--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -176,7 +176,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Alternate compilers
 -------------------

--- a/source/Installation/Crystal/Linux-Development-Setup.rst
+++ b/source/Installation/Crystal/Linux-Development-Setup.rst
@@ -155,17 +155,6 @@ Set up your environment by sourcing the following file.
 
    . ~/ros2_crystal/install/setup.bash
 
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 Try some examples
 -----------------
 

--- a/source/Installation/Crystal/Linux-Install-Binary.rst
+++ b/source/Installation/Crystal/Linux-Install-Binary.rst
@@ -130,36 +130,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   . ~/ros2_crystal/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Uninstall
 ---------

--- a/source/Installation/Crystal/Linux-Install-Debians.rst
+++ b/source/Installation/Crystal/Linux-Install-Debians.rst
@@ -60,8 +60,6 @@ ROS-Base Install (Bare Bones): Communication libraries, message packages, comman
 
    sudo apt install ros-$CHOOSE_ROS_DISTRO-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -115,57 +113,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-If using Ardent OpenSplice is also installed.
-
-To install support for OpenSplice or RTI Connext on Bouncy:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice instead.
-For ROS 2 releases Bouncy and newer, ``RMW_IMPLEMENTATION=rmw_connext_cpp`` can also be selected to use RTI Connext.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-ros1-bridge
-
-The turtlebot2 packages are available in Bouncy but not Crystal.
-
-.. code-block:: bash
-
-   sudo apt install ros-$CHOOSE_ROS_DISTRO-turtlebot2-*
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Uninstall
 ---------

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -266,7 +266,7 @@ Hooray!
 Next steps after installing
 ---------------------------
 Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
- 
+
 Extra stuff for Debug mode
 --------------------------
 

--- a/source/Installation/Crystal/Windows-Development-Setup.rst
+++ b/source/Installation/Crystal/Windows-Development-Setup.rst
@@ -259,12 +259,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
 
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+ 
 Extra stuff for Debug mode
 --------------------------
 

--- a/source/Installation/Crystal/Windows-Install-Binary.rst
+++ b/source/Installation/Crystal/Windows-Install-Binary.rst
@@ -211,12 +211,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Crystal/macOS-Development-Setup.rst
+++ b/source/Installation/Crystal/macOS-Development-Setup.rst
@@ -168,7 +168,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Crystal/macOS-Install-Binary.rst
+++ b/source/Installation/Crystal/macOS-Install-Binary.rst
@@ -146,12 +146,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -150,16 +150,6 @@ Set up your environment by sourcing the following file.
 
    . ~/ros2_dashing/install/setup.bash
 
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 Try some examples
 -----------------
 

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -171,7 +171,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -124,36 +124,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   . ~/ros2_dashing/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -59,8 +59,6 @@ No GUI tools.
 
    sudo apt install ros-dashing-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Dashing_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Dashing_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Dashing_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -102,52 +100,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Dashing_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-
-To install support for OpenSplice or RTI Connext:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-dashing-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-dashing-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice.
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Dashing_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-dashing-ros1-bridge
-
-The turtlebot2 packages are not currently available in Dashing.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -258,11 +258,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -199,12 +199,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -182,7 +182,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -168,12 +168,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -178,7 +178,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -157,16 +157,6 @@ Set up your environment by sourcing the following file.
 
    . ~/ros2_eloquent/install/setup.bash
 
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 Try some examples
 -----------------
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -129,36 +129,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   . ~/ros2_eloquent/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -64,8 +64,6 @@ No GUI tools.
 
    sudo apt install ros-eloquent-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Eloquent_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Eloquent_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Eloquent_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -111,53 +109,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Eloquent_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-``Cyclone DDS`` is also installed.
-
-To install support for ``OpenSplice`` or ``RTI Connext``:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-eloquent-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-eloquent-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice instead.
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Eloquent_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-eloquent-ros1-bridge
-
-The turtlebot2 packages are not currently available in Eloquent.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -272,11 +272,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -204,12 +204,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -191,7 +191,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Stay up to date
 ---------------

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -174,12 +174,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -173,7 +173,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Alternate compilers
 -------------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -150,16 +150,6 @@ Set up your environment by sourcing the following file.
 
    . ~/ros2_foxy/install/setup.bash
 
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 .. _latest-examples:
 
 Try some examples

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -122,36 +122,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/noetic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   . ~/ros2_foxy/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -59,8 +59,6 @@ No GUI tools.
 
    sudo apt install ros-foxy-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Foxy_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Foxy_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Foxy_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -106,51 +104,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Foxy_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-``Cyclone DDS`` is also installed.
-
-To install support for ``RTI Connext``:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-foxy-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext instead.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Foxy_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=noetic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:noetic`` or ``osrf/ros:noetic-desktop``.
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-foxy-ros1-bridge
-
-The turtlebot2 packages are not currently available in Foxy.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -255,11 +255,13 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -215,12 +215,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -190,7 +190,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Stay up to date
 ---------------

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -172,12 +172,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -161,16 +161,6 @@ Set up your environment by sourcing the following file.
 
    . ~/ros2_rolling/install/setup.bash
 
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 Try some examples
 -----------------
 

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -182,7 +182,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -125,36 +125,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/noetic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   . ~/ros2_rolling/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -62,8 +62,6 @@ No GUI tools.
 
    sudo apt install ros-rolling-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Rolling_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Rolling_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Rolling_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -109,51 +107,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Rolling_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-``Cyclone DDS`` is also installed.
-
-To install support for ``RTI Connext``:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-rolling-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext instead.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Rolling_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:noetic`` or ``osrf/ros:noetic-desktop``.
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-rolling-ros1-bridge
-
-The turtlebot2 packages are not currently available in Rolling.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -257,12 +257,15 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
 
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+ 
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -265,7 +265,7 @@ Hooray!
 Next steps after installing
 ---------------------------
 Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
- 
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -217,12 +217,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -192,7 +192,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -176,12 +176,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -103,7 +103,36 @@ If you don’t want to have to source the setup file every time you open a new s
 
 To undo this (to change to another distro) in Linux and macOS, locate your system’s shell startup script and remove the appended source command.
 
-3 Check environment variables
+3 Add ``roscd`` to your shell startup script
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The command ``colcon_cd`` (alias ``roscd``) allows to quickly change the current working directory of your shell by reaching the codebase of a desired package.
+As an example ``roscd some_ros_package`` would quickly bring you to the directory ``~/ros2_install/src/some_ros_package``.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+        echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
+        echo "alias roscd='colcon_cd'" >> ~/.bashrc
+        echo "export _colcon_cd_root=~/ros2_install" >> ~/.bashrc
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+        TODO
+
+   .. group-tab:: Windows
+
+      Not yet available
+
+According to the way you installed ``colcon_cd`` and where your workspace is, the instructions hereabove may vary, please refer to `the documentation <https://colcon.readthedocs.io/en/released/user/installation.html#quick-directory-changes>`__ for more details.
+To undo this in Linux and macOS, locate your system’s shell startup script and remove the appended source command.
+
+4 Check environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sourcing ROS 2 setup files will set several environment variables necessary for operating ROS 2.


### PR DESCRIPTION
## argcomplete already installed via pip3
In these instructions, argcomplete is already installed via pip a few lines before.

Also, I wonder if `python3-argcomplete` shouldn't be added as a dependency for debian package `ros-distro-desktop`: it's very likely that the users installing the desktop version will be happy with autocompletion and that would [shorten the installing procedure](https://github.com/ros2/ros2_documentation/blob/master/source/Installation/Foxy/Linux-Install-Debians.rst#install-argcomplete-optional) of a few lines. 

## Go straight to the tutorials after installing
RIght after "hoorray" you installed ROS successfully", I propose to redirect more clearly people to the tutorials, to keep the flow to important core information. RMW implementation and ROS1 bridge are already covered in advanced tutorials, so I propsoe to skip them in the installing procedure.

## roscd/colcon_cd advice
I propose to advise users to source and setup an alias for colcon_cd while they are configuring their environment. 