### PR TITLE
Add comment to install command of package marker file

### DIFF
--- a/source/Tutorials/Developing-a-ROS-2-Package.rst
+++ b/source/Tutorials/Developing-a-ROS-2-Package.rst
@@ -112,6 +112,7 @@ and a ``setup.py`` file that looks like:
        packages=[package_name],
        # Files we want to install, specifically launch files
        data_files=[
+           # Install marker file in the package index
            ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
            # Include our package.xml file
            (os.path.join('share', package_name), ['package.xml']),


### PR DESCRIPTION
Add a comment to the line installing the package index marker file.

This may also make it easier to recognise that this file is meant when getting the "Package 'foobar' doesn't explicitly install a marker in the package index" warning.