### PR TITLE
Add undocumented dependency to ROS Bag tutorial

### DIFF
--- a/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.rst
@@ -34,6 +34,8 @@ If you've installed from Debians on Linux and your system doesn’t recognize th
   sudo apt-get install ros-{DISTRO}-ros2bag \
                        ros-{DISTRO}-rosbag2-storage-default-plugins
 
+You must also have ``console_bridge`` installed on your machine. The steps to install it are documented `here <http://wiki.ros.org/console_bridge>`_.
+
 This tutorial talks about concepts covered in previous tutorials, like :doc:`nodes <../Understanding-ROS2-Nodes>` and :doc:`topics <../Topics/Understanding-ROS2-Topics>`.
 It also uses the :doc:`turtlesim package <../Turtlesim/Introducing-Turtlesim>`.
 


### PR DESCRIPTION
After following the steps on [this tutorial](https://docs.ros.org/en/galactic/Tutorials/Ros2bag/Recording-And-Playing-Back-Data.html), I was unable to execute the `ros2 bag record ...` command. I received the following error:
```
Failed to load entry point 'record': libconsole_bridge.so.1.0: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/home/abell/Repositories/ros2_galactic/install/ros2cli/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli', 'console_scripts', 'ros2')()
  File "/home/abell/Repositories/ros2_galactic/build/ros2cli/ros2cli/cli.py", line 39, in main
    add_subparsers_on_demand(
  File "/home/abell/Repositories/ros2_galactic/build/ros2cli/ros2cli/command/__init__.py", line 250, in add_subparsers_on_demand
    extension.add_arguments(
  File "/home/abell/Repositories/ros2_galactic/build/ros2bag/ros2bag/command/bag.py", line 26, in add_arguments
    add_subparsers_on_demand(
  File "/home/abell/Repositories/ros2_galactic/build/ros2cli/ros2cli/command/__init__.py", line 237, in add_subparsers_on_demand
    extension = command_extensions[name]
KeyError: 'record'
```
Following the steps in the page linked above resolved this issue for me. Just wanted to add this to the tutorial in case other beginners with ROS2 run into this error and are unsure of what to do to proceed.