### PR TITLE
Move argcomplete install to pip

### DIFF
--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -54,10 +54,10 @@ Install development tools and ROS tools
      python3-pip \
      python-rosdep \
      python3-vcstool \
+     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
-     argcomplete \
      flake8 \
      flake8-blind-except \
      flake8-builtins \
@@ -149,16 +149,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    . ~/ros2_dashing/install/setup.bash
-
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -54,10 +54,10 @@ Install development tools and ROS tools
      python3-pip \
      python-rosdep \
      python3-vcstool \
-     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
+     argcomplete \
      flake8 \
      flake8-blind-except \
      flake8-builtins \

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -75,7 +75,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -74,7 +74,7 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev
+       sudo apt install -y libpython3-dev python3-argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,16 +92,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
   . ~/ros2_dashing/ros2-linux/setup.bash
-
-Installing python3 argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete for autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -74,7 +74,8 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev python3-argcomplete
+   sudo apt install -y libpython3-dev python3-pip
+   sudo pip3 install argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -75,7 +75,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -82,7 +82,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -82,7 +82,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -81,7 +81,8 @@ So if you want autocompletion, installing argcomplete is necessary.
 
 .. code-block:: bash
 
-   sudo apt install python3-argcomplete
+   sudo apt install -y python3-pip
+   sudo pip3 install argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -59,10 +59,10 @@ Install development tools and ROS tools
      python3-pip \
      python-rosdep \
      python3-vcstool \
+     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
-     argcomplete \
      flake8 \
      flake8-blind-except \
      flake8-builtins \
@@ -156,16 +156,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    . ~/ros2_eloquent/install/setup.bash
-
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -59,10 +59,10 @@ Install development tools and ROS tools
      python3-pip \
      python-rosdep \
      python3-vcstool \
-     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
+     argcomplete \
      flake8 \
      flake8-blind-except \
      flake8-builtins \

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -79,7 +79,8 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev python3-argcomplete
+   sudo apt install -y libpython3-dev python3-pip
+   pip install --user argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -80,7 +80,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   pip install --user argcomplete
+   pip3 install --user argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -79,7 +79,7 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev
+       sudo apt install -y libpython3-dev python3-argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,16 +97,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
   . ~/ros2_eloquent/ros2-linux/setup.bash
-
-Installing python3 argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete for autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -80,7 +80,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -87,7 +87,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -86,7 +86,8 @@ So if you want autocompletion, installing argcomplete is necessary.
 
 .. code-block:: bash
 
-   sudo apt install python3-argcomplete
+   sudo apt install -y python3-pip
+   sudo pip3 install argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -87,7 +87,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -58,10 +58,10 @@ Install development tools and ROS tools
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
+     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
-     argcomplete \
      flake8-blind-except \
      flake8-builtins \
      flake8-class-newline \
@@ -149,16 +149,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    . ~/ros2_foxy/install/setup.bash
-
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
 
 .. _latest-examples:
 

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -58,10 +58,10 @@ Install development tools and ROS tools
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
-     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
+     argcomplete \
      flake8-blind-except \
      flake8-builtins \
      flake8-class-newline \

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -72,7 +72,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -72,7 +72,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -71,7 +71,7 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev
+       sudo apt install -y libpython3-dev python3-argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,17 +89,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
   . ~/ros2_foxy/ros2-linux/setup.bash
-
-Installing python3 argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete for autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 
 Try some examples
 -----------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -71,7 +71,8 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev python3-argcomplete
+   sudo apt install -y libpython3-dev python3-pip
+   sudo pip3 install argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -82,7 +82,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -82,7 +82,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -81,7 +81,8 @@ So if you want autocompletion, installing argcomplete is necessary.
 
 .. code-block:: bash
 
-   sudo apt install python3-argcomplete
+   sudo apt install -y python3-pip
+   sudo pip3 install argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -62,10 +62,10 @@ Install development tools and ROS tools
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
-     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
+     argcomplete \
      flake8-blind-except \
      flake8-builtins \
      flake8-class-newline \

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -62,10 +62,10 @@ Install development tools and ROS tools
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
+     python3-argcomplete \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
-     argcomplete \
      flake8-blind-except \
      flake8-builtins \
      flake8-class-newline \
@@ -160,16 +160,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    . ~/ros2_rolling/install/setup.bash
-
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -75,7 +75,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -74,7 +74,8 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev python3-argcomplete
+   sudo apt install -y libpython3-dev python3-pip
+   sudo pip3 install argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -75,7 +75,7 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -74,7 +74,7 @@ Installing the python3 libraries
 
 .. code-block:: bash
 
-       sudo apt install -y libpython3-dev
+       sudo apt install -y libpython3-dev python3-argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,17 +92,6 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
   . ~/ros2_rolling/ros2-linux/setup.bash
-
-Installing python3 argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete for autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install python3-argcomplete
-
 
 Try some examples
 -----------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -84,7 +84,8 @@ So if you want autocompletion, installing argcomplete is necessary.
 
 .. code-block:: bash
 
-   sudo apt install python3-argcomplete
+   sudo apt install -y python3-pip
+   sudo pip3 install argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -85,7 +85,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   sudo pip3 install argcomplete
+   pip3 install --user argcomplete
 
 Try some examples
 -----------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -85,7 +85,7 @@ So if you want autocompletion, installing argcomplete is necessary.
 .. code-block:: bash
 
    sudo apt install -y python3-pip
-   pip3 install --user argcomplete
+   pip3 install -U argcomplete
 
 Try some examples
 -----------------


### PR DESCRIPTION
Follows https://github.com/ros2/ros2_documentation/pull/841#pullrequestreview-463883706
Other "Installing python3 argcomplete (optional)" steps could to be deleted later when argparse is installed by default 