### PR TITLE
Add Google Analytics Tags

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -94,6 +94,7 @@ intersphinx_mapping = {
 #
 html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
+    'analytics_id': 'UA-17821189-2',
     'collapse_navigation': False,
     'sticky_navigation': True,
     'navigation_depth': -1,


### PR DESCRIPTION
We just created the metrics report but realized that we don't have introspection on this new very active site.

This looks to be a standard field in our theme: https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-analytics_id