### PR TITLE
Fixed `lcov` installation code snippet rendering

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -751,6 +751,7 @@ How to measure coverage locally using lcov (Ubuntu)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To measure coverage on your own machine, install ``lcov``.
+
 .. code-block:: bash
 
      sudo apt install -y lcov


### PR DESCRIPTION
Previously, that snippet was not properly highlighted like the other code blocks because the `.. code-block` identifier was not preceded by an empty line.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>