### PR TITLE
fix links in tf2 main tutorials page

### DIFF
--- a/source/Tutorials/Tf2/Tf2-Main.rst
+++ b/source/Tutorials/Tf2/Tf2-Main.rst
@@ -51,16 +51,16 @@ Learning tf2
 
    This tutorial teaches you how to use tf2 to get access to frame transformations.
 
-#. :ref:`Adding a frame (Python) <AddingAFramePy>`.
+#. Adding a frame :ref:`(Python) <AddingAFramePy>`.
 
    This tutorial teaches you how to add an extra fixed frame to tf2.
 
-#. :ref:`Learning about tf2 and time (Python) <LearningAboutTf2AndTimePy>`.
+#. Learning about tf2 and time :ref:`(Python) <LearningAboutTf2AndTimePy>`.
 
    This tutorial teaches you to use the timeout in ``lookup_transform`` function to
    wait for a transform to be available on the tf2 tree.
 
-#. :ref:`Time travel with tf2 (Python) <TimeTravelWithTf2Py>`.
+#. Time travel with tf2 :ref:`(Python) <TimeTravelWithTf2Py>`.
 
    This tutorial teaches you about advanced time travel features of tf2.
 


### PR DESCRIPTION
Links are not correctly displayed on the tf2 main page. 

Signed-off-by: Shyngyskhan Abilkassov abilkasov@gmail.com