### PR TITLE
[galactic] Remove false statement about interoperability

### DIFF
--- a/source/Concepts/About-Different-Middleware-Vendors.rst
+++ b/source/Concepts/About-Different-Middleware-Vendors.rst
@@ -66,7 +66,6 @@ For many cases you will find that nodes using different RMW implementations are 
 Here is a list of inter-vendor communication configurations that are not supported:
 
 - Fast DDS <-> Connext
-   - does not support communication over pub/sub
    - ``WString`` published by Fast DDS can't be received correctly by Connext on macOS
 - OpenSplice <-> OpenSplice
    - does not support ``WString``


### PR DESCRIPTION
The documentation wrongly states that Fast DDS <-> Connext does not support communication over pub/sub, which is not true.