### PR TITLE
Update Writing-A-Tf2-Listener-Py.rst

### DIFF
--- a/source/Tutorials/Tf2/Writing-A-Tf2-Listener-Py.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Listener-Py.rst
@@ -123,7 +123,8 @@ Open the file using your preferred text editor.
                         trans = self.tf_buffer.lookup_transform(
                             to_frame_rel,
                             from_frame_rel,
-                            now)
+                            now,
+                            timeout=rclpy.duration.Duration(seconds=2.0))
                     except TransformException as ex:
                         self.get_logger().info(
                             f'Could not transform {to_frame_rel} to {from_frame_rel}: {ex}')


### PR DESCRIPTION
Add a timeout like is proposed in [Geometry examples](https://github.com/ros2/geometry2/blob/foxy/examples_tf2_py/examples_tf2_py/blocking_waits_for_transform.py), because it not return the result sometimes