### PR TITLE
Update Introducing-Turtlesim.rst

### DIFF
--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -145,7 +145,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt update
 
-      sudo apt install ros-<distro>-rqt*
+      sudo apt-get install ros-<distro>-rqt*
 
   .. group-tab:: Linux
 
@@ -153,7 +153,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt update
 
-      sudo apt install ros-<distro>-rqt*
+      sudo apt-get install ros-<distro>-rqt*
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
for Ubuntu 20.04 it needs to be apt-get instead of apt