### PR TITLE
Remove the line numbering in examples.

### DIFF
--- a/source/Tutorials/Actions/Writing-a-Cpp-Action-Server-Client.rst
+++ b/source/Tutorials/Actions/Writing-a-Cpp-Action-Server-Client.rst
@@ -130,7 +130,6 @@ Open up ``action_tutorials_cpp/src/fibonacci_action_server.cpp``, and put the fo
 
 .. literalinclude:: server.cpp
     :language: c++
-    :linenos:
 
 The first few lines include all of the headers we need to compile.
 
@@ -257,7 +256,6 @@ Open up ``action_tutorials_cpp/src/fibonacci_action_client.cpp``, and put the fo
 
 .. literalinclude:: client.cpp
     :language: c++
-    :linenos:
 
 The first few lines include all of the headers we need to compile.
 

--- a/source/Tutorials/Actions/Writing-a-Py-Action-Server-Client.rst
+++ b/source/Tutorials/Actions/Writing-a-Py-Action-Server-Client.rst
@@ -45,7 +45,6 @@ and add the following code:
 
 .. literalinclude:: server_0.py
     :language: python
-    :linenos:
 
 Line 8 defines a class ``FibonacciActionServer`` that is a subclass of ``Node``.
 The class is initialized by calling the ``Node`` constructor, naming our node ``fibonacci_action_server``:
@@ -111,7 +110,6 @@ We can use the method `succeed() <http://docs.ros2.org/latest/api/rclpy/api/acti
 
 .. literalinclude:: server_1.py
     :language: python
-    :linenos:
     :lines: 18-22
     :emphasize-lines: 3
 
@@ -121,7 +119,6 @@ Now let's make our goal execution actually compute and return the requested Fibo
 
 .. literalinclude:: server_2.py
     :language: python
-    :linenos:
     :lines: 18-30
     :emphasize-lines: 4-7,12
 
@@ -141,7 +138,6 @@ After every update of the feedback message in the for-loop, we publish the feedb
 
 .. literalinclude:: server_3.py
     :language: python
-    :linenos:
     :lines: 1-37
     :emphasize-lines: 1,23,24,27-31,36
 
@@ -159,7 +155,6 @@ Open a new file, let's call it ``fibonacci_action_client.py``, and add the follo
 
 .. literalinclude:: client_0.py
     :language: python
-    :linenos:
 
 We've defined a class ``FibonacciActionClient`` that is a subclass of ``Node``.
 The class is initialized by calling the ``Node`` constructor, naming our node ``fibonacci_action_client``:
@@ -267,7 +262,6 @@ Here's the complete code for this example:
 
 .. literalinclude:: client_1.py
     :language: python
-    :linenos:
 
 The `ActionClient.send_goal_async() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.client.ActionClient.send_goal_async>`_ method returns a future to a goal handle.
 First we register a callback for when the future is complete:
@@ -333,7 +327,6 @@ Here's the complete code for this example:
 
 .. literalinclude:: client_2.py
     :language: python
-    :linenos:
 
 Here's the callback function for feedback messages:
 

--- a/source/Tutorials/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Creating-Your-First-ROS2-Package.rst
@@ -386,7 +386,6 @@ From ``dev_ws/src/my_package``, open ``package.xml`` using your preferred text e
    .. group-tab:: CMake
 
     .. code-block:: xml
-     :linenos:
 
      <?xml version="1.0"?>
      <?xml-model
@@ -412,7 +411,6 @@ From ``dev_ws/src/my_package``, open ``package.xml`` using your preferred text e
    .. group-tab:: Python
 
     .. code-block:: xml
-     :linenos:
 
      <?xml version="1.0"?>
      <?xml-model
@@ -435,16 +433,15 @@ From ``dev_ws/src/my_package``, open ``package.xml`` using your preferred text e
       </export>
      </package>
 
-Input your name and email on line 7 if it hasn't been automatically populated for you.
-Then, edit the description on line 6 to summarize the package:
+Input your name and email on the ``maintainer`` line if it hasn't been automatically populated for you.
+Then, edit the ``description`` line to summarize the package:
 
 .. code-block:: xml
 
   <description>Beginner client libraries tutorials practice package</description>
 
-Then, update the license on line 8.
+Then update the ``license`` line.
 You can read more about open source licenses `here <https://opensource.org/licenses/alphabetical>`__.
-
 Since this package is only for practice, it’s safe to use any license. We use ``Apache License 2.0``:
 
 .. code-block:: xml
@@ -472,7 +469,6 @@ This is where your ``package.xml`` would list its dependencies on other packages
       Open ``setup.py`` with your preferred text editor.
 
       .. code-block:: python
-       :linenos:
 
        from setuptools import setup
 
@@ -501,7 +497,7 @@ This is where your ``package.xml`` would list its dependencies on other packages
           },
        )
 
-      Edit lines 16-19 to match ``package.xml``.
+      Edit the ``maintainer``, ``maintainer_email``, and ``description`` lines to match ``package.xml``.
 
       Don’t forget to save the file.
 


### PR DESCRIPTION
This is inconsistent with having the boxes be cut-n-paste.
We also have to rewrite a small amount of text around it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #1885 