### PR TITLE
Add libeigen3-dev to the required packages.

### DIFF
--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -47,6 +47,7 @@ Install development tools and ROS tools
      cmake \
      git \
      libbullet-dev \
+     libeigen3-dev \
      python3-colcon-common-extensions \
      python3-flake8 \
      python3-pip \


### PR DESCRIPTION
The Eigen3 library is now required for ROS2 (specifically orocos_kdl), so adding it to the list of packages to install.