### PR TITLE
Add ament_cmake_python user documentation

### DIFF
--- a/source/Concepts/About-Build-System.rst
+++ b/source/Concepts/About-Build-System.rst
@@ -98,6 +98,7 @@ Here a list of the |packages| in the repository along with a short description:
 -  ``ament_cmake_python``
 
    - provides CMake functions for |packages| that contain Python code
+   - see the `ament_cmake_python user documentation <../Guides/Ament-CMake-Python-Documentation>`__
 
 -  ``ament_cmake_test``
 

--- a/source/Guides.rst
+++ b/source/Guides.rst
@@ -19,6 +19,7 @@ If you are new and looking to learn the ropes, start with the :ref:`Tutorials <T
    Guides/Installation-Troubleshooting
    Guides/Developing-a-ROS-2-Package
    Guides/Ament-CMake-Documentation
+   Guides/Ament-CMake-Python-Documentation
    Guides/Launch-files-migration-guide
    Guides/Launch-file-different-formats
    Guides/Parameters-YAML-files-migration-guide

--- a/source/Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/Guides/Ament-CMake-Python-Documentation.rst
@@ -33,7 +33,7 @@ The outline of a package called "my_project" with the ament_cmake build type tha
            └── my_script.py
 
 The ``__init__.py`` file can be empty, but it is needed to `make Python treat the directory containing it as a package <https://docs.python.org/3/tutorial/modules.html#packages>`__.
-There can also be a ``src`` or ``include`` directory alongside the ``CMakeLists.txt``.
+There can also be a ``src`` or ``include`` directory alongside the ``CMakeLists.txt`` which holds C/C++ code.
 
 Using ament_cmake_python
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/Guides/Ament-CMake-Python-Documentation.rst
@@ -32,7 +32,7 @@ The outline of a package called "my_project" with the ament_cmake build type tha
            ├── __init__.py
            └── my_script.py
 
-The ``__init__.py`` file can be empty.
+The ``__init__.py`` file can be empty, but it is needed to `make Python treat the directory containing it as a package <https://docs.python.org/3/tutorial/modules.html#packages>`__.
 There can also be a ``src`` or ``include`` directory alongside the ``CMakeLists.txt``.
 
 Using ament_cmake_python

--- a/source/Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/Guides/Ament-CMake-Python-Documentation.rst
@@ -1,0 +1,68 @@
+.. redirect-from::
+
+  Tutorials/Ament-CMake-Python-Documentation
+
+ament_cmake_python user documentation
+=====================================
+
+ament_cmake_python is a package that provides CMake functions for packages of the ``ament_cmake`` build type that contain Python code.
+See the `ament_cmake user documentation <Ament-CMake-Documentation>`__ for more information.
+
+.. note::
+
+   Pure Python packages should use the ament_python build type in most cases.
+   To create an ament_python package, see `Creating your first ROS 2 package <../Tutorials/Creating-Your-First-ROS2-Package>`__.
+   ament_cmake_python should only be used in cases where that is not possible, like when mixing C/C++ and Python code.
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Basics
+------
+
+Basic project outline
+^^^^^^^^^^^^^^^^^^^^^
+
+The outline of a package called "my_project" with the ament_cmake build type that uses ament_cmake_python looks like:
+
+.. code-block::
+
+   .
+   └── my_project
+       ├── CMakeLists.txt
+       ├── package.xml
+       └── my_project
+           ├── __init__.py
+           └── my_script.py
+
+The ``__init__.py`` file can be empty.
+There can also be a ``src`` or ``include`` directory alongside the ``CMakeLists.txt``.
+
+Using ament_cmake_python
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The package must declare a dependency on ``ament_cmake_python`` in its ``package.xml``.
+
+.. code-block:: xml
+
+   <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+The ``CMakeLists.txt`` should contain:
+
+.. code-block:: cmake
+
+   find_package(ament_cmake_python REQUIRED)
+   # ...
+   ament_python_install_package(${PROJECT_NAME})
+
+The argument to ``ament_python_install_package()`` is the name of the directory alongside the ``CMakeLists.txt`` that contains the Python file.
+In this case, it is ``my_project``, or ``${PROJECT_NAME}``.
+
+Then, another Python package that correctly depends on ``my_project`` can use it as a normal Python module:
+
+.. code-block:: python
+
+   from my_project.my_script import my_function
+
+Assuming ``my_script.py`` contains a function called ``my_function()``.

