### PR TITLE
Add sitemap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ help:
 multiversion: Makefile
 	sphinx-multiversion $(OPTS) "$(SOURCE)" build/html
 	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=galactic/index.html\" /></head></html>" > build/html/index.html
+	python3 make_sitemapindex.py
 
 .PHONY: help Makefile multiversion
 %: Makefile

--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,16 @@ pygments_style = 'sphinx'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-extensions = ['sphinx.ext.intersphinx', 'sphinx_tabs.tabs', 'sphinx_multiversion', 'sphinx_rtd_theme', 'sphinx.ext.ifconfig', 'sphinx_copybutton', 'sphinx.ext.graphviz']
+extensions = [
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.intersphinx',
+    'sphinx_copybutton',
+    'sphinx.ext.graphviz',
+    'sphinx_multiversion',
+    'sphinx_tabs.tabs',
+    'sphinx_rtd_theme',
+    'sphinx_sitemap',
+]
 
 # Intersphinx mapping
 

--- a/conf.py
+++ b/conf.py
@@ -74,10 +74,10 @@ pygments_style = 'sphinx'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 extensions = [
+    'sphinx.ext.graphviz',
     'sphinx.ext.ifconfig',
     'sphinx.ext.intersphinx',
     'sphinx_copybutton',
-    'sphinx.ext.graphviz',
     'sphinx_multiversion',
     'sphinx_tabs.tabs',
     'sphinx_rtd_theme',

--- a/make_sitemapindex.py
+++ b/make_sitemapindex.py
@@ -1,0 +1,17 @@
+from xml.etree.ElementTree import Element, SubElement, ElementTree
+from conf import distro_full_names, html_baseurl
+
+
+def make_sitemapindex(sitemap_file):
+
+    sitemapindex = Element('sitemapindex')
+    sitemapindex.set('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9')
+    for distro in distro_full_names.keys():
+        node = SubElement(sitemapindex, 'sitemap')
+        SubElement(node, 'loc').text = f'{html_baseurl}/{distro}/sitemap.xml'
+
+    ElementTree(sitemapindex).write(sitemap_file, encoding='utf-8', xml_declaration=True)
+
+if __name__ == '__main__':
+    sitemap_file = 'build/html/sitemap.xml'
+    make_sitemapindex(sitemap_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ sphinx
 sphinx-copybutton
 sphinx-multiversion
 sphinx-rtd-theme
+sphinx-sitemap
 sphinx-tabs
-sphinx_sitemap

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx-copybutton
 sphinx-multiversion
 sphinx-rtd-theme
 sphinx-tabs
+sphinx_sitemap


### PR DESCRIPTION
This PR uses the [`sphinx-sitemap`](https://pypi.org/project/sphinx-sitemap/) plugin for generating a [sitemap](https://www.sitemaps.org/). The sitemap is then available at `/sitemap.xml` Adding the sitemap should improve SEO for our documentation's.

(Also, generating a sitemap seemed easier than scraping our website for the Humble tutorial party.)
