### PR TITLE
Rewriting of the end of install procedures of Dashing/Eloquent/Foxy/Rolling

### DIFF
--- a/source/Features.rst
+++ b/source/Features.rst
@@ -17,7 +17,7 @@ For planned future development, see the :ref:`Roadmap <Roadmap>`.
      - `Article <https://design.ros2.org/articles/ros_on_dds.html>`__
      -
    * - Support for `multiple DDS implementations <Concepts/DDS-and-ROS-middleware-implementations>`, chosen at runtime
-     - `Tutorials <Tutorials/Working-with-multiple-RMW-implementations>`
+     - `Tutorials </Tutorials/Working-with-multiple-RMW-implementations>`
      - Currently eProsima Fast RTPS, RTI Connext and ADLINK OpenSplice are fully supported.
    * - Common core client library that is wrapped by language-specific libraries
      - `Details <Concepts/ROS-2-Client-Libraries>`

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -185,6 +185,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Alternate compilers
 -------------------
 

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -111,9 +111,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the code in the workspace
 -------------------------------
-
-Note: to build the ROS 1 bridge, read the `ros1_bridge instructions <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__.
-
 More info on working with a ROS workspace can be found in `this tutorial </Tutorials/Colcon-Tutorial>`.
 
 .. code-block:: bash

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -184,7 +184,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -189,6 +189,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -183,7 +183,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -183,7 +183,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -181,7 +181,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -128,6 +128,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -130,7 +130,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -126,7 +126,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -126,7 +126,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -132,6 +132,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Binary.rst
+++ b/source/Installation/Dashing/Linux-Install-Binary.rst
@@ -124,36 +124,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   . ~/ros2_dashing/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -102,7 +102,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -108,6 +108,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -59,8 +59,6 @@ No GUI tools.
 
    sudo apt install ros-dashing-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Dashing_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Dashing_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Dashing_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -102,52 +100,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Dashing_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-
-To install support for OpenSplice or RTI Connext:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-dashing-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-dashing-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice.
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Dashing_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-dashing-ros1-bridge
-
-The turtlebot2 packages are not currently available in Dashing.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -104,6 +104,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -102,7 +102,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/Linux-Install-Debians.rst
+++ b/source/Installation/Dashing/Linux-Install-Debians.rst
@@ -106,7 +106,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -270,6 +270,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -264,7 +264,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -266,6 +266,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -268,7 +268,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -258,11 +258,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Dashing/Windows-Development-Setup.rst
+++ b/source/Installation/Dashing/Windows-Development-Setup.rst
@@ -264,7 +264,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -206,7 +206,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -204,6 +204,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -199,12 +199,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -202,7 +202,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -202,7 +202,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/Windows-Install-Binary.rst
+++ b/source/Installation/Dashing/Windows-Install-Binary.rst
@@ -208,6 +208,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -182,7 +182,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -184,7 +184,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -142,9 +142,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the ROS 2 code
 --------------------
-
-**Note**\ : if you are trying to build the ROS 1 <-> ROS 2 bridge, follow instead these `modified instructions <https://github.com/ros2/ros1_bridge/blob/master/README#build-the-bridge-from-source>`__.
-
 Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this tutorial </Tutorials/Colcon-Tutorial>`):
 
 .. code-block:: bash

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -190,6 +190,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Stay up to date
 ---------------

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -184,7 +184,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -186,6 +186,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Stay up to date
 ---------------
 

--- a/source/Installation/Dashing/macOS-Development-Setup.rst
+++ b/source/Installation/Dashing/macOS-Development-Setup.rst
@@ -185,7 +185,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -171,7 +171,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -171,7 +171,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -173,6 +173,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -168,12 +168,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -175,7 +175,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Dashing/macOS-Install-Binary.rst
+++ b/source/Installation/Dashing/macOS-Install-Binary.rst
@@ -177,6 +177,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -191,7 +191,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -190,7 +190,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -192,6 +192,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Alternate compilers
 -------------------
 

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -196,6 +196,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -188,7 +188,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -118,9 +118,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the code in the workspace
 -------------------------------
-
-Note: to build the ROS 1 bridge, read the `ros1_bridge instructions <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__.
-
 More info on working with a ROS workspace can be found in `this tutorial </Tutorials/Colcon-Tutorial>`.
 
 .. code-block:: bash

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -190,7 +190,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -132,7 +132,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -136,7 +136,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -132,7 +132,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -134,6 +134,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -138,6 +138,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Install-Binary.rst
+++ b/source/Installation/Eloquent/Linux-Install-Binary.rst
@@ -129,36 +129,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/melodic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/melodic/setup.bash
-   . ~/ros2_eloquent/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -111,7 +111,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -113,6 +113,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -117,6 +117,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -111,7 +111,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -115,7 +115,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/Linux-Install-Debians.rst
+++ b/source/Installation/Eloquent/Linux-Install-Debians.rst
@@ -64,8 +64,6 @@ No GUI tools.
 
    sudo apt install ros-eloquent-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Eloquent_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Eloquent_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Eloquent_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -111,53 +109,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Eloquent_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-``Cyclone DDS`` is also installed.
