### PR TITLE
Apply global macros

### DIFF
--- a/source/Concepts/About-RQt.rst
+++ b/source/Concepts/About-RQt.rst
@@ -50,7 +50,7 @@ Installing From Debian
 
 .. code-block:: bash
 
-   sudo apt install ros-rolling-rqt*
+   sudo apt install ros-{DISTRO}-rqt*
 
 
 Building From Source

--- a/source/Contributing/Code-Style-Language-Versions.rst
+++ b/source/Contributing/Code-Style-Language-Versions.rst
@@ -54,7 +54,7 @@ C++
 Standard
 ^^^^^^^^
 
-Rolling targets C++17.
+{DISTRO_TITLE} targets C++17.
 
 Style
 ^^^^^

--- a/source/Guides/Installation-Troubleshooting.rst
+++ b/source/Guides/Installation-Troubleshooting.rst
@@ -235,7 +235,7 @@ While following the `Creating a workspace <../Tutorials/Workspace/Creating-A-Wor
 
 .. code-block:: bash
 
-   $ rosdep install -i --from-path src --rosdistro rolling -y
+   $ rosdep install -i --from-path src --rosdistro {DISTRO} -y
    executing command [brew install qt5]
    Warning: qt 5.15.0 is already installed and up-to-date
    To reinstall 5.15.0, run `brew reinstall qt`
@@ -253,7 +253,7 @@ Running the ``rosdep`` command should now execute normally:
 
 .. code-block:: bash
 
-   $ rosdep install -i --from-path src --rosdistro rolling -y
+   $ rosdep install -i --from-path src --rosdistro {DISTRO} -y
    #All required rosdeps installed successfully
 
 

--- a/source/Guides/Package-maintainer-guide.rst
+++ b/source/Guides/Package-maintainer-guide.rst
@@ -135,11 +135,11 @@ To do a binary release of a package, run:
 
   $ bloom-release --track <rosdistro> --rosdistro <rosdistro> <repository_name>
 
-For instance, to release the ``rclcpp`` repository to the Rolling distribution, the command would be:
+For instance, to release the ``rclcpp`` repository to the {DISTRO_TITLE} distribution, the command would be:
 
 .. code-block:: bash
 
-  $ bloom-release --track rolling --rosdistro rolling rclcpp
+  $ bloom-release --track {DISTRO} --rosdistro {DISTRO} rclcpp
 
 This command will fetch the release repository, make the necessary changes to make the release, push the changes to the release repository, and finally open a pull request to https://github.com/ros/rosdistro .
 

--- a/source/Guides/Working-with-multiple-RMW-implementations.rst
+++ b/source/Guides/Working-with-multiple-RMW-implementations.rst
@@ -109,7 +109,7 @@ it will generate a daemon with a Cyclone DDS implementation:
 
 .. code-block:: bash
 
-   21318 22.0  0.6 535896 55044 pts/8    Sl   16:14   0:00 /usr/bin/python3 /opt/ros/rolling/bin/_ros2_daemon --rmw-implementation rmw_cyclonedds_cpp --ros-domain-id 22
+   21318 22.0  0.6 535896 55044 pts/8    Sl   16:14   0:00 /usr/bin/python3 /opt/ros/{DISTRO}/bin/_ros2_daemon --rmw-implementation rmw_cyclonedds_cpp --ros-domain-id 22
 
 Even if you run the command line tool again with the correct RMW implementation, the daemon's RMW implementation will not change and the ROS 2 command line tools will fail.
 

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -4,7 +4,7 @@
 Installation
 ============
 
-Options for installing ROS 2 Rolling Ridley:
+Options for installing ROS 2 {DISTRO_TITLE_FULL}:
 
 .. toctree::
    :hidden:

--- a/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
@@ -22,7 +22,7 @@ The easiest way is to install from ROS 2 apt repository.
 
 .. code-block:: bash
 
-   sudo apt install ros-rolling-rmw-cyclonedds-cpp
+   sudo apt install ros-{DISTRO}-rmw-cyclonedds-cpp
 
 Build from source code
 ----------------------

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -55,7 +55,7 @@ If you wish to checkout the latest development code for the upcoming ROS release
 Update your repositories
 ------------------------
 
-You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
+You will notice that in the `ros2.repos <https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos>`__ file, each repository has a ``version`` associated with it that points to a particular commit hash, tag, or branch name.
 It is possible that these versions refer to new tags/branches that your local copy of the repositories will not recognize as they are out-of-date.
 Because of this, you should update the repositories that you have already checked out with the following command:
 

--- a/source/Installation/Prerelease-Testing.rst
+++ b/source/Installation/Prerelease-Testing.rst
@@ -31,7 +31,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 
    .. code-block:: sh
 
-      sudo apt install ros-rolling-my-just-released-package
+      sudo apt install ros-{DISTRO}-my-just-released-package
 
 5. Alternatively, you can move your entire ROS 2 installation to the testing repository:
 

--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -10,7 +10,7 @@ Building ROS 2 on RHEL
 
 System requirements
 -------------------
-The current target Red Hat platforms for Rolling Ridley are:
+The current target Red Hat platforms for {DISTRO_TITLE_FULL} are:
 
 - Tier 2: RHEL 8 64-bit
 
@@ -79,9 +79,9 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_rolling/src
-   cd ~/ros2_rolling
-   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+   mkdir -p ~/ros2_{DISTRO}/src
+   cd ~/ros2_{DISTRO}
+   wget https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos
    vcs import src < ros2.repos
 
 .. _rhel-development-setup-install-dependencies-using-rosdep:
@@ -93,7 +93,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers pydocstyle python3-mypy python3-babeltrace python3-lttng asio"
+   rosdep install --from-paths src --ignore-src --rosdistro {DISTRO} -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers pydocstyle python3-mypy python3-babeltrace python3-lttng asio"
 
 Install additional DDS implementations (optional)
 -------------------------------------------------
@@ -112,7 +112,7 @@ More info on working with a ROS workspace can be found in `this tutorial <../Tut
 
 .. code-block:: bash
 
