### PR TITLE
Add in distribution name to title.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,7 +40,7 @@ default_role = 'any'
 suppress_warnings = ['image.nonlocal_uri']
 
 # General information about the project.
-project = 'ros2 documentation'
+project = 'ROS 2 documentation'
 author = 'Open Robotics'
 copyright = '{}, {}'.format(time.strftime('%Y'), author)
 
@@ -248,6 +248,7 @@ def smv_rewrite_baseurl(app, config):
     # to rewrite the html_baseurl with the current version.
     if app.config.smv_current_version != '':
         app.config.html_baseurl = app.config.html_baseurl + '/' + app.config.smv_current_version
+        app.config.project = 'ROS 2 Documentation: ' + app.config.smv_current_version.title()
 
 def github_link_rewrite_branch(app, pagename, templatename, context, doctree):
     if app.config.smv_current_version != '':


### PR DESCRIPTION
This should make it a little easier for readers to understand
which branch of the documentation they are reading.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This fixes #1157 