### PR TITLE
Remove prompt symbol from installation commands, fix indentation

### DIFF
--- a/source/Installation/Fedora-Development-Setup.rst
+++ b/source/Installation/Fedora-Development-Setup.rst
@@ -8,7 +8,7 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
 
 .. code-block:: bash
 
-   $ sudo dnf install \
+   sudo dnf install \
      cmake \
      cppcheck \
      eigen3-devel \

--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -117,7 +117,7 @@ More info on working with a ROS workspace can be found in `this tutorial <../Tut
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
 Take for instance: you would like to avoid installing the large OpenCV library.
-Well then simply ``$ touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
+Well then simply run ``touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
 
 Environment setup
 -----------------

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -126,7 +126,7 @@ More info on working with a ROS workspace can be found in `this tutorial </Tutor
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
 Take for instance: you would like to avoid installing the large OpenCV library.
-Well then simply ``$ touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
+Well then simply run ``touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
 
 Environment setup
 -----------------

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -3,7 +3,7 @@ First, make sure that the `Ubuntu Universe repository <https://help.ubuntu.com/c
 
 .. code-block:: bash
 
-       $ apt-cache policy | grep universe
+       apt-cache policy | grep universe
         500 http://us.archive.ubuntu.com/ubuntu focal/universe amd64 Packages
             release v=20.04,o=Ubuntu,a=focal,n=focal,l=Ubuntu,c=universe,b=amd64
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -3,16 +3,16 @@ First, make sure that the `Ubuntu Universe repository <https://help.ubuntu.com/c
 
 .. code-block:: bash
 
-       apt-cache policy | grep universe
-        500 http://us.archive.ubuntu.com/ubuntu focal/universe amd64 Packages
-            release v=20.04,o=Ubuntu,a=focal,n=focal,l=Ubuntu,c=universe,b=amd64
+   apt-cache policy | grep universe
+    500 http://us.archive.ubuntu.com/ubuntu focal/universe amd64 Packages
+        release v=20.04,o=Ubuntu,a=focal,n=focal,l=Ubuntu,c=universe,b=amd64
 
 If you don't see an output line like the one above, then enable the Universe repository with these instructions.
 
 .. code-block:: bash
 
-       sudo apt install software-properties-common
-       sudo add-apt-repository universe
+   sudo apt install software-properties-common
+   sudo add-apt-repository universe
 
 
 Now add the ROS 2 apt repository to your system.


### PR DESCRIPTION
#1846 added a button to copy commands*, and overall I think we omit the command prompt symbol (i.e., `$`, `>`), especially in the installation instructions https://github.com/ros2/ros2_documentation/pull/1316#pullrequestreview-635865685.

*although, with some config options, `sphinx_copybutton` can strip out those symbols and even strip out the output examples/samples: https://sphinx-copybutton.readthedocs.io/en/latest/#strip-and-configure-input-prompts-for-code-cells

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>