### PR TITLE
Include instructions for enabling Ubuntu Universe

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -1,12 +1,29 @@
-You will need to add the ROS 2 apt repositories to your system.
-To do so, first authorize our GPG key with apt like this:
+You will need to add the ROS 2 apt repository to your system.
+Make sure the `Ubuntu Universe repository <https://help.ubuntu.com/community/Repositories/Ubuntu>`_ is enabled first by checking the output of this command.
+
+.. code-block:: bash
+
+       $ apt-cache policy | grep universe
+        500 http://us.archive.ubuntu.com/ubuntu focal/universe amd64 Packages
+            release v=20.04,o=Ubuntu,a=focal,n=focal,l=Ubuntu,c=universe,b=amd64
+
+If you don't see output like the above, then enable the Universe repository with these instructions.
+
+.. code-block:: bash
+
+       sudo apt install software-properties-common
+       sudo add-apt-repository universe
+
+
+Now add the ROS 2 apt repository to your system.
+First authorize our GPG key with apt.
 
 .. code-block:: bash
 
    sudo apt update && sudo apt install curl gnupg2 lsb-release
    sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
-And then add the repository to your sources list:
+Then add the repository to your sources list.
 
 .. code-block:: bash
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -20,7 +20,7 @@ First authorize our GPG key with apt.
 
 .. code-block:: bash
 
-   sudo apt update && sudo apt install curl gnupg2 lsb-release
+   sudo apt update && sudo apt install curl gnupg lsb-release
    sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 Then add the repository to your sources list.


### PR DESCRIPTION
I needed to enable the Universe repository before I could install ~`gnupg2`~ *any `ros-rolling-*` debian package* inside a container. This PR adds instructions for that.