### PR TITLE
Suggest adding exec_depend on ros2launch for packages with launch files

### DIFF
--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -259,17 +259,6 @@ or run the file directly by specifying the path to the launch file
 
   ros2 launch <path_to_launch_file>
 
-.. note::
-
-  For packages with launch files, it is a good idea to add an ``exec_depend`` dependency on the ``ros2launch`` package in your package's ``package.xml``:
-
-  .. code-block:: xml
-
-    <exec_depend>ros2launch</exec_depend>
-
-  This helps make sure that the ``ros2 launch`` command is available after building your package.
-  It also ensures that all launch file formats are recognized.
-
 Setting arguments
 ^^^^^^^^^^^^^^^^^
 

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -259,6 +259,17 @@ or run the file directly by specifying the path to the launch file
 
   ros2 launch <path_to_launch_file>
 
+.. note::
+
+  For packages with launch files, it is a good idea to add an ``exec_depend`` dependency on the ``ros2launch`` package in your package's ``package.xml``:
+
+  .. code-block:: xml
+
+    <exec_depend>ros2launch</exec_depend>
+
+  This helps make sure that the ``ros2 launch`` command is available after building your package.
+  It also ensures that all launch file formats are recognized.
+
 Setting arguments
 ^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -201,6 +201,17 @@ To launch ``turtlesim_mimic_launch.py``, enter into the directory you created ea
 
   You will learn more about :doc:`creating packages <../Creating-Your-First-ROS2-Package>` in a later tutorial.
 
+.. note::
+
+  For packages with launch files, it is a good idea to add an ``exec_depend`` dependency on the ``ros2launch`` package in your package's ``package.xml``:
+
+  .. code-block:: xml
+
+    <exec_depend>ros2launch</exec_depend>
+
+  This helps make sure that the ``ros2 launch`` command is available after building your package.
+  It also ensures that all launch file formats are recognized.
+
 Two turtlesim windows will open, and you will see the following ``[INFO]`` messages telling you which nodes your launch file has started:
 
 .. code-block:: console

--- a/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
+++ b/source/Tutorials/Launch-Files/Creating-Launch-Files.rst
@@ -210,7 +210,7 @@ To launch ``turtlesim_mimic_launch.py``, enter into the directory you created ea
     <exec_depend>ros2launch</exec_depend>
 
   This helps make sure that the ``ros2 launch`` command is available after building your package.
-  It also ensures that all launch file formats are recognized.
+  It also ensures that all :doc:`launch file formats <../../How-To-Guides/Launch-file-different-formats>` are recognized.
 
 Two turtlesim windows will open, and you will see the following ``[INFO]`` messages telling you which nodes your launch file has started:
 


### PR DESCRIPTION
This is a change suggested here after we realized that the launch frontends may not get built if your 
 package doesn't depend on them (almost none of the common CLI/launch packages do): https://github.com/ros2/launch/pull/516#issuecomment-880342455

> I don't know if we have it documented anywhere, but we should recommend depending on `ros2launch` always, it seems. Otherwise important parts will not be included.

Note that the last line in this proposed change isn't currently valid. Depending on `ros2launch` will only ensure `launch_xml`/`launch_yaml` are built after this PR (or an equivalent PR) is merged: https://github.com/ros2/launch_ros/pull/256

I couldn't really find a perfect place to put this note, but this seemed like an okay spot.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>