### PR TITLE
Put Foxy back as the latest version.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -117,7 +117,7 @@ smv_branch_whitelist = r'^(rolling|galactic|foxy|eloquent|dashing|crystal)$'
 
 smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(galactic|foxy|eloquent|dashing|crystal).*$'
 smv_remote_whitelist = r'^(origin)$'
-smv_latest_version = 'galactic'
+smv_latest_version = 'foxy'
 
 
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I made a mistake here and made Galactic the latest, which isn't true until the release date.  Put it back to Foxy for now.