### PR TITLE
Cleanup github actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,8 @@ jobs:
 
       - name: Install dependencies with pip
         run: |
-          pip install doc8 sphinx
+          pip install doc8 sphinx sphinx-multiversion
           pip install git+https://github.com/osrf/sphinx-tabs
 
-      - run: make html 2> stderr.log
-      - run: cat stderr.log
-      - run: doc8 --ignore D001 --ignore-path build --ignore-path source/Tutorials/Actions
-      # ignore D000 in action tutorials to allow for :linenos:
-      - run: doc8 --ignore D000 --ignore D001 --ignore-path build source/Tutorials/Actions
-      # fail the build for any stderr output
-      - run: if [ -s "stderr.log" ]; then false; fi
+      - run: make html
+      - run: doc8 --ignore D001 --ignore-path build


### PR DESCRIPTION
1.  Add in the sphinx-multiversion pip dependency.  It isn't
required on the master branch, but it doesn't hurt anything
and is needed on the rolling, foxy, and dashing branches.

2.  Github actions fail immediately if the command returns
non-zero.  Since we were capturing the output, this was
effectively hiding the error from us.  We now just check
things sequentially.  This is better in that it is simpler,
but worse in that you don't get all of the errors at once.
I still like the simpler approach.

3.  Get rid of the exclusions for the action tutorials, as
it doesn't seem to be needed anymore.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that I am targeting *master* with this PR on purpose.  Once we are happy with this on master, I'll backport by hand to the rolling, dashing, and foxy branches.