### PR TITLE
Correct graphviz install path

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -166,7 +166,7 @@ To run rqt_graph, you'll need `Graphviz <https://graphviz.gitlab.io/>`__.
 
    choco install graphviz
 
-You will need to append the Graphviz bin folder ``C:\Program Files (x86)\GraphvizX.XX\bin`` to your PATH, by navigating to "Edit the system environment variables" as described above.
+You will need to append the Graphviz bin folder ``C:\Program Files\Graphviz\bin`` to your PATH, by navigating to "Edit the system environment variables" as described above.
 
 Downloading ROS 2
 -----------------


### PR DESCRIPTION
Following the previous instructions results in a graphviz installation at "C:\Program Files\Graphviz\bin". There weren't program files at the listed location "C:\Program Files (x86)\Graphviz\bin", therefore the instructions should be changed as proposed.