### PR TITLE
Dashing no longer marked active (EOL)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -118,7 +118,7 @@ smv_branch_whitelist = r'^(rolling|galactic|foxy|eloquent|dashing|crystal)$'
 smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(galactic|foxy|eloquent|dashing|crystal).*$'
 smv_remote_whitelist = r'^(origin)$'
 smv_latest_version = 'galactic'
-smv_eol_versions = ['crystal', 'eloquent']
+smv_eol_versions = ['crystal', 'dashing', 'eloquent']
 
 
 

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -56,7 +56,6 @@ Rows in the table marked in green are the currently supported distributions.
    <style>
      .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
      .rst-content tr:nth-child(2) {background-color: #33cc66;}
-     .rst-content tr:nth-child(4) {background-color: #33cc66;}
    </style>
 
 .. |galactic| image:: Releases/galactic-small.png


### PR DESCRIPTION
Dashing no longer marked active in the releases overview due to Dashing EOL.

Don't know how to remove it from the https://docs.ros.org/ landing page though. That is, removing it from the _"Active ROS 2 distributions"_ at the top and adding it to the _"End-of-life ROS 2 distributions"_ at the bottom.

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>