### PR TITLE
[cpp_pubsub] Improve instructions on Windows

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -71,9 +71,17 @@ Download the example talker code by entering the following command:
 
    .. group-tab:: Windows
 
-      Right click this link and select Save As ``publisher_member_function.cpp``:
+      In a Windows command line prompt:
 
-      https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp
+      .. code-block:: console
+
+            curl -sk https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp -o publisher_member_function.cpp
+
+      Or in powershell:
+
+      .. code-block:: console
+
+            curl https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp -o publisher_member_function.cpp
 
 Now there will be a new file named ``publisher_member_function.cpp``.
 Open the file using your preferred text editor.
@@ -309,9 +317,17 @@ Enter the following code in your terminal:
 
    .. group-tab:: Windows
 
-      Right click this link and select Save As ``subscriber_member_function.cpp``:
+      In a Windows command line prompt:
 
-      https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp
+      .. code-block:: console
+
+            curl -sk https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp -o subscriber_member_function.cpp
+
+      Or in powershell:
+
+      .. code-block:: console
+
+            curl https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp -o subscriber_member_function.cpp
 
 Entering ``ls`` in the console will now return:
 
@@ -436,9 +452,25 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
 Still in the root of your workspace, ``dev_ws``, build your new package:
 
-.. code-block:: console
+.. tabs::
 
-    colcon build --packages-select cpp_pubsub
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+      colcon build --packages-select cpp_pubsub
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+      colcon build --packages-select cpp_pubsub
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+      colcon build --merge-install --packages-select cpp_pubsub
 
 Open a new terminal, navigate to ``dev_ws``, and source the setup files:
 


### PR DESCRIPTION
Use `--merge-install` on Windows, for consistency with the "creating a workspace" tutorial.

Download files with curl.
[Curl is installed on Windows 10 by default!](https://techcommunity.microsoft.com/t5/containers/tar-and-curl-come-to-windows/ba-p/382409)