### PR TITLE
Documents minor differences between ROS1 and ROS2 bloom releases.

### DIFF
--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -57,9 +57,8 @@ Since stable distributions created from Rolling will start with release reposito
 
 A ros2-gbp release repository may become a hard requirement for Rolling in the future and maintaining a single release repository for all ROS 2 distributions simplifies the maintenance of releases for both the Rolling distribution maintainers and package maintainers.
 
-In the meantime, a new workflow
-`based on Terraform <https://discourse.ros.org/t/upcoming-changes-to-ros2-gbp-organization/21878/4>`
-is in the making. Stay tuned!
+In order to request new release repositories or update maintainer access to existing release repositories in the ros2-gbp organization you can `create an issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new/choose>`__ in the `ros2-gbp-github-org <https://github.com/ros2-gbp/ros2-gbp-github-org`__ management repository.
+
 
 Procedure
 ---------

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -47,8 +47,8 @@ If you're using a version of bloom older than 0.6.8 you'll need to use the v3 in
 Minor differences from ROS 1 Bloom
 ----------------------------------
 
-If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you. The major
-difference is that release repositories for ROS 2 packages live in a dedicated github organization:
+If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you.
+The major difference is that release repositories for ROS 2 packages live in a dedicated github organization:
 `ROS 2 release repositories <https://github.com/ros2-gbp/>`.
 If you don't have a respository there for your package, yet, create a ticket for
 `nuclearsandwich <https://github.com/nuclearsandwich>` or give him a ping

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -71,4 +71,4 @@ Build Status
 ------------
 
 * Individual build details on the build farm `Jenkins <http://build.ros2.org/>`__ frontend.
