### PR TITLE
Use same command for Ubuntu derivatives such as Mint and Zorin

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -27,6 +27,4 @@ Then add the repository to your sources list.
 
 .. code-block:: bash
 
-   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
-.. include:: _Apt-Repositories_Linux_Mint.rst
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null

--- a/source/Installation/_Apt-Repositories_Linux_Mint.rst
+++ b/source/Installation/_Apt-Repositories_Linux_Mint.rst
@@ -1,5 +1,0 @@
-**Note**: Even though `Linux Mint 20 <https://linuxmint.com/download_all.php>`__ is based on Ubuntu Focal, the ``lsb_release -cs`` command returns the codename of Linux Mint. In that case, edit the ``ros2.list`` file above to replace with ``focal``:
-
-.. code-block:: bash
-
-   sudo sed -i -e 's/ubuntu .* main/ubuntu focal main/g' /etc/apt/sources.list.d/ros2.list


### PR DESCRIPTION
No need for a special Linux Mint chapter if ubuntu derivatives such as linux Mint and Zorin OS provide the `UBUNTU_CODENAME` variable.