### PR TITLE
Mention possible need for English language pack for Windows 10

### DIFF
--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -14,6 +14,12 @@ System requirements
 
 Only Windows 10 is supported.
 
+Language support
+^^^^^^^^^^^^^^^^
+
+Make sure you have a locale which supports ``UTF-8``.
+For example, for a Chinese-language Windows 10 installation, you may need to install an `English language pack <https://support.microsoft.com/en-us/windows/language-packs-for-windows-a5094319-a92d-18de-5b53-1cfc697cfca8>`_.
+
 .. include:: _Windows-Install-Prerequisites.rst
 
 Additional prerequisites


### PR DESCRIPTION
Someone got a weird compiler error (C2001 newline in constant): https://answers.ros.org/question/383382/building-galactic-with-source-code-on-windows-fails/. It turns out that they had a Chinese-language Windows 10 installation, and that by adding English-language support, the problem disappeared.

I'm not really sure about the exact details or cause, which is why I explicitly mentioned "for a Chinese-language Windows 10 installation." Googling "Windows 10 error c2001 chinese" returns many results, and it seems to be related to file encoding: https://github.com/libusb/libusb/issues/207#issuecomment-288664124.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>