### PR TITLE
remove sphinx-tabs from deprecated version of the site

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -72,7 +72,7 @@ pygments_style = 'sphinx'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-extensions = ['sphinx.ext.intersphinx', 'sphinx_tabs.tabs']
+extensions = ['sphinx.ext.intersphinx']
 
 # Intersphinx mapping
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pip
 sphinx
-sphinx-tabs


### PR DESCRIPTION
our fork is out of date and it's breaking the backwards compatibility doc_rosindex build. removing it is easier than fixing it, and we don't need to worry about it in the future.

