### PR TITLE
Remove galactic note in logging tutorial

### DIFF
--- a/source/Tutorials/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Logging-and-logger-configuration.rst
@@ -22,10 +22,6 @@ Note that the first message will only be logged once, though the line is reached
 Logging directory configuration
 -------------------------------
 
-.. note::
-
-   The logging directory can only be configured starting in Galactic.
-
 The logging directory can be configured through two environment variables: ``ROS_LOG_DIR`` and ``ROS_HOME``.
 The logic is as follows:
 


### PR DESCRIPTION
It is no longer needed since this repo switched to using one branch per distro.