### PR TITLE
Add a couple of extra steps for Windows Debug mode.

### DIFF
--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -235,6 +235,7 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    copy python3_d.dll C:\Python38 /Y
    copy python38_d.lib C:\Python38\libs /Y
    copy python3_d.lib C:\Python38\libs /Y
+   copy sqlite3_d.dll C:\Python38\DLLs /Y
    for %I in (*_d.pyd) do copy %I C:\Python38\DLLs /Y
 
 
@@ -242,7 +243,7 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
 
 .. code-block:: bash
 
-   python_d -c "import _ctypes"
+   python_d -c "import _ctypes ; import coverage"
 
 * Once you have verified the operation of ``python_d``, it is necessary to reinstall a few dependencies with the debug-enabled libraries:
 


### PR DESCRIPTION
While working in Windows debug mode, I noticed that it couldn't
import pytest, and hence none of the pytest tests in the core
were running.  After some debugging, I found that pytest (or
more specifically, pytest-cov/coverage) requires the sqlite3_d.dll
to be in place for it to work.  Add the instruction to copy that
over, as well as add a test to make sure it worked.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>