### PR TITLE
Update Linux-Development-Setup. Making sure no ROS 2 is sourced.

### DIFF
--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -129,7 +129,8 @@ On Windows due to limitations of the length of environment variables you should 
 
 Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
 You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
-You can make sure that ROS 2 is not sourced with the command ``printenv | grep -i ROS``. The output should be empty.
+You can make sure that ROS 2 is not sourced with the command ``printenv | grep -i ROS``.
+The output should be empty.
 
 .. code-block:: bash
 

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -128,7 +128,8 @@ Optionally install all packages into a combined directory (rather than each pack
 On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
 
 Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
-You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``. You can make sure that ROS 2 is not sourced with the command ``printenv | grep -i ROS``. The output should be empty.
+You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
+You can make sure that ROS 2 is not sourced with the command ``printenv | grep -i ROS``. The output should be empty.
 
 .. code-block:: bash
 

--- a/source/Installation/Rolling/Linux-Development-Setup.rst
+++ b/source/Installation/Rolling/Linux-Development-Setup.rst
@@ -128,8 +128,7 @@ Optionally install all packages into a combined directory (rather than each pack
 On Windows due to limitations of the length of environment variables you should use this option when building workspaces with many (~ >> 100 packages).
 
 Also, if you have already installed ROS 2 from Debian make sure that you run the ``build`` command in a fresh environment.
-You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
-
+You may want to make sure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``. You can make sure that ROS 2 is not sourced with the command ``printenv | grep -i ROS``. The output should be empty.
 
 .. code-block:: bash
 


### PR DESCRIPTION
If you have build another workspace (e.g. the turtlebot workspace) and sourced that one, you also source the previous ROS version. Someone in our group ran into this issue. You get a lot of build errors in that case. To make sure that there is no ROS sourced in the terminal, you can check it.