### PR TITLE
Start a draft for an Ament Python guide.

### DIFF
--- a/source/Guides/Ament-Python-Documentation.rst
+++ b/source/Guides/Ament-Python-Documentation.rst
@@ -1,0 +1,18 @@
+ament_python user documentation
+===============================
+
+ament_python is the name of the Python build type for ROS 2.
+ament_python packages are "pure" Python packages which create resources for the ament package index.
+
+Unlike in ROS 1, most Python packages in ROS 2 can use the standard python build tools.
+Colcon will use setuptools to build and install ament_python packages and bloom will create templates that use the
+respective standard platform-specific tools for building python packages when generating package metadata for the ROS build farm.
+
+Although ament_python packages use the standard ``setup.py`` for build and installation, ament_python packages must also include a
+``package.xml`` file.
+An unfortunate effect of this is that both ``package.xml`` and ``setup.py`` may contain some duplicated information if you want both package systems to accurately report information about installed packages.
+You may wish to create a minimal setup.py and describe package metadata and dependency information only in your ``package.xml`` file.
+That will be sufficient for building with Colcon and on the ROS build farm but may not be sufficient to build individual Python packages directly.
+
+Compiled extensions to Python packages are not supported by Colcon and are untested on the ROS build farm.
+When building Python packages with native extensions it is recommended to switch to the Ament CMake build system and use the ``ament_python_install_package`` helper.


### PR DESCRIPTION
This is very much a work in progress and is littered with implicit
TODOs in addition to lacking much organization.

I started by trying to jot down as many major questions or known
limitations of ament_python packages as I could think of.

I'm going to keep iterating on this as a draft but if anyone else would
like to throw on extra info I invite anyone on the team to toss a few
commits on the branch.

@sloretz do you have suggestions for exemplary ament_cmake packages containing python extensions? I have always used rclpy but I'm not sure if it has become "special" either due to the pybind11 work or by being the rcl binding for the language rather than an application package which builds python extensions.