### PR TITLE
Creating-A-Workspace.rst: Update rosdep --from-path argument

### DIFF
--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -183,6 +183,8 @@ From the root of your workspace (``dev_ws``), run the following command:
 
       .. code-block:: console
 
+        # cd if you're still in the ``src`` directory with the ``ros_tutorials`` clone
+        cd ..
         rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS


### PR DESCRIPTION
In order to work in a cut & paste fashion, the --from-path argument needs to match the directory name of the cloned ros_tutorials.