### PR TITLE
Add graphviz to the list of packages to be installed.

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -13,6 +13,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         git-all \
+        graphviz \
         make \
         python3-pip && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is needed for the 'dot' command.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #2252 