### PR TITLE
Pin mypy to version 0.761 to match Ubuntu Focal.

### DIFF
--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -63,7 +63,7 @@ Install development tools and ROS tools
      flake8-docstrings \
      flake8-import-order \
      flake8-quotes \
-     mypy \
+     mypy==0.716 \
      pydocstyle \
      pytest-repeat \
      pytest-rerunfailures \

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -39,7 +39,7 @@ Installing additional Python dependencies:
 
 .. code-block:: bash
 
-   > pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock mypy pep8 pydocstyle pytest pytest-mock vcstool
+   > pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock mypy==0.761 pep8 pydocstyle pytest pytest-mock vcstool
 
 Install miscellaneous prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -109,7 +109,7 @@ You need the following things installed to build ROS 2:
         cryptography empy flake8 flake8-blind-except flake8-builtins \
         flake8-class-newline flake8-comprehensions flake8-deprecated \
         flake8-docstrings flake8-import-order flake8-quotes ifcfg \
-        importlib-metadata lark-parser lxml mock mypy netifaces \
+        importlib-metadata lark-parser lxml mock mypy==0.761 netifaces \
         nose pep8 pydocstyle pydot pygraphviz pyparsing \
         pytest-mock rosdep setuptools vcstool matplotlib psutil rosdistro
 


### PR DESCRIPTION
mypy 0.901 split library type annotations out into separate packages.
This makes mypy more modular but causes issues when running tests since
the type stubs are not currently part of our documentation and cannot be
used in released distributions where those stubs are still built in to
mypy.

Since our installation instructions for Linux Development have us
installing mypy via apt (by way of rosdep) the current solution is to
use the same version of mypy on other platforms as well.

When Ubuntu 22.04 comes online mypy and its separate type-stub libraries
will need to be evaluated for upstreaming and this pin revisited.

See also: https://github.com/ros2/ci/pull/581 