### PR TITLE
updated to correctly show as "Eclipse Cyclone DDS"

### DIFF
--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -68,11 +68,11 @@ Related PRs: `ros2/rclcpp#1408 <https://github.com/ros2/rclcpp/pull/1408>`_ and 
 Changes since the Foxy release
 ------------------------------
 
-Default RMW vendor changed to Cyclone DDS
+Default RMW changed to Eclipse Cyclone DDS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-During the Galactic development process, the ROS 2 Technical Steering Committee `voted <https://discourse.ros.org/t/ros-2-galactic-default-middleware-announced/18064>`__ to change the default ROS middleware (RMW) to Cyclone DDS.
-Without any configuration changes, users will get Cyclone DDS by default.
+During the Galactic development process, the ROS 2 Technical Steering Committee `voted <https://discourse.ros.org/t/ros-2-galactic-default-middleware-announced/18064>`__ to change the default ROS middleware (RMW) to `Eclipse Cyclone DDS <https://github.com/eclipse-cyclonedds/cyclonedds>`__ project of `Eclipse Foundation <https://www.eclipse.org>`__.
+Without any configuration changes, users will get Eclipse Cyclone DDS by default.
 Fast-DDS and Connext are still Tier-1 supported RMW vendors, and users can opt-in to use one of these RMWs at their discretion by using the ``RMW_IMPLEMENTATION`` environment variable.
 See the `Working with multiple RMW implementations guide <../Guides/Working-with-multiple-RMW-implementations>` for more information.
 

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -69,7 +69,7 @@ Changes since the Foxy release
 ------------------------------
 
 Default RMW changed to Eclipse Cyclone DDS
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 During the Galactic development process, the ROS 2 Technical Steering Committee `voted <https://discourse.ros.org/t/ros-2-galactic-default-middleware-announced/18064>`__ to change the default ROS middleware (RMW) to `Eclipse Cyclone DDS <https://github.com/eclipse-cyclonedds/cyclonedds>`__ project of `Eclipse Foundation <https://www.eclipse.org>`__.
 Without any configuration changes, users will get Eclipse Cyclone DDS by default.


### PR DESCRIPTION
Update to show as "Eclipse Cyclone DDS project of Eclipse Foundation". The project name is "Eclipse Cyclone DDS" not "Cyclone DDS". Is fine to say "Eclipse Cyclone DDS" for first mentions and then shorten to "Cyclone DDS" for subsequent ones.