### PR TITLE
Fix ParameterDescriptor typo

### DIFF
--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -128,7 +128,6 @@ For that to work, the ``__init__`` code has to be changed to:
             from rcl_interfaces.msg import ParameterDescriptor
             my_parameter_descriptor = ParameterDescriptor(type=ParameterType.PARAMETER_STRING,
                                                           description='This parameter is mine!')
-                                                          
             self.declare_parameter("my_parameter",
                                    "default value for my_parameter",
                                    my_parameter_descriptor)

--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -125,8 +125,10 @@ For that to work, the ``__init__`` code has to be changed to:
             timer_period = 2  # seconds
             self.timer = self.create_timer(timer_period, self.timer_callback)
 
-            my_parameter_descriptor = rclpy.node.ParameterDescriptor(type=ParameterType.PARAMETER_STRING,
-                                                                          description='This parameter is mine!')
+            from rcl_interfaces.msg import ParameterDescriptor
+            my_parameter_descriptor = ParameterDescriptor(type=ParameterType.PARAMETER_STRING,
+                                                          description='This parameter is mine!')
+                                                          
             self.declare_parameter("my_parameter",
                                    "default value for my_parameter",
                                    my_parameter_descriptor)

--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -128,6 +128,7 @@ For that to work, the ``__init__`` code has to be changed to:
             from rcl_interfaces.msg import ParameterDescriptor
             my_parameter_descriptor = ParameterDescriptor(type=ParameterType.PARAMETER_STRING,
                                                           description='This parameter is mine!')
+
             self.declare_parameter("my_parameter",
                                    "default value for my_parameter",
                                    my_parameter_descriptor)

--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -125,7 +125,7 @@ For that to work, the ``__init__`` code has to be changed to:
             timer_period = 2  # seconds
             self.timer = self.create_timer(timer_period, self.timer_callback)
 
-            my_parameter_descriptor = rclpy.node.Node.ParameterDescriptor(type=ParameterType.PARAMETER_STRING,
+            my_parameter_descriptor = rclpy.node.ParameterDescriptor(type=ParameterType.PARAMETER_STRING,
                                                                           description='This parameter is mine!')
             self.declare_parameter("my_parameter",
                                    "default value for my_parameter",


### PR DESCRIPTION
Been working through these tutorials, as I will be using ROS for a project soon. I noticed a small typo in the creation of a parameter descriptor. The class `ParameterDescriptor()` is not a subclass of `Node()`, but instead is on the same level as it, being a class within the `rclpy.node` package. 