### PR TITLE
Add installation steps for rosdistro, ros2doctor dependency

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -145,7 +145,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy ifcfg importlib-metadata lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools
+   python -m pip install -U catkin_pkg cryptography empy ifcfg importlib-metadata lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools rosdistro
 
 Install Qt5
 ^^^^^^^^^^^

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -145,7 +145,7 @@ You must also install some python dependencies for command-line tools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy ifcfg importlib-metadata lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml setuptools rosdistro
+   python -m pip install -U catkin_pkg cryptography empy ifcfg importlib-metadata lark-parser lxml netifaces numpy opencv-python pyparsing pyyaml rosdistro setuptools
 
 Install Qt5
 ^^^^^^^^^^^

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -116,7 +116,7 @@ You need the following things installed to build ROS 2:
         flake8-docstrings flake8-import-order flake8-quotes ifcfg \
         importlib-metadata lark-parser lxml mock mypy netifaces \
         nose pep8 pydocstyle pydot pygraphviz pyparsing \
-        pytest-mock rosdep setuptools vcstool matplotlib psutil
+        pytest-mock rosdep setuptools vcstool matplotlib psutil rosdistro
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
 

--- a/source/Installation/macOS-Install-Binary.rst
+++ b/source/Installation/macOS-Install-Binary.rst
@@ -85,6 +85,11 @@ You need the following things installed before installing ROS 2.
        brew install cunit
 
 *
+  Install ros2 doctor dependencies
+
+  ``python3 -m pip install rosdistro``
+
+*
   Install rqt dependencies
 
   ``brew install sip pyqt5``


### PR DESCRIPTION
Some of the ros2doctor plugins requires rosdistro, see https://github.com/ros2/ros2cli/pull/631.
I have only tried this on Windows, but I guess it works on macOS as well.