### PR TITLE
Small cleanups to the Windows development instructions.

### DIFF
--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -70,23 +70,35 @@ First setup a development folder, for example ``C:\dev\ros2_{DISTRO}``:
 
 Get the ``ros2.repos`` file which defines the repositories to clone from:
 
-.. code-block:: bash
+.. tabs::
 
-   # CMD
-   curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+  .. group-tab:: CMD
 
-   # PowerShell
-   curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+    .. code-block:: bash
+
+      curl -sk https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
+
+  .. group-tab:: Powershell
+
+    .. code-block:: bash
+
+      curl https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos -o ros2.repos
 
 Next you can use ``vcs`` to import the repositories listed in the ``ros2.repos`` file:
 
-.. code-block:: bash
+.. tabs::
 
-   # CMD
-   vcs import src < ros2.repos
+  .. group-tab:: CMD
 
-   # PowerShell
-   vcs import --input ros2.repos src
+    .. code-block:: bash
+
+      vcs import src < ros2.repos
+
+  .. group-tab:: Powershell
+
+    .. code-block:: bash
+
+      vcs import --input ros2.repos src
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -123,7 +123,7 @@ You must also install some additional python dependencies:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy ifcfg importlib-metadata lark-parser lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing pyyaml rosdistro setuptools
+   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark-parser lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing pyyaml rosdistro setuptools
 
 
 Install Qt5


### PR DESCRIPTION
1.  Remove ifcfg from the list of pip packages, as it is
no longer required on Rolling.
2.  Change the curl and vcs commands to use tabs for CMD vs.
Powershell.  Besides being more like what we do elsewhere,
also makes the commands copy-n-pastable.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>