### PR TITLE
Pin docutils to version 0.16.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pip
+docutils==0.16
 sphinx
 sphinx-tabs
 sphinx-multiversion


### PR DESCRIPTION
The sphinx-rtd-theme only works with docutils < 0.17 right now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>