### PR TITLE
1.2 Publishing Feedback

### DIFF
--- a/source/Tutorials/Actions/Writing-a-Py-Action-Server-Client.rst
+++ b/source/Tutorials/Actions/Writing-a-Py-Action-Server-Client.rst
@@ -140,7 +140,8 @@ After every update of the feedback message in the for-loop, we publish the feedb
     :language: python
     :lines: 1-37
     :emphasize-lines: 1,23,24,27-31,36
-
+    I am not sure how to edit the code in yellow here. But this is where the changes have to be made. 
+    
 After restarting the action server, we can confirm that feedback is now published by using the command line tool with the ``--feedback`` option:
 
 .. code-block:: bash


### PR DESCRIPTION
In section 1.2 there is some code missing in the python script. After lines 141-142 in the instructions, the following lines of code should be included at the end of the script: 

```py
def main(args=None):
    rclpy.init(args=args)

    fibonacci_action_server = FibonacciActionServer()

    rclpy.spin(fibonacci_action_server)

if __name__ == '__main__':
    main()
```

Currently, if users copy and paste the current python script, then try and initialize it in the terminal it won't work.