### PR TITLE
typo in Writing-A-Simple-Cpp-Publisher-And-Subscriber

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -225,7 +225,7 @@ Add a new line after the ``ament_cmake`` buildtool dependency and paste the foll
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
 
-This declares the package needs ``rclpp`` and ``std_msgs`` when its code is executed.
+This declares the package needs ``rclcpp`` and ``std_msgs`` when its code is executed.
 
 Make sure to save the file.
 
@@ -413,7 +413,7 @@ Make sure to save the file, and then your pub/sub system should be ready for use
 
 4 Build and run
 ^^^^^^^^^^^^^^^
-You likely already have the ``rclpp`` and ``std_msgs`` packages installed as part of your ROS 2 system.
+You likely already have the ``rclcpp`` and ``std_msgs`` packages installed as part of your ROS 2 system.
 It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) to check for missing dependencies before building:
 
 .. tabs::


### PR DESCRIPTION
fix typos, led to

    CMake Error at CMakeLists.txt:22 (find_package):
    By not providing "Findrclpp.cmake" in CMAKE_MODULE_PATH this project has
    asked CMake to find a package configuration file provided by "rclpp", but
    CMake did not find one.

    Could not find a package configuration file provided by "rclpp" with any of
    the following names:

    rclppConfig.cmake
    rclpp-config.cmake

    Add the installation prefix of "rclpp" to CMAKE_PREFIX_PATH or set
    "rclpp_DIR" to a directory containing one of the above files.  If "rclpp"
    provides a separate development package or SDK, be sure it has been
    installed.

when accidentally declaring

    find_package(rclpp REQUIRED)

in `CMakeLists.txt` of a user defined package