### PR TITLE
Use proper code blocks and format some paths in Windows instructions

### DIFF
--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -51,12 +51,12 @@ If you wish to checkout the latest code for ROS 2 {DISTRO_TITLE}, you can get th
     .. code-block:: bash
 
        # CMD
-       > cd \dev\ros2_{DISTRO}
-       > curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+       cd \dev\ros2_{DISTRO}
+       curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
        # PowerShell
-       > cd \dev\ros2_{DISTRO}
-       > curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+       cd \dev\ros2_{DISTRO}
+       curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
 
 Update your repositories
@@ -96,12 +96,12 @@ You should now be able to download the sources associated with the new repositor
     .. code-block:: bash
 
        # CMD
-       > vcs import src < ros2.repos
-       > vcs pull src
+       vcs import src < ros2.repos
+       vcs pull src
 
        # PowerShell
-       > vcs import --input ros2.repos src
-       > vcs pull src
+       vcs import --input ros2.repos src
+       vcs pull src
 
 Rebuild your workspace
 ----------------------
@@ -138,7 +138,7 @@ If you wish to know the versions of the set of repositories in your workspace, y
 
     .. code-block:: bash
 
-       > cd \dev\ros2_{DISTRO}
-       > vcs export src > my_ros2.repos
+       cd \dev\ros2_{DISTRO}
+       vcs export src > my_ros2.repos
 
 This ``my_ros2.repos`` file can then be shared with others so that they can reproduce the state of the repositories in your workspace.

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -32,7 +32,7 @@ Install additional prerequisites from Chocolatey
 
 .. code-block:: bash
 
-   > choco install -y cppcheck curl git winflexbison3
+   choco install -y cppcheck curl git winflexbison3
 
 You will need to append the Git cmd folder ``C:\Program Files\Git\cmd`` to the PATH (you can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".
 In the resulting dialog, click "Environment Variables", the click "Path" on the bottom pane, then click "Edit" and add the path).
@@ -45,7 +45,7 @@ Installing additional Python dependencies:
 
 .. code-block:: bash
 
-   > pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock mypy==0.761 pep8 pydocstyle pytest pytest-mock vcstool
+   pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock mypy==0.761 pep8 pydocstyle pytest pytest-mock vcstool
 
 Install miscellaneous prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,28 +65,28 @@ First setup a development folder, for example ``C:\dev\ros2_{DISTRO}``:
 
 .. code-block:: bash
 
-   > md \dev\ros2_{DISTRO}\src
-   > cd \dev\ros2_{DISTRO}
+   md \dev\ros2_{DISTRO}\src
+   cd \dev\ros2_{DISTRO}
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
 .. code-block:: bash
 
    # CMD
-   > curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+   curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
    # PowerShell
-   > curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+   curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
 
 .. code-block:: bash
 
    # CMD
-   > vcs import src < ros2.repos
+   vcs import src < ros2.repos
 
    # PowerShell
-   > vcs import --input ros2.repos src
+   vcs import --input ros2.repos src
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +106,7 @@ To build the ``\dev\ros2_{DISTRO}`` folder tree:
 
 .. code-block:: bash
 
-   > colcon build --merge-install
+   colcon build --merge-install
 
 .. note::
 
@@ -125,7 +125,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2_{DISTRO}\install\local_setup.bat
+   call C:\dev\ros2_{DISTRO}\install\local_setup.bat
 
 This will automatically set up the environment for any DDS vendors that support was built for.
 
@@ -140,7 +140,7 @@ You can run the tests using this command:
 
 .. code-block:: bash
 
-   > colcon test --merge-install
+   colcon test --merge-install
 
 .. note::
 
@@ -150,22 +150,22 @@ Afterwards you can get a summary of the tests using this command:
 
 .. code-block:: bash
 
-   > colcon test-result
+   colcon test-result
 
 To run the examples, first open a clean new ``cmd.exe`` and set up the workspace by sourcing the ``local_setup.bat`` file.
 Then, run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   > call install\local_setup.bat
-   > ros2 run demo_nodes_cpp talker
+   call install\local_setup.bat
+   ros2 run demo_nodes_cpp talker
 
 In a separate shell you can do the same, but instead run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   > call install\local_setup.bat
-   > ros2 run demo_nodes_py listener
+   call install\local_setup.bat
+   ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
 This verifies both the C++ and Python APIs are working properly.
@@ -200,14 +200,14 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
 .. code-block:: bash
 
-   > choco install -y peazip
+   choco install -y peazip
 
 
 * You'll also need SVN, since some of the Python source-build dependencies are checked out via SVN:
 
 .. code-block:: bash
 
-   > choco install -y svn hg
+   choco install -y svn hg
 
 
 * You'll need to quit and restart the command prompt after installing the above.
@@ -220,59 +220,55 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
 .. code-block:: bash
 
-   > cd C:\dev\Python-3.8.3\PCbuild
-   > get_externals.bat
-   > build.bat -p x64 -d
+   cd C:\dev\Python-3.8.3\PCbuild
+   get_externals.bat
+   build.bat -p x64 -d
 
 
 * Finally, copy the build products into the Python38 installation directories, next to the Release-mode Python executable and DLL's:
 
 .. code-block:: bash
 
