### PR TITLE
update installation page to note REP-2000

### DIFF
--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -28,6 +28,16 @@ Binary packages
 
 We provide ROS 2 binary packages for the following platforms:
 
+.. note::
+
+    OpenRobotics only creates binaries for Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023>`_. This means that only the following operating systems can use the Foxy Fitzroy binary package installation method:
+    
+    * Ubuntu 20.04
+    * macOS Mojave (10.14)
+    * Windows (VS 2019)
+    
+    If you are not running any of these operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run Foxy Fitzroy.
+
 * Ubuntu Linux - Focal Fossa (20.04)
 
  * :doc:`Debian packages <Installation/Ubuntu-Install-Debians>`

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -31,11 +31,11 @@ We provide ROS 2 binary packages for the following platforms:
 .. note::
 
     OpenRobotics only creates binaries for Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023>`_. This means that only the following operating systems can use the Foxy Fitzroy binary package installation method:
-    
+
     * Ubuntu 20.04
     * macOS Mojave (10.14)
     * Windows (VS 2019)
-    
+
     If you are not running any of these operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run Foxy Fitzroy.
 
 * Ubuntu Linux - Focal Fossa (20.04)

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -26,11 +26,10 @@ Options for installing ROS 2 {DISTRO_TITLE_FULL}:
 Binary packages
 ---------------
 
+Binaries are only created for the Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023>`__.
+If you are not running any of the following operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run ROS 2 on your platform.
+
 We provide ROS 2 binary packages for the following platforms:
-
-.. note::
-
-    OpenRobotics only creates binaries for Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023>`_. If you are not running any of the following operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run Foxy Fitzroy.
 
 * Ubuntu Linux - Focal Fossa (20.04)
 

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -30,21 +30,15 @@ We provide ROS 2 binary packages for the following platforms:
 
 .. note::
 
-    OpenRobotics only creates binaries for Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023>`_. This means that only the following operating systems can use the Foxy Fitzroy binary package installation method:
-
-    * Ubuntu 20.04
-    * macOS Mojave (10.14)
-    * Windows (VS 2019)
-
-    If you are not running any of these operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run Foxy Fitzroy.
+    OpenRobotics only creates binaries for Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023>`_. If you are not running any of the following operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run Foxy Fitzroy.
 
 * Ubuntu Linux - Focal Fossa (20.04)
 
  * :doc:`Debian packages <Installation/Ubuntu-Install-Debians>`
  * :doc:`"fat" archive <Installation/Ubuntu-Install-Binary>`
 
-* :doc:`macOS <Installation/macOS-Install-Binary>`
-* :doc:`Windows <Installation/Windows-Install-Binary>`
+* :doc:`macOS Mojave (10.14) <Installation/macOS-Install-Binary>`
+* :doc:`Windows (VS 2019) <Installation/Windows-Install-Binary>`
 
 
 .. _building-from-source:


### PR DESCRIPTION
While browsing the ROS subreddit I noticed that the [OpenRobotics](https://www.reddit.com/r/ROS/comments/stnf58/ubuntu_foxy_installation_issues/hx8llll/) account mentioned that explaining to new users REP-2000 is a source of frustration. Therefore, I provided a small change to the binary installation section of the documentation that points users to REP-2000 for Foxy Fitzroy while also spelling out *specifically* which OS versions are supported by the installation method.