### PR TITLE
Use macros for distribution names.

### DIFF
--- a/source/Tutorials/Tf2/Introduction-To-Tf2.rst
+++ b/source/Tutorials/Tf2/Introduction-To-Tf2.rst
@@ -24,7 +24,7 @@ Let's start by installing the demo package and its dependencies.
 
       .. code-block:: console
 
-         sudo apt-get install ros-rolling-turtle-tf2-py ros-rolling-tf2-tools
+         sudo apt-get install ros-{DISTRO}-turtle-tf2-py ros-{DISTRO}-tf2-tools
 
    .. group-tab:: From Source
 

--- a/source/Tutorials/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -324,7 +324,7 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro rolling -y
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 

--- a/source/Tutorials/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -288,7 +288,7 @@ check for missing dependencies before building:
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro rolling -y
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 


### PR DESCRIPTION
That way backports are easier.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@kurshakuz FYI