### PR TITLE
Update uninstall instructions to use apt-get

### DIFF
--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -117,4 +117,4 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo apt-get remove ros-{DISTRO}-* && sudo apt autoremove
+  sudo apt remove ~nros-{DISTRO}-* && sudo apt autoremove

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -117,4 +117,4 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo apt remove ros-{DISTRO}-* && sudo apt autoremove
+  sudo apt-get remove ros-{DISTRO}-* && sudo apt autoremove


### PR DESCRIPTION
The apt interface in 20.04 does not support wildcards. Trying to uninstall with this command yields
`E: Unable to locate package ros-foxy-rviz-*`