### PR TITLE
Update Creating-an-Action.rst

### DIFF
--- a/source/Tutorials/Actions/Creating-an-Action.rst
+++ b/source/Tutorials/Actions/Creating-an-Action.rst
@@ -171,7 +171,7 @@ We can check that our action built successfully with the command line tool:
    # On Windows: call install/setup.bat
    . install/setup.bash
    # Check that our action definition exists
-   ros2 interface show action_tutorials/action/Fibonacci
+   ros2 interface show action_tutorials_interfaces/action/Fibonacci
 
 
 You should see the Fibonacci action definition printed to the screen.


### PR DESCRIPTION
right now, line 174 is wrong. In the tutorial, it currently says to call "action_tutorials" when in actuality, it should be "action_tutorials_interfaces"