-
-To install support for ``OpenSplice`` or ``RTI Connext``:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-eloquent-rmw-opensplice-cpp # for OpenSplice
-   sudo apt install ros-eloquent-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_opensplice_cpp`` you can switch to use OpenSplice instead.
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Eloquent_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:melodic`` or ``osrf/ros:melodic-desktop`` (or Kinetic if using Ardent).
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-eloquent-ros1-bridge
-
-The turtlebot2 packages are not currently available in Eloquent.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -278,7 +278,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -278,7 +278,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -282,7 +282,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -284,6 +284,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -272,11 +272,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Eloquent/Windows-Development-Setup.rst
+++ b/source/Installation/Eloquent/Windows-Development-Setup.rst
@@ -280,6 +280,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -213,6 +213,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -207,7 +207,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -207,7 +207,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -204,12 +204,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -211,7 +211,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/Windows-Install-Binary.rst
+++ b/source/Installation/Eloquent/Windows-Install-Binary.rst
@@ -209,6 +209,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -191,7 +191,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Stay up to date
 ---------------

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -195,6 +195,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Stay up to date
 ---------------

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -193,7 +193,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -151,9 +151,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the ROS 2 code
 --------------------
-
-**Note**\ : if you are trying to build the ROS 1 <-> ROS 2 bridge, follow instead these `modified instructions <https://github.com/ros2/ros1_bridge/blob/master/README#build-the-bridge-from-source>`__.
-
 Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this tutorial </Tutorials/Colcon-Tutorial>`):
 
 .. code-block:: bash

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -194,7 +194,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -193,7 +193,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Stay up to date

--- a/source/Installation/Eloquent/macOS-Development-Setup.rst
+++ b/source/Installation/Eloquent/macOS-Development-Setup.rst
@@ -199,6 +199,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Stay up to date

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -177,7 +177,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -183,6 +183,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -177,7 +177,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -181,7 +181,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -179,6 +179,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Eloquent/macOS-Install-Binary.rst
+++ b/source/Installation/Eloquent/macOS-Install-Binary.rst
@@ -174,12 +174,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -111,9 +111,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the code in the workspace
 -------------------------------
-
-Note: to build the ROS 1 bridge, read the `ros1_bridge instructions <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__.
-
 More info on working with a ROS workspace can be found in `this tutorial </Tutorials/Colcon-Tutorial>`.
 
 .. code-block:: bash

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -186,7 +186,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -185,7 +185,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Alternate compilers

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -187,6 +187,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Alternate compilers
 -------------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -185,7 +185,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -191,6 +191,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Alternate compilers

--- a/source/Installation/Foxy/Linux-Development-Setup.rst
+++ b/source/Installation/Foxy/Linux-Development-Setup.rst
@@ -183,7 +183,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Alternate compilers
 -------------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -122,36 +122,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/noetic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   . ~/ros2_foxy/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -124,7 +124,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -124,7 +124,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -130,6 +130,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -128,7 +128,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -126,6 +126,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -106,7 +106,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -106,7 +106,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -112,6 +112,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -108,6 +108,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -110,7 +110,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -59,8 +59,6 @@ No GUI tools.
 
    sudo apt install ros-foxy-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Foxy_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Foxy_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Foxy_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -106,51 +104,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Foxy_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-``Cyclone DDS`` is also installed.
