### PR TITLE
Removing setuptools from python3 pip install

### DIFF
--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -70,8 +70,7 @@ Install development tools and ROS tools
      flake8-quotes \
      pytest-repeat \
      pytest-rerunfailures \
-     pytest \
-     setuptools
+     pytest
 
 Ubuntu 18.04 is not an officially supported platform, but may still work.  You'll need at least the following additional dependencies:
 


### PR DESCRIPTION
Installing setuptools using python3 pip installs `setuptools-59.1.1` on top of `python3-setuptools 45.2.0-1` installed by `apt install` in the previous step.

This results in following warning and prevents python packages from building.
```

Starting >>> rmf_visualization_building_systems
stderr: rmf_visualization_building_systems                   
/home/veera/.local/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(

Finished <<< rmf_visualization_building_systems [0.60s]

Summary: 1 package finished [0.81s]
  1 package had stderr output: rmf_visualization_building_systems
```