-   cd ~/ros2_rolling/
+   cd ~/ros2_{DISTRO}/
    colcon build --symlink-install --cmake-args -DTHIRDPARTY_Asio=ON --no-warn-unused-cli
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
@@ -129,7 +129,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/local_setup.bash
+   . ~/ros2_{DISTRO}/install/local_setup.bash
 
 .. _rhel_talker-listener:
 
@@ -140,14 +140,14 @@ In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/local_setup.bash
+   . ~/ros2_{DISTRO}/install/local_setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/local_setup.bash
+   . ~/ros2_{DISTRO}/install/local_setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -198,10 +198,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_rolling
+    rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/RHEL-Install-Binary.rst
+++ b/source/Installation/RHEL-Install-Binary.rst
@@ -11,7 +11,7 @@ This page explains how to install ROS 2 on RHEL from a pre-built binary package.
 
     The pre-built binary does not include all ROS 2 packages.
     All packages in the `ROS base variant <https://ros.org/reps/rep-2001.html#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://ros.org/reps/rep-2001.html#desktop-variants>`_ are included.
-    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/master/ros2.repos>`_.
+    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
 
 There are also `RPM packages <RHEL-Install-RPMs>` available.
 
@@ -56,8 +56,8 @@ Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_rolling
-       cd ~/ros2_rolling
+       mkdir -p ~/ros2_{DISTRO}
+       cd ~/ros2_{DISTRO}
        tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
@@ -78,7 +78,7 @@ Set your rosdistro according to the release you downloaded.
 
 .. code-block:: bash
 
-       rosdep install --from-paths ~/ros2_rolling/ros2-linux/share --ignore-src --rosdistro rolling -y --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rti-connext-dds-5.3.1 urdfdom_headers pydocstyle python3-mypy python3-babeltrace python3-lttng"
+       rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src --rosdistro {DISTRO} -y --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rti-connext-dds-5.3.1 urdfdom_headers pydocstyle python3-mypy python3-babeltrace python3-lttng"
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-  . ~/ros2_rolling/ros2-linux/setup.bash
+  . ~/ros2_{DISTRO}/ros2-linux/setup.bash
 
 Try some examples
 -----------------
@@ -104,14 +104,14 @@ In one terminal, source the setup file and then run a C++ ``talker``:
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/ros2-linux/setup.bash
+   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/ros2-linux/setup.bash
+   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -136,10 +136,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_rolling
+    rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -5,7 +5,7 @@ Installing ROS 2 via RPM Packages
    :depth: 2
    :local:
 
-RPM packages for ROS 2 Rolling Ridley are currently available for RHEL 8.
+RPM packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for RHEL 8.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
 Most people will want to use a stable ROS distribution.
@@ -15,7 +15,7 @@ Resources
 
 * Status Page:
 
-  * ROS 2 Rolling (RHEL 8): `amd64 <http://repo.ros2.org/status_page/ros_rolling_rhel.html>`__
+  * ROS 2 {DISTRO_TITLE} (RHEL 8): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_rhel.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
@@ -60,14 +60,14 @@ Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash
 
