### PR TITLE
Add preliminary timeline for Galactic

### DIFF
--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -94,7 +94,7 @@ Timeline before the release
         Call for general testing.
 
     Mon. May 17, 2021 - RC
-        Relese Candidate packages are built.
+        Release Candidate packages are built.
         Updated releases of ROS Desktop [2]_ packages available.
 
     Thu. May 20, 2021 - Distro Freeze

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -75,14 +75,14 @@ Known Issues
 Timeline before the release
 ---------------------------
 
-    Mon. March 15, 2021 - Freeze
+    Mon. March 15, 2021 - Alpha
+        Preliminary testing and stabilization of ROS Core [1]_ packages.
+
+    Mon. March 29, 2021 - Freeze
         API and feature freeze for ROS Core [1]_ packages in Rolling Ridley.
         Note that this includes ``rmw``, which is a recursive dependency of ``ros_core``.
         Only bug fix releases should be made after this point.
         New packages can be released independently.
-
-    Mon. March 29, 2021 - Alpha
-        Preliminary testing and stabilization of ROS Core [1]_ packages.
 
     Mon. April 12, 2021 - Branch
         Branch from Rolling Ridley.

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -75,21 +75,21 @@ Known Issues
 Timeline before the release
 ---------------------------
 
-    Mon. March 15, 2021 - Alpha
+    Mon. March 22, 2021 - Alpha
         Preliminary testing and stabilization of ROS Core [1]_ packages.
 
-    Mon. March 29, 2021 - Freeze
+    Mon. April 5, 2021 - Freeze
         API and feature freeze for ROS Core [1]_ packages in Rolling Ridley.
         Note that this includes ``rmw``, which is a recursive dependency of ``ros_core``.
         Only bug fix releases should be made after this point.
         New packages can be released independently.
 
-    Mon. April 12, 2021 - Branch
+    Mon. April 19, 2021 - Branch
         Branch from Rolling Ridley.
         ``rosdistro`` is reopened for Rolling PRs for ROS Core [1]_ packages.
         Galactic development shifts from ``ros-rolling-*`` packages to ``ros-galactic-*`` packages.
 
-    Mon. April 19, 2021 - Beta
+    Mon. April 26, 2021 - Beta
         Updated releases of ROS Desktop [2]_ packages available.
         Call for general testing.
 

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -105,5 +105,5 @@ Timeline before the release
         Release announcement.
         ``rosdistro`` is reopened for Galactic PRs.
 
-.. [1] The ``ros_core`` variant is described in `REP 2001 <https://www.ros.org/reps/rep-2001.html#ros-core>`_.
-.. [2] The ``desktop`` variant is described in `REP 2001 <https://www.ros.org/reps/rep-2001.html#desktop-variants>`_.
+.. [1] The ``ros_core`` variant is described in `REP 2001 (ros-core) <https://www.ros.org/reps/rep-2001.html#ros-core>`_.
+.. [2] The ``desktop`` variant is described in `REP 2001 (desktop-variants) <https://www.ros.org/reps/rep-2001.html#desktop-variants>`_.

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -76,34 +76,34 @@ Timeline before the release
 ---------------------------
 
     Mon. March 15, 2021 - Freeze
-        API and feature freeze for ``ros_core`` [1]_ packages in Rolling Ridley.
+        API and feature freeze for ROS Core [1]_ packages in Rolling Ridley.
         Note that this includes ``rmw``, which is a recursive dependency of ``ros_core``.
         Only bug fix releases should be made after this point.
         New packages can be released independently.
 
     Mon. March 29, 2021 - Alpha
-        Preliminary testing and stabilization of ``ros_core`` [1]_ packages.
-    
+        Preliminary testing and stabilization of ROS Core [1]_ packages.
+
     Mon. April 12, 2021 - Branch
         Branch from Rolling Ridley.
-        ``rosdistro`` is reopened for Rolling PRs for ``ros_core`` [1]_ packages.
+        ``rosdistro`` is reopened for Rolling PRs for ROS Core [1]_ packages.
         Galactic development shifts from ``ros-rolling-*`` packages to ``ros-galactic-*`` packages.
-         
+
     Mon. April 19, 2021 - Beta
-        Updated releases of ``desktop`` [2]_ packages available.
+        Updated releases of ROS Desktop [2]_ packages available.
         Call for general testing.
-         
+
     Mon. May 17, 2021 - RC
         Relese Candidate packages are built.
-        Updated releases of ``desktop`` [2]_ packages available.
+        Updated releases of ROS Desktop [2]_ packages available.
 
     Thu. May 20, 2021 - Distro Freeze
         Freeze rosdistro.
-        No PRs for Galactic on the `rosdistro` repo will be merged (reopens after the release announcement).
+        No PRs for Galactic on the ``rosdistro`` repo will be merged (reopens after the release announcement).
 
     Sun. May 23, 2021 - General Availability
         Release announcement.
         ``rosdistro`` is reopened for Galactic PRs.
 
-.. [1] The ``ros_core`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.
-.. [2] The ``desktop`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.
+.. [1] The ``ros_core`` variant is described in `REP 2001 <https://www.ros.org/reps/rep-2001.html#ros-core>`_.
+.. [2] The ``desktop`` variant is described in `REP 2001 <https://www.ros.org/reps/rep-2001.html#desktop-variants>`_.

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -75,4 +75,35 @@ Known Issues
 Timeline before the release
 ---------------------------
 
-TBD
+    Mon. March 15, 2021 - Freeze
+        API and feature freeze for ``ros_core`` [1]_ packages in Rolling Ridley.
+        Note that this includes ``rmw``, which is a recursive dependency of ``ros_core``.
+        Only bug fix releases should be made after this point.
+        New packages can be released independently.
+
+    Mon. March 29, 2021 - Alpha
+        Preliminary testing and stabilization of ``ros_core`` [1]_ packages.
+    
+    Mon. April 12, 2021 - Branch
+        Branch from Rolling Ridley.
+        ``rosdistro`` is reopened for Rolling PRs for ``ros_core`` [1]_ packages.
+        Galactic development shifts from ``ros-rolling-*`` packages to ``ros-galactic-*`` packages.
+         
+    Mon. April 19, 2021 - Beta
+        Updated releases of ``desktop`` [2]_ packages available.
+        Call for general testing.
+         
+    Mon. May 17, 2021 - RC
+        Relese Candidate packages are built.
+        Updated releases of ``desktop`` [2]_ packages available.
+
+    Thu. May 20, 2021 - Distro Freeze
+        Freeze rosdistro.
+        No PRs for Galactic on the `rosdistro` repo will be merged (reopens after the release announcement).
+
+    Sun. May 23, 2021 - General Availability
+        Release announcement.
+        ``rosdistro`` is reopened for Galactic PRs.
+
+.. [1] The ``ros_core`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.
+.. [2] The ``desktop`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.


### PR DESCRIPTION
This is the same timeline discussed during the ROS 2 meeting, and includes the 1 week bump in the duration of the freeze event and the addition of a preliminary "alpha" window for Linux-only testing prior to branching from Rolling.