### PR TITLE
Remove the instructions to install log4cxx.

### DIFF
--- a/source/Guides/Installation-Troubleshooting.rst
+++ b/source/Guides/Installation-Troubleshooting.rst
@@ -301,8 +301,8 @@ In the dialog, select Enabled and click OK.
 
 Close and open your terminal to reset the environment and try building again.
 
-CMake packages unable to find asio, tinyxml2, tinyxml, eigen, or log4cxx
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+CMake packages unable to find asio, tinyxml2, tinyxml, or eigen
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We've seen that sometimes the chocolatey packages for ``asio``, ``tinyxml2``, etc. do not add important registry entries and CMake will be unable to find them when building ROS 2.
 We've not yet been able to identify the root cause, but uninstalling the chocolatey packages (with ``-n`` if the uninstall fails the first time), and then reinstalling them will fix the issue.

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -109,13 +109,12 @@ Please download these packages from `this <https://github.com/ros2/choco-package
 * eigen-3.3.4.nupkg
 * tinyxml-usestl.2.6.2.nupkg
 * tinyxml2.6.0.0.nupkg
-* log4cxx.0.10.0.nupkg
 
 Once these packages are downloaded, open an administrative shell and execute the following command:
 
 .. code-block:: bash
 
-   choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml-usestl tinyxml2 log4cxx bullet
+   choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml-usestl tinyxml2 bullet
 
 Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -75,7 +75,7 @@ You need the following things installed to build ROS 2:
        echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
 
        # install dependencies for rcl_logging
-       brew install log4cxx spdlog
+       brew install spdlog
 
        # install dependencies for Cyclone DDS
        brew install bison cunit


### PR DESCRIPTION
It is no longer required as of https://github.com/ros2/rcl_logging/pull/78

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this should *not* be backported to Galactic or Foxy, as those still have log4cxx in the checkouts.