### PR TITLE
Improve and extend launch file tutorial

### DIFF
--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -550,6 +550,7 @@ In the following example, we will launch two turtlesims that draw a circle, and 
   ros2 topic pub -r 1 /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
 
 .. code-block:: console
+
   # In another terminal
   ros2 launch turtlesim_mimic_launch.py turtlesim_ns1:=drawing_squares_1 turtlesim_ns2:=drawing_squares_2 mimic_name:=mimic_squares
   ros2 run turtlesim draw_square --ros-args -r __ns:=/drawing_squares_1

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -477,14 +477,13 @@ The provided arguments are being queried in the rest of the launch files using s
 
   .. group-tab:: XML launch file
 
-    .. code-block:: xml
+    .. code-block:: none
 
-          <node ... namespace="$(var turtlesim_ns1)"/>
-          <node ... namespace="$(var turtlesim_ns2)"/>
-          <node ... name="$(var mimic_name)">
-            <remap ... to="/$(var turtlesim_ns1)/turtle1/pose"/>
-            <remap ... to="/$(var turtlesim_ns2)/turtle1/cmd_vel"/>
-          </node>
+          namespace="$(var turtlesim_ns1)"
+          namespace="$(var turtlesim_ns2)"
+          name="$(var mimic_name)"
+          to="/$(var turtlesim_ns1)/turtle1/pose"
+          to="/$(var turtlesim_ns2)/turtle1/cmd_vel"
 
   .. group-tab:: Python launch file, Foxy and newer
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -707,8 +707,11 @@ WRITE AN EXPLANATION HERE
 
 
 TBD: Conditions look too ugly in XML (those scape characters!), we should improve them.
-  We could use https://github.com/ros2/launch/pull/457, and make that available in XML.
-TBD2: Using forward slashes should work in XML launch files, even on Windows. Double check if that's the case.
+We could use https://github.com/ros2/launch/pull/457, and make that available in XML.
+
+TBD2: Using forward slashes should work in XML launch files, even on Windows.
+Double check if that's the case.
+
 TDB3: Should this be part of a separate tutorial?
 
 Summary

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -312,7 +312,7 @@ Summary
 -------
 
 Launch files simplify running complex systems with many nodes and specific configuration details.
-You can create launch files using Python, and run them using the ``ros2 launch`` command.
+You can create launch files using XML or Python, and run them using the ``ros2 launch`` command.
 
 Next steps
 ----------

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -52,7 +52,7 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
 
 .. tabs::
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: xml
 
@@ -156,7 +156,7 @@ The first two actions in the launch description launch two turtlesim windows:
 
 .. tabs::
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: xml
 
@@ -208,7 +208,7 @@ The final node is also from the ``turtlesim`` package, but a different executabl
 .. tabs::
 
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: xml
 
@@ -315,7 +315,7 @@ We're going to now edit the same launch file we previously created to make it mo
 
 .. tabs::
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: xml
 
@@ -434,7 +434,7 @@ In this example, we're first declaring three arguments, the namespace of each tu
 
 .. tabs::
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: xml
 
@@ -475,7 +475,7 @@ The provided arguments are being queried in the rest of the launch files using s
 
 .. tabs::
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: none
 
@@ -558,7 +558,7 @@ Create a new launch file named ``turtlesim_draw_launch.py/xml`` in the same dire
 
 .. tabs::
 
-  .. group-tab:: XML launch file
+  .. group-tab:: XML launch file, Eloquent and later
 
     .. code-block:: xml
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -40,37 +40,8 @@ Tasks
 1 Setup
 ^^^^^^^
 
-Create a new directory to store your launch file:
-
-.. code-block:: console
-
-  mkdir launch
-
-Create a launch file named ``turtlesim_mimic_launch.py`` by entering the following command in the terminal:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        touch launch/turtlesim_mimic_launch.py
-
-   .. group-tab:: macOS
-
-      .. code-block:: console
-
-        touch launch/turtlesim_mimic_launch.py
-
-   .. group-tab:: Windows
-
-      .. code-block:: console
-
-        type nul > launch/turtlesim_mimic_launch.py
-
-You can also go into your system’s file directory using the GUI and create a new file that way.
-
-Open the new file in your preferred text editor.
+Create a launch file named ``turtlesim_mimic_launch.xml`` or ``turtlesim_mimic_launch.py``, depending if you're using XML or Python launch files.
+Open it in your preferred text editor.
 
 2 Write the launch file
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +52,20 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
 
 .. tabs::
 
-  .. group-tab:: Foxy and newer
+  .. group-tab:: XML launch file
+
+    .. code-block:: xml
+
+        <launch>
+          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
+          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
+          <node pkg="turtlesim" exec="mimic" name="mimic">
+            <remap from="/input/pose" to="/turtlesim1/turtle1/pose"/>
+            <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel"/>
+          </node>
+        </launch>
+
+  .. group-tab:: Python launch file, Foxy and newer
 
     .. code-block:: python
 
@@ -113,7 +97,7 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
                 )
             ])
 
