### PR TITLE
Fix override qos policies rosbag guide

### DIFF
--- a/source/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
+++ b/source/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
@@ -71,7 +71,7 @@ ROS2 publishers by default request ``volatile`` Durability.
 
 .. code-block:: console
 
-    ros2 topic pub /talker std_msgs/String "data: Hello World"
+    ros2 topic pub -r 0.1 --qos-durability transient_local /talker std_msgs/String "data: Hello World"
 
 In order for Ros2Bag to record the data, we would want to override the recording policy for that specific topic like so:
 
@@ -79,7 +79,7 @@ In order for Ros2Bag to record the data, we would want to override the recording
 
     # durability_override.yaml
     /talker:
-      durability: volatile
+      durability: transient_local
       history: keep_all
 
 And call it from the CLI:

--- a/source/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
+++ b/source/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
@@ -79,7 +79,7 @@ In order for Ros2Bag to record the data, we would want to override the recording
 
     # durability_override.yaml
     /talker:
-      durability: transient_local
+      durability: volatile
       history: keep_all
 
 And call it from the CLI:


### PR DESCRIPTION
The subscriber cannot have "transient local" durability, if not it will not be compatible with the publisher above.