### PR TITLE
Update Ubuntu-Development-Setup.rst

### DIFF
--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -101,7 +101,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-5.3.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
 
 .. include:: _rosdep_Linux_Mint.rst
 


### PR DESCRIPTION
The `rti-connext-dds` key is version 6.0.1 for rolling.