### PR TITLE
Update required versions of bloom and catkin_pkg.

### DIFF
--- a/source/Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -18,8 +18,8 @@ This page describes how to prepare a repository for release on the public ROS 2 
 Required Tools
 --------------
 
-* ``bloom`` >= 0.9.7
-* ``catkin_pkg`` >= 0.4.10
+* ``bloom`` >= 0.10.7
+* ``catkin_pkg`` >= 0.4.23
 
 Ensure that you have the latest version of bloom and catkin_pkg
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The latest versions of ROS 2 (Rolling and soon-to-be Galactic as of
writing) require updated versions of bloom to be properly released.
There's nothing strictly required about the current catkin_pkg version
but there are numerous fixes for package conditions that are probably
soft-required for things to work now anyways.