-  .. group-tab:: Eloquent and older
+  .. group-tab:: Python launch file, Eloquent and older
 
     .. code-block:: python
 
@@ -149,6 +133,16 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
 2.1 Examine the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+XML launch files specifics
+##########################
+
+XML launch files must have a `<launch>` parent tag.
+That's start of the launch description, and each of it's children tags is an action.
+In this example, the `<node>` action was used.
+
+Python Launch files specifics
+#############################
+
 These import statements pull in some Python ``launch`` modules.
 
 .. code-block:: python
@@ -165,14 +159,24 @@ Next, the launch description itself begins:
 
       ])
 
-Within the ``LaunchDescription`` is a system of three nodes, all from the ``turtlesim`` package.
+Common (please put a nice subtitle here)
+########################################
+
+Within the launch description, there is a system of three nodes, all from the ``turtlesim`` package.
 The goal of the system is to launch two turtlesim windows, and have one turtle mimic the movements of the other.
 
 The first two actions in the launch description launch two turtlesim windows:
 
 .. tabs::
 
-  .. group-tab:: Foxy and newer
+  .. group-tab:: XML launch file
+
+    .. code-block:: xml
+
+          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
+          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
+
+  .. group-tab:: Python, Foxy and newer
 
     .. code-block:: python
 
@@ -189,7 +193,7 @@ The first two actions in the launch description launch two turtlesim windows:
                name='sim'
            ),
 
-  .. group-tab:: Eloquent and older
+  .. group-tab:: Python, Eloquent and older
 
     .. code-block:: python
 
@@ -217,7 +221,16 @@ The final node is also from the ``turtlesim`` package, but a different executabl
 .. tabs::
 
 
-  .. group-tab:: Foxy and newer
+  .. group-tab:: XML launch file
+
+    .. code-block:: xml
+
+          <node pkg="turtlesim" exec="mimic" name="mimic">
+            <remap from="/input/pose" to="/turtlesim1/turtle1/pose"/>
+            <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel"/>
+          </node>
+
+  .. group-tab:: Python, Foxy and newer
 
     .. code-block:: python
 
@@ -231,7 +244,7 @@ The final node is also from the ``turtlesim`` package, but a different executabl
               ]
           )
 
-  .. group-tab:: Eloquent and older
+  .. group-tab:: Python, Eloquent and older
 
     .. code-block:: python
 
@@ -256,11 +269,10 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 3 ros2 launch
 ^^^^^^^^^^^^^
 
-To launch ``turtlesim_mimic_launch.py``, enter into the directory you created earlier and run the following command:
+Open in a terminal the directory where you created the launch file, then you can run the following command:
 
 .. code-block:: console
 
-  cd launch
   ros2 launch turtlesim_mimic_launch.py
 
 .. note::

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -133,36 +133,23 @@ Copy and paste the complete code into the ``turtlesim_mimic_launch.py`` file:
 2.1 Examine the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-XML launch files specifics
-##########################
+Launch files begin with a launch description:
 
-XML launch files must have a `<launch>` parent tag.
-That's start of the launch description, and each of it's children tags is an action.
-In this example, the `<node>` action was used.
+.. code-block:: xml
 
-Python Launch files specifics
-#############################
+  <launch>
 
-These import statements pull in some Python ``launch`` modules.
+  </launch>
 
 .. code-block:: python
 
-    from launch import LaunchDescription
-    from launch_ros.actions import Node
+  def generate_launch_description():
+    return LaunchDescription([
 
-Next, the launch description itself begins:
+    ])
 
-.. code-block:: python
-
-   def generate_launch_description():
-      return LaunchDescription([
-
-      ])
-
-Common (please put a nice subtitle here)
-########################################
-
-Within the launch description, there is a system of three nodes, all from the ``turtlesim`` package.
+The launch description is a collection of actions that describes the system to be run.
+In this case, there is a system of three nodes, all from the ``turtlesim`` package.
 The goal of the system is to launch two turtlesim windows, and have one turtle mimic the movements of the other.
 
 The first two actions in the launch description launch two turtlesim windows:
@@ -173,8 +160,8 @@ The first two actions in the launch description launch two turtlesim windows:
 
     .. code-block:: xml
 
-          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
-          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
+      <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
+      <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
 
   .. group-tab:: Python, Foxy and newer
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -540,7 +540,7 @@ In the following example, we will launch two turtlesims that draw a circle, and 
 
   # In one terminal
   ros2 launch turtlesim_mimic_launch.py turtlesim_ns1:=drawing_circles_1 turtlesim_ns2:=drawing_circles_2 mimic_name:=mimic_circles
-  ros2 topic pub -r 1 /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
+  ros2 topic pub -r 1 /turtlesim_ns1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
 
 .. code-block:: console
 


### PR DESCRIPTION
To start with the new tutorials, I have migrated the existing one to a XML launch file.
The python examples are still there, in a different tab.
I have also added a few sections showing more advance launch features (in progress).

I have deleted the explanation of how to create a folder/file. I think that's a bit unnecessary, but I can add that again.