### PR TITLE
Update Fast DDS information in ROS 2 documentation

### DIFF
--- a/source/Concepts/About-Different-Middleware-Vendors.rst
+++ b/source/Concepts/About-Different-Middleware-Vendors.rst
@@ -9,7 +9,7 @@ ROS 2 is built on top of DDS/RTPS as its middleware, which provides discovery, s
 `This article <https://design.ros2.org/articles/ros_on_dds.html>`__ explains the motivation behind using DDS implementations, and/or the RTPS wire protocol of DDS, in detail.
 In summary, DDS is an end-to-end middleware that provides features which are relevant to ROS systems, such as distributed discovery (not centralized like in ROS 1) and control over different "Quality of Service" options for the transportation.
 
-`DDS <https://www.omg.org/omg-dds-portal>`__ is an industry standard which is implemented by a range of vendors, such as RTI's `Connext DDS <https://www.rti.com/products/>`__, eProsima's `Fast-DDS <https://fast-dds.docs.eprosima.com/>`__, or Eclipse's `Cyclone DDS <https://projects.eclipse.org/projects/iot.cyclonedds>`__.
+`DDS <https://www.omg.org/omg-dds-portal>`__ is an industry standard which is implemented by a range of vendors, such as RTI's `Connext DDS <https://www.rti.com/products/>`__, eProsima's `Fast DDS <https://fast-dds.docs.eprosima.com/>`__, or Eclipse's `Cyclone DDS <https://projects.eclipse.org/projects/iot.cyclonedds>`__.
 RTPS (a.k.a. `DDSI-RTPS <https://www.omg.org/spec/DDSI-RTPS/About-DDSI-RTPS/>`__\ ) is the wire protocol used by DDS to communicate over the network.
 
 ROS 2 supports multiple DDS/RTPS implementations because it is not necessarily "one size fits all" when it comes to choosing a vendor/implementation.
@@ -52,7 +52,7 @@ The ROS 2 binary releases for currently active distros have built-in support for
 Since Galactic, the default is Cyclone DDS, which works without any additional installation steps, because we distribute it with our binary packages.
 Prior to Galactic, the default was Fast DDS, which works without any additional installation steps.
 
-Other RMWs like Fast-DDS or Connext can be enabled by `installing additional packages <../Installation/DDS-Implementations>`, but without having to rebuild anything or replace any existing packages.
+Other RMWs like Fast DDS or Connext can be enabled by `installing additional packages <../Installation/DDS-Implementations>`, but without having to rebuild anything or replace any existing packages.
 
 A ROS 2 workspace that has been built from source may build and install multiple RMW implementations simultaneously.
 While the core ROS 2 code is being compiled, any RMW implementation that is found will be built if the relevant DDS/RTPS implementation has been installed properly and the relevant environment variables have been configured.
@@ -61,9 +61,9 @@ For example, if the code for the `RMW package for RTI Connext DDS <https://githu
 For many cases you will find that nodes using different RMW implementations are able to communicate, however this is not true under all circumstances.
 Here is a list of inter-vendor communication configurations that are not supported:
 
-- Fast-DDS <-> Connext
+- Fast DDS <-> Connext
    - does not support communication over pub/sub
-   - ``WString`` published by Fast-DDS can't be received correctly by Connext on macOS
+   - ``WString`` published by Fast DDS can't be received correctly by Connext on macOS
 - OpenSplice <-> OpenSplice
    - does not support ``WString``
    - ``WString`` is mapped to ``String`` which has a different wire representation

--- a/source/Concepts/About-Middleware-Implementations.rst
+++ b/source/Concepts/About-Middleware-Implementations.rst
@@ -10,7 +10,7 @@ Common Packages for DDS Middleware Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All of the current ROS middleware implementations are based on full or partial DDS implementations.
-For example, there is a middleware implementation that uses RTI's Connext DDS and an implementation which uses eProsima's Fast-DDS.
+For example, there is a middleware implementation that uses RTI's Connext DDS and an implementation which uses eProsima's Fast DDS.
 Because of this, there are some shared |packages| amongst most DDS based middleware implementations.
 
 In the `ros2/rosidl_dds <https://github.com/ros2/rosidl_dds>`_ repository on |GitHub|_, there is the following |package|:
@@ -31,7 +31,7 @@ A ROS middleware implementation is typically made up of a few |packages| in a si
 
 The ``<implementation_name>_cmake_module`` |package| contains any CMake Modules and functions needed to find the supporting dependencies for the middleware implementation.
 For example, ``rti_connext_dds_cmake_module`` provides wrapper logic around the CMake Module shipped with RTI Connext DDS to make sure that all packages that depend on it will select the same installation of RTI Connext DDS.