-
-To install support for ``RTI Connext``:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-foxy-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext instead.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Foxy_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <https://wiki.ros.org/Installation/Ubuntu?distro=noetic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:noetic`` or ``osrf/ros:noetic-desktop``.
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-foxy-ros1-bridge
-
-The turtlebot2 packages are not currently available in Foxy.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -267,6 +267,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -255,11 +255,13 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -263,6 +263,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -261,7 +261,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -261,7 +261,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Foxy/Windows-Development-Setup.rst
+++ b/source/Installation/Foxy/Windows-Development-Setup.rst
@@ -265,7 +265,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -220,6 +220,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -224,6 +224,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -215,12 +215,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -218,7 +218,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -222,7 +222,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -218,7 +218,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -150,9 +150,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the ROS 2 code
 --------------------
-
-**Note**\ : if you are trying to build the ROS 1 <-> ROS 2 bridge, follow instead these `modified instructions <https://github.com/ros2/ros1_bridge/blob/master/README#build-the-bridge-from-source>`__.
-
 Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this tutorial </Tutorials/Colcon-Tutorial>`):
 
 .. code-block:: bash

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -198,6 +198,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Stay up to date

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -190,7 +190,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+
 
 Stay up to date
 ---------------

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -193,7 +193,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -192,7 +192,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -192,7 +192,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Stay up to date

--- a/source/Installation/Foxy/macOS-Development-Setup.rst
+++ b/source/Installation/Foxy/macOS-Development-Setup.rst
@@ -194,6 +194,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Stay up to date
 ---------------

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -172,12 +172,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -181,6 +181,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -175,7 +175,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -177,6 +177,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -179,7 +179,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -175,7 +175,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -122,9 +122,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the code in the workspace
 -------------------------------
-
-Note: to build the ROS 1 bridge, read the `ros1_bridge instructions <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__.
-
 More info on working with a ROS workspace can be found in `this tutorial </Tutorials/Colcon-Tutorial>`.
 
 .. code-block:: bash

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -200,6 +200,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -194,7 +194,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -194,7 +194,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -195,7 +195,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -192,7 +192,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -196,6 +196,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Alternate compilers
 -------------------
 

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -127,7 +127,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -125,36 +125,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-Using the ROS 1 bridge
-----------------------
-
-If you have ROS 1 installed, you can try the ROS 1 bridge, by first sourcing your ROS 1 setup file.
-We'll assume that it is ``/opt/ros/noetic/setup.bash`` in the following.
-
-If you haven't already, start a roscore:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   roscore
-
-
-In another terminal, start the bridge:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   . ~/ros2_rolling/ros2-linux/setup.bash
-   ros2 run ros1_bridge dynamic_bridge
-
-For more information on the bridge, read the `tutorial <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -131,7 +131,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -127,7 +127,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -133,6 +133,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Install-Binary.rst
+++ b/source/Installation/Rolling/Linux-Install-Binary.rst
@@ -129,6 +129,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -109,7 +109,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -109,7 +109,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -115,6 +115,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -113,7 +113,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -111,6 +111,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Rolling/Linux-Install-Debians.rst
+++ b/source/Installation/Rolling/Linux-Install-Debians.rst
@@ -62,8 +62,6 @@ No GUI tools.
 
    sudo apt install ros-rolling-ros-base
 
-See specific sections below for how to also install the :ref:`ros1_bridge <Rolling_linux-ros1-add-pkgs>`, :ref:`TurtleBot packages <Rolling_linux-ros1-add-pkgs>`, or :ref:`alternative RMW packages <Rolling_linux-install-additional-rmw-implementations>`.
-
 Environment setup
 -----------------
 
@@ -109,51 +107,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
-
-.. _Rolling_linux-install-additional-rmw-implementations:
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-By default the RMW implementation ``Fast RTPS`` is used.
-``Cyclone DDS`` is also installed.
-
-To install support for ``RTI Connext``:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-rolling-rmw-connext-cpp # for RTI Connext (requires license agreement)
-
-By setting the environment variable ``RMW_IMPLEMENTATION=rmw_connext_cpp`` you can switch to use RTI Connext instead.
-
-You can also install `the Connext DDS-Security plugins <../DDS-Implementations/Install-Connext-Security-Plugins>` or use the `University, purchase or evaluation <../DDS-Implementations/Install-Connext-University-Eval>` options for RTI Connext.
-
-.. _Rolling_linux-ros1-add-pkgs:
-
-Install additional packages using ROS 1 packages
-------------------------------------------------
-
-The ``ros1_bridge`` as well as the TurtleBot demos are using ROS 1 packages.
-To be able to install them please start by adding the ROS 1 sources as documented `here <http://wiki.ros.org/Installation/Ubuntu?distro=melodic>`__.
-
-If you're using Docker for isolation you can start with the image ``ros:noetic`` or ``osrf/ros:noetic-desktop``.
-This will also avoid the need to setup the ROS sources as they will already be integrated.
-
-Now you can install the remaining packages:
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt install ros-rolling-ros1-bridge
-
-The turtlebot2 packages are not currently available in Rolling.
-
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -270,6 +270,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -264,7 +264,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -266,6 +266,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -268,7 +268,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -257,11 +257,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
+
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Rolling/Windows-Development-Setup.rst
+++ b/source/Installation/Rolling/Windows-Development-Setup.rst
@@ -264,7 +264,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 
 Extra stuff for Debug mode

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -220,7 +220,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -224,7 +224,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -220,7 +220,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -217,12 +217,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -222,6 +222,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Rolling/Windows-Install-Binary.rst
+++ b/source/Installation/Rolling/Windows-Install-Binary.rst
@@ -226,6 +226,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -192,7 +192,9 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -194,7 +194,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Stay up to date
 ---------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -194,7 +194,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -195,7 +195,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -196,6 +196,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Stay up to date
 ---------------
 

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -200,6 +200,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Stay up to date
 ---------------

