### PR TITLE
Add the pip package testresources for testing

### DIFF
--- a/source/Installation/Linux-Development-Setup.rst
+++ b/source/Installation/Linux-Development-Setup.rst
@@ -65,6 +65,7 @@ Install development tools and ROS tools
      flake8-docstrings \
      flake8-import-order \
      flake8-quotes \
+     testresources \
      pytest-repeat \
      pytest-rerunfailures \
      pytest \


### PR DESCRIPTION
Eliminate the "ERROR: launchpadlib 1.10.13 requires testresources, which is not installed", in Ubuntu 20.04

Seems like the error won't affect the succeeding installation, but it's always better to make errors disappear :)