### PR TITLE
Add missing dependencies for rqt_top and rqt_plot on macOS

### DIFF
--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -116,7 +116,7 @@ You need the following things installed to build ROS 2:
         flake8-docstrings flake8-import-order flake8-quotes ifcfg \
         importlib-metadata lark-parser lxml mock mypy netifaces \
         nose pep8 pydocstyle pydot pygraphviz pyparsing \
-        pytest-mock rosdep setuptools vcstool
+        pytest-mock rosdep setuptools vcstool matplotlib psutil
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
 

--- a/source/Installation/macOS-Install-Binary.rst
+++ b/source/Installation/macOS-Install-Binary.rst
@@ -95,7 +95,7 @@ You need the following things installed before installing ROS 2.
 
   ``brew install graphviz``
 
-  ``python3 -m pip install pygraphviz pydot``
+  ``python3 -m pip install pygraphviz pydot matplotlib psutil``
 
   .. note::
 


### PR DESCRIPTION
Similar to https://github.com/ros2/ros2_documentation/pull/1351 but for macOS.

The following dependencies were missing:

* Need matplotlib for rqt_plot
* Need psutil for rqt_top