### PR TITLE
Put all of the information about releases in conf.py.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -115,9 +115,10 @@ templates_path = [
 smv_branch_whitelist = r'^(rolling|galactic|foxy|eloquent|dashing|crystal)$'
 
 
-smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(galactic|foxy|eloquent|dashing|crystal).*$'
+smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(foxy|eloquent|dashing|crystal).*$'
 smv_remote_whitelist = r'^(origin)$'
 smv_latest_version = 'foxy'
+smv_eol_versions = ['crystal', 'eloquent']
 
 
 
@@ -256,8 +257,10 @@ def smv_rewrite_configs(app, config):
 def github_link_rewrite_branch(app, pagename, templatename, context, doctree):
     if app.config.smv_current_version != '':
         context['github_version'] = app.config.smv_current_version + '/source/'
+        context['eol_versions'] = app.config.smv_eol_versions
 
 def setup(app):
     app.connect('config-inited', smv_rewrite_configs)
     app.connect('html-page-context', github_link_rewrite_branch)
+    app.add_config_value('smv_eol_versions', [], 'html')
     RedirectFrom.register(app)

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -23,7 +23,7 @@
 {% if current_version and latest_version and current_version != latest_version %}
 <p>
   <strong>
-    {% if current_version.name|string() in ['eloquent', 'crystal'] %}
+    {% if current_version.name|string() in eol_versions %}
     You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% elif current_version.is_released %}

--- a/source/_templates/versions.html
+++ b/source/_templates/versions.html
@@ -11,7 +11,7 @@
       {%- for item in versions.releases|sort(reverse=True) %}
         {%- if item.name == latest_version.name %}
         <dd><a href="{{ item.url }}">{{ item.name|title }} (latest)</a></dd>
-        {%- elif item.name in ['eloquent', 'crystal'] %}
+        {%- elif item.name in eol_versions %}
         <dd><a href="{{ item.url }}">{{ item.name|title }} (EOL)</a></dd>
         {% else %}
         <dd><a href="{{ item.url }}">{{ item.name|title }}</a></dd>


### PR DESCRIPTION
Previously we had put some hard-coded lists of EOL distributions
in some page templates.  However, it is much better to have
all of the information about distributions in the configuration
file.  To support this, add in a new config variable 'smv_eol_versions'
that has a list of the EOL versions.  When in multiversion mode,
propagate this into the page context so that the pages can just
reference the variable.

Finally, while we are in here, take galactic out of the "released"
list until it is actually released.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>