### PR TITLE
Fixes for the binary installation instructions 

### DIFF
--- a/source/Installation/Foxy/Linux-Install-Binary.rst
+++ b/source/Installation/Foxy/Linux-Install-Binary.rst
@@ -74,6 +74,8 @@ Installing the python3 libraries
    sudo apt install -y libpython3-dev python3-pip
    pip3 install -U argcomplete
 
+See :ref:`this tutorial <install-colcon>` to install colcon.
+
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -73,6 +73,11 @@ So if you want autocompletion, installing argcomplete is necessary.
    sudo apt install -y python3-pip
    pip3 install -U argcomplete
 
+Install colcon (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See :ref:`this tutorial <install-colcon>` to install colcon.
+
 Try some examples
 -----------------
 

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -231,6 +231,12 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
   .. group-tab:: PowerShell
 
+   Navigate to the ROS 2 setup file using Windows Explorer, right click on ``local_setup.ps1``\, and select **Properties**. Then check unblock in file properties.
+
+    .. image:: https://i.imgur.com/nDipuaC.png
+
+   Once applied, you won't need to unblock the script again. To source the setup file, run:
+
     .. code-block:: bash
 
        > C:\ci\ws\install\local_setup.ps1

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -173,6 +173,33 @@ Colcon
 
 See :ref:`this tutorial <install-colcon>` to install colcon.
 
+Install Qt5
+^^^^^^^^^^^
+
+First get the installer from Qt's website:
+
+https://www.qt.io/download
+
+Select the Open Source version and then the ``Qt Online Installer for Windows``.
+
+Run the installer and install Qt5.
+
+We recommend you install it to the default location of ``C:\Qt``, but if you choose somewhere else, make sure to update the paths below accordingly.
+When selecting components to install, the only thing you absolutely need for Foxy and later is the appropriate MSVC 64-bit component under the ``Qt`` -> ``Qt 5.15.0`` tree.
+We're using ``5.15.0`` as of the writing of this document and that's what we recommend since that's all we test on Windows, but later version will probably work too.
+For Foxy and later, be sure to select ``MSVC 2019 64-bit``.
+After that, the default settings are fine.
+
+Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` (open as Administrator privileges) where you intend to build so that CMake can find it:
+
+.. code-block:: bash
+
+   > setx -m Qt5_DIR C:\Qt\5.15.0\msvc2019_64
+
+.. note::
+
+   This path might change based on which MSVC version you're using or if you installed it to a different directory.
+
 Downloading ROS 2
 -----------------
 

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -168,6 +168,11 @@ To run rqt_graph, you'll need `Graphviz <https://graphviz.gitlab.io/>`__.
 
 You will need to append the Graphviz bin folder ``C:\Program Files (x86)\GraphvizX.XX\bin`` to your PATH, by navigating to "Edit the system environment variables" as described above.
 
+Colcon
+~~~~~~
+
+See :ref:`this tutorial <install-colcon>` to install colcon.
+
 Downloading ROS 2
 -----------------
 

--- a/source/Installation/Foxy/Windows-Install-Binary.rst
+++ b/source/Installation/Foxy/Windows-Install-Binary.rst
@@ -187,7 +187,7 @@ Downloading ROS 2
 
     To download the ROS 2 debug libraries you'll need to download ``ros2-foxy-*-windows-debug-AMD64.zip``
 
-* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_foxy``\ ).
+* Unpack the zip file to ``C:\ci\ws\install``\ .
 
 Environment setup
 -----------------
@@ -200,13 +200,13 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
     .. code-block:: bash
 
-       > call C:\dev\ros2_foxy\local_setup.bat
+       > call C:\ci\ws\install\local_setup.bat
 
   .. group-tab:: PowerShell
 
     .. code-block:: bash
 
-       > C:\dev\ros2_foxy\local_setup.ps1
+       > C:\ci\ws\install\local_setup.ps1
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -50,6 +50,9 @@ You need the following things installed before installing ROS 2.
 
   .. code-block:: bash
 
+       # install sip and pyqt5 for rqt
+       brew install sip pyqt5
+
        brew install python@3.8
        # Unlink in case you have python@3.7 installed already
        brew unlink python
