### PR TITLE
Add note about installation on Linux Mint 20

### DIFF
--- a/source/Installation/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Ubuntu-Install-Binary.rst
@@ -30,6 +30,7 @@ Add the ROS 2 apt repository
 ----------------------------
 
 .. include:: _Apt-Repositories.rst
+.. include:: _Apt-Repositories_Linux_Mint.rst
 
 Downloading ROS 2
 -----------------

--- a/source/Installation/_Apt-Repositories_Linux_Mint.rst
+++ b/source/Installation/_Apt-Repositories_Linux_Mint.rst
@@ -1,0 +1,6 @@
+**Note**: Even if `Linux Mint 20 <https://linuxmint.com/download_all.php>`__ bases on Ubuntu Focal, the ``lsb_release -cs`` command returns the codename of Linux Mint. Thus you've to edit the ros2.list file and replace the codename of Linux Mint 20 with ``focal``.
+
+.. code-block:: bash
+
+   sudo nano /etc/apt/sources.list.d/ros2.list
+


### PR DESCRIPTION
`lsb_release -cs` returns the codename of Linux Mint and not Ubuntu even if Linux Mint 20 is based on Ubuntu Focal.