-Similarly, ``fastrtps_cmake_module`` includes a CMake Module to find eProsima's Fast-DDS.
+Similarly, ``fastrtps_cmake_module`` includes a CMake Module to find eProsima's Fast DDS.
 Not all implementations will have a package like this: for example, Eclipe's Cyclone DDS already provides a CMake Module which is used directly by its RMW implementation without the need of additional wrappers.
 
 The ``rmw_<implementation_name>_<language>`` |package| implements the ``rmw`` C |API| in a particular language.
@@ -48,7 +48,7 @@ As such, rmw implementations may provide support for the X-Types standard, and/o
 
 As an example of an rmw implementation repository, the ``Eclipse Cyclone DDS`` ROS middleware implementation is on |GitHub|_ at `ros2/rmw_cyclonedds <https://github.com/ros2/rmw_cyclonedds>`_.
 
-The rmw implementation for ``Fast-DDS`` is on |GitHub|_ at `ros2/rmw_fastrtps_cpp <https://github.com/ros2/rmw_fastrtps_cpp>`_.
+The rmw implementation for ``Fast DDS`` is on |GitHub|_ at `ros2/rmw_fastrtps_cpp <https://github.com/ros2/rmw_fastrtps_cpp>`_.
 
 The rmw implementation for ``Connext DDS`` is on |GitHub|_ at `ros2/rmw_connextdds <https://github.com/ros2/rmw_connextdds>`_.
 

--- a/source/Installation/DDS-Implementations.rst
+++ b/source/Installation/DDS-Implementations.rst
@@ -3,13 +3,14 @@ Installing DDS implementations
 
 By default, ROS 2 uses DDS as its `middleware <https://design.ros2.org/articles/ros_on_dds.html>`__.
 It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
-There is currently support for eProsima's Fast RTPS, RTI's Connext DDS and Eclipse Cyclone DDS.
+There is currently support for eProsima's Fast DDS, RTI's Connext DDS and Eclipse Cyclone DDS.
 ADLINK's OpenSplice is no longer supported as of Foxy.
 See https://ros.org/reps/rep-2000.html for supported DDS vendors by distribution.
 
-For distros before Eloquent, the only bundled vendor is eProsima's Fast RTPS.
-Since Eloquent, both Fast RTPS and Cyclone DDS are bundled, but Fast RTPS is still the default.
+For distros before Eloquent, the only bundled vendor is eProsima's Fast DDS.
+Since Eloquent, both Fast DDS and Cyclone DDS are bundled, but Fast DDS is still the default.
 `Working with Eclipse Cyclone DDS <DDS-Implementations/Working-with-Eclipse-CycloneDDS>` explains how to utilize Cyclone DDS.
+`Working with eProsima Fast DDS <DDS-Implementations/Working-with-eProsima-Fast DDS>` explains how to utilize Fast DDS.
 
 .. toctree::
    :hidden:

--- a/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
@@ -1,0 +1,76 @@
+.. redirect-from::
+
+    Working-with-eProsima-Fast DDS
+
+Working with eProsima Fast DDS
+==============================
+
+eProsima Fast DDS is the most complete open-source DDS implementation for real time embedded architectures and
+operating systems.
+See also: https://www.eprosima.com/index.php/products-all/eprosima-fast-dds
+
+
+Prerequisites
+-------------
+
+Have `rosdep installed  <https://wiki.ros.org/rosdep#Installing_rosdep>`__
+
+Install packages
+----------------
+
+The easiest way is to install from ROS 2 apt repository.
+
+.. code-block:: bash
+
+   sudo apt install ros-galactic-rmw-fastrtps-cpp
+
+Build from source code
+----------------------
+
+Building from source code is also another way to install.
+
+First, clone Fast DDS and rmw_fastrtps in the ROS 2 workspace source directory.
+
+.. code-block:: bash
+
+   cd ros2_ws/src
+   git clone https://github.com/ros2/rmw_fastrtps ros2/rmw_fastrtps
+   git clone https://github.com/eProsima/Fast-DDS eProsima/fastrtps
+
+Then, install necessary packages for Fast DDS.
+
+.. code-block:: bash
+
+   cd ..
+   rosdep install --from src -i
+
+Finally, run colcon build.
+
+.. code-block:: bash
+
+   colcon build --symlink-install
+
+Switch to rmw_fastrtps
+------------------------
+
+Switch from other rmw to rmw_fastrtps by specifying the environment variable.
+
+.. code-block:: bash
+
+   export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+
+See also: `Working with multiple RMW implementations <../../Guides/Working-with-multiple-RMW-implementations>`
+
+Run the talker and listener
+---------------------------
+
+Now run ``talker`` and ``listener`` to test Fast DDS.
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp talker
+
+.. code-block:: bash
+
+   ros2 run demo_nodes_cpp listener
+

