### PR TITLE
Fix up minor issues in the parameter tutorial.

### DIFF
--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -68,8 +68,6 @@ Inside the ``dev_ws/src/python_parameters/python_parameters`` directory, create 
 
     import rclpy
     import rclpy.node
-    from rclpy.exceptions import ParameterNotDeclaredException
-    from rcl_interfaces.msg import ParameterType
 
     class MinimalParam(rclpy.node.Node):
         def __init__(self):
@@ -112,8 +110,6 @@ The ``import`` statements below are used to import the package dependencies.
 
     import rclpy
     import rclpy.node
-    from rclpy.exceptions import ParameterNotDeclaredException
-    from rcl_interfaces.msg import ParameterType
 
 The next piece of code creates the class and the constructor.
 ``timer`` is initialized (with timer_period set as 2 seconds), which causes the ``timer_callback`` function to be executed once every two seconds.
@@ -184,7 +180,7 @@ For that to work, the ``__init__`` code has to be changed to:
             my_parameter_descriptor = ParameterDescriptor(description='This parameter is mine!')
 
             self.declare_parameter('my_parameter',
-                                   'default value for my_parameter',
+                                   'world',
                                    my_parameter_descriptor)
 
 The rest of the code remains the same.
@@ -287,7 +283,7 @@ Now run the node:
 
      ros2 run python_parameters param_talker
 
-Except the first message where the parameter had a default value (an empty string), the terminal should return the following message every 2 seconds:
+The terminal should return the following message every 2 seconds:
 
 .. code-block:: console
 

--- a/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Using-Parameters-In-A-Class-Python.rst
@@ -113,8 +113,8 @@ The ``import`` statements below are used to import the package dependencies.
 
 The next piece of code creates the class and the constructor.
 ``timer`` is initialized (with timer_period set as 2 seconds), which causes the ``timer_callback`` function to be executed once every two seconds.
-The line ``self.declare_parameter('my_parameter', 'world')`` of the constructor creates a
-parameter with the name ``my_parameter`` and a default value of ``world``.
+The line ``self.declare_parameter('my_parameter', 'world')`` of the constructor creates a parameter with the name ``my_parameter`` and a default value of ``world``.
+The parameter type is inferred from the default value, so in this case it would be set to a string type.
 
 .. code-block:: Python
 
@@ -128,7 +128,8 @@ parameter with the name ``my_parameter`` and a default value of ``world``.
 
 The first line of our ``timer_callback`` function gets the parameter ``my_parameter`` from the node, and stores it in ``my_param``.
 Next,the ``get_logger`` function ensures the message is logged.
-Then, we set the parameter 'my_parameter' back to the default string value 'world'.
+The ``set_parameters`` function then sets the parameter ``my_parameter`` back to the default string value ``world``.
+In the case that the user changed the parameter externally, this ensures it is always reset back to the original.
 
 .. code-block:: Python
 


### PR DESCRIPTION
Remove imports that are not necessary, clarify a bit of the
language, and make sure to set the default value properly when
we are using a parameter description.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>