### PR TITLE
Correct sample command line call to match the docs

### DIFF
--- a/source/Tutorials/Launch/CLI-Intro.rst
+++ b/source/Tutorials/Launch/CLI-Intro.rst
@@ -91,7 +91,7 @@ In the third terminal:
 
 .. code-block:: console
 
-   ros2 topic pub  /turtlesim2/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}"
+   ros2 topic pub  /turtlesim2/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
 
 After running these commands, you should see something like the following:
 


### PR DESCRIPTION
the documentation suggests the turtles will rotate in opposite directions, but the two commands are the same. changing the second command to a negative value causes the rotation to match the tutorial text