### PR TITLE
Fix a broken redirect from index.ros.org .

### DIFF
--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -1,3 +1,7 @@
 :orphan:
 
+.. redirect-from::
+
+    ROS-2-Client-Libraries
+
 The files on this branch are no longer used.  See the 'rolling' branch instead.


### PR DESCRIPTION
It turns out that sometime in the past, we had a page called
https://index.ros.org/doc/ros2/ROS-2-Client-Libraries.  Sometime
during the shuffling of the pages internally and from index.ros.org
to docs.ros.org, we lost the redirect for that page.  Since
there are things out in the wild that depend on it (like
https://www.theconstructsim.com/wp-content/uploads/2019/03/ROS2-IN-5-DAYS-e-book.pdf),
resurrect this link, which should link all the way through to
docs.ros.org

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>