--- a/source/Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/Guides/Ament-CMake-Python-Documentation.rst
@@ -1,14 +1,14 @@
 ament_cmake_python user documentation
 =====================================
 
-ament_cmake_python is a package that provides CMake functions for packages of the ``ament_cmake`` build type that contain Python code.
+``ament_cmake_python`` is a package that provides CMake functions for packages of the ``ament_cmake`` build type that contain Python code.
 See the `ament_cmake user documentation <Ament-CMake-Documentation>`__ for more information.
 
 .. note::
 
-   Pure Python packages should use the ament_python build type in most cases.
-   To create an ament_python package, see `Creating your first ROS 2 package <../Tutorials/Creating-Your-First-ROS2-Package>`__.
-   ament_cmake_python should only be used in cases where that is not possible, like when mixing C/C++ and Python code.
+   Pure Python packages should use the ``ament_python`` build type in most cases.
+   To create an ``ament_python`` package, see `Creating your first ROS 2 package <../Tutorials/Creating-Your-First-ROS2-Package>`__.
+   ``ament_cmake_python`` should only be used in cases where that is not possible, like when mixing C/C++ and Python code.
 
 .. contents:: Table of Contents
    :depth: 2
@@ -20,7 +20,7 @@ Basics
 Basic project outline
 ^^^^^^^^^^^^^^^^^^^^^
 
-The outline of a package called "my_project" with the ament_cmake build type that uses ament_cmake_python looks like:
+The outline of a package called "my_project" with the ``ament_cmake`` build type that uses ``ament_cmake_python`` looks like:
 
 .. code-block::
 

--- a/source/Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/Guides/Ament-CMake-Python-Documentation.rst
@@ -1,7 +1,3 @@
-.. redirect-from::
-
-  Tutorials/Ament-CMake-Python-Documentation
-
 ament_cmake_python user documentation
 =====================================
 

--- a/source/Tutorials/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Creating-Your-First-ROS2-Package.rst
@@ -514,9 +514,3 @@ Next steps
 
 Next, let's add something meaningful to a package.
 You'll start with a simple publisher/subscriber system, which you can choose to write in either :ref:`C++ <CppPubSub>` or :ref:`Python <PyPubSub>`.
-
-Related content
----------------
-
-For more advanced use-cases, CMake packages can contain Python code.
-See the `ament_cmake_python user documentation <../Guides/Ament-CMake-Python-Documentation>`__.

--- a/source/Tutorials/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Creating-Your-First-ROS2-Package.rst
@@ -514,3 +514,9 @@ Next steps
 
 Next, let's add something meaningful to a package.
 You'll start with a simple publisher/subscriber system, which you can choose to write in either :ref:`C++ <CppPubSub>` or :ref:`Python <PyPubSub>`.
+
+Related content
+---------------
+
+For more advanced use-cases, CMake packages can contain Python code.
+See the `ament_cmake_python user documentation <../Guides/Ament-CMake-Python-Documentation>`__.


### PR DESCRIPTION
Closes #1735

There's a "basics" section and nothing else because I wasn't sure if I should mention the other CMake macros, like:

* `ament_get_python_install_dir`: https://github.com/ament/ament_cmake/blob/099871343a8e0b6cee2e90cdc815dd61eaf5abf3/ament_cmake_python/cmake/ament_get_python_install_dir.cmake
* `ament_python_install_module`: https://github.com/ament/ament_cmake/blob/099871343a8e0b6cee2e90cdc815dd61eaf5abf3/ament_cmake_python/cmake/ament_python_install_module.cmake

The last one isn't used anywhere from what I can tell.

If #1385 gets picked up again, it should probably link to this.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>