### PR TITLE
Changing the order and more explicit instructions

### DIFF
--- a/source/Tutorials/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -277,7 +277,7 @@ Now open the CMakeLists.txt file. Below the existing dependency ``find_package(a
 .. code-block:: console
 
    find_package(geometry_msgs REQUIRED)
-   find_package(rclcpp REQUIRED)
+   find_package(rclcpp REQUIRWe can now check that the static transform has been published by echoing the tf_static topicED)
    find_package(tf2 REQUIRED)
    find_package(tf2_ros REQUIRED)
    find_package(turtlesim REQUIRED)
@@ -373,7 +373,13 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
          # Powershell
          .\install\setup.ps1
 
-Now run the ``static_turtle_tf2_broadcaster`` node:
+Open a new terminal. We can now check that the static transform has been published by echoing the ``tf_static`` topic
+
+.. code-block:: console
+
+   ros2 topic echo /tf_static
+   
+Open a new terminal. Now run the ``static_turtle_tf2_broadcaster`` node:
 
 .. code-block:: console
 
@@ -381,13 +387,7 @@ Now run the ``static_turtle_tf2_broadcaster`` node:
 
 This sets a turtle pose broadcast for ``mystaticturtle`` to float 1 meter above the ground.
 
-We can now check that the static transform has been published by echoing the ``tf_static`` topic
-
-.. code-block:: console
-
-   ros2 topic echo /tf_static
-
-If everything went well you should see a single static transform
+Go back to the terminal where you echoed the ``tf_static`` topic. If everything went well you should see a single static transform
 
 .. code-block:: console
 


### PR DESCRIPTION
I am recommending to explicitly tell the user to open a new terminal and changing the order that the instructions are presented. While I was going through the tutorial, if you start the broadcaster node then echo "tf_static" you won't see a static transform. You need to do these two things in reverse order. You first need to echo "tf_static" then run the broadcaster node. And then if you go back to the terminal where you ran the echo command, you will see the static transform.