### PR TITLE
Change the wording for version banners

### DIFF
--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -4,10 +4,10 @@
 <p>
   <strong>
     {% if current_version.name|string() == 'eloquent' %}
-    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer kept up-to-date.
+    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% elif current_version.is_released %}
-    You're reading the documentation for an older version of ROS 2.
+    You're reading the documentation for an older but still supported version of ROS 2.
     For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% else %}
     You're reading the documentation for a development version.

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -4,11 +4,11 @@
 <p>
   <strong>
     {% if current_version.name|string() == 'eloquent' %}
-    You're reading a version of this documentation that is no longer kept up-to-date, as the distribution has reached its EOL (end-of-life).
+    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer kept up-to-date.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% elif current_version.is_released %}
-    You're reading an old version of this documentation.
-    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    You're reading the documentation for an older version of ROS 2.
+    For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% else %}
     You're reading the documentation for a development version.
     For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -7,7 +7,7 @@
     You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% elif current_version.is_released %}
-    You're reading the documentation for an older but still supported version of ROS 2.
+    You're reading the documentation for an older, but still supported, version of ROS 2.
     For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% else %}
     You're reading the documentation for a development version.


### PR DESCRIPTION
Adding the version banner for EOL distros in #990 made me think the wording for other distros that aren't EOL but also aren't the latest recommended version, needed to be changed. I think this is more explicit, albeit a little wordier. 

Signed-off-by: maryaB-osr <marya@openrobotics.org>