### PR TITLE
Fix deprecated subscription callbacks in tutorials

### DIFF
--- a/source/Tutorials/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Custom-ROS2-Interfaces.rst
@@ -325,7 +325,7 @@ Subscriber:
         }
 
       private:
-        void topic_callback(const tutorial_interfaces::msg::Num::SharedPtr msg) const  // CHANGE
+        void topic_callback(const tutorial_interfaces::msg::Num::ConstSharedPtr msg) const  // CHANGE
         {
           RCLCPP_INFO_STREAM(this->get_logger(), "I heard: '" << msg->num << "'");     // CHANGE
         }

--- a/source/Tutorials/FastDDS-Configuration/FastDDS-Configuration.rst
+++ b/source/Tutorials/FastDDS-Configuration/FastDDS-Configuration.rst
@@ -343,7 +343,7 @@ In a new source file named ``src/sync_async_reader.cpp`` write the following con
         /**
          * Actions to run every time a new message is received
          */
-        void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
+        void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
         {
             RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
         }

--- a/source/Tutorials/Ros2bag/Recording-A-Bag-From-Your-Own-Node.rst
+++ b/source/Tutorials/Ros2bag/Recording-A-Bag-From-Your-Own-Node.rst
@@ -104,7 +104,7 @@ Inside the ``dev_ws/src/bag_recorder_nodes/src`` directory, create a new file ca
         writer_->write(msg, "chatter", "std_msgs/msg/String", time_stamp);
       }
 
-      rclcpp::Subscription<rclcpp::SerializedMessage>::SharedPtr subscription_;
+      rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
       std::unique_ptr<rosbag2_cpp::Writer> writer_;
     };
 
@@ -184,7 +184,7 @@ The class contains two member variables.
 
 .. code-block:: C++
 
-      rclcpp::Subscription<rclcpp::SerializedMessage>::SharedPtr subscription_;
+      rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
       std::unique_ptr<rosbag2_cpp::Writer> writer_;
 
 The file finishes with the ``main`` function used to create an instance of the node and start ROS processing it.

--- a/source/Tutorials/Ros2bag/Recording-A-Bag-From-Your-Own-Node.rst
+++ b/source/Tutorials/Ros2bag/Recording-A-Bag-From-Your-Own-Node.rst
@@ -101,7 +101,7 @@ Inside the ``dev_ws/src/bag_recorder_nodes/src`` directory, create a new file ca
       {
         rclcpp::Time time_stamp = this->now();
 
-        writer_->write(*msg, "chatter", "std_msgs/msg/String", time_stamp);
+        writer_->write(msg, "chatter", "std_msgs/msg/String", time_stamp);
       }
 
       rclcpp::Subscription<rclcpp::SerializedMessage>::SharedPtr subscription_;
@@ -171,7 +171,7 @@ This is why we pass in the topic name and the topic type.
 
 .. code-block:: C++
 
-        writer_->write(*msg, "chatter", "std_msgs/msg/String", time_stamp);
+        writer_->write(msg, "chatter", "std_msgs/msg/String", time_stamp);
 
 The class contains two member variables.
 

--- a/source/Tutorials/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -106,7 +106,7 @@ Open the file using your preferred text editor.
      }
 
    private:
-     void handle_turtle_pose(const std::shared_ptr<turtlesim::msg::Pose> msg)
+     void handle_turtle_pose(const std::shared_ptr<const turtlesim::msg::Pose> msg)
      {
        rclcpp::Time now = this->get_clock()->now();
        geometry_msgs::msg::TransformStamped t;

--- a/source/Tutorials/Topics/Topic-Statistics-Tutorial.rst
+++ b/source/Tutorials/Topics/Topic-Statistics-Tutorial.rst
@@ -104,7 +104,7 @@ Open the file using your preferred text editor.
       }
 
     private:
-      void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
+      void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
       {
         RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
       }

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -356,7 +356,7 @@ Open the ``subscriber_member_function.cpp`` with your text editor.
         }
 
       private:
-        void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
+        void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
         {
           RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
         }
@@ -398,7 +398,7 @@ The only field declaration in this class is the subscription.
 .. code-block:: C++
 
     private:
-      void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
+      void topic_callback(const std_msgs::msg::String::ConstSharedPtr msg) const
       {
         RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
       }


### PR DESCRIPTION
Namely, the `void (shared_ptr<MsgT>)` subscription callback has
been deprecated (see https://github.com/ros2/rclcpp/pull/1713).

As such, snippets using that signature have been updated with the
`void (shared_ptr<const MsgT>)` subscription callback.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>