### PR TITLE
Use rosidl_get_typesupport_target in msg tutorial

### DIFF
--- a/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
@@ -310,8 +310,10 @@ In order to use the messages generated in the same package we need to use the fo
 
 .. code-block:: cmake
 
-  rosidl_target_interfaces(publish_address_book
+  rosidl_get_typesupport_target(cpp_typesupport_target
     ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+  target_link_libraries(publish_address_book "${cpp_typesupport_target}")
 
 This finds the relevant generated C++ code from ``AddressBook.msg`` and allows your target to link against it.
 


### PR DESCRIPTION
This PR replaces the deprecated (https://github.com/ros2/rosidl/pull/606) `rosidl_cmake`
function `rosidl_target_interfaces` with `rosidl_get_typesupport_target`
in the "Expanding on ROS 2 interfaces" tutorial page.

Closes #2063.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>