--- a/source/Installation/Rolling/macOS-Development-Setup.rst
+++ b/source/Installation/Rolling/macOS-Development-Setup.rst
@@ -152,9 +152,6 @@ If you would like to use another DDS or RTPS vendor besides the default, eProsim
 
 Build the ROS 2 code
 --------------------
-
-**Note**\ : if you are trying to build the ROS 1 <-> ROS 2 bridge, follow instead these `modified instructions <https://github.com/ros2/ros1_bridge/blob/master/README#build-the-bridge-from-source>`__.
-
 Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this tutorial </Tutorials/Colcon-Tutorial>`):
 
 .. code-block:: bash

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -179,7 +179,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -185,6 +185,10 @@ Using the ROS 1 bridge
 ----------------------
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
 
+Additional RMW implementations (optional)
+-----------------------------------------
+The default middleware that ROS 2 uses is ``Fast-RTPS``, but the middleware (RMW) can be replaced at runtime.
+See the `tutorial </Tutorials/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshooting
 ---------------

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -183,7 +183,7 @@ Continue with the `tutorials and demos </Tutorials>` to configure your environme
 
 Using the ROS 1 bridge
 ----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -179,7 +179,7 @@ Hooray!
 
 Next steps after installing
 ---------------------------
-Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
+Continue with the `tutorials and demos </Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -181,6 +181,11 @@ Next steps after installing
 ---------------------------
 Continue with the `tutorials and demos </Tutorials>` to configure of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
+Using the ROS 1 bridge
+----------------------
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated [documentation](https://github.com/ros2/ros1_bridge/blob/master/README.md) on how to build and use the ROS 1 bridge.
+
+
 Troubleshooting
 ---------------
 

--- a/source/Installation/Rolling/macOS-Install-Binary.rst
+++ b/source/Installation/Rolling/macOS-Install-Binary.rst
@@ -176,12 +176,10 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-See the `tutorials and demos </Tutorials>` for other things to try.
 
-Build your own packages
------------------------
-
-If you would like to build your own packages, refer to the tutorial `"Using Colcon to build packages" </Tutorials/Colcon-Tutorial>`.
+Next steps after installing
+---------------------------
+Go on with the `tutorials and demos </Tutorials>` to pursue the configuration of your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Troubleshooting
 ---------------

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -103,11 +103,11 @@ If you don’t want to have to source the setup file every time you open a new s
 
 To undo this (to change to another distro) in Linux and macOS, locate your system’s shell startup script and remove the appended source command.
 
-3 Add ``roscd`` to your shell startup script
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 Add ``colcon_cd`` to your shell startup script
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The command ``colcon_cd`` (alias ``roscd``) allows to quickly change the current working directory of your shell by reaching the codebase of a desired package.
-As an example ``roscd some_ros_package`` would quickly bring you to the directory ``~/ros2_install/src/some_ros_package``.
+The command ``colcon_cd`` allows to quickly change the current working directory of your shell by reaching the codebase of a desired package.
+As an example ``colcon_cd some_ros_package`` would quickly bring you to the directory ``~/ros2_install/src/some_ros_package``.
 
 .. tabs::
 
@@ -116,7 +116,6 @@ As an example ``roscd some_ros_package`` would quickly bring you to the director
       .. code-block:: console
 
         echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
-        echo "alias roscd='colcon_cd'" >> ~/.bashrc
         echo "export _colcon_cd_root=~/ros2_install" >> ~/.bashrc
 
    .. group-tab:: macOS
@@ -130,7 +129,7 @@ As an example ``roscd some_ros_package`` would quickly bring you to the director
       Not yet available
 
 According to the way you installed ``colcon_cd`` and where your workspace is, the instructions hereabove may vary, please refer to `the documentation <https://colcon.readthedocs.io/en/released/user/installation.html#quick-directory-changes>`__ for more details.
