### PR TITLE
Fix example of `ros2 interface` command in sect 6

### DIFF
--- a/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Topics/Understanding-ROS2-Topics.rst
@@ -197,7 +197,7 @@ Now we can run ``ros2 interface show <type>.msg`` on this type to learn its deta
 
 .. code-block:: console
 
-  ros2 msg show geometry_msgs/msg/Twist
+  ros2 interface show geometry_msgs/msg/Twist
 
 .. code-block:: console
 


### PR DESCRIPTION
Fixed a typo in the example shown for `ros2 interface`, where it used `ros2 msg` by accident.

Looks like this example was missed in ff9b14662e6a4e1ee553253d79ea5c5fe04d902f. (See [this line](https://github.com/ros2/ros2_documentation/commit/ff9b14662e6a4e1ee553253d79ea5c5fe04d902f#diff-0697110605ca82601d9350c18e49e9f24cd62cf790cce18730a5ba3660d14231R216).)
