### PR TITLE
TSC Charter Amendment: abolish membership cap

### DIFF
--- a/source/Governance/ROS2-TSC-Charter.rst
+++ b/source/Governance/ROS2-TSC-Charter.rst
@@ -61,8 +61,8 @@ The TSC cannot compel or oblige any action on the part of a member, his or her o
 
 #. TSC membership is not time-limited.
 
-#. The size of the TSC is limited to **30 members**.
-   This limit may be changed by the TSC via a standard TSC motion and vote.
+#. There is no maximum size for the TSC.
+   A size limit may be established by the TSC via a standard TSC motion and vote.
 
 #. The TSC may add additional members to the TSC by a standard TSC motion and vote.
    When considering the addition of a new member, the TSC is responsible for determining whether that potential member’s material contributions to the project are appropriate and sufficient to qualify for membership.


### PR DESCRIPTION
[Do not merge until I report the result of a TSC vote.]

Following a series of discussions within the TSC, there appears to be consensus on the idea of abolishing the membership size cap, with the goal of allowing as much participation as feasible. 