### PR TITLE
Update Understanding-ROS2-Services.rst

### DIFF
--- a/source/Tutorials/Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Services/Understanding-ROS2-Services.rst
@@ -216,7 +216,7 @@ To see the arguments in a ``/spawn`` call-and-request, run the command:
 
     .. code-block:: console
 
-      ros2 interface show turtlesim/srv/Spawn.srv
+      ros2 interface show turtlesim/srv/Spawn
 
   .. group-tab:: Dashing
 


### PR DESCRIPTION
The correct command line is ros2 interface show turtlesim/srv/Spawn
The original command line ros2 interface show turtlesim/srv/Spawn.srv results in an error.
:-)