### PR TITLE
Add a section on becoming a core maintainer

### DIFF
--- a/source/Contributing.rst
+++ b/source/Contributing.rst
@@ -17,11 +17,11 @@ Tenets
   ROS has been around for more than a decade and is used by developers and across the world.
   Keep a humble attitude and an open mindset while contributing.
 
-* Embed OSRF as early as possible
+* Engage Open Robotics as early as possible
 
-  * OSRF acts as a gate-keeper and advocate for the ROS community.
+  * Open Robotics acts as a gate-keeper and advocate for the ROS community.
     Rely on their expertise and technical judgement from the design phase.
-  * Start discussions with OSRF and the community early.
+  * Start discussions with Open Robotics and the community early.
     Long time ROS contributors may have a clearer vision of the bigger picture.
     If you implement a feature and send a pull request without discussing with the community first, you are taking the risk of it being rejected, or you may be asked to largely rethink your design.
   * Opening issues or using Discourse to socialize an idea before starting the implementation is generally preferable.

--- a/source/Contributing.rst
+++ b/source/Contributing.rst
@@ -92,3 +92,23 @@ Code contributions should be made via pull requests to `the appropriate ros2 rep
 We ask all contributors to follow the practices explained in `the developer guide <Contributing/Developer-Guide>`.
 
 Please be sure to `run tests <colcon-run-the-tests>` for your code changes because most packages have tests that check that the code complies with our style guidelines.
+
+Becoming a core maintainer
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ROS 2 maintainers ensure that the project is generally making progress.  The responsibilities of the maintainers include:
+
+* Reviewing incoming code contributions for style, quality, and overall fit into the goals of the repository/ROS 2.
+* Ensuring that CI continues to stay green.
+* Merging pull requests that meet the quality and CI standards above.
+* Addressing issues opened up by users.
+
+Each repository in the `ros2 <https://github.com/ros2>`__ and `ament <https://github.com/ament>`__ organizations has a separate set of maintainers.
+Becoming a maintainer of one or more of those repositories is an invitation-only process, and generally involves the following steps:
+
+* Within the last year, have a substantial number of code contributions to the repository.
+* Within the last year, do a substantial number of reviews on incoming pull requests to the repository.
+
+Approximately every 3 months, the ROS 2 team will review the contributions in all of the repositories and send out invitations to new maintainers.
+Once the invitation is accepted, the new maintainer will be asked to go through a short training process on the mechanisms and policies of the ROS 2 repositories.
+After that training process is completed, the new maintainer will be given write access to the appropriate repositories.

--- a/source/Contributing.rst
+++ b/source/Contributing.rst
@@ -96,7 +96,8 @@ Please be sure to `run tests <colcon-run-the-tests>` for your code changes becau
 Becoming a core maintainer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ROS 2 maintainers ensure that the project is generally making progress.  The responsibilities of the maintainers include:
+The ROS 2 maintainers ensure that the project is generally making progress.
+The responsibilities of the maintainers include:
 
 * Reviewing incoming code contributions for style, quality, and overall fit into the goals of the repository/ROS 2.
 * Ensuring that CI continues to stay green.


### PR DESCRIPTION
This PR adds a section to the "Contributing" page with the new process to become a core maintainer on the ROS 2 repositories.  The wording is still a bit vague since we haven't yet totally defined what a "substantial" number of contributions is, but I think that is OK to start with.  @ros2/team please take a look.