### PR TITLE
Remove some hard-coded packages.

### DIFF
--- a/source/Installation/Fedora-Development-Setup.rst
+++ b/source/Installation/Fedora-Development-Setup.rst
@@ -9,8 +9,6 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
 .. code-block:: bash
 
    $ sudo dnf install \
-     asio-devel \
-     bison \
      cmake \
      cppcheck \
      eigen3-devel \
@@ -21,19 +19,13 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      make \
      opencv-devel \
      patch \
-     python3-argcomplete \
      python3-colcon-common-extensions \
      python3-coverage \
      python3-devel \
      python3-empy \
-     python3-lark-parser \
-     python3-lxml \
-     python3-mock \
-     python3-mypy \
      python3-nose \
      python3-pip \
      python3-pydocstyle \
-     python3-pyflakes \
      python3-pyparsing \
      python3-pytest \
      python3-pytest-cov \
@@ -42,14 +34,11 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
-     python3-yaml \
      poco-devel \
      poco-foundation \
      python3-flake8 \
      python3-flake8-import-order \
      redhat-rpm-config \
-     tinyxml-devel \
-     tinyxml2-devel \
      uncrustify \
      wget
 

--- a/source/Installation/Linux-Development-Setup.rst
+++ b/source/Installation/Linux-Development-Setup.rst
@@ -45,7 +45,6 @@ Install development tools and ROS tools
      build-essential \
      cmake \
      git \
-     libbullet-dev \
      python3-colcon-common-extensions \
      python3-flake8 \
      python3-pip \
@@ -56,7 +55,6 @@ Install development tools and ROS tools
      wget
    # install some pip packages needed for testing
    python3 -m pip install -U \
-     argcomplete \
      flake8-blind-except \
      flake8-builtins \
      flake8-class-newline \
@@ -69,13 +67,6 @@ Install development tools and ROS tools
      pytest-rerunfailures \
      pytest \
      setuptools
-   # install Fast-RTPS dependencies
-   sudo apt install --no-install-recommends -y \
-     libasio-dev \
-     libtinyxml2-dev
-   # install Cyclone DDS dependencies
-   sudo apt install --no-install-recommends -y \
-     bison libcunit1-dev
 
 Ubuntu 18.04 is not an officially supported platform, but may still work.  You'll need at least the following additional dependencies:
 

--- a/source/Installation/Linux-Install-Binary.rst
+++ b/source/Installation/Linux-Install-Binary.rst
@@ -76,12 +76,11 @@ Installing the python3 libraries
 .. code-block:: bash
 
    sudo apt install -y libpython3-dev python3-pip
-   pip3 install -U argcomplete
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you would like to use another DDS or RTPS vendor besides the default, eProsima's Fast RTPS, you can find instructions `here <DDS-Implementations>`.
+If you would like to use another DDS or RTPS vendor besides the default, Eclipse Cyclone DDS, you can find instructions `here <DDS-Implementations>`.
 
 Environment setup
 -----------------

--- a/source/Installation/Linux-Install-Debians.rst
+++ b/source/Installation/Linux-Install-Debians.rst
@@ -68,17 +68,6 @@ Set up your environment by sourcing the following file.
 
    source /opt/ros/rolling/setup.bash
 
-Install argcomplete (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ROS 2 command line tools use argcomplete to autocompletion.
-So if you want autocompletion, installing argcomplete is necessary.
-
-.. code-block:: bash
-
-   sudo apt install -y python3-pip
-   pip3 install -U argcomplete
-
 Try some examples
 -----------------
 


### PR DESCRIPTION
On Rolling we have proper dependencies on most packages
in the package.xml.  That means we'll get these dependencies
installed via the rosdep commands on Linux, so we don't need
to explicitly call them out.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>