### PR TITLE
Don't propose to simply close a terminal

### DIFF
--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -311,7 +311,7 @@ If you run the above command with ``turtle1/cmd_vel`` instead of ``turtle1/pose`
 ^^^^^^^^^^
 
 At this point you'll have a lot of nodes running.
-Don’t forget to stop them, either by closing the terminal windows or entering ``Ctrl+C`` in each terminal.
+Don’t forget to stop them by entering ``Ctrl+C`` in each terminal.
 
 Summary
 -------

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -247,8 +247,7 @@ Now you can move turtle2 when this terminal is active, and turtle1 when the othe
 7 Close turtlesim
 ^^^^^^^^^^^^^^^^^
 
-To stop the simulation, you can simply close the terminal windows where you ran ``turtlesim_node`` and ``turtle_teleop_key``.
-If you want to keep those terminals open, but end the simulation, you can enter ``Ctrl + C`` in the ``turtlesim_node`` terminal, and ``q`` in the teleop terminal.
+To stop the simulation, you can enter ``Ctrl + C`` in the ``turtlesim_node`` terminal, and ``q`` in the teleop terminal.
 
 Summary
 -------


### PR DESCRIPTION
Terminals offer a command line into the system where you can start
arbitrary and multiple processes. Closes the terminal does not guarantee
that all subprocesses will be closed as well. Even more, there are
situations where you don't want to have the subprocesses closed, for
example when you have an editor with unsaved data suspended in the
background.

As this is an introduction tutorial probably read by a lot of people who
just start with the command line and given that Ctrl+C is easy to reach,
I propose to drop the comment to close terminals.