-   > cd C:\dev\Python-3.8.3\PCbuild\amd64
-   > copy python_d.exe C:\Python38 /Y
-   > copy python38_d.dll C:\Python38 /Y
-   > copy python3_d.dll C:\Python38 /Y
-   > copy python38_d.lib C:\Python38\libs /Y
-   > copy python3_d.lib C:\Python38\libs /Y
-   > for %I in (*_d.pyd) do copy %I C:\Python38\DLLs /Y
+   cd C:\dev\Python-3.8.3\PCbuild\amd64
+   copy python_d.exe C:\Python38 /Y
+   copy python38_d.dll C:\Python38 /Y
+   copy python3_d.dll C:\Python38 /Y
+   copy python38_d.lib C:\Python38\libs /Y
+   copy python3_d.lib C:\Python38\libs /Y
+   for %I in (*_d.pyd) do copy %I C:\Python38\DLLs /Y
 
 
 * Now, from a fresh command prompt, make sure that ``python_d`` works:
 
 .. code-block:: bash
 
-   > python_d
-   > import _ctypes
+   python_d -c "import _ctypes"
 
 * Once you have verified the operation of ``python_d``, it is necessary to reinstall a few dependencies with the debug-enabled libraries:
 
 .. code-block:: bash
 
-   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.18.4-cp38-cp38d-win_amd64.whl
-   > python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.5.1-cp38-cp38d-win_amd64.whl
+   python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/numpy-archives/numpy-1.18.4-cp38-cp38d-win_amd64.whl
+   python_d -m pip install --force-reinstall https://github.com/ros2/ros2/releases/download/lxml-archives/lxml-4.5.1-cp38-cp38d-win_amd64.whl
 
 * To verify the installation of these dependencies:
 
 .. code-block:: bash
 
-   > python_d
-   # No import errors should appear when executing the following lines
-   > from lxml import etree
-   > import numpy
+   python_d -c "from lxml import etree ; import numpy"
 
 * When you wish to return to building release binaries, it is necessary to uninstall the debug variants and use the release variants:
 
 .. code-block:: bash
 
-   > python -m pip uninstall numpy lxml
-   > python -m pip install numpy lxml
+   python -m pip uninstall numpy lxml
+   python -m pip install numpy lxml
 
 * To create executables python scripts(.exe), python_d should be used to invoke colcon
 
 .. code-block:: bash
 
-   > python_d path\to\colcon_executable build
+   python_d path\to\colcon_executable build
 
 * Hooray, you're done!
 
@@ -296,4 +292,4 @@ Uninstall
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_{DISTRO}
+      rmdir /s /q \ros2_{DISTRO}

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -47,7 +47,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2_{DISTRO}\local_setup.bat
+   call C:\dev\ros2_{DISTRO}\local_setup.bat
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 
@@ -58,13 +58,13 @@ In a command shell, set up the ROS 2 environment as described above and then run
 
 .. code-block:: bash
 
-   > ros2 run demo_nodes_cpp talker
+   ros2 run demo_nodes_cpp talker
 
 Start another command shell and run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   > ros2 run demo_nodes_py listener
+   ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
 This verifies both the C++ and Python APIs are working properly.
@@ -99,4 +99,4 @@ Uninstall
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_{DISTRO}
+      rmdir /s /q \ros2_{DISTRO}

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -17,7 +17,7 @@ Open a Command Prompt and type the following to install Python via Chocolatey:
 
 .. code-block:: bash
 
-   > choco install -y python --version 3.8.3
+   choco install -y python --version 3.8.3
 
 Install Visual C++ Redistributables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ Open a Command Prompt and type the following to install them via Chocolatey:
 
 .. code-block:: bash
 
-   > choco install -y vcredist2013 vcredist140
+   choco install -y vcredist2013 vcredist140
 
 Install OpenSSL
 ^^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ As some chocolatey packages rely on it, we start by installing CMake
 
 .. code-block:: bash
 
-   > choco install -y cmake
+   choco install -y cmake
 
 You will need to append the CMake bin folder ``C:\Program Files\CMake\bin`` to your PATH.
 
@@ -115,7 +115,7 @@ Once these packages are downloaded, open an administrative shell and execute the
 
 .. code-block:: bash
 
-   > choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
+   choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
 
 Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 
@@ -149,8 +149,8 @@ Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` where you i
 
 .. code-block:: bash
 
-   > set Qt5_DIR=C:\Qt\5.15.0\msvc2019_64
-   > set QT_QPA_PLATFORM_PLUGIN_PATH=C:\Qt\5.15.0\msvc2019_64\plugins\platforms
+   set Qt5_DIR=C:\Qt\5.15.0\msvc2019_64
+   set QT_QPA_PLATFORM_PLUGIN_PATH=C:\Qt\5.15.0\msvc2019_64\plugins\platforms
 
 You could set it permanently with ``setx -m Qt5_DIR C:\Qt\5.15.0\msvc2019_64`` and ``setx -m QT_QPA_PLATFORM_PLUGIN_PATH C:\Qt\5.15.0\msvc2019_64\plugins\platforms`` instead, but that requires Administrator.
 


### PR DESCRIPTION
It makes the Windows installation/building instructions a bit more uniform.