-To undo this in Linux and macOS, locate your system’s shell startup script and remove the appended source command.
+To undo this in Linux and macOS, locate your system’s shell startup script and remove the appended source and export commands.
 
 4 Check environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -103,7 +103,36 @@ If you don’t want to have to source the setup file every time you open a new s
 
 To undo this (to change to another distro) in Linux and macOS, locate your system’s shell startup script and remove the appended source command.
 
-3 Check environment variables
+3 Add ``roscd`` to your shell startup script
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The command ``colcon_cd`` (alias ``roscd``) allows to quickly change the current working directory of your shell by reaching the codebase of a desired package.
+As an example ``roscd some_ros_package`` would quickly bring you to the directory ``~/ros2_install/src/some_ros_package``.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+        echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
+        echo "alias roscd='colcon_cd'" >> ~/.bashrc
+        echo "export _colcon_cd_root=~/ros2_install" >> ~/.bashrc
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+        TODO
+
+   .. group-tab:: Windows
+
+      Not yet available
+
+According to the way you installed ``colcon_cd`` and where your workspace is, the instructions hereabove may vary, please refer to `the documentation <https://colcon.readthedocs.io/en/released/user/installation.html#quick-directory-changes>`__ for more details.
+To undo this in Linux and macOS, locate your system’s shell startup script and remove the appended source command.
+
+4 Check environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sourcing ROS 2 setup files will set several environment variables necessary for operating ROS 2.

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -128,7 +128,7 @@ As an example ``colcon_cd some_ros_package`` would quickly bring you to the dire
 
       Not yet available
 
-According to the way you installed ``colcon_cd`` and where your workspace is, the instructions hereabove may vary, please refer to `the documentation <https://colcon.readthedocs.io/en/released/user/installation.html#quick-directory-changes>`__ for more details.
+Depending to the way you installed ``colcon_cd`` and where your workspace is, the instructions above may vary, please refer to `the documentation <https://colcon.readthedocs.io/en/released/user/installation.html#quick-directory-changes>`__ for more details.
 To undo this in Linux and macOS, locate your system’s shell startup script and remove the appended source and export commands.
 
 4 Check environment variables

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -106,7 +106,7 @@ To undo this (to change to another distro) in Linux and macOS, locate your syste
 3 Add ``colcon_cd`` to your shell startup script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The command ``colcon_cd`` allows to quickly change the current working directory of your shell by reaching the codebase of a desired package.
+The command ``colcon_cd`` allows you to quickly change the current working directory of your shell to the directory of a package.
 As an example ``colcon_cd some_ros_package`` would quickly bring you to the directory ``~/ros2_install/src/some_ros_package``.
 
 .. tabs::


### PR DESCRIPTION
Follows https://github.com/ros2/ros2_documentation/pull/841#pullrequestreview-463883706

The rewriting includes:
* ROS 1 bridge and other RMW implementations will likely not be used by beginners. So I cleaned them in a wish to keep the installing procedure as short as possible
* I highlight the tutorials as the immediate steps to follow after installing 
* I advise to create the alias `roscd` during the environment setup. **Help is requested** to fill in the `macOS` commands [in the TODO here](https://github.com/ymollard/ros2_documentation/blob/no_rmw_bridge/source/Tutorials/Configuring-ROS2-Environment.rst#add-roscd-to-your-shell-startup-script): I think it's very similar to Linux but in `.bash_profile`, but some check is needed.