### PR TITLE
Macroname for GTest is ament_cmake_gtest

### DIFF
--- a/source/Guides/Ament-CMake-Documentation.rst
+++ b/source/Guides/Ament-CMake-Documentation.rst
@@ -290,7 +290,7 @@ Ament contains CMake macros to simplify setting up GTests. Call:
 
 .. code-block:: cmake
 
-    find_package(ament_gtest)
+    find_package(ament_cmake_gtest)
     ament_add_gtest(some_test <test_sources>)
 
 to add a GTest.
@@ -302,7 +302,7 @@ The macros have additional parameters:
 
 .. code-block:: cmake
 
-    find_package(ament_gtest REQUIRED)
+    find_package(ament_cmake_gtest REQUIRED)
     ament_add_gtest(some_test <test_sources>
       APPEND_ENV PATH=some/addtional/path/for/testing/resources)
 


### PR DESCRIPTION
see also https://answers.ros.org/question/341155/ros2-cmake-cant-find-ament_gtest/