### PR TITLE
Remove args=None because it does nothing

### DIFF
--- a/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
@@ -108,8 +108,8 @@ Inside the ``dev_ws/src/py_srvcli/py_srvcli`` directory, create a new file calle
           return response
 
 
-  def main(args=None):
-      rclpy.init(args=args)
+  def main():
+      rclpy.init()
 
       minimal_service = MinimalService()
 
@@ -195,8 +195,8 @@ Inside the ``dev_ws/src/py_srvcli/py_srvcli`` directory, create a new file calle
           self.future = self.cli.call_async(self.req)
 
 
-  def main(args=None):
-      rclpy.init(args=args)
+  def main():
+      rclpy.init()
 
       minimal_client = MinimalClientAsync()
       minimal_client.send_request()


### PR DESCRIPTION
`setuptools` does not pass an argument `args` to a `console_scripts` entry point, so the local variable `args` in `main()` is always `None`. The only way to get arguments is `sys.argv`, which [`rclpy.Context.init` and therefor `rclpy.init` does already](https://github.com/ros2/rclpy/blob/2bb0a8065d437668b145a71c165193365b116312/rclpy/rclpy/context.py#L69). Since the `args` keyword argument will never have an affect, this PR removes it from the Service/Client Python tutorial

```
def main(args=None):
    rclpy.init(args=args)
```

is the same as

```
def main():
    rclpy.init(args=None)
```

which [is also the same as](https://github.com/ros2/rclpy/blob/2bb0a8065d437668b145a71c165193365b116312/rclpy/rclpy/__init__.py#L64)

```
def main():
    rclpy.init()
```