-   sudo dnf install ros-rolling-desktop
+   sudo dnf install ros-{DISTRO}-desktop
 
 ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools.
 No GUI tools.
 
 .. code-block:: bash
 
-   sudo dnf install ros-rolling-ros-base
+   sudo dnf install ros-{DISTRO}-ros-base
 
 Environment setup
 -----------------
@@ -79,25 +79,25 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   source /opt/ros/rolling/setup.bash
+   source /opt/ros/{DISTRO}/setup.bash
 
 Try some examples
 -----------------
 
-If you installed ``ros-rolling-desktop`` above you can try some examples.
+If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
 In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   source /opt/ros/rolling/setup.bash
+   source /opt/ros/{DISTRO}/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   source /opt/ros/rolling/setup.bash
+   source /opt/ros/{DISTRO}/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -126,4 +126,4 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo dnf remove ros-rolling-*
+  sudo dnf remove ros-{DISTRO}-*

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -14,7 +14,7 @@ Building ROS 2 on Ubuntu Linux
 
 System requirements
 -------------------
-The current Debian-based target platforms for Rolling Ridley are:
+The current Debian-based target platforms for {DISTRO_TITLE_FULL} are:
 
 - Tier 1: Ubuntu Linux - Focal Fossa (20.04) 64-bit
 - Tier 3: Debian Linux - Bullseye (11) 64-bit
@@ -88,9 +88,9 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_rolling/src
-   cd ~/ros2_rolling
-   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+   mkdir -p ~/ros2_{DISTRO}/src
+   cd ~/ros2_{DISTRO}
+   wget https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos
    vcs import src < ros2.repos
 
 .. _linux-development-setup-install-dependencies-using-rosdep:
@@ -102,7 +102,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src --rosdistro {DISTRO} -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"
 
 Install additional DDS implementations (optional)
 -------------------------------------------------
@@ -121,7 +121,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 
 .. code-block:: bash
 
-   cd ~/ros2_rolling/
+   cd ~/ros2_{DISTRO}/
    colcon build --symlink-install
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
@@ -138,7 +138,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/local_setup.bash
+   . ~/ros2_{DISTRO}/install/local_setup.bash
 
 .. _talker-listener:
 
