### PR TITLE
Updated migration guide for ``let`` action

### DIFF
--- a/source/How-To-Guides/Launch-files-migration-guide.rst
+++ b/source/How-To-Guides/Launch-files-migration-guide.rst
@@ -330,7 +330,7 @@ It's a replacement of ``arg`` tag with a value attribute.
 
 .. code-block:: xml
 
-   <let var="foo" value="asd"/>
+   <let name="foo" value="asd"/>
 
 executable
 ^^^^^^^^^^


### PR DESCRIPTION
This is in response to https://github.com/ros2/ros2_documentation/issues/2322, according to which the ``let`` tag is not supposed to take an argument called ``var``. It should be ``name`` instead of ``var``.