### PR TITLE
Update the list of available command line tools

### DIFF
--- a/source/Concepts/About-Command-Line-Tools.rst
+++ b/source/Concepts/About-Command-Line-Tools.rst
@@ -26,10 +26,14 @@ To see all available sub-commands run:
 Examples of sub-commands that are available include:
 
 
+* action Introspect/interact with ROS actions
+* bag Record/play a rosbag
+* component Manage component containers
 * daemon: Introspect/configure the ROS 2 daemon
-* launch: Run a launch file
+* doctor: Check ROS setup for potential issues
+* interface:  Show information about ROS interfaces
+* launch: Run/introspect a launch file
 * lifecycle: Introspect/manage nodes with managed lifecycles
-* msg: Introspect ``msg`` types
 * node: Introspect ROS nodes
 * param: Introspect/configure parameters on a node
 * pkg: Introspect ROS packages
@@ -37,6 +41,7 @@ Examples of sub-commands that are available include:
 * security: Configure security settings
 * service: Introspect/call ROS services
 * srv: Introspect ``srv`` types
+* test: Run a ROS launch test
 * topic: Introspect/publish ROS topics
 
 Example

--- a/source/Concepts/About-Command-Line-Tools.rst
+++ b/source/Concepts/About-Command-Line-Tools.rst
@@ -43,6 +43,7 @@ Examples of sub-commands that are available include:
 * srv: Introspect ``srv`` types
 * test: Run a ROS launch test
 * topic: Introspect/publish ROS topics
+* trace: Tracing tools to get information on ROS nodes execution (only available on Linux)
 
 Example
 -------

--- a/source/Concepts/About-Command-Line-Tools.rst
+++ b/source/Concepts/About-Command-Line-Tools.rst
@@ -26,9 +26,9 @@ To see all available sub-commands run:
 Examples of sub-commands that are available include:
 
 
-* action Introspect/interact with ROS actions
-* bag Record/play a rosbag
-* component Manage component containers
+* action: Introspect/interact with ROS actions
+* bag: Record/play a rosbag
+* component: Manage component containers
 * daemon: Introspect/configure the ROS 2 daemon
 * doctor: Check ROS setup for potential issues
 * interface:  Show information about ROS interfaces

--- a/source/Concepts/About-Command-Line-Tools.rst
+++ b/source/Concepts/About-Command-Line-Tools.rst
@@ -31,7 +31,7 @@ Examples of sub-commands that are available include:
 * component: Manage component containers
 * daemon: Introspect/configure the ROS 2 daemon
 * doctor: Check ROS setup for potential issues
-* interface:  Show information about ROS interfaces
+* interface: Show information about ROS interfaces
 * launch: Run/introspect a launch file
 * lifecycle: Introspect/manage nodes with managed lifecycles
 * node: Introspect ROS nodes


### PR DESCRIPTION
`ros2 msg` isn't available anymore, replace it with `ros2 interface`.

I have also added: action, bag, component, doctor, launch, test.

The following are also available, but I haven't listed them for different reasons:

* ros2 multicast: It allows you to send/receive multicast messages.
  IIUC it was mainly intended as a debugging tool, but it's not really ros2 related and it isn't worth adding to the list.
  I also think `ros2 doctor hello` provides similar debugging functionality.
* ros2 wtf: Alias of `ros2 doctor`.
* ros2 trace: "too niche", I can list it here though.