@@ -149,14 +149,14 @@ In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/local_setup.bash
+   . ~/ros2_{DISTRO}/install/local_setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/local_setup.bash
+   . ~/ros2_{DISTRO}/install/local_setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -207,10 +207,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_rolling
+    rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Ubuntu-Install-Binary.rst
@@ -15,7 +15,7 @@ This page explains how to install ROS 2 on Ubuntu Linux from a pre-built binary 
 
     The pre-built binary does not include all ROS 2 packages.
     All packages in the `ROS base variant <https://ros.org/reps/rep-2001.html#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://ros.org/reps/rep-2001.html#desktop-variants>`_ are included.
-    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/master/ros2.repos>`_.
+    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
 
 There are also `Debian packages <Ubuntu-Install-Debians>` available.
 
@@ -46,8 +46,8 @@ Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_rolling
-       cd ~/ros2_rolling
+       mkdir -p ~/ros2_{DISTRO}
+       cd ~/ros2_{DISTRO}
        tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
 Installing and initializing rosdep
@@ -69,7 +69,7 @@ Set your rosdistro according to the release you downloaded.
 
 .. code-block:: bash
 
-       rosdep install --from-paths ~/ros2_rolling/ros2-linux/share --ignore-src --rosdistro rolling -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connextdds rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
+       rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src --rosdistro {DISTRO} -y --skip-keys "console_bridge fastcdr fastrtps osrf_testing_tools_cpp poco_vendor rmw_connextdds rti-connext-dds-5.3.1 tinyxml_vendor tinyxml2_vendor urdfdom urdfdom_headers"
 
 #. *Optional*\ : if you want to use the ROS 1<->2 bridge, then you must also install ROS 1.
    Follow the normal install instructions: http://wiki.ros.org/noetic/Installation/Ubuntu
@@ -96,7 +96,7 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-  . ~/ros2_rolling/ros2-linux/setup.bash
+  . ~/ros2_{DISTRO}/ros2-linux/setup.bash
 
 Try some examples
 -----------------
@@ -105,14 +105,14 @@ In one terminal, source the setup file and then run a C++ ``talker``:
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/ros2-linux/setup.bash
+   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``:
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/ros2-linux/setup.bash
+   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -141,10 +141,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_rolling
+    rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -9,7 +9,7 @@ Installing ROS 2 via Debian Packages
    :depth: 2
    :local:
 
-Debian packages for ROS 2 Rolling Ridley are currently available for Ubuntu Focal.
+Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Focal.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
 Most people will want to use a stable ROS distribution.
@@ -19,7 +19,7 @@ Resources
 
 * Status Page:
 
-  * ROS 2 Rolling (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_rolling_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_rolling_ufv8.html>`__
+  * ROS 2 {DISTRO_TITLE} (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_ufv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
@@ -51,14 +51,14 @@ Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash
 
-   sudo apt install ros-rolling-desktop
+   sudo apt install ros-{DISTRO}-desktop
 
 ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools.
 No GUI tools.
 
 .. code-block:: bash
 
-   sudo apt install ros-rolling-ros-base
+   sudo apt install ros-{DISTRO}-ros-base
 
 Environment setup
 -----------------
@@ -70,25 +70,25 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
-   source /opt/ros/rolling/setup.bash
+   source /opt/ros/{DISTRO}/setup.bash
 
 Try some examples
 -----------------
 
-If you installed ``ros-rolling-desktop`` above you can try some examples.
+If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
 In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   source /opt/ros/rolling/setup.bash
+   source /opt/ros/{DISTRO}/setup.bash
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   source /opt/ros/rolling/setup.bash
+   source /opt/ros/{DISTRO}/setup.bash
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
@@ -121,4 +121,4 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo apt remove ros-rolling-* && sudo apt autoremove
+  sudo apt remove ros-{DISTRO}-* && sudo apt autoremove

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -55,22 +55,22 @@ Get the ROS 2 code
 
 Now that we have the development tools we can get the ROS 2 source code.
 
-First setup a development folder, for example ``C:\dev\ros2_rolling``:
+First setup a development folder, for example ``C:\dev\ros2_{DISTRO}``:
 
 .. code-block:: bash
 
-   > md \dev\ros2_rolling\src
-   > cd \dev\ros2_rolling
+   > md \dev\ros2_{DISTRO}\src
+   > cd \dev\ros2_{DISTRO}
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
 .. code-block:: bash
 
    # CMD
-   > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+   > curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
    # PowerShell
-   > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+   > curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
 
@@ -96,7 +96,7 @@ To build ROS 2 you will need a Visual Studio Command Prompt ("x64 Native Tools C
 
 Fast RTPS is bundled with the ROS 2 source and will always be built unless you put an ``AMENT_IGNORE`` file in the ``src\eProsima`` folder.
 
-To build the ``\dev\ros2_rolling`` folder tree:
+To build the ``\dev\ros2_{DISTRO}`` folder tree:
 
 .. code-block:: bash
 
@@ -119,7 +119,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2_rolling\install\local_setup.bat
+   > call C:\dev\ros2_{DISTRO}\install\local_setup.bat
 
 This will automatically set up the environment for any DDS vendors that support was built for.
 
@@ -284,10 +284,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_rolling
+    rmdir /s /q \ros2_{DISTRO}

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -11,7 +11,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 
     The pre-built binary does not include all ROS 2 packages.
     All packages in the `ROS base variant <https://ros.org/reps/rep-2001.html#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://ros.org/reps/rep-2001.html#desktop-variants>`_ are included.
-    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/master/ros2.repos>`_.
+    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
 
 System requirements
 -------------------
@@ -25,7 +25,7 @@ Only Windows 10 is supported.
 Downloading ROS 2
 -----------------
 
-Binary releases of Rolling Ridley are not provided.
+Binary releases of {DISTRO_TITLE_FULL} are not provided.
 Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
 
 * Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
@@ -38,7 +38,7 @@ Instead you may download nightly `prerelease binaries <Prerelease_binaries>`.
 
     To download the ROS 2 debug libraries you'll need to download ``ros2-package-windows-debug-AMD64.zip``
 
-* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_rolling``\ ).
+* Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_{DISTRO}``\ ).
 
 Environment setup
 -----------------
@@ -47,7 +47,7 @@ Start a command shell and source the ROS 2 setup file to set up the workspace:
 
 .. code-block:: bash
 
-   > call C:\dev\ros2_rolling\local_setup.bat
+   > call C:\dev\ros2_{DISTRO}\local_setup.bat
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 
@@ -93,10 +93,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_rolling
+    rmdir /s /q \ros2_{DISTRO}

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -144,9 +144,9 @@ Create a workspace and clone all repos:
 
 .. code-block:: bash
 
-   mkdir -p ~/ros2_rolling/src
-   cd ~/ros2_rolling
-   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+   mkdir -p ~/ros2_{DISTRO}/src
+   cd ~/ros2_{DISTRO}
+   wget https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos
    vcs import src < ros2.repos
 
 Install additional DDS vendors (optional)
@@ -161,7 +161,7 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in `this t
 
 .. code-block:: bash
 
-   cd ~/ros2_rolling/
+   cd ~/ros2_{DISTRO}/
    colcon build --symlink-install --packages-skip-by-dep python_qt_binding
 
 Note: due to an unresolved issue with SIP, Qt@5, and PyQt5, we need to disable ``python_qt_binding`` to have the build succeed.
@@ -174,7 +174,7 @@ Source the ROS 2 setup file:
 
 .. code-block:: bash
 
-   . ~/ros2_rolling/install/setup.bash
+   . ~/ros2_{DISTRO}/install/setup.bash
 
 This will automatically set up the environment for any DDS vendors that support was built for.
 
@@ -224,10 +224,10 @@ Uninstall
 ---------
 
 1. If you installed your workspace with colcon as instructed above, "uninstalling" could be just a matter of opening a new terminal and not sourcing the workspace's ``setup`` file.
-   This way, your environment will behave as though there is no Rolling install on your system.
+   This way, your environment will behave as though there is no {DISTRO_TITLE} install on your system.
 
 2. If you're also trying to free up space, you can delete the entire workspace directory with:
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_rolling
+    rm -rf ~/ros2_{DISTRO}

--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -121,7 +121,7 @@ Let's clone the `examples <https://github.com/ros2/examples>`__ repository into 
 
 .. code-block:: bash
 
-    git clone https://github.com/ros2/examples src/examples -b master
+    git clone https://github.com/ros2/examples src/examples -b {REPOS_FILE_BRANCH}
 
 Now the workspace should have the source code to the ROS 2 examples:
 

--- a/source/Tutorials/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Configuring-ROS2-Environment.rst
@@ -54,7 +54,7 @@ You will need to run this command on every new shell you open to have access to 
 
       .. code-block:: console
 
-        source /opt/ros/rolling/setup.bash
+        source /opt/ros/{DISTRO}/setup.bash
 
    .. group-tab:: macOS
 
@@ -83,7 +83,7 @@ If you don’t want to have to source the setup file every time you open a new s
 
       .. code-block:: console
 
-        echo "source /opt/ros/rolling/setup.bash" >> ~/.bashrc
+        echo "source /opt/ros/{DISTRO}/setup.bash" >> ~/.bashrc
 
      To undo this, locate your system’s shell startup script and remove the appended source command.
 
@@ -103,14 +103,14 @@ If you don’t want to have to source the setup file every time you open a new s
 
       .. code-block:: console
 
-        C:\dev\ros2_rolling\local_setup.ps1
+        C:\dev\ros2_{DISTRO}\local_setup.ps1
 
       PowerShell will request permission to run this script everytime a new shell is opened.
       To avoid that issue you can run:
 
       .. code-block:: console
 
-        Unblock-File C:\dev\ros2_rolling\local_setup.ps1
+        Unblock-File C:\dev\ros2_{DISTRO}\local_setup.ps1
 
       To undo this, remove the new 'Microsoft.PowerShell_profile.ps1' file.
 
@@ -174,7 +174,7 @@ Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set.
 
   ROS_VERSION=2
   ROS_PYTHON_VERSION=3
-  ROS_DISTRO=rolling
+  ROS_DISTRO={DISTRO}
 
 If the environment variables are not set correctly, return to the ROS 2 package installation section of the installation guide you followed.
 If you need more specific help (because environment setup files can come from different places), you can `get answers <https://answers.ros.org>`__ from the community.

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -30,14 +30,14 @@ You will also need the ROS package ``image_tools``.
 
       .. code-block:: bash
 
-        sudo apt-get install ros-rolling-image-tools
+        sudo apt-get install ros-{DISTRO}-image-tools
 
    .. group-tab:: From Source
 
       .. code-block:: bash
 
         # Clone and build the demos repo using the branch that matches your installation
-        git clone https://github.com/ros2/demos.git -b master
+        git clone https://github.com/ros2/demos.git -b {REPOS_FILE_BRANCH}
 
 
 Run the demo

--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -31,8 +31,8 @@ If you've installed from Debians on Linux and your system doesn’t recognize th
 
 .. code-block:: console
 
-  sudo apt-get install ros-rolling-ros2bag \
-                       ros-rolling-rosbag2-storage-default-plugins
+  sudo apt-get install ros-{DISTRO}-ros2bag \
+                       ros-{DISTRO}-rosbag2-storage-default-plugins
 
 This tutorial talks about concepts covered in previous tutorials, like :ref:`nodes <ROS2Nodes>` and :ref:`topics <ROS2Topics>`.
 It also uses the :ref:`turtlesim package <Turtlesim>`.

--- a/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Turtlesim/Introducing-Turtlesim.rst
@@ -48,7 +48,7 @@ Install the turtlesim package for your ROS 2 distro:
 
         sudo apt update
 
-        sudo apt install ros-rolling-turtlesim
+        sudo apt install ros-{DISTRO}-turtlesim
 
    .. group-tab:: macOS
 
@@ -143,7 +143,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt update
 
-      sudo apt install ~nros-rolling-rqt*
+      sudo apt install ~nros-{DISTRO}-rqt*
 
   .. group-tab:: Linux (apt 1.x/Ubuntu 18.04 and older)
 
@@ -151,7 +151,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt update
 
-      sudo apt install ros-rolling-rqt*
+      sudo apt install ros-{DISTRO}-rqt*
 
   .. group-tab:: macOS
 

--- a/source/Tutorials/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-CPP.rst
@@ -183,7 +183,7 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro rolling -y
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 

--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -227,7 +227,7 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro rolling -y
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 

--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -54,7 +54,7 @@ Depending on how you installed ROS 2 (from source or binaries), and which platfo
 
       .. code-block:: console
 
-        source /opt/ros/rolling/setup.bash
+        source /opt/ros/{DISTRO}/setup.bash
 
    .. group-tab:: macOS
 
@@ -128,7 +128,7 @@ In the ``dev_ws/src`` directory, run the following command for the distro you're
 
 .. code-block:: console
 
-  git clone https://github.com/ros/ros_tutorials.git -b galactic-devel
+  git clone https://github.com/ros/ros_tutorials.git -b {DISTRO}-devel
 
 Now ``ros_tutorials`` is cloned in your workspace.
 If you view the contents of ``dev_ws/src`` now, you will see the new ``ros_tutorials`` directory.
@@ -183,7 +183,7 @@ From the root of your workspace (``dev_ws``), run the following command:
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro rolling -y
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 
@@ -272,7 +272,7 @@ In the new terminal, source your main ROS 2 environment as the “underlay”, s
 
       .. code-block:: console
 
-        source /opt/ros/rolling/setup.bash
+        source /opt/ros/{DISTRO}/setup.bash
 
    .. group-tab:: macOS
 

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -439,7 +439,7 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
       .. code-block:: console
 
-            rosdep install -i --from-path src --rosdistro rolling -y
+            rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 

--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -315,7 +315,7 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
     .. code-block:: console
 
-      rosdep install -i --from-path src --rosdistro rolling -y
+      rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
   .. group-tab:: macOS
 

--- a/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -419,7 +419,7 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro rolling -y
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 

--- a/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
@@ -268,7 +268,7 @@ It's good practice to run ``rosdep`` in the root of your workspace (``dev_ws``) 
 
       .. code-block:: console
 
-            rosdep install -i --from-path src --rosdistro rolling -y
+            rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 


### PR DESCRIPTION
Requires #1694 (for Rolling). This PR is separate from #1694 so that we can backport the actual changes/macro applications.

There are a number of cases where the macros can be applied:

* `{DISTRO_TITLE_FULL}` and `{DISTRO_TITLE}` (mostly in text, when referring to the current distro) 
* `https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos` and `https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos`
* `/opt/ros/{DISTRO}/*setup.*`
* `ros2_{DISTRO}/` (workspace directories or directory under which to extract pre-built binaries archive)
* `rosdep install ... --rosdistro {DISTRO}`
* `ros-{DISTRO}-*`
* `git clone ... -b {DISTRO}`/`git clone ... -b {REPOS_FILE_BRANCH}`/`git clone ... -b {DISTRO}-devel` (depends on the name of the branch the repo uses for Rolling and the nomenclature in general (if they use `*-devel` or not))
* `http://repo.ros2.org/status_page/ros_{DISTRO}_*.html`

In most cases, the documentation is referring to Rolling as the "current distro" (for the current version of the docs). So in those cases the Galactic docs refer to Galactic. I cross-checked to make sure. In other cases, the documentation refers to Rolling as the rolling distribution (always the latest code); those instances don't exist in the Galactic docs and so I didn't apply the macros.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>