### PR TITLE
Add global macros

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -120,7 +120,22 @@ smv_remote_whitelist = r'^(origin)$'
 smv_latest_version = 'galactic'
 smv_eol_versions = ['crystal', 'dashing', 'eloquent']
 
+distro_full_names = {
+    'crystal': 'Crystal Clemmys',
+    'dashing': 'Dashing Diademata',
+    'eloquent': 'Eloquent Elusor',
+    'foxy': 'Foxy Fitzroy',
+    'galactic': 'Galactic Geochelone',
+    'rolling': 'Rolling Ridley',
+}
 
+# These default values will be overridden when building multiversion
+macros = {
+    'DISTRO': 'rolling',
+    'DISTRO_TITLE': 'Rolling',
+    'DISTRO_TITLE_FULL': 'Rolling Ridley',
+    'REPOS_FILE_BRANCH': 'master',
+}
 
 html_favicon = 'favicon.ico'
 
@@ -254,13 +269,30 @@ def smv_rewrite_configs(app, config):
         if app.config.smv_current_version not in ['rolling']:
             app.config.html_logo = 'source/Releases/' + app.config.smv_current_version + '-small.png'
 
+        # Override default values
+        distro = app.config.smv_current_version
+        app.config.macros = {
+            'DISTRO': distro,
+            'DISTRO_TITLE': distro.title(),
+            'DISTRO_TITLE_FULL': distro_full_names[distro],
+            'REPOS_FILE_BRANCH' : 'master' if distro == 'rolling' else distro,
+        }
+
 def github_link_rewrite_branch(app, pagename, templatename, context, doctree):
     if app.config.smv_current_version != '':
         context['github_version'] = app.config.smv_current_version + '/source/'
         context['eol_versions'] = app.config.smv_eol_versions
 
+def expand_macros(app, docname, source):
+    result = source[0]
+    for key, value in app.config.macros.items():
+        result = result.replace(f'{{{key}}}', value)
+    source[0] = result
+
 def setup(app):
     app.connect('config-inited', smv_rewrite_configs)
     app.connect('html-page-context', github_link_rewrite_branch)
+    app.connect('source-read', expand_macros)
     app.add_config_value('smv_eol_versions', [], 'html')
+    app.add_config_value('macros', {}, True)
     RedirectFrom.register(app)


### PR DESCRIPTION
Relates to #1422 (closes?)

This adds global macros to the sphinx config. For example, writing `https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos` will expand to `https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos` for Rolling and to `https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos` for Galactic.

Note that I first tried to add some [global `replace::` configs through `rst_prolog` in the `conf.py` file](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-rst_prolog). However, it doesn't work in `code-block::`, so I found this alternative solution: https://stackoverflow.com/a/56328457. It doesn't seem to affect build time in any way (from my limited testing anyway).

I applied the macros in some places as a demo, but I'm not really sure exactly which macros we should define and where to use them/where to draw the line. I wanted to get feedback first before spending time replacing/using the macros. I'm guessing it would be quite a pain to apply this retroactively, so I assume we could just slowly get this ready for Humble.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>