### PR TITLE
Installation: future proof apt repo instructions

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -4,10 +4,10 @@ To do so, first authorize our GPG key with apt like this:
 .. code-block:: bash
 
    sudo apt update && sudo apt install curl gnupg2 lsb-release
-   curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+   curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | gpg --dearmor | sudo tee /usr/share/keyrings/ros.gpg > /dev/null
 
 And then add the repository to your sources list:
 
 .. code-block:: bash
 
-   sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2-latest.list > /dev/null

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -4,7 +4,7 @@ To do so, first authorize our GPG key with apt like this:
 .. code-block:: bash
 
    sudo apt update && sudo apt install curl gnupg2 lsb-release
-   curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | gpg --dearmor | sudo tee /usr/share/keyrings/ros.gpg > /dev/null
+   sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 And then add the repository to your sources list:
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -10,4 +10,4 @@ And then add the repository to your sources list:
 
 .. code-block:: bash
 
-   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2-latest.list > /dev/null
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null


### PR DESCRIPTION
In future debian releases, the way how you configure a third-party repository is going to change, see  https://wiki.debian.org/DebianRepository/UseThirdParty

**Note:** I tried this under Ubuntu Focal & Groovy and can confirm it works.

This is my first contribution to your docs, and I don't know what your policy is for changing instructions as such; and since this is a very sensitive step in the installation process, I would suggest someone confirms this works under Ubuntu 20.04 & 20.10

**This is a list of the changes in this PR:**
* The GPG key is now converted to a binary with `gpg --dearmor`
* The location of the ROS repository key changes to the recommended path under
`/usr/share/keyrings`
* The sources.list entry requires a `signed-by` option to be set
pointing to the GPG binary key

**TODO:** Standard Pinning needs to be set to allow apt to understand the level of priority that should be given to the sources found on the ROS repository

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858406