### PR TITLE
[dashing] Fix some references to foxy that should be dashing

### DIFF
--- a/source/Concepts/About-Client-Interfaces.rst
+++ b/source/Concepts/About-Client-Interfaces.rst
@@ -33,7 +33,7 @@ The ROS Client Library for C++ (``rclcpp``) is the user facing, C++ idiomatic in
 The ``rclcpp`` repository is located on |GitHub|_ at `ros2/rclcpp <https://github.com/ros2/rclcpp>`_ and contains the |package| ``rclcpp``.
 The generated |API| documentation is here:
 
-`api/rclcpp/index.html <http://docs.ros2.org/foxy/api/rclcpp/index.html>`_
+`api/rclcpp/index.html <http://docs.ros2.org/dashing/api/rclcpp/index.html>`_
 
 The ``rclpy`` Package
 ~~~~~~~~~~~~~~~~~~~~~
@@ -51,4 +51,4 @@ The ``rclpy`` repository is located on |GitHub|_ at `ros2/rclpy <https://github.
 The generated |API| documentation is here:
 
 
-`api/rclpy/index.html <http://docs.ros2.org/foxy/api/rclpy/index.html>`_
+`api/rclpy/index.html <http://docs.ros2.org/dashing/api/rclpy/index.html>`_

--- a/source/Concepts/About-Internal-Interfaces.rst
+++ b/source/Concepts/About-Internal-Interfaces.rst
@@ -123,7 +123,7 @@ The ``rcl`` |API| is located in the `ros2/rcl <https://github.com/ros2/rcl>`_ re
 The ``rcl`` C implementation is provided by the ``rcl`` |package| in the same repository.
 This implementation avoids direct contact with the middleware by instead using the ``rmw`` and ``rosidl`` |APIs|.
 
-For a complete definition of the ``rcl`` |API|, see its `API documentation <http://docs.ros2.org/foxy/api/rcl/index.html>`_:
+For a complete definition of the ``rcl`` |API|, see its `API documentation <http://docs.ros2.org/dashing/api/rcl/index.html>`_:
 
 The ``rmw`` Repository
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -137,7 +137,7 @@ The ``rmw`` |package| contains the C headers which define the interface, the imp
 
 For a definition of the ``rmw`` |API|, see the |API| docs:
 
-`api/rmw/index.html <http://docs.ros2.org/foxy/api/rmw/index.html>`_
+`api/rmw/index.html <http://docs.ros2.org/dashing/api/rmw/index.html>`_
 
 
 The ``rosidl`` Repository
@@ -189,4 +189,4 @@ These are mainly used for error handling, commandline argument parsing, and logg
 
 The ``rcutils`` |API| and implementation are located in the `ros2/rcutils <https://github.com/ros2/rcutils>`_ repository on |GitHub|_ which contains the interface as C headers.
 
-For a complete definition of the ``rcutils`` |API|, see `its API documentation <http://docs.ros2.org/foxy/api/rcutils/index.html>`_
+For a complete definition of the ``rcutils`` |API|, see `its API documentation <http://docs.ros2.org/dashing/api/rcutils/index.html>`_

--- a/source/Guides/Using-Python-Packages.rst
+++ b/source/Guides/Using-Python-Packages.rst
@@ -86,8 +86,8 @@ Now you can build your workspace and run your python node that depends on packag
 
 .. code-block:: console
 
-    # Source Foxy and build
-    source /opt/ros/foxy/setup.bash
+    # Source Dashing and build
+    source /opt/ros/dashing/setup.bash
     colcon build
 
 .. note::


### PR DESCRIPTION
While showing the docs to some people I noticed some foxy that should be dashing.