### PR TITLE
Fix CMake code snippets

### DIFF
--- a/source/Tutorials/Actions/Writing-a-Cpp-Action-Server-Client.rst
+++ b/source/Tutorials/Actions/Writing-a-Cpp-Action-Server-Client.rst
@@ -208,7 +208,7 @@ To get it to compile and run, we need to do a couple of additional things.
 First we need to setup the CMakeLists.txt so that the action server is compiled.
 Open up ``action_tutorials_cpp/CMakeLists.txt``, and add the following right after the ``find_package`` calls:
 
-.. code-block:: console
+.. code-block:: cmake
 
   add_library(action_server SHARED
     src/fibonacci_action_server.cpp)
@@ -337,7 +337,7 @@ To get it to compile and run, we need to do a couple of additional things.
 First we need to setup the CMakeLists.txt so that the action client is compiled.
 Open up ``action_tutorials_cpp/CMakeLists.txt``, and add the following right after the ``find_package`` calls:
 
-.. code-block:: console
+.. code-block:: cmake
 
   add_library(action_client SHARED
     src/fibonacci_action_client.cpp)

--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -91,7 +91,7 @@ This is your custom service that requests three integers named ``a``, ``b``, and
 
 To convert the interfaces you defined into language-specific code (like C++ and Python) so that they can be used in those languages, add the following lines to ``CMakeLists.txt``:
 
-.. code-block:: console
+.. code-block:: cmake
 
   find_package(rosidl_default_generators REQUIRED)
 
@@ -366,9 +366,9 @@ CMakeLists.txt:
 
 Add the following lines (C++ only):
 
-.. code-block:: console
+.. code-block:: cmake
 
-    ...
+    #...
 
     find_package(ament_cmake REQUIRED)
     find_package(rclcpp REQUIRED)
@@ -649,9 +649,9 @@ CMakeLists.txt:
 
 Add the following lines (C++ only):
 
-.. code-block:: console
+.. code-block:: cmake
 
-    ...
+    #...
 
     find_package(ament_cmake REQUIRED)
     find_package(rclcpp REQUIRED)

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -398,7 +398,7 @@ Since this node has the same dependencies as the publisher node, there’s nothi
 
 Reopen ``CMakeLists.txt`` and add the executable and target for the subscriber node below the publisher’s entries.
 
-.. code-block:: console
+.. code-block:: cmake
 
   add_executable(listener src/subscriber_member_function.cpp)
   ament_target_dependencies(listener rclcpp std_msgs)


### PR DESCRIPTION
So that copy-pasting lines with '$' works.

Fixes #1259

I also changed other instances of `.. code-block:: console` to `.. code-block:: cmake` just to get the correct CMake highlighting. I'm sure there are many more instances though.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>