### PR TITLE
Add known issue to the Foxy documentation

### DIFF
--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -336,6 +336,8 @@ Known Issues
 * `[ros2/ros2#922] <https://github.com/ros2/ros2/issues/922>`_ Services' performance is flaky for ``rclcpp`` nodes using eProsima Fast-RTPS or ADLINK CycloneDDS as RMW implementation.
   Specifically, service clients sometimes do not receive the response from servers.
 
+* `[ros2/rclcpp#1212] <https://github.com/ros2/rclcpp/issues/1212>`_ Ready reentrant Waitable objects can attempt to execute multiple times.
+
 
 Timeline before the release
 ---------------------------


### PR DESCRIPTION
Add a known issue to the list pointing to the issue in `rclcpp` related to the multithread intra process test disabled with https://github.com/ros2/system_tests/pull/495.

I'm not sure if I should tag the system test as well in the documentation, or just the `rclcpp` issue as it is.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>