### PR TITLE
Rolling has no converter package

### DIFF
--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -32,7 +32,6 @@ If you've installed from Debians on Linux and your system doesn’t recognize th
 .. code-block:: console
 
   sudo apt-get install ros-rolling-ros2bag \
-                       ros-rolling-rosbag2-converter-default-plugins \
                        ros-rolling-rosbag2-storage-default-plugins
 
 This tutorial talks about concepts covered in previous tutorials, like :ref:`nodes <ROS2Nodes>` and :ref:`topics <ROS2Topics>`.


### PR DESCRIPTION
This command fails with `Unable to locate package ros-rolling-rosbag2-converter-default-plugins`. There does not seem to be such a package on Rolling, and the rest of the tutorial works fine without it.