### PR TITLE
Add EOL banner to eloquent

### DIFF
--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -3,7 +3,10 @@
 {% if current_version and latest_version and current_version != latest_version %}
 <p>
   <strong>
-    {% if current_version.is_released %}
+    {% if current_version.name|string() == 'eloquent' %}
+    You're reading a version of this documentation that is no longer kept up-to-date, as the distribution has reached its EOL (end-of-life).
+    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    {% elif current_version.is_released %}
     You're reading an old version of this documentation.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% else %}

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -4,11 +4,11 @@
 <p>
   <strong>
     {% if current_version.name|string() == 'eloquent' %}
-    You're reading a version of this documentation that is no longer kept up-to-date, as the distribution has reached its EOL (end-of-life).
+    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% elif current_version.is_released %}
-    You're reading an old version of this documentation.
-    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    You're reading the documentation for an older, but still supported, version of ROS 2.
+    For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% else %}
     You're reading the documentation for a development version.
     For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.


### PR DESCRIPTION
A nicer way would be to have an `eol_version` variable instead of doing a string compare, but that would require some work on the plugin, so for now we'll just do it this way. 

Signed-off-by: maryaB-osr <marya@openrobotics.org>