### PR TITLE
Switch pytest/flake8 installation to apt for Eloquent & Dashing

### DIFF
--- a/source/Installation/Dashing/Linux-Development-Setup.rst
+++ b/source/Installation/Dashing/Linux-Development-Setup.rst
@@ -54,24 +54,13 @@ Install development tools and ROS tools
      python3-pip \
      python-rosdep \
      python3-vcstool \
+     python3-flake8 \
+     python3-pytest \
+     python3-pytest-cov \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
      argcomplete \
-     flake8 \
-     flake8-blind-except \
-     flake8-builtins \
-     flake8-class-newline \
-     flake8-comprehensions \
-     flake8-deprecated \
-     flake8-docstrings \
-     flake8-import-order \
-     flake8-quotes \
-     pytest-repeat \
-     pytest-rerunfailures \
-     pytest \
-     pytest-cov \
-     pytest-runner \
      setuptools
    # install Fast-RTPS dependencies
    sudo apt install --no-install-recommends -y \

--- a/source/Installation/Eloquent/Linux-Development-Setup.rst
+++ b/source/Installation/Eloquent/Linux-Development-Setup.rst
@@ -59,24 +59,13 @@ Install development tools and ROS tools
      python3-pip \
      python-rosdep \
      python3-vcstool \
+     python3-flake8 \
+     python3-pytest \
+     python3-pytest-cov \
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
      argcomplete \
-     flake8 \
-     flake8-blind-except \
-     flake8-builtins \
-     flake8-class-newline \
-     flake8-comprehensions \
-     flake8-deprecated \
-     flake8-docstrings \
-     flake8-import-order \
-     flake8-quotes \
-     pytest-repeat \
-     pytest-rerunfailures \
-     pytest \
-     pytest-cov \
-     pytest-runner \
      setuptools
    # install Fast-RTPS dependencies
    sudo apt install --no-install-recommends -y \


### PR DESCRIPTION
Currently, following the instructions for building Eloquent (and Dashing most likely) on Linux and running tests leads to flake8 failures.

This switches the installation of pytest and flake8 from pip to apt, as explained in #825. It removes some flake8 pluggins since they're not available from apt, but since linter tests are generally ignored on older distros, I assume that it's fine.

Closes #825