### PR TITLE
Add missing rqt dependencies on Windows

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -184,7 +184,7 @@ RQt dependencies
 
 .. code-block:: bash
 
-   python -m pip install -U pydot PyQt5
+   python -m pip install -U pydot PyQt5 pyqtgraph psutil
 
 .. _Rolling_windows-install-binary-installing-rqt-dependencies:
 

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -184,7 +184,7 @@ RQt dependencies
 
 .. code-block:: bash
 
-   python -m pip install -U pydot PyQt5 pyqtgraph psutil
+   python -m pip install -U pydot PyQt5 matplotlib psutil
 
 .. _Rolling_windows-install-binary-installing-rqt-dependencies:
 


### PR DESCRIPTION
Precisely what the title says:

- Need `pyqtgraph` for `rqt_plot`
- Need `psutil` for `rqt_top`

There are other choices for `rqt_plot`. Shall we list them too?