### PR TITLE
Fix "Subscriber count" -> "Subscription count"

### DIFF
--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -176,7 +176,7 @@ Which will return:
 
   Type: geometry_msgs/msg/Twist
   Publisher count: 1
-  Subscriber count: 2
+  Subscription count: 2
 
 6 ros2 interface show
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As pointed out by Erik Boasson, the latter is what is actually
printed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>