### PR TITLE
Add in redirects for JSON builder

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -164,7 +164,7 @@ redirects = {
     'Installation/Maintaining-a-Source-Checkout': 'https://docs.ros.org/en/rolling/Installation/Maintaining-a-Source-Checkout.html',
     'Installation/Prerelease-Testing': 'https://docs.ros.org/en/rolling/Installation/Prerelease-Testing.html',
 
-    'Installation/Crystal': 'https://docs.ros.org/en/crystal/Installation/Summary.html',
+    'Installation/Crystal': 'https://docs.ros.org/en/crystal/Installation.html',
     'Installation/Crystal/Fedora-Development-Setup': 'https://docs.ros.org/en/crystal/Installation/Fedora-Development-Setup.html',
     'Installation/Crystal/Linux-Development-Setup': 'https://docs.ros.org/en/crystal/Installation/Linux-Development-Setup.html',
     'Installation/Crystal/Linux-Install-Binary': 'https://docs.ros.org/en/crystal/Installation/Linux-Install-Binary.html',
@@ -174,7 +174,7 @@ redirects = {
     'Installation/Crystal/Windows-Development-Setup': 'https://docs.ros.org/en/crystal/Installation/Windows-Development-Setup.html',
     'Installation/Crystal/Windows-Install-Binary': 'https://docs.ros.org/en/crystal/Installation/Windows-Install-Binary.html',
 
-    'Installation/Dashing': 'https://docs.ros.org/en/dashing/Installation/Summary.html',
+    'Installation/Dashing': 'https://docs.ros.org/en/dashing/Installation.html',
     'Installation/Dashing/Fedora-Development-Setup': 'https://docs.ros.org/en/dashing/Installation/Fedora-Development-Setup.html',
     'Installation/Dashing/Linux-Development-Setup': 'https://docs.ros.org/en/dashing/Installation/Linux-Development-Setup.html',
     'Installation/Dashing/Linux-Install-Binary': 'https://docs.ros.org/en/dashing/Installation/Linux-Install-Binary.html',
@@ -188,7 +188,7 @@ redirects = {
     'Installation/DDS-Implementations/Install-Connext-University-Eval': 'https://docs.ros.org/en/foxy/Installation/DDS-Implementations/Install-Connext-University-Eval.html',
     'Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS': 'https://docs.ros.org/en/foxy/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.html',
 
-    'Installation/Eloquent': 'https://docs.ros.org/en/eloquent/Installation/Summary.html',
+    'Installation/Eloquent': 'https://docs.ros.org/en/eloquent/Installation.html',
     'Installation/Eloquent/Fedora-Development-Setup': 'https://docs.ros.org/en/eloquent/Installation/Fedora-Development-Setup.html',
     'Installation/Eloquent/Linux-Development-Setup': 'https://docs.ros.org/en/eloquent/Installation/Linux-Development-Setup.html',
     'Installation/Eloquent/Linux-Install-Binary': 'https://docs.ros.org/en/eloquent/Installation/Linux-Install-Binary.html',
@@ -198,7 +198,7 @@ redirects = {
     'Installation/Eloquent/Windows-Development-Setup': 'https://docs.ros.org/en/eloquent/Installation/Windows-Development-Setup.html',
     'Installation/Eloquent/Windows-Install-Binary': 'https://docs.ros.org/en/eloquent/Installation/Windows-Install-Binary.html',
 
-    'Installation/Foxy': 'https://docs.ros.org/en/foxy/Installation/Summary.html',
+    'Installation/Foxy': 'https://docs.ros.org/en/foxy/Installation.html',
     'Installation/Foxy/Fedora-Development-Setup': 'https://docs.ros.org/en/foxy/Installation/Fedora-Development-Setup.html',
     'Installation/Foxy/Linux-Development-Setup': 'https://docs.ros.org/en/foxy/Installation/Linux-Development-Setup.html',
     'Installation/Foxy/Linux-Install-Binary': 'https://docs.ros.org/en/foxy/Installation/Linux-Install-Binary.html',
@@ -208,7 +208,7 @@ redirects = {
     'Installation/Foxy/Windows-Development-Setup': 'https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html',
     'Installation/Foxy/Windows-Install-Binary': 'https://docs.ros.org/en/foxy/Installation/Windows-Install-Binary.html',
 
-    'Installation/Rolling': 'https://docs.ros.org/en/rolling/Installation/Summary.html',
+    'Installation/Rolling': 'https://docs.ros.org/en/rolling/Installation.html',
     'Installation/Rolling/Fedora-Development-Setup': 'https://docs.ros.org/en/rolling/Installation/Fedora-Development-Setup.html',
     'Installation/Rolling/Linux-Development-Setup': 'https://docs.ros.org/en/rolling/Installation/Linux-Development-Setup.html',
     'Installation/Rolling/Linux-Install-Binary': 'https://docs.ros.org/en/rolling/Installation/Linux-Install-Binary.html',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pip
 sphinx
-sphinx-reredirects
 sphinx-tabs


### PR DESCRIPTION
Earlier today I merged in #1108 and then deployed it by running https://build.ros.org/job/doc_rosindex/ .  When I did that, the whole site just showed snippets of:

```
The files on this branch are no longer used.  See the 'rolling' branch instead.
```

That should never have been; those messages are meant for those who are modifying the sources.  For the deployment, there should be redirects in place for all of these pages.

It turns out that using [sphinx-reredirects](https://gitlab.com/documatt/sphinx-reredirects) with the [rosindex](https://github.com/ros-infrastructure/rosindex) site generator does not work.  The basic problem is that rosindex uses the JSON builder output and snippets from sphinx, while `sphinx-reredirects` only outputs HTML redirect pages (which rosindex ignores).

The solution I came up with here is to stop using `sphinx-reredirects`, and instead write a hand-rolled version.  When doing an HTML build, the hand-rolled version does exactly the same thing as `sphinx-reredirects` (this makes local testing easy).  However, when doing a JSON build (passing `-b json` on the sphinx command-line), it instead modifies the JSON output to have a 'canonical_url' dictionary key.  In turn, this makes the rosindex site generator generate an `http-equiv="refresh"` tag for us (with no changes necessary to that code).

I've tested this locally, and I can see the `http-equiv="refresh"` tags being generated as I expect.  