@@ -84,8 +87,6 @@ You need the following things installed before installing ROS 2.
 
 *
   Install rqt dependencies
-
-  ``brew install sip pyqt5``
 
   Fix some path names when looking for sip stuff during install (see `ROS 1 wiki <https://wiki.ros.org/kinetic/Installation/OSX/Homebrew/Source#Qt_naming_issue>`__):
 

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -117,6 +117,9 @@ You need the following things installed before installing ROS 2.
 
        python3 -m pip install catkin_pkg empy ifcfg lark-parser lxml netifaces numpy pyparsing pyyaml setuptools argcomplete
 
+*
+  See :ref:`this tutorial <install-colcon>` to install colcon.
+
 Disable System Integrity Protection (SIP)
 -----------------------------------------
 

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -85,6 +85,9 @@ You need the following things installed before installing ROS 2.
        # install CUnit for Cyclone DDS
        brew install cunit
 
+       # install cmake
+       brew install cmake
+
 *
   Install rqt dependencies
 

--- a/source/Installation/Foxy/macOS-Install-Binary.rst
+++ b/source/Installation/Foxy/macOS-Install-Binary.rst
@@ -153,9 +153,19 @@ Environment setup
 
 Source the ROS 2 setup file:
 
-.. code-block:: bash
+.. tabs::
 
-   . ~/ros2_foxy/ros2-osx/setup.bash
+  .. group-tab:: Bash
+
+    .. code-block:: bash
+
+       > . ~/ros2_foxy/ros2-osx/setup.bash
+
+  .. group-tab:: Zsh
+
+    .. code-block:: bash
+
+       > . ~/ros2_foxy/ros2-osx/setup.zsh
 
 Try some examples
 -----------------

--- a/source/Troubleshooting/Installation-Troubleshooting.rst
+++ b/source/Troubleshooting/Installation-Troubleshooting.rst
@@ -294,6 +294,17 @@ Running the ``rosdep`` command should now execute normally:
 Windows
 -------
 
+Colon build triggers "VisualStudioVersion not set" error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you receive ``RuntimeError: VisualStudioVersion is not set, please run within a Visual Studio Command Prompt``, you can use a PowerShell module to make PowerShell act like a Visual Studio Command Prompt.
+
+Open PowerShell with Administrative privileges. Run ``Install-module posh-vs`` and ``Install-PoshVs``.
+
+Next, create a folder within Documents called "WindowsPowerShell". Within the folder, create a file called "Microsoft.PowerShell_profile.ps1". Open the file for editing and add this text: "Import-VisualStudioEnvironment".
+
+If you are familiar with ".bashrc" from Unix systems, the file created acts similarly. You may add aliases and source the setup script in it.
+
 Import failing even with library present on the system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -25,6 +25,8 @@ The source code can be found in the `colcon GitHub organization <https://github.
 Prerequisites
 -------------
 
+.. _install-colcon:
+
 Install colcon
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Changes ordered in decreasing level of importance:

 * In MacOS binary instructions, move install of RQt dependencies, sip & pyqt5, to before instructions on symlinking python3.8. This is needed because sip and pyqt5 [depend on python3.9](https://formulae.brew.sh/formula/sip) and brew will symlink 3.9 over 3.8. There's a rclpy error with python3.9.
 * In MacOS binary instructions, cmake must be installed. Colcon complains about cmake not being found when trying to build a package with CMakeLists.
 * In Windows binary instructions, building with Colcon in PowerShell fails due to script permissions. We show how to give it run privileges.
 * In Troubleshooting Windows section, added instructions on how to make PowerShell act like a Visual Studio Command Prompt. Trying to build from a non VS CMD gives a VisualStudioVersion not set error
 * In Windows binary instructions, added QT5 installation section. External Rviz2 plugins depend it.
 * In MacOS binary instructions, added zsh equivalents to bash commands.
 * In all instructions, pointed to colcon tutorial for installation.

Not sure if commit b143500 belongs here. It's my fix to ros2/rviz#601

All changes visualized locally.