### PR TITLE
Fix the Windows Install Binary instructions.

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -57,10 +57,11 @@ Download the *Win64 OpenSSL v1.1.1k* OpenSSL installer from `this page <https://
 Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1k*.
 Don't download the Win32 or Light versions.
 
-Run the installer with default parameters.
-The following commands assume you used the default installation directory:
+Run the installer with default parameters, as the following commands assume you used the default installation directory.
 
-* ``setx -m OPENSSL_CONF C:\Program Files\OpenSSL-Win64\bin\openssl.cfg``
+This command sets an environment variable that persists over sessions:
+
+* ``setx -m OPENSSL_CONF "C:\Program Files\OpenSSL-Win64\bin\openssl.cfg"``
 
 You will need to append the OpenSSL-Win64 bin folder to your PATH.
 You can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".


### PR DESCRIPTION
In particular, you *must* have quotes around the setx command
(as it contains spaces).  Also make the language more similar
to the Foxy language.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>