### PR TITLE
Fix URLs to ros2.repos files

### DIFF
--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -28,7 +28,7 @@ If you wish to update a particular release, you can get its repository list by s
 
        cd ~/ros2_ws
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/release-foxy/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/foxy-release/ros2.repos
 
   .. group-tab:: macOS
 
@@ -36,7 +36,7 @@ If you wish to update a particular release, you can get its repository list by s
 
        cd ~/ros2_ws
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/release-foxy/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/foxy-release/ros2.repos
 
   .. group-tab:: Windows
 
@@ -44,11 +44,11 @@ If you wish to update a particular release, you can get its repository list by s
 
        # CMD
        > cd \dev\ros2
-       > curl -sk https://raw.githubusercontent.com/ros2/ros2/release-foxy/ros2.repos -o ros2.repos
+       > curl -sk https://raw.githubusercontent.com/ros2/ros2/foxy-release/ros2.repos -o ros2.repos
 
        # PowerShell
        > cd \dev\ros2
-       > curl https://raw.githubusercontent.com/ros2/ros2/release-foxy/ros2.repos -o ros2.repos
+       > curl https://raw.githubusercontent.com/ros2/ros2/foxy-release/ros2.repos -o ros2.repos
 
 The format of the name of the release comes from the tag associated with the release `here <https://github.com/ros2/ros2/tags>`__.
 
@@ -126,7 +126,7 @@ If you wish to checkout the latest development code for the upcoming ROS release
 Update your repositories
 ------------------------
 
-You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/release-latest/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
+You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
 It is possible that these versions refer to new tags/branches that your local copy of the repositories will not recognize as they are out-of-date.
 Because of this, you should update the repositories that you have already checked out with the following command:
 


### PR DESCRIPTION
'release-foxy' does not point to a valid file and 'release-latest' is no longer used.