### PR TITLE
Update Foxy's conf.py so we can build standalone.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Install dependencies with pip
         run: |
-          pip install doc8 sphinx sphinx-multiversion
-          pip install git+https://github.com/osrf/sphinx-tabs
+          pip install --no-warn-script-location --user --upgrade -r requirements.txt
+          pip install doc8
 
       - run: make html
       - run: doc8 --ignore D001 --ignore-path build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pip
-Sphinx
+docutils==0.16
+sphinx
 sphinx-tabs
+sphinx-multiversion
+sphinx-rtd-theme


### PR DESCRIPTION
One of the easier way to work on branches in this documentation
is to make local changes and then run "make html".  This works
fine on the rolling and galactic branches, but because Foxy's
conf.py was so out-of-date, it didn't really work here.  Update
the conf.py so it is compatible with the galactic one, which
makes it work a lot better.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>