### PR TITLE
Pyparsing generates broken dependencies with CMake ls

### DIFF
--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -104,7 +104,7 @@ You need the following things installed to build ROS 2:
         flake8-class-newline flake8-comprehensions flake8-deprecated \
         flake8-docstrings flake8-import-order flake8-quotes ifcfg \
         importlib-metadata lark-parser lxml mock mypy==0.761 netifaces \
-        nose pep8 pydocstyle pydot pygraphviz pyparsing \
+        nose pep8 pydocstyle pydot pygraphviz "pyparsing>=2.4,<3" \
         pytest-mock rosdep setuptools vcstool matplotlib psutil rosdistro
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)


### PR DESCRIPTION
I know that probably this is not a ROS problem at all, but when I was building ROS2 on my M1 system I noticed that problem, so in case you would think that this could be useful in general.

If you think that this doesn't make sense at the ROS docs, just close the PR, don't worry!
