### PR TITLE
Update the parameter documentation to be much more comprehensive.

### DIFF
--- a/source/Concepts/About-ROS-2-Parameters.rst
+++ b/source/Concepts/About-ROS-2-Parameters.rst
@@ -13,29 +13,104 @@ About parameters in ROS 2
 Overview
 --------
 
-ROS parameters are associated with ROS nodes.
-Parameters are used to externally configure nodes at runtime (and during runtime).
+Parameters in ROS are associated with individual nodes.
+Parameters are used to configure nodes at startup (and during runtime), without changing the code.
 The lifetime of a parameter is tied to the lifetime of the node (though the node could implement some sort of persistence to reload values after restart).
 
 Parameters are addressed by node name, node namespace, parameter name, and parameter namespace.
 Providing a parameter namespace is optional.
 
-Each parameter consists of a key and a value, where the key is a string and the value could be one of the following types: bool, int64, float64, string, byte[], bool[], int64[], float64[] or string[]
+Each parameter consists of a key, a value, and a descriptor.
+The key is a string and the value is one of the following types: bool, int64, float64, string, byte[], bool[], int64[], float64[] or string[].
+By default all descriptors are empty, but can contain parameter descriptions, value ranges, type information, and additional constraints.
 
 For an hands-on tutorial with ROS parameters see :doc:`../Tutorials/Parameters/Understanding-ROS2-Parameters`.
 
-Setting parameters
-------------------
+Parameters background
+---------------------
 
-Parameters can be set in many different ways.
-They can be set from the command-line, from launch files, or programmatically.
-They can be set individually or together in a parameters file.
+Declaring parameters
+^^^^^^^^^^^^^^^^^^^^
 
-In order to set a parameter on a node, the node must first *declare* that it has that parameter.
+By default, a node needs to *declare* all of the parameters that it will accept during its lifetime.
+This is so that the type and the name of the parameter are well-defined at node startup time, which reduces the chances of misconfiguration later on.
 See :doc:`../Tutorials/Using-Parameters-In-A-Class-CPP` or :doc:`../Tutorials/Using-Parameters-In-A-Class-Python` for tutorials on declaring and using parameters from a node.
-These tutorials also demonstrate how to dynamically set a parameter with the ``ros2 param`` tool and from a launch file.
 
