### PR TITLE
Add a guide for using and creating variant packages.

### DIFF
--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -40,6 +40,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/Package-maintainer-guide
    How-To-Guides/Building-a-Custom-Debian-Package
    How-To-Guides/Topics-Services-Actions
+   How-To-Guides/Using-Variants
 
 .. toctree::
   :hidden:

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -1,0 +1,34 @@
+Using variants
+==============
+
+Variants, refered to as "metapackages" in ROS 1 are packages which provide no functionality directly but depend on a specified set of ROS packages in order to provide a convenient installation mechansim for the entire group of packages at once.
+
+The different variants in ROS 2 are specified in [REP-2001](https://ros.org/reps/rep-2001.html).
+
+In addition to the official variants, there may be metapackages for specific institutions or robots as described in [REP-108](https://www.ros.org/reps/rep-0108.html#institution-specific).
+
+Adding variants
+---------------
+
+Additional variants that are of general use to the ROS community can be proposed by contributing an update to [REP-2001 via pull request](https://github.com/ros-infrastructure/rep/blob/master/rep-2001.rst) describing the packages included in the new variant.
+Institution and robot specific variants can be published directly by their respective maintainers and no update to REP-2001 is required.
+
+Creating project-specific variants
+----------------------------------
+
+If you are creating ROS packages to use privately in your own projects, you can create variants specific to your projects using the official variants as examples.
+A minimal variant package is created as a package with the ``ament_cmake`` build type, a ``buildtool_depend`` on ``ament_cmake`` and ``exec_depend`` entries for each package you want to include in the variant.
+
+
+You can then build and install your variant package alongside your other private packages.
+
+Creating custom variants with platform-specific tools
+*****************************************************
+
+Some platforms have tools for creating basic packages that do not require a full ROS build farm environment or equivalent infrastructure.
+It is possible to use these tools to create platform-dependent variants.
+This approach does not include support for ROS packaging tools and is platform dependent but requires much less infrastructure to produce if you are creating collections of existing packages rather than a mix of public and private ROS packages.
+For example, on Debian or Ubuntu systems you can use the ``equivs`` utilities.
+The Debian Administrator's handbook has a `Section on meta-packages <https://www.debian.org/doc/manuals/debian-handbook/sect.building-first-package.en.html#id-1.18.5.2>`_.
+
+

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -17,10 +17,40 @@ Creating project-specific variants
 ----------------------------------
 
 If you are creating ROS packages to use privately in your own projects, you can create variants specific to your projects using the official variants as examples.
-A minimal variant package is created as a package with the ``ament_cmake`` build type, a ``buildtool_depend`` on ``ament_cmake`` and ``exec_depend`` entries for each package you want to include in the variant.
+To do so you need only create two files:
+
+#. A minimal variant package is created as a package with the ``ament_cmake`` build type, a ``buildtool_depend`` on ``ament_cmake`` and ``exec_depend`` entries for each package you want to include in the variant.
 
 
-You can then build and install your variant package alongside your other private packages.
+.. code-block:: xml
+  <?xml version="1.0"?>
+  <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+  <package format="2">
+    <name>my_project_variant</name>
+    <version>1.0.0</version>
+    <description>A package to aggregate all packages in my_project.</description>
+    <maintainer email="maintainer-email">Maintainer Name</maintainer>
+    <license>Apache License 2.0</license>
+    <!-- packages in my_project -->
+    <exec_depend>my_project_msgs</exec_depend>
+    <exec_depend>my_project_services</exec_depend>
+    <exec_depend>my_project_examples</exec_depend>
+
+    <export>
+      <build_type>ament_cmake</build_type>
+    </export>
+  </package>
+
+#. A minimal ament_cmake package includes a ``CMakeLists.txt`` which registers the package.xml as an ament package for use in ROS 2.
+
+.. code-block:: CMakeLists.txt
+  cmake_minimum_required(VERSION 3.5)
+
+  project(my_project_variant NONE)
+  find_package(ament_cmake REQUIRED)
+  ament_package()
+
+#. You can then build and install your variant package alongside your other private packages.
 
 Creating custom variants with platform-specific tools
 *****************************************************

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -23,6 +23,7 @@ To do so you need only create two files:
 
 
 .. code-block:: xml
+
   <?xml version="1.0"?>
   <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
   <package format="2">
@@ -44,6 +45,7 @@ To do so you need only create two files:
 #. A minimal ament_cmake package includes a ``CMakeLists.txt`` which registers the package.xml as an ament package for use in ROS 2.
 
 .. code-block:: CMakeLists.txt
+
   cmake_minimum_required(VERSION 3.5)
 
   project(my_project_variant NONE)

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -1,7 +1,11 @@
 Using variants
 ==============
 
-Variants, referred to as "metapackages" in ROS 1 are packages which provide no functionality directly but depend on a specified set of ROS packages in order to provide a convenient installation mechanism for the entire group of packages at once.
+Metapackages do not provide software directly but depend on a group of other related packages to provide a convienent installation mechanism for the complete group of packages. [#]_ [#]_
+Variants are a list of official metapackages for commonly useful groups of ROS packages.
+
+.. [#] https://wiki.debian.org/metapackage
+.. [#] https://help.ubuntu.com/community/MetaPackages
 
 The different variants in ROS 2 are specified in `REP-2001 <https://ros.org/reps/rep-2001.html>`_.
 

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -3,14 +3,14 @@ Using variants
 
 Variants, refered to as "metapackages" in ROS 1 are packages which provide no functionality directly but depend on a specified set of ROS packages in order to provide a convenient installation mechansim for the entire group of packages at once.
 
-The different variants in ROS 2 are specified in [REP-2001](https://ros.org/reps/rep-2001.html).
+The different variants in ROS 2 are specified in `REP-2001 <https://ros.org/reps/rep-2001.html>`_.
 
-In addition to the official variants, there may be metapackages for specific institutions or robots as described in [REP-108](https://www.ros.org/reps/rep-0108.html#institution-specific).
+In addition to the official variants, there may be metapackages for specific institutions or robots as described in `REP-108 <(https://www.ros.org/reps/rep-0108.html#institution-specific>`_.
 
 Adding variants
 ---------------
 
-Additional variants that are of general use to the ROS community can be proposed by contributing an update to [REP-2001 via pull request](https://github.com/ros-infrastructure/rep/blob/master/rep-2001.rst) describing the packages included in the new variant.
+Additional variants that are of general use to the ROS community can be proposed by contributing an update to `REP-2001 via pull request <https://github.com/ros-infrastructure/rep/blob/master/rep-2001.rst>`_ describing the packages included in the new variant.
 Institution and robot specific variants can be published directly by their respective maintainers and no update to REP-2001 is required.
 
 Creating project-specific variants

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -44,7 +44,7 @@ To do so you need only create two files:
 
 #. A minimal ament_cmake package includes a ``CMakeLists.txt`` which registers the package.xml as an ament package for use in ROS 2.
 
-.. code-block:: CMakeLists.txt
+.. code-block:: cmake
 
   cmake_minimum_required(VERSION 3.5)
 

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -66,4 +66,3 @@ It is possible to use these tools to create platform-dependent variants.
 This approach does not include support for ROS packaging tools and is platform dependent but requires much less infrastructure to produce if you are creating collections of existing packages rather than a mix of public and private ROS packages.
 For example, on Debian or Ubuntu systems you can use the ``equivs`` utilities.
 The Debian Administrator's handbook has a `Section on meta-packages <https://www.debian.org/doc/manuals/debian-handbook/sect.building-first-package.en.html#id-1.18.5.2>`_.
-

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -1,7 +1,7 @@
 Using variants
 ==============
 
-Variants, refered to as "metapackages" in ROS 1 are packages which provide no functionality directly but depend on a specified set of ROS packages in order to provide a convenient installation mechansim for the entire group of packages at once.
+Variants, referred to as "metapackages" in ROS 1 are packages which provide no functionality directly but depend on a specified set of ROS packages in order to provide a convenient installation mechanism for the entire group of packages at once.
 
 The different variants in ROS 2 are specified in `REP-2001 <https://ros.org/reps/rep-2001.html>`_.
 
@@ -62,5 +62,4 @@ It is possible to use these tools to create platform-dependent variants.
 This approach does not include support for ROS packaging tools and is platform dependent but requires much less infrastructure to produce if you are creating collections of existing packages rather than a mix of public and private ROS packages.
 For example, on Debian or Ubuntu systems you can use the ``equivs`` utilities.
 The Debian Administrator's handbook has a `Section on meta-packages <https://www.debian.org/doc/manuals/debian-handbook/sect.building-first-package.en.html#id-1.18.5.2>`_.
-
 


### PR DESCRIPTION
Following up from ros2/variants#33 this adds a minimal document linking to the descriptions for official variant packages and guidelines for creating institution- or robot-specific variants as well as how to create variants for private use using both ROS tools and a tool called `equivs` for Debian and Ubuntu.

Rendered deployment: https://ros2-documentation-pr-1459.herokuapp.com/Guides/Using-Variants.html