### PR TITLE
Documents minor differences between ROS1 and ROS2 blooming

### DIFF
--- a/source/Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -43,10 +43,19 @@ If you're using a version of bloom older than 0.6.8 you'll need to use the v3 in
 
    export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml'
 
-No differences from ROS 1 Bloom
--------------------------------
+Minor differences from ROS 1 Bloom
+----------------------------------
 
-If you've bloomed packages before in ROS 1, the ROS 2 process is exactly the same.
+If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you. The major
+difference is that release repositories for ROS 2 packages live in a dedicated github organization:
+`ROS 2 release repositories <https://github.com/ros2-gbp/>`.
+If you don't have a respository there for your package, yet, create a ticket for
+`nuclearsandwich <https://github.com/nuclearsandwich>` or give him a ping
+`on discourse <https://discourse.ros.org/u/nuclearsandwich/summary>`.
+
+In the meantime, a new workflow
+`based on Terraform <https://discourse.ros.org/t/upcoming-changes-to-ros2-gbp-organization/21878/4>`
+is in the making. Stay tuned!
 
 Procedure
 ---------


### PR DESCRIPTION
Documents minor differences between ROS1 and ROS2 blooming, i.e. mainly the new release repository organization. /cc @nuclearsandwich 

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>