### PR TITLE
Specify instructions in Maintaining a Source Checkout to point to distro release's source checkout and not development (rolling)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,7 @@ pygments_style = 'sphinx'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-extensions = ['sphinx.ext.intersphinx', 'sphinx_tabs.tabs', 'sphinx_multiversion', 'sphinx_rtd_theme']
+extensions = ['sphinx.ext.intersphinx', 'sphinx_tabs.tabs', 'sphinx_multiversion', 'sphinx_rtd_theme', 'sphinx.ext.ifconfig']
 
 # Intersphinx mapping
 

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -5,7 +5,7 @@ Maintaining a source checkout of {DISTRO_TITLE_FULL}
 
 .. note::
 
-   For instructions on maintaining a source checkout of the **latest development version of ROS2, refer to 
+   For instructions on maintaining a source checkout of the **latest development version** of ROS2, refer to 
    `Maintaining a source checkout of Rolling Ridley <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
 
 .. contents::

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -3,10 +3,12 @@
 Maintaining a source checkout of ROS 2 {DISTRO_TITLE}
 =====================================================
 
-.. note::
+.. ifconfig:: smv_current_version != '' and smv_current_version != 'rolling'
 
-   For instructions on maintaining a source checkout of the **latest development version** of ROS2, refer to
-   `Maintaining a source checkout of ROS 2 Rolling <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
+  .. note::
+
+     For instructions on maintaining a source checkout of the **latest development version** of ROS 2, refer to
+     `Maintaining a source checkout of ROS 2 Rolling <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
 
 .. contents::
    :depth: 2

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -1,7 +1,12 @@
 .. _MaintainingSource:
 
-Maintaining a source checkout of ROS 2
-======================================
+Maintaining a source checkout of {DISTRO_TITLE_FULL}
+====================================================
+
+.. note::
+
+   For instructions on maintaining a source checkout of the **latest development version of ROS2, refer to 
+   `Maintaining a source checkout of Rolling Ridley <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
 
 .. contents::
    :depth: 2
@@ -16,10 +21,10 @@ Update your repository list
 Each ROS 2 release includes a ``ros2.repos`` file that contains the list of repositories and their version for that release.
 
 
-Latest development branches
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Latest {DISTRO_TITLE_FULL} branches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you wish to checkout the latest development code for the upcoming ROS release, you can get the relevant repository list by running:
+If you wish to checkout the latest code for ROS 2 {DISTRO_TITLE}, you can get the relevant repository list by running:
 
 .. tabs::
 
@@ -27,17 +32,17 @@ If you wish to checkout the latest development code for the upcoming ROS release
 
     .. code-block:: bash
 
-       cd ~/ros2_ws
+       cd ~/ros2_{DISTRO}
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos
 
   .. group-tab:: macOS
 
     .. code-block:: bash
 
-       cd ~/ros2_ws
+       cd ~/ros2_{DISTRO}
        mv -i ros2.repos ros2.repos.old
-       wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+       wget https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos
 
   .. group-tab:: Windows
 
@@ -45,11 +50,11 @@ If you wish to checkout the latest development code for the upcoming ROS release
 
        # CMD
        > cd \dev\ros2
-       > curl -sk https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+       > curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
        # PowerShell
        > cd \dev\ros2
-       > curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos -o ros2.repos
+       > curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
 
 Update your repositories
@@ -117,14 +122,14 @@ If you wish to know the versions of the set of repositories in your workspace, y
 
     .. code-block:: bash
 
-       cd ~/ros2_ws
+       cd ~/ros2_{DISTRO}
        vcs export src > my_ros2.repos
 
   .. group-tab:: macOS
 
     .. code-block:: bash
 
-       cd ~/ros2_ws
+       cd ~/ros2_{DISTRO}
        vcs export src > my_ros2.repos
 
   .. group-tab:: Windows

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -5,7 +5,7 @@ Maintaining a source checkout of ROS 2 {DISTRO_TITLE}
 
 .. note::
 
-   For instructions on maintaining a source checkout of the **latest development version** of ROS2, refer to 
+   For instructions on maintaining a source checkout of the **latest development version** of ROS2, refer to
    `Maintaining a source checkout of ROS 2 Rolling <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
 
 .. contents::
@@ -22,7 +22,7 @@ Each ROS 2 release includes a ``ros2.repos`` file that contains the list of repo
 
 
 Latest ROS 2 {DISTRO_TITLE} branches
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you wish to checkout the latest code for ROS 2 {DISTRO_TITLE}, you can get the relevant repository list by running:
 

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -49,11 +49,11 @@ If you wish to checkout the latest code for ROS 2 {DISTRO_TITLE}, you can get th
     .. code-block:: bash
 
        # CMD
-       > cd \dev\ros2
+       > cd \dev\ros2_{DISTRO}
        > curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
        # PowerShell
-       > cd \dev\ros2
+       > cd \dev\ros2_{DISTRO}
        > curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
 
@@ -136,7 +136,7 @@ If you wish to know the versions of the set of repositories in your workspace, y
 
     .. code-block:: bash
 
-       > cd \dev\ros2
+       > cd \dev\ros2_{DISTRO}
        > vcs export src > my_ros2.repos
 
 This ``my_ros2.repos`` file can then be shared with others so that they can reproduce the state of the repositories in your workspace.

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -1,12 +1,12 @@
 .. _MaintainingSource:
 
-Maintaining a source checkout of {DISTRO_TITLE_FULL}
-====================================================
+Maintaining a source checkout of ROS 2 {DISTRO_TITLE}
+=====================================================
 
 .. note::
 
    For instructions on maintaining a source checkout of the **latest development version** of ROS2, refer to 
-   `Maintaining a source checkout of Rolling Ridley <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
+   `Maintaining a source checkout of ROS 2 Rolling <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
 
 .. contents::
    :depth: 2
@@ -21,7 +21,7 @@ Update your repository list
 Each ROS 2 release includes a ``ros2.repos`` file that contains the list of repositories and their version for that release.
 
 
-Latest {DISTRO_TITLE_FULL} branches
+Latest ROS 2 {DISTRO_TITLE} branches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you wish to checkout the latest code for ROS 2 {DISTRO_TITLE}, you can get the relevant repository list by running:


### PR DESCRIPTION
Resolves #1706 .

Each distro should have instructions for checking out the corresponding distro branches.
A note at the top directs users that want to work on the latest development branch, to rolling's wiki page.

https://docs.ros.org/en/galactic/Installation/Latest-Development-Setup.html still requires updating, but won't be included in this PR.

[Foxy's instructions](https://docs.ros.org/en/foxy/Installation/Maintaining-a-Source-Checkout.html#release-versions) covers checking out the release version aswell, but I'm not sure if anyone has to ever checkout the release version so it has been left out.