### PR TITLE
Fix the branch used for the ros_tutorials repository.

### DIFF
--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -126,13 +126,7 @@ In the ``dev_ws/src`` directory, run the following command for the distro you're
 
 .. code-block:: console
 
-  git clone https://github.com/ros/ros_tutorials.git -b rolling-devel
-
-For example, if you're using Foxy:
-
-.. code-block:: console
-
-  git clone https://github.com/ros/ros_tutorials.git -b foxy-devel
+  git clone https://github.com/ros/ros_tutorials.git -b galactic-devel
 
 Now ``ros_tutorials`` is cloned in your workspace.
 If you view the contents of ``dev_ws/src`` now, you will see the new ``ros_tutorials`` directory.


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>