### PR TITLE
Fix up the apt commands for install rqt in the Turtlesim tutorial.

### DIFF
--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -145,15 +145,15 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt update
 
-      sudo apt-get install ros-<distro>-rqt*
+      sudo apt install ~nros-<distro>-rqt*
 
-  .. group-tab:: Linux
+  .. group-tab:: Linux (apt 1.x/Ubuntu 18.04 and older)
 
     .. code-block:: console
 
       sudo apt update
 
-      sudo apt-get install ros-<distro>-rqt*
+      sudo apt install ros-<distro>-rqt*
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
Also try to make it a bit more clear which you should use in
which situation.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>