-* The `ROS 2 Package Status Pages <http://repo.ros2.org/status_page/>`__ (e.g. `Galactic-Default <http://repo.ros2.org/status_page/ros_galactic_default.html>`__).
+* The `ROS 2 Package Status Pages <http://repo.ros2.org/status_page/>`__ (e.g. `{DISTRO_TITLE} Default <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__).

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -49,7 +49,7 @@ Minor differences from ROS 1 Bloom
 
 If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you.
 The major difference is that release repositories for ROS 2 packages live in a dedicated GitHub organization:
-`ROS 2 release repositories <https://github.com/ros2-gbp/>`.
+`ROS 2 release repositories <https://github.com/ros2-gbp/>`__.
 The dedicated organization allows new automation supporting the :doc:`Rolling distribution <../Releases/Release-Rolling-Ridley>`.
 
 Release repositories hosted elsewhere are still supported for stable distributions if you are not planning to release the repository into Rolling.
@@ -57,7 +57,7 @@ Since stable distributions created from Rolling will start with release reposito
 
 A ros2-gbp release repository may become a hard requirement for Rolling in the future and maintaining a single release repository for all ROS 2 distributions simplifies the maintenance of releases for both the Rolling distribution maintainers and package maintainers.
 
-In order to request new release repositories or update maintainer access to existing release repositories in the ros2-gbp organization you can `create an issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new/choose>`__ in the `ros2-gbp-github-org <https://github.com/ros2-gbp/ros2-gbp-github-org`__ management repository.
+In order to request new release repositories or update maintainer access to existing release repositories in the ros2-gbp organization you can `create an issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new/choose>`__ in the `ros2-gbp-github-org <https://github.com/ros2-gbp/ros2-gbp-github-org>`__ management repository.
 
 
 Procedure

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -44,10 +44,19 @@ If you're using a version of bloom older than 0.6.8 you'll need to use the v3 in
 
    export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml'
 
-No differences from ROS 1 Bloom
--------------------------------
+Minor differences from ROS 1 Bloom
+----------------------------------
 
-If you've bloomed packages before in ROS 1, the ROS 2 process is exactly the same.
+If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you. The major
+difference is that release repositories for ROS 2 packages live in a dedicated github organization:
+`ROS 2 release repositories <https://github.com/ros2-gbp/>`.
+If you don't have a respository there for your package, yet, create a ticket for
+`nuclearsandwich <https://github.com/nuclearsandwich>` or give him a ping
+`on discourse <https://discourse.ros.org/u/nuclearsandwich/summary>`.
+
+In the meantime, a new workflow
+`based on Terraform <https://discourse.ros.org/t/upcoming-changes-to-ros2-gbp-organization/21878/4>`
+is in the making. Stay tuned!
 
 Procedure
 ---------

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -50,7 +50,7 @@ Minor differences from ROS 1 Bloom
 If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you.
 The major difference is that release repositories for ROS 2 packages live in a dedicated GitHub organization:
 `ROS 2 release repositories <https://github.com/ros2-gbp/>`.
-In order to take advantage of new automation supporting the `Rolling distribution <../Releases/Release-Rolling-Ridley>` Open Robotics recommends that release repositories for ROS 2 are hosted in the dedicated `ros2-gbp GitHub organization <https://github.com/ros2-gbp/>`.
+The dedicated organization allows new automation supporting the :doc:`Rolling distribution <../Releases/Release-Rolling-Ridley>`.
 
 Release repositories hosted elsewhere are still supported for stable distributions if you are not planning to release the repository into Rolling.
 Since stable distributions created from Rolling will start with release repositories in the ros2-gbp organization it is recommend that you use the ros2-gbp release repositories for all ROS 2 distributions to avoid fragmenting the release information.

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -48,7 +48,7 @@ Minor differences from ROS 1 Bloom
 ----------------------------------
 
 If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you.
-The major difference is that release repositories for ROS 2 packages live in a dedicated github organization:
+The major difference is that release repositories for ROS 2 packages live in a dedicated GitHub organization:
 `ROS 2 release repositories <https://github.com/ros2-gbp/>`.
 In order to take advantage of new automation supporting the `Rolling distribution <../Releases/Release-Rolling-Ridley>` Open Robotics recommends that release repositories for ROS 2 are hosted in the dedicated `ros2-gbp GitHub organization <https://github.com/ros2-gbp/>`.
 

--- a/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
+++ b/source/How-To-Guides/Releasing-a-ROS-2-package-with-bloom.rst
@@ -50,9 +50,12 @@ Minor differences from ROS 1 Bloom
 If you've bloomed packages before in ROS 1, the ROS 2 process should be familiar to you.
 The major difference is that release repositories for ROS 2 packages live in a dedicated github organization:
 `ROS 2 release repositories <https://github.com/ros2-gbp/>`.
-If you don't have a respository there for your package, yet, create a ticket for
-`nuclearsandwich <https://github.com/nuclearsandwich>` or give him a ping
-`on discourse <https://discourse.ros.org/u/nuclearsandwich/summary>`.
+In order to take advantage of new automation supporting the `Rolling distribution <../Releases/Release-Rolling-Ridley>` Open Robotics recommends that release repositories for ROS 2 are hosted in the dedicated `ros2-gbp GitHub organization <https://github.com/ros2-gbp/>`.
+
+Release repositories hosted elsewhere are still supported for stable distributions if you are not planning to release the repository into Rolling.
+Since stable distributions created from Rolling will start with release repositories in the ros2-gbp organization it is recommend that you use the ros2-gbp release repositories for all ROS 2 distributions to avoid fragmenting the release information.
+
+A ros2-gbp release repository may become a hard requirement for Rolling in the future and maintaining a single release repository for all ROS 2 distributions simplifies the maintenance of releases for both the Rolling distribution maintainers and package maintainers.
 
 In the meantime, a new workflow
 `based on Terraform <https://discourse.ros.org/t/upcoming-changes-to-ros2-gbp-organization/21878/4>`


### PR DESCRIPTION
Continuing from https://github.com/ros2/ros2_documentation/pull/2030

This is an update of that pull request which includes links to the ros2-gbp-github-org management repository and a more detailed explanation of why release repositories for ROS 2 are maintained in a single organization.