### PR TITLE
Minor tweak Python publisher tutorial wording

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -213,7 +213,7 @@ As mentioned in the :ref:`previous tutorial <CreatePkg>`, make sure to fill in t
   <maintainer email="you@email.com">Your Name</maintainer>
   <license>Apache License 2.0</license>
 
-Add a new line after  the ``ament_python`` buildtool dependency and paste the following dependencies corresponding to your node’s import statements:
+After the lines above, add the following dependencies corresponding to your node’s import statements:
 
 .. code-block:: xml
 


### PR DESCRIPTION
Tweaked wording as discovered in response to https://github.com/ros2/examples/issues/303

Following the tutorial, the `ament_python` dependency is generated inside the `<export>` tag. The `<exec_depend>` lines should not be inside that tag. Simplified wording.