### PR TITLE
Use `push_ros_namespace` alias instead of `push-ros-namespace`

### DIFF
--- a/source/Guides/Launch-file-different-formats.rst
+++ b/source/Guides/Launch-file-different-formats.rst
@@ -70,7 +70,7 @@ Each launch file performs the following actions:
             # include another launch file in the chatter_ns namespace
             launch_include_with_namespace = GroupAction(
                 actions=[
-                    # push-ros-namespace to set namespace of included nodes
+                    # push_ros_namespace to set namespace of included nodes
                     PushRosNamespace(LaunchConfiguration('chatter_ns')),
                     IncludeLaunchDescription(
                         PythonLaunchDescriptionSource(
@@ -144,8 +144,8 @@ Each launch file performs the following actions:
           <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener.launch.py"/>
           <!-- include another launch file in the chatter_ns namespace-->
           <group>
-            <!-- push-ros-namespace to set namespace of included nodes -->
-            <push-ros-namespace namespace="$(var chatter_ns)"/>
+            <!-- push_ros_namespace to set namespace of included nodes -->
+            <push_ros_namespace namespace="$(var chatter_ns)"/>
             <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener.launch.py"/>
           </group>
 
@@ -194,7 +194,7 @@ Each launch file performs the following actions:
 
         # include another launch file in the chatter_ns namespace
         - group:
-            - push-ros-namespace:
+            - push_ros_namespace:
                 namespace: "$(var chatter_ns)"
             - include:
                 file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener.launch.py"

--- a/source/Guides/Launch-files-migration-guide.rst
+++ b/source/Guides/Launch-files-migration-guide.rst
@@ -175,7 +175,7 @@ include
      In ROS 2, it's not.
      Nest includes in ``group`` tags to scope them.
    * ``ns`` attribute is not supported.
-     See example of ``push-ros-namespace`` tag for a workaround.
+     See example of ``push_ros_namespace`` tag for a workaround.
    * ``arg`` tags nested in an ``include`` tag don't support conditionals (``if`` or ``unless``).
    * There is no support for nested ``env`` tags.
      ``set_env`` and ``unset_env`` can be used instead.
@@ -255,10 +255,10 @@ group
 
 * `Available in ROS 1 <https://wiki.ros.org/roslaunch/XML/group>`__.
 * Allows limiting the scope of launch configurations.
-  Usually used together with ``let``, ``include`` and ``push-ros-namespace`` tags.
+  Usually used together with ``let``, ``include`` and ``push_ros_namespace`` tags.
 * Differences from ROS 1:
    * There is no ``ns`` attribute.
-     See the new ``push-ros-namespace`` tag as a workaround.
+     See the new ``push_ros_namespace`` tag as a workaround.
    * ``clear_params`` attribute isn't available.
    * It doesn't accept ``remap`` nor ``param`` tags as children.
 
@@ -297,7 +297,7 @@ set_env and unset_env
 
 See `env`_ tag decription.
 
-push-ros-namespace
+push_ros_namespace
 ^^^^^^^^^^^^^^^^^^
 
 ``include`` and ``group`` tags don't accept an ``ns`` attribute.
@@ -307,12 +307,12 @@ This action can be used as a workaround:
 
    <!-Other tags-->
    <group>
-      <push-ros-namespace namespace="my_ns"/>
+      <push_ros_namespace namespace="my_ns"/>
       <!--Nodes here are namespaced with "my_ns".-->
       <!--If there is an include action here, its nodes will also be namespaced.-->
-      <push-ros-namespace namespace="another_ns"/>
+      <push_ros_namespace namespace="another_ns"/>
       <!--Nodes here are namespaced with "another_ns/my_ns".-->
-      <push-ros-namespace namespace="/absolute_ns"/>
+      <push_ros_namespace namespace="/absolute_ns"/>
       <!--Nodes here are namespaced with "/absolute_ns".-->
       <!--The following node receives an absolute namespace, so it will ignore the others previously pushed.-->
       <!--The full path of the node will be /asd/my_node.-->
@@ -355,12 +355,12 @@ To have exactly the same behavior as Available in ROS 1, ``include`` tags must b
       <include file="another_launch_file"/>
    </group>
 
-To replace the ``ns`` attribute, ``push-ros-namespace`` action must be used:
+To replace the ``ns`` attribute, ``push_ros_namespace`` action must be used:
 
 .. code-block:: xml
 
    <group>
-      <push-ros-namespace namespace="my_ns"/>
+      <push_ros_namespace namespace="my_ns"/>
       <include file="another_launch_file"/>
    </group>
 


### PR DESCRIPTION
See https://github.com/ros2/launch_ros/pull/250

This basically reverts https://github.com/ros2/ros2_documentation/pull/539 and also changes new instances.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>