### PR TITLE
Add crystal to the list of branches to be built by multiversion.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -107,7 +107,7 @@ html_sidebars = {
 smv_branch_whitelist = r'^(rolling|foxy|eloquent|dashing|crystal)$'
 
 
-smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(foxy|eloquent|dashing).*$'
+smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(foxy|eloquent|dashing|crystal).*$'
 smv_remote_whitelist = r'^(origin)$'
 smv_latest_version = 'foxy'
 

--- a/conf.py
+++ b/conf.py
@@ -104,7 +104,7 @@ html_sidebars = {
 
 # smv_tag_whitelist = None
 
-smv_branch_whitelist = r'^(rolling|foxy|eloquent|dashing)$'
+smv_branch_whitelist = r'^(rolling|foxy|eloquent|dashing|crystal)$'
 
 
 smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(foxy|eloquent|dashing).*$'

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -23,7 +23,7 @@
 {% if current_version and latest_version and current_version != latest_version %}
 <p>
   <strong>
-    {% if current_version.name|string() == 'eloquent' %}
+    {% if current_version.name|string() in ['eloquent', 'crystal'] %}
     You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% elif current_version.is_released %}

--- a/source/_templates/versioning.html
+++ b/source/_templates/versioning.html
@@ -6,6 +6,8 @@
   {%- for item in versions.releases|sort(reverse=True) %}
     {% if item.name == latest_version.name %}
     <li><a href="{{ item.url }}">{{ item.name | title }} (latest)</a></li>
+    {% elif item.name in ['eloquent', 'crystal'] %}
+    <li><a href="{{ item.url }}">{{ item.name | title }} (EOL)</a></li>
     {% else %}
     <li><a href="{{ item.url }}">{{ item.name | title }}</a></li>
     {% endif %}


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is so that we can make *all* redirects from index.ros.org work in https://github.com/ros2/ros2_documentation/pull/1108 .  Once this is merged, I'll update #1108 to have the final Crystal redirects.