### PR TITLE
Fix the sphinx highlighting.

### DIFF
--- a/source/Tutorials/Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Workspace/Creating-A-Workspace.rst
@@ -181,7 +181,7 @@ From the root of your workspace (``dev_ws``), run the following command:
 
    .. group-tab:: Linux
 
-      .. code-block:: console
+      .. code-block:: bash
 
         # cd if you're still in the ``src`` directory with the ``ros_tutorials`` clone
         cd ..


### PR DESCRIPTION
Since we are using a hash in it now, we have to specify it to
be 'bash' instead of 'console'.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>