### PR TITLE
Mention need to add dependencies in rosidl_generate_interfaces

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -102,6 +102,7 @@ To convert the interfaces you defined into language-specific code (like C++ and 
   rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/Num.msg"
     "srv/AddThreeInts.srv"
+    DEPENDENCIES geometry_msgs # Add packages of used message-types
   )
 
 .. note::

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -80,7 +80,7 @@ You can also use message types from other packages to e.g. define a message that
 .. code-block:: console
 
     geometry_msgs/Point center
-    float64  radius
+    float64 radius
 
 
 2.2 srv definition
@@ -109,7 +109,7 @@ To convert the interfaces you defined into language-specific code (like C++ and 
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/Num.msg"
-    "msg/Sphere.msg
+    "msg/Sphere.msg"
     "srv/AddThreeInts.srv"
     DEPENDENCIES geometry_msgs # Add packages of used message-types, in this case geometry_msgs for Sphere.msg
   )

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -75,6 +75,14 @@ In the ``tutorial_interfaces/msg`` directory you just created, make a new file c
 
 This is your custom message that transfers a single 64-bit integer called ``num``.
 
+You can also use message types from other packages to e.g. define a message that describes a sphere at a given position (``Sphere.msg``):
+
+.. code-block:: console
+
+    geometry_msgs/Point center
+    float64  radius
+
+
 2.2 srv definition
 ~~~~~~~~~~~~~~~~~~
 
@@ -101,8 +109,9 @@ To convert the interfaces you defined into language-specific code (like C++ and 
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/Num.msg"
+    "msg/Sphere.msg
     "srv/AddThreeInts.srv"
-    DEPENDENCIES geometry_msgs # Add packages of used message-types
+    DEPENDENCIES geometry_msgs # Add packages of used message-types, in this case geometry_msgs for Sphere.msg
   )
 
 .. note::

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -73,15 +73,16 @@ In the ``tutorial_interfaces/msg`` directory you just created, make a new file c
 
     int64 num
 
-This is your custom message that transfers a single 64-bit integer called ``num``.
+This is a custom message that transfers a single 64-bit integer called ``num``.
 
-You can also use message types from other packages to e.g. define a message that describes a sphere at a given position (``Sphere.msg``):
+Also in the ``tutorial_interfaces/msg`` directory you just created, make a new file called ``Sphere.msg`` with the following content:
 
 .. code-block:: console
 
     geometry_msgs/Point center
     float64 radius
 
+This custom message uses a message from another message package (``geometry_msgs/Point`` in this case).
 
 2.2 srv definition
 ~~~~~~~~~~~~~~~~~~
@@ -105,13 +106,14 @@ To convert the interfaces you defined into language-specific code (like C++ and 
 
 .. code-block:: cmake
 
+  find_package(geometry_msgs REQUIRED)
   find_package(rosidl_default_generators REQUIRED)
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/Num.msg"
     "msg/Sphere.msg"
     "srv/AddThreeInts.srv"
-    DEPENDENCIES geometry_msgs # Add packages of used message-types, in this case geometry_msgs for Sphere.msg
+    DEPENDENCIES geometry_msgs # Add packages that above messages depend on, in this case geometry_msgs for Sphere.msg
   )
 
 .. note::
@@ -127,6 +129,8 @@ The ``<exec_depend>`` tag is used to specify runtime or execution-stage dependen
 Add the following lines to ``package.xml``
 
 .. code-block:: xml
+
+  <depend>geometry_msgs</depend>
 
   <build_depend>rosidl_default_generators</build_depend>
 
@@ -189,7 +193,6 @@ In a new terminal, run the following command from within your workspace (``dev_w
 
 Now you can confirm that your interface creation worked by using the ``ros2 interface show`` command:
 
-
 .. code-block:: console
 
   ros2 interface show tutorial_interfaces/msg/Num
@@ -199,6 +202,22 @@ should return:
 .. code-block:: console
 
     int64 num
+
+And
+
+.. code-block:: console
+
+  ros2 interface show tutorial_interfaces/msg/Sphere
+
+should return:
+
+.. code-block:: console
+
+    geometry_msgs/Point center
+            float64 x
+            float64 y
+            float64 z
+    float64 radius
 
 And
 


### PR DESCRIPTION
Added hint to list dependencies for used packages in rosidl_generate_interfaces. Otherwise the user will only get this message

"rosidl_generator_py.import_type_support_impl.UnsupportedTypeSupport: Could not import 'rosidl_typesupport_c' for package"

that's not really helpful