### PR TITLE
.srv at end of ros2-interface-show is unnecessary

### DIFF
--- a/source/Tutorials/Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Services/Understanding-ROS2-Services.rst
@@ -167,13 +167,13 @@ You can call services from the command line, but first you need to know the stru
 
 .. code-block:: console
 
-  ros2 interface show <type_name>.srv
+  ros2 interface show <type_name>
 
 To run this command on the ``/clear`` service’s type, ``Empty``:
 
 .. code-block:: console
 
-  ros2 interface show std_srvs/srv/Empty.srv
+  ros2 interface show std_srvs/srv/Empty
 
 Which will return:
 


### PR DESCRIPTION
`ros2 interface show std_srvs/srv/Empty.srv` works, but the `.srv` at the end isn't necessary. `ros2 interface show std_srvs/srv/Empty` has the same output.