### PR TITLE
Update Understanding-ROS2-Services.rst

### DIFF
--- a/source/Tutorials/Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Services/Understanding-ROS2-Services.rst
@@ -167,13 +167,13 @@ You can call services from the command line, but first you need to know the stru
 
 .. code-block:: console
 
-  ros2 srv show <type_name>
+  ros2 interface show <type_name>
 
 To run this command on the ``/clear`` service’s type, ``Empty``:
 
 .. code-block:: console
 
-  ros2 srv show std_srvs/srv/Empty
+  ros2 interface show std_srvs/srv/Empty
 
 Which will return:
 
@@ -193,7 +193,7 @@ To see the arguments in a ``/spawn`` call-and-request, run the command:
 
 .. code-block:: console
 
-  ros2 srv show turtlesim/srv/Spawn
+  ros2 interface show turtlesim/srv/Spawn
 
 
 


### PR DESCRIPTION
There is a mistake in the interface show section. The examples use the parameter "srv", it should be "interface".