--- a/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
@@ -1,12 +1,7 @@
-.. redirect-from::
-
-    Working-with-eProsima-Fast DDS
-
 Working with eProsima Fast DDS
 ==============================
 
-eProsima Fast DDS is the most complete open-source DDS implementation for real time embedded architectures and
-operating systems.
+eProsima Fast DDS is a complete open-source DDS implementation for real time embedded architectures and operating systems.
 See also: https://www.eprosima.com/index.php/products-all/eprosima-fast-dds
 
 
@@ -51,9 +46,9 @@ Finally, run colcon build.
    colcon build --symlink-install
 
 Switch to rmw_fastrtps
-------------------------
+----------------------
 
-Switch from other rmw to rmw_fastrtps by specifying the environment variable.
+The eProsima Fast DDS RMW can be selected by specifying the environment variable:
 
 .. code-block:: bash
 

--- a/source/Releases/Galactic-Geochelone-Complete-Changelog.rst
+++ b/source/Releases/Galactic-Geochelone-Complete-Changelog.rst
@@ -3877,7 +3877,7 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * updating quality declaration links (re: `ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>`__) (`#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>`__)
-* Expose FastRTPS C typesupport generation via rosidl generate CLI (`#65 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/65>`__)
+* Expose Fast DDS C typesupport generation via rosidl generate CLI (`#65 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/65>`__)
 * Update QDs with up-to-date content (`#64 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/64>`__)
 * Fix item number in QD (`#59 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/59>`__)
 * Update QL to 2
@@ -3896,7 +3896,7 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * updating quality declaration links (re: `ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>`__) (`#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>`__)
-* Expose FastRTPS C++ typesupport generation via rosidl generate CLI (`#66 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/66>`__)
+* Expose Fast DDS C++ typesupport generation via rosidl generate CLI (`#66 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/66>`__)
 * Update QDs with up-to-date content (`#64 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/64>`__)
 * Fix item number in QD (`#59 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/59>`__)
 * Update QL to 2

--- a/source/Releases/Galactic-Geochelone-Complete-Changelog.rst
+++ b/source/Releases/Galactic-Geochelone-Complete-Changelog.rst
@@ -3877,7 +3877,7 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * updating quality declaration links (re: `ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>`__) (`#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>`__)
-* Expose Fast DDS C typesupport generation via rosidl generate CLI (`#65 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/65>`__)
+* Expose FastRTPS C typesupport generation via rosidl generate CLI (`#65 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/65>`__)
 * Update QDs with up-to-date content (`#64 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/64>`__)
 * Fix item number in QD (`#59 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/59>`__)
 * Update QL to 2
@@ -3896,7 +3896,7 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * updating quality declaration links (re: `ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>`__) (`#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>`__)
-* Expose Fast DDS C++ typesupport generation via rosidl generate CLI (`#66 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/66>`__)
+* Expose FastRTPS C++ typesupport generation via rosidl generate CLI (`#66 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/66>`__)
 * Update QDs with up-to-date content (`#64 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/64>`__)
 * Fix item number in QD (`#59 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/59>`__)
 * Update QL to 2

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -280,7 +280,7 @@ Default RMW vendor changed to Cyclone DDS
 
 During the Galactic development process, the ROS 2 Technical Steering Committee `voted <https://discourse.ros.org/t/ros-2-galactic-default-middleware-announced/18064>`__ to change the default ROS middleware (RMW) to Cyclone DDS.
 Without any configuration changes, users will get Cyclone DDS by default.
-Fast-DDS and Connext are still Tier-1 supported RMW vendors, and users can opt-in to use one of these RMWs at their discretion by using the ``RMW_IMPLEMENTATION`` environment variable.
+Fast DDS and Connext are still Tier-1 supported RMW vendors, and users can opt-in to use one of these RMWs at their discretion by using the ``RMW_IMPLEMENTATION`` environment variable.
 See the `Working with multiple RMW implementations guide <../Guides/Working-with-multiple-RMW-implementations>` for more information.
 
 Connext RMW changed to rmw_connextdds

--- a/source/Tutorials/FastDDS-Configuration/FastDDS-Configuration.rst
+++ b/source/Tutorials/FastDDS-Configuration/FastDDS-Configuration.rst
@@ -2,7 +2,7 @@
 
     FastDDS-Configuration
 
-Unlock all the potential of Fast-DDS as ROS 2 middleware [community-contributed]
+Unlock all the potential of Fast DDS as ROS 2 middleware [community-contributed]
 ================================================================================
 
 **Goal:** This tutorial will show how to use the extended configuration capabilities of Fast DDS in ROS 2.


### PR DESCRIPTION
This PR unifies the naming of Fast DDS. It also adds the section to explain how to install and use Fast DDS with ROS 2 Galactic.

Signed-off-by: JLBuenoLopez-eProsima joseluisbueno@eprosima.com