### PR TITLE
make sure ros2.repos is pointing to ros2 galactic, and not ros2 rolling

### DIFF
--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -29,7 +29,7 @@ If you wish to checkout the latest development code for the upcoming ROS release
 
        cd ~/ros2_ws
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
 
   .. group-tab:: macOS
 
@@ -37,7 +37,7 @@ If you wish to checkout the latest development code for the upcoming ROS release
 
        cd ~/ros2_ws
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
 
   .. group-tab:: Windows
 
@@ -45,17 +45,17 @@ If you wish to checkout the latest development code for the upcoming ROS release
 
        # CMD
        > cd \dev\ros2
-       > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+       > curl -sk https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos -o ros2.repos
 
        # PowerShell
        > cd \dev\ros2
-       > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+       > curl https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos -o ros2.repos
 
 
 Update your repositories
 ------------------------
 
-You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
+You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
 It is possible that these versions refer to new tags/branches that your local copy of the repositories will not recognize as they are out-of-date.
 Because of this, you should update the repositories that you have already checked out with the following command:
 

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -19,7 +19,7 @@ Each ROS 2 release includes a ``ros2.repos`` file that contains the list of repo
 Latest development branches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you wish to checkout the latest development code for this ROS release, you can get the relevant repository list by running:
+If you wish to checkout the latest development code for the upcoming ROS release, you can get the relevant repository list by running:
 
 .. tabs::
 
@@ -29,7 +29,7 @@ If you wish to checkout the latest development code for this ROS release, you ca
 
        cd ~/ros2_ws
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
 
   .. group-tab:: macOS
 
@@ -37,7 +37,7 @@ If you wish to checkout the latest development code for this ROS release, you ca
 
        cd ~/ros2_ws
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
 
   .. group-tab:: Windows
 
@@ -45,17 +45,17 @@ If you wish to checkout the latest development code for this ROS release, you ca
 
        # CMD
        > cd \dev\ros2
-       > curl -sk https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos -o ros2.repos
+       > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
 
        # PowerShell
        > cd \dev\ros2
-       > curl https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos -o ros2.repos
+       > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
 
 
 Update your repositories
 ------------------------
 
-You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
+You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
 It is possible that these versions refer to new tags/branches that your local copy of the repositories will not recognize as they are out-of-date.
 Because of this, you should update the repositories that you have already checked out with the following command:
 

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -19,7 +19,7 @@ Each ROS 2 release includes a ``ros2.repos`` file that contains the list of repo
 Latest development branches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you wish to checkout the latest development code for the upcoming ROS release, you can get the relevant repository list by running:
+If you wish to checkout the latest development code for this ROS release, you can get the relevant repository list by running:
 
 .. tabs::
 

--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -79,7 +79,7 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_galactic/src
    cd ~/ros2_galactic
-   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
    vcs import src < ros2.repos
 
 .. _rhel-development-setup-install-dependencies-using-rosdep:

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -90,7 +90,7 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_galactic/src
    cd ~/ros2_galactic
-   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
    vcs import src < ros2.repos
 
 .. _linux-development-setup-install-dependencies-using-rosdep:

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -67,10 +67,10 @@ Get the ``ros2.repos`` file which defines the repositories to clone from:
 .. code-block:: bash
 
    # CMD
-   > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos -o ros2.repos
 
    # PowerShell
-   > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+   > curl https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos -o ros2.repos
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
 

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -140,7 +140,7 @@ Create a workspace and clone all repos:
 
    mkdir -p ~/ros2_galactic/src
    cd ~/ros2_galactic
-   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+   wget https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
    vcs import src < ros2.repos
 
 Install additional DDS vendors (optional)


### PR DESCRIPTION
Fix for the issue found in ROS Answers: [**$ ROSDISTRO is rolling, although ROS2 Galactic is installed**](https://answers.ros.org/question/380657/rosdistro-is-rolling-although-ros2-galactic-is-installed/)

ros2.repos was pointing to ROS2 rolling (master) version, rather than ROS2 galactic version.