-For examples on setting parameters from the command-line or from a parameters file, see :ref:`NodeArgsParameters`.
+For some types of nodes, not all of the parameters will be known ahead of time.
+In these cases, the node can be instantiated with ``allow_undeclared_parameters`` set to ``true``, which will allow parameters to be get and set on the node even if they haven't been declared.
+
+Parameter types
+^^^^^^^^^^^^^^^
+
+Each parameter on a ROS 2 node has one of the pre-defined parameter types as mentioned in the Overview.
+By default, attempts to change the type of a declared parameter at runtime will fail.
+This prevents common mistakes, such as putting a boolean value into an integer parameter.
+
+If a parameter needs to be multiple different types, and the code using the parameter can handle it, this default behavior can be changed.
+When the parameter is declared, it should be declared using a ``ParameterDescriptor`` with the ``dynamic_typing`` member variable set to ``true``.
+
+Parameter callbacks
+^^^^^^^^^^^^^^^^^^^
+
+A ROS 2 node can register two different types of callbacks to be informed when changes are happening to parameters.
+The reason that there are two types of callbacks is to have a chance to intervene before the parameter change happens, and to have a chance to react after the parameter change happens.
+A node can register for both, either, or none of the callback types.
+Both types are described below.
+
+The first type is known as a "set parameter" callback, and can be installed by calling ``add_on_set_parameters_callback``.
+The callback should accept a list of ``Parameter`` objects, and return an ``rcl_interfaces/msg/SetParametersResult``.
+This callback will be called before a parameter is declared or changed on a node.
+The main purpose of this callback is to give the user the ability to inspect the upcoming change to the parameter and explicitly reject the change.
+
+.. note::
+   It is important that "set parameter" callbacks have no side-effects.
+   Since multiple "set parameter" callbacks can be chained, there is no way for an individual callback to know if a later callback will reject the update.
+   If the individual callback were to make changes to the class it is in, for instance, it may get out-of-sync with the actual parameter.
+   To get a callback *after* a parameter has been successfully changed, see the next type of callback below.
+
+The second type of callback is known as an "on parameter event" callback, and can be installed by calling ``on_parameter_event``.
+The callback should accept an ``rcl_interfaces/msg/ParameterEvent`` object, and return nothing.
+This callback will be called after all parameters have been declared, changed, or deleted.
+The main purpose of this callback is to give the user the ability to react to changes from parameters that have successfully been accepted.
+
+Interacting with parameters
+---------------------------
+
+ROS 2 nodes can perform parameter operations through node APIs as described in :doc:`../Tutorials/Using-Parameters-In-A-Class-CPP` or :doc:`../Tutorials/Using-Parameters-In-A-Class-Python`.
+External processes can perform parameter operations via parameter services that are created by default when a node is instantiated.
+The services that are created by default are:
+
+* /node_name/describe_parameters: Uses a service type of ``rcl_interfaces/srv/DescribeParameters``.
+  Given a list of parameter names, returns a list of descriptors associated with the parameters.
+* /node_name/get_parameter_types: Uses a service type of ``rcl_interfaces/srv/GetParameterTypes``.
+  Given a list of parameter names, returns a list of parameter types associated with the parameters.
+* /node_name/get_parameters: Uses a service type of ``rcl_interfaces/srv/GetParameters``.
+  Given a list of parameter names, returns a list of parameter values associated with the parameters.
+* /node_name/list_parameters: Uses a service type of ``rcl_interfaces/srv/ListParameters``.
+  Given an optional list of parameter prefixes, returns a list of the available parameters with that prefix.  If the prefixes are empty, returns all parameters.
+* /node_name/set_parameters: Uses a service type of ``rcl_interfaces/srv/SetParameters``.
+  Given a list of parameter names and values, attempts to set the parameters on the node.  Returns a list of results from trying to set each parameter; some of them may have succeeded and some may have failed.
+* /node_name/set_parameters_atomically: Uses a service type of ``rcl_interfaces/srv/SetParametersAtomically``.
+  Given a list of parameter names and values, attempts to set the parameters on the node.  Returns a single result from trying to set all parameters, so if one failed, all of them failed.
+
+Setting initial parameter values when running a node
+----------------------------------------------------
+
+Initial parameter values can be set when running the node either through individual command-line arguments, or through YAML files.
+See :ref:`NodeArgsParameters` for examples on how to set initial parameter values.
+
+Setting initial parameter values when launching nodes
+-----------------------------------------------------
+
+Initial parameter values can also be set when running the node through the ROS 2 launch facility.
+See :doc:`this document <../Tutorials/Launch/Using-ROS2-Launch-For-Large-Projects>` for information on how to specify parameters via launch.
+
+Manipulating parameter values at runtime
+----------------------------------------
+
+The ``ros2 param`` command is the general way to interact with parameters for nodes that are already running.
+``ros2 param`` uses the parameter service API as described above to perform the various operations.
+See :doc:`the how-to guide <../How-To-Guides/Using-ros2-param>` for details on how to use ``ros2 param``.
 
 Migrating from ROS 1
 --------------------
@@ -43,3 +118,15 @@ Migrating from ROS 1
 The :doc:`Launch file migration guide <../How-To-Guides/Launch-files-migration-guide>` explains how to migrate ``param`` and ``rosparam`` launch tags from ROS 1 to ROS 2.
 
 The :doc:`YAML parameter file migration guide <../How-To-Guides/Parameters-YAML-files-migration-guide>` explains how to migrate parameter files from ROS 1 to ROS 2.
+
+In ROS 1, the ``roscore`` acted like a global parameter blackboard where all nodes could get and set parameters.
+Since there is no central ``roscore`` in ROS 2, that functionality no longer exists.
+The recommended approach in ROS 2 is to use per-node parameters that are closely tied to the nodes that use them.
+If a global blackboard is still needed, it is possible to create a dedicated node for this purpose.
+ROS 2 ships with one in in the ``ros-{DISTRO}-demo-nodes-cpp`` package called ``parameter_blackboard``; it can be run with:
+
+.. code-block:: console
+
+   ros2 run demo_nodes_cpp parameter_blackboard
+
+The code for the ``parameter_blackboard`` is `here <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp>`__.

--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -41,6 +41,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/Building-a-Custom-Debian-Package
    How-To-Guides/Topics-Services-Actions
    How-To-Guides/Using-Variants
+   How-To-Guides/Using-ros2-param
 
 .. toctree::
   :hidden:

--- a/source/How-To-Guides/Using-ros2-param.rst
+++ b/source/How-To-Guides/Using-ros2-param.rst
@@ -1,0 +1,104 @@
+Using the ``ros2 param`` command-line tool
+==========================================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+Parameters in ROS 2 can be get, set, listed, and described through a set of services as described in :doc:`the concept document <../Concepts/About-ROS-2-Parameters>`.
+The ``ros2 param`` command-line tool is a wrapper around these service calls that makes it easy to manipulate parameters from the command-line.
+
+``ros2 param list``
+-------------------
+
+This command will list all of the available parameters on a given node, or on all discoverable nodes if no node is given.
+
+To get all of the parameters on a given node:
+
+.. code-block:: console
+
+  ros2 param list /my_node
+
+To get all of the parameters on all nodes in the system (this can take a long time on a complicated network):
+
+.. code-block:: console
+
+  ros2 param list
+
+``ros2 param get``
+------------------
+
+This command will get the value of a particular parameter on a particular node.
+
+To get the value of a parameter on a node:
+
+.. code-block:: console
+
+  ros param get /my_node use_sim_time
+
+``ros2 param set``
+------------------
+
+This command will set the value of a particular parameter on a particular node.
+For most parameters, the type of the new value must be the same as the existing type.
+
+To set the value of a parameter on a node:
+
+.. code-block:: console
+
+  ros param set /my_node use_sim_time false
+
+The value that is passed on the command-line is in YAML, which allows arbitrary YAML expressions to be used.
+However, it also means that certain expressions will be interpreted than might be expected.
+For instance, if the parameter ``my_string`` on node ``my_node`` is of type string, the following will not work:
+
+.. code-block:: console
+
+  ros param set /my_node my_string off
+
+That's because YAML is interpreting "off" as a boolean, and ``my_string`` is a string type.
+This can be worked around by using the YAML syntax for explicitly setting strings, e.g.:
+
+.. code-block:: console
+
+  ros param set /my_node my_string '!!str off'
+
+``ros2 param delete``
+---------------------
+
+This command will remove a parameter from a particular node.
+However, note that this can only remove dynamic parameters (not declared parameters).
+See :doc:`the concept document <../Concepts/About-ROS-2-Parameters>` for more information.
+
+.. code-block:: console
+
+  ros param delete /my_node my_string
+
+``ros2 param describe``
+-----------------------
+
+This command will provide a textual description of a particular parameter on a particular node:
+
+.. code-block:: console
+
+  ros param describe /my_node use_sim_time
+
+``ros2 param dump``
+-------------------
+
+This command will print out all of the parameters on a particular node in a YAML file format.
+The output of this command can then be used to re-run the node with the same parameters later:
+
+.. code-block:: console
+
+  ros param dump /my_node
+
+``ros2 param load``
+-------------------
+
+This command will load the values of the parameters from a YAML file into a particular node.
+That is, this command can reload values at runtime that were dumped out by ``ros2 param dump``:
+
+.. code-block:: console
+
+  ros param load /my_node my_node.yaml

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -284,6 +284,13 @@ See https://github.com/ros2/ros2cli/pull/642 for more details.
 
       ros2 param dump /my_node_name > my_node_name.yaml
 
+``ros2 param set`` now accepts more YAML syntax
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+Previously, attempting to set a string like "off" to a parameter that was of string type did not work.
+That's because ``ros2 param set`` interprets the command-line arguments as YAML, and YAML considers "off" to be a boolean type.
+As of https://github.com/ros2/ros2cli/pull/684 , ``ros2 param set`` now accepts the YAML escape sequence of "!!str off" to ensure that the value is considered a string.
+
 robot_state_publisher
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Parameters/Understanding-ROS2-Parameters.rst
@@ -18,9 +18,9 @@ Background
 
 A parameter is a configuration value of a node.
 You can think of parameters as node settings.
-A node can store parameters as integers, floats, booleans, strings and lists.
+A node can store parameters as integers, floats, booleans, strings, and lists.
 In ROS 2, each node maintains its own parameters.
-All parameters are dynamically reconfigurable, and built off of :doc:`ROS 2 services <../Services/Understanding-ROS2-Services>`.
+For more background on parameters, please see :doc:`the concept document <../../Concepts/About-ROS-2-Parameters>`.
 
 Prerequisites
 -------------


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This PR adds a lot more information to the documentation about Parameters.  In particular, it expands the Concept document about Parameters pretty substantially, and adds in a How-To Guide on how to use `ros2 param`.  It also adds a release note about the change in https://github.com/ros2/ros2cli/pull/684 which allows us to handle "!!str mystr".