### PR TITLE
Update Linux-Install-Debians.rst

### DIFF
--- a/source/Installation/Foxy/Linux-Install-Debians.rst
+++ b/source/Installation/Foxy/Linux-Install-Debians.rst
@@ -49,6 +49,13 @@ No GUI tools.
 .. code-block:: bash
 
    sudo apt install ros-foxy-ros-base
+   
+Install python3-colcon-common-extensions
+----------------------
+   
+.. code-block:: bash
+ 
+   sudo apt install python3-colcon-common-extensions
 
 Environment setup
 -----------------


### PR DESCRIPTION
Without python3-colcon-common-extensions the command:
source /usr/share/colcon_cd/function/colcon_cd.sh
gives result:
bash: /usr/share/colcon_cd/function/colcon_cd.sh: No such file or directory