### PR TITLE
Fix rosidl generation CLI examples in Galactic release notes.

### DIFF
--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -107,8 +107,8 @@ it is easy to generate C, C++, and Python support source code:
 
 .. code-block:: bash
 
-  rosidl generate -o gen -t c -t cpp -t py -I$(ros2 pkg prefix --share std_msgs) \
-    -I$(ros2 pkg prefix --share geometry_msgs) demo msg/Demo.msg
+  rosidl generate -o gen -t c -t cpp -t py -I$(ros2 pkg prefix --share std_msgs)/.. \
+    -I$(ros2 pkg prefix --share geometry_msgs)/.. demo msg/Demo.msg
 
 Generated source code will be put in the ``gen`` directory.
 
@@ -116,8 +116,8 @@ One may also translate the message definition to a different format for a third-
 
 .. code-block:: bash
 
-  rosidl translate -o gen --to idl -I$(ros2 pkg prefix --share std_msgs) \
-    -I$(ros2 pkg prefix --share geometry_msgs) demo msg/Demo.msg
+  rosidl translate -o gen --to idl -I$(ros2 pkg prefix --share std_msgs)/.. \
+    -I$(ros2 pkg prefix --share geometry_msgs)/.. demo msg/Demo.msg
 
 The translated message definition will be put in the ``gen`` directory.
 


### PR DESCRIPTION
Follow-up after #1520. Share directory as returned by `ros2 pkg prefix --share <package-name>` is `.../share/<package-name>`, but includes in `.idl` files typically follow the `<package-name>/*/*.idl` pattern.

This didn't pop up before because there's no core `rosidl` generator plugin using these include paths (`rosidl_typesupport_connext` packages were).