### PR TITLE
Fix typo in bounded types example

### DIFF
--- a/source/Concepts/About-ROS-Interfaces.rst
+++ b/source/Concepts/About-ROS-Interfaces.rst
@@ -170,7 +170,7 @@ All types that are more permissive than their ROS definition enforce the ROS con
    string<=10 up_to_ten_characters_string
 
    string[<=5] up_to_five_unbounded_strings
-   string<=10[] unbounded_array_of_string_up_to_ten_characters each
+   string<=10[] unbounded_array_of_string_up_to_ten_characters_each
    string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
 
 2.1.2 Field names


### PR DESCRIPTION
Missing an underscore.