### PR TITLE
add note on retining callback group reference

### DIFF
--- a/source/Concepts/About-Executors.rst
+++ b/source/Concepts/About-Executors.rst
@@ -102,11 +102,13 @@ Callback groups
 
 The rclcpp allows organizing the callbacks of a node in groups.
 Such a *callback group* can be created by the ``create_callback_group`` function of the Node class.
+Make sure the callback group is stored (eg. as a class member) throughout execution of the node,
+or otherwise the executor won't be able to trigger the callbacks.
 Then, this callback group can be specified when creating a subscription, timer, etc. - for example by the subscription options:
 
 .. code-block:: cpp
 
-   auto my_callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+   my_callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
    rclcpp::SubscriptionOptions options;
    options.callback_group = my_callback_group;


### PR DESCRIPTION
Came across this [issue on ROS Answers](https://answers.ros.org/question/332813/ros-timer-not-working-after-including-callbackgroups/?answer=397654#post-id-397654), and adding a note in the docs would be nice.

Removes the `auto` variable declaration, since the existing sample makes it seem like `my_callback_group` is a local variable, while `my_subscription` is a class member.