### PR TITLE
Add back the anchor for the Windows binary installation.

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -18,6 +18,8 @@ System requirements
 
 Only Windows 10 is supported.
 
+.. _windows-install-binary-installing-prerequisites:
+
 .. include:: _Windows-Install-Prerequisites.rst
 
 Downloading ROS 2


### PR DESCRIPTION
This anchor is used elsewhere in the instructions, so we need
to maintain it here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>