### PR TITLE
Fix references to index.ros.org.

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -156,7 +156,7 @@ Guidelines for backporting PRs
 When changing an older version of ROS:
 
 * Make sure the features or fixes are accepted and merged in the master branch before opening a PR to backport the changes to older versions.
-* When backporting to older versions, also backport to any [newer, still supported versions](https://index.ros.org/doc/ros2/Releases/), even non-LTS versions.
+* When backporting to older versions, also consider backporting to any other `still supported versions <../Releases>`, even non-LTS versions.
 * If you are backporting a single PR in its entirety, title the backport PR "[Distro] <name of original PR>".
   If backporting a subset of changes from one or multiple PRs, the title should be "[Distro] <description of changes>".
 * Link to all PRs whose changes you're backporting from the description of your backport PR.

--- a/source/Contributing/Migration-Guide.rst
+++ b/source/Contributing/Migration-Guide.rst
@@ -84,7 +84,7 @@ Build system
 ^^^^^^^^^^^^
 
 The build system in ROS 2 is called `ament <https://design.ros2.org/articles/ament.html>`__
-and the build tool is  `colcon <https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/>`__.
+and the build tool is  `colcon <../Tutorials/Colcon-Tutorial/>`.
 Ament is built on CMake: ``ament_cmake`` provides CMake functions to make writing ``CMakeLists.txt`` files easier.
 
 Build tool
@@ -407,7 +407,7 @@ In ROS 2, parameters are associated per node and are configurable at runtime wit
 
 * See `ROS 2 Parameter design document <https://design.ros2.org/articles/ros_parameters.html>`_ for more details about the system model.
 
-* See `ROS 2 CLI usage <https://index.ros.org/doc/ros2/Tutorials/Parameters/Understanding-ROS2-Parameters/>`_ for a better understanding of how the CLI tools work and its differences with ROS 1 tooling.
+* See `ROS 2 CLI usage <../Tutorials/Parameters/Understanding-ROS2-Parameters>` for a better understanding of how the CLI tools work and its differences with ROS 1 tooling.
 
 * See :ref:`yaml-ros1-ros2` to see how YAML parameter files are parsed in ROS 2 and their differences with ROS implementation.
 
@@ -415,7 +415,7 @@ Launch files
 ------------
 
 While launch files in ROS 1 are always specified using `.xml <https://wiki.ros.org/roslaunch/XML>`__ files, ROS 2 supports Python scripts to enable more flexibility (see `launch package <https://github.com/ros2/launch/tree/master/launch>`__) as well as XML and YAML files.
-See `separate tutorial <https://index.ros.org/doc/ros2/Tutorials/Launch-files-migration-guide/>`__ on migrating launch files from ROS 1 to ROS 2.
+See `separate tutorial <../Guides/Launch-files-migration-guide>` on migrating launch files from ROS 1 to ROS 2.
 
 Example: Converting an existing ROS 1 package to use ROS 2
 ----------------------------------------------------------
@@ -607,7 +607,7 @@ To further control how message delivery is handled, a quality of service
 The default profile is ``rmw_qos_profile_default``.
 For more details, see the
 `design document <https://design.ros2.org/articles/qos.html>`__
-and `concept overview <https://index.ros.org/doc/ros2/Concepts/About-Quality-of-Service-Settings>`__.
+and `concept overview <../Concepts/About-Quality-of-Service-Settings>`.
 
 The creation of the outgoing message is different in the namespace:
 

--- a/source/Guides/Cross-compilation.rst
+++ b/source/Guides/Cross-compilation.rst
@@ -271,7 +271,7 @@ Instead of downloading the ROS 2 stack, just populate your workspace with your p
     git clone https://github.com/ros-tooling/cross_compile.git -b 0.0.1
     cd ..
 
-Generate and export the file-system as described in `3. Prepare the sysroot`_, but with the provided ``Dockerfile_ubuntu_arm64_prebuilt``. These ``_prebuilt`` Dockerfile will use the `binary packages <https://index.ros.org/doc/ros2/Linux-Install-Debians/>`__ to install ROS 2 instead of building from source.
+Generate and export the file-system as described in `3. Prepare the sysroot`_, but with the provided ``Dockerfile_ubuntu_arm64_prebuilt``. These ``_prebuilt`` Dockerfile will use the `binary packages <../Installation/Linux-Install-Debians>` to install ROS 2 instead of building from source.
 
 Modify the environment variable ``ROS2_INSTALL_PATH`` to point to the installation directory:
 

--- a/source/Guides/Installation-Troubleshooting.rst
+++ b/source/Guides/Installation-Troubleshooting.rst
@@ -231,7 +231,7 @@ To fix this issue, follow `these steps <RQt-Source-Install-MacOS>` to install de
 
 rosdep install error ``homebrew: Failed to detect successful installation of [qt5]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-While following the `Creating a workspace <https://index.ros.org/doc/ros2/Tutorials/Workspace/Creating-A-Workspace/#creating-a-workspace>`__ tutorial, you might encounter the following error stating that ``rosdep`` failes to install Qt5.
+While following the `Creating a workspace <../Tutorials/Workspace/Creating-A-Workspace>` tutorial, you might encounter the following error stating that ``rosdep`` failes to install Qt5.
 
 .. code-block:: bash
 

--- a/source/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
+++ b/source/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
@@ -18,7 +18,7 @@ Background
 ----------
 
 With the introduction of DDS in ROS 2, Quality of Service (QoS) compatibility for publisher/subscriber nodes needs to be considered when recording and playing back data.
-More detail on how QoS works can be found `here <https://index.ros.org/doc/ros2/Concepts/About-Quality-of-Service-Settings>`__.
+More detail on how QoS works can be found `here <../Concepts/About-Quality-of-Service-Settings>`.
 For the purposes of this guide, it is sufficient to know that only the reliability and durability policies affect whether publishers/subscribers are compatible and can receive data from one other.
 
 Ros2Bag adapts its requested/offered QoS profile when recording/playing data from a topic to prevent dropped messages.

--- a/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
@@ -59,7 +59,7 @@ Switch from other rmw to rmw_cyclonedds by specifying the environment variable.
 
    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
-See also: https://index.ros.org/doc/ros2/Tutorials/Working-with-multiple-RMW-implementations/
+See also: `Working with multiple RMW implementations <../../Guides/Working-with-multiple-RMW-implementations>`
 
 Run the talker and listener
 ---------------------------

--- a/source/Tutorials/Topics/Topic-Statistics-Tutorial.rst
+++ b/source/Tutorials/Topics/Topic-Statistics-Tutorial.rst
@@ -30,8 +30,7 @@ For more details please see the :ref:`Topic Statistics Concepts Page<AboutTopicS
 Prerequisites
 -------------
 
-An installation from either binaries or source, where the version must be at least
-`ROS2 Foxy <https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/>`__.
+An installation from either binaries or source.
 
 In previous tutorials, you learned how to :ref:`create a workspace <ROS2Workspace>`,
 :ref:`create a package <CreatePkg>`, and create a :ref:`C++ <CppPubSub>` publisher and subscriber.


### PR DESCRIPTION
In most cases, make them relative so we don't have to go
outside to get the references.  In at least one case, just
remove the link completely.

With this commit in place, the only references to index.ros.org
have to do with package-specific documentation, and some links
in the release notes that I was reluctant to change.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>