### PR TITLE
Mention the foxy-future branch of rosbag2 in the rosbag2 Foxy tutorial.

### DIFF
--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -25,6 +25,11 @@ Recording topics is also a great way to share your work and allow others to recr
 Prerequisites
 -------------
 
+**NOTE on "Foxy-future" rosbag2: **
+for users of ROS 2 Foxy who need a more performant version of rosbag2, please see the `foxy-future branch of rosbag2 <https://github.com/ros2/rosbag2/tree/foxy-future >`__.
+This is an officially-supported branch that is closer to the Galactic version, adding performance improvements and features, but is not API-compatible with the Foxy release.
+For users just getting into this tutorial on Foxy, you can ignore this and move on with the default installation.
+
 You should have ``ros2 bag`` installed as a part of your regular ROS 2 setup.
 
 If you've installed from Debians on Linux and your system doesn’t recognize the command, install it like so:

--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -27,10 +27,9 @@ Prerequisites
 
 .. note::
 
-"Foxy-future" rosbag2:
-for users of ROS 2 Foxy who need a more performant version of rosbag2, please see the `foxy-future branch of rosbag2 <https://github.com/ros2/rosbag2/tree/foxy-future >`__.
-This is an officially-supported branch that is closer to the Galactic version, adding performance improvements and features, but is not API-compatible with the Foxy release.
-For users just getting into this tutorial on Foxy, you can ignore this and move on with the default installation.
+  For users of ROS 2 Foxy who need a more performant version of rosbag2, please see the `foxy-future branch of rosbag2 <https://github.com/ros2/rosbag2/tree/foxy-future>`__.
+  This is an officially-supported branch that is closer to the Galactic version, adding performance improvements and features, but is not API-compatible with the Foxy release.
+  For users just getting into this tutorial on Foxy, you can ignore this and move on with the default installation.
 
 You should have ``ros2 bag`` installed as a part of your regular ROS 2 setup.
 

--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -25,7 +25,9 @@ Recording topics is also a great way to share your work and allow others to recr
 Prerequisites
 -------------
 
-**NOTE on "Foxy-future" rosbag2: **
+.. note::
+
+"Foxy-future" rosbag2:
 for users of ROS 2 Foxy who need a more performant version of rosbag2, please see the `foxy-future branch of rosbag2 <https://github.com/ros2/rosbag2/tree/foxy-future >`__.
 This is an officially-supported branch that is closer to the Galactic version, adding performance improvements and features, but is not API-compatible with the Foxy release.
 For users just getting into this tutorial on Foxy, you can ignore this and move on with the default installation.


### PR DESCRIPTION
This is intended to be a simple pointer to the branch, which contains instructions for usage, so that this branch is discoverable for users who may need it.