### PR TITLE
for_each_callback_group release note

### DIFF
--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -152,7 +152,7 @@ For more details, see `REP 2007 <https://ros.org/reps/rep-2007.html>`_.
 ``get_callback_groups`` method removed from ``NodeBase`` and ``Node`` classes
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-``for_each_callback_group()`` method has replaced ``get_callback_groups()`` by providing a thread-safe way to access ``callback_groups_`` vector. 
+``for_each_callback_group()`` method has replaced ``get_callback_groups()`` by providing a thread-safe way to access ``callback_groups_`` vector.
 ``for_each_callback_group()`` accepts a function as an argument, iterates over the stored callback groups, and calls the passed function to ones that are valid.
 
 ros2cli

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -155,6 +155,8 @@ For more details, see `REP 2007 <https://ros.org/reps/rep-2007.html>`_.
 ``for_each_callback_group()`` method has replaced ``get_callback_groups()`` by providing a thread-safe way to access ``callback_groups_`` vector.
 ``for_each_callback_group()`` accepts a function as an argument, iterates over the stored callback groups, and calls the passed function to ones that are valid.
 
+For more details, please refer to this (pull request)[https://github.com/ros2/rclcpp/pull/1723]
+
 ros2cli
 ^^^^^^^
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -149,6 +149,12 @@ And an example of how the type adapter can be used:
 To learn more, see the `publisher <https://github.com/ros2/examples/blob/b83b18598b198b4a5ba44f9266c1bb39a393fa17/rclcpp/topics/minimal_publisher/member_function_with_type_adapter.cpp>`_ and `subscription <https://github.com/ros2/examples/blob/b83b18598b198b4a5ba44f9266c1bb39a393fa17/rclcpp/topics/minimal_subscriber/member_function_with_type_adapter.cpp>`_) examples, as well as a more complex `demo <https://github.com/ros2/demos/pull/482>`_.
 For more details, see `REP 2007 <https://ros.org/reps/rep-2007.html>`_.
 
+``get_callback_groups`` method removed from ``NodeBase`` and ``Node`` classes
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+``for_each_callback_group()`` method has replaced ``get_callback_groups()`` by providing a thread-safe way to access ``callback_groups_`` vector. 
+``for_each_callback_group()`` accepts a function as an argument, iterates over the stored callback groups, and calls the passed function to ones that are valid.
+
 ros2cli
 ^^^^^^^
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -155,7 +155,7 @@ For more details, see `REP 2007 <https://ros.org/reps/rep-2007.html>`_.
 ``for_each_callback_group()`` method has replaced ``get_callback_groups()`` by providing a thread-safe way to access ``callback_groups_`` vector.
 ``for_each_callback_group()`` accepts a function as an argument, iterates over the stored callback groups, and calls the passed function to ones that are valid.
 
-For more details, please refer to this (pull request)[https://github.com/ros2/rclcpp/pull/1723]
+For more details, please refer to this `pull request <https://github.com/ros2/rclcpp/pull/1723>`_.
 
 ros2cli
 ^^^^^^^


### PR DESCRIPTION
``get_callback_groups()`` method in ``NodeBase`` and ``Node`` classes replaced by ``for_each_callback_group()``