### PR TITLE
Add recommendation for repository branches

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -291,19 +291,26 @@ Branches
 ^^^^^^^^
 
 .. note::
-    These are really just guidelines though! It’s up to the package maintainers to manage their preferences.
+    These are just guidelines.
+    It is up to the package maintainer to choose branch names that match their own workflow.
 
-It is good practice to have **separate branches** in a package's source repository for each ros distro it is targeting. Releases are made **FROM** those branches, targeting the appropriate distro. Development can also happen on those branches.
+It is good practice to have **separate branches** in a package's source repository for each ROS distribution it is targeting.
+These branches are typically named after the distribution they target.
+For example, a `humble` branch for development targeted specifically at the Humble distribution.
+Releases are also made from these branches, targeting the appropriate distribution.
+Development targeted at a specific ROS distribution can happen on the appropriate branch.
 
-Example: Development commits and releases targeting `foxy` are made from the `foxy` branch.
+For example: Development commits targeting `foxy` are made to the `foxy` branch, and package releases for `foxy` are made from that same branch.
 
 .. note::
-    This means to keep all branches targeting different distros up to date, maintenance, backporting and upkeep has to be done!
-    You might even need to, where necessary, make independent releases for those distros if there are any changes to be made.
+    This requires the package maintainers to perform backports or forwardports as appropriate to keep all branches up to date with features.
+    The maintainers must also perform general maintenance (bug fixes, etc.) on all branches from which package releases are still made.
+    For example, if a feature is merged into the Rolling-specific branch (e.g. `rolling` or `main`), and that feature is also appropriate to the Galactic distribution (does not break API, etc.), then it is good practice to backport the feature to the Galactic-specific branch.
+    The maintainers may make releases for those older distributions if there are new features or bug fixes available.
 
-**What about Main and Rolling?**
+**What about `main` and `rolling`?**
 
-`main` typically targets the next unreleased ROS distro, though with `rolling` (for rolling releases), you might decide to develop and release from a `rolling` branch instead.
+`main` typically targets `rolling <https://docs.ros.org/en/rolling/Releases/Release-Rolling-Ridley.html/>` (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a `rolling` branch instead.
 
 Pull requests
 ^^^^^^^^^^^^^

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -286,7 +286,7 @@ When filing an issue please make sure to:
     See `this section <building-from-source>` and follow the instructions to get the "master" branches.
   - Trying with a different RMW implementation.
     See `this page <../How-To-Guides/Working-with-multiple-RMW-implementations>` for how to do that.
-    
+
 Branches
 ^^^^^^^^
 

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -296,24 +296,24 @@ Branches
 
 It is good practice to have **separate branches** in a package's source repository for each ROS distribution it is targeting.
 These branches are typically named after the distribution they target.
-For example, a `humble` branch for development targeted specifically at the Humble distribution.
+For example, a ``humble`` branch for development targeted specifically at the Humble distribution.
 
 Releases are also made from these branches, targeting the appropriate distribution.
 Development targeted at a specific ROS distribution can happen on the appropriate branch.
-For example: Development commits targeting `foxy` are made to the `foxy` branch, and package releases for `foxy` are made from that same branch.
+For example: Development commits targeting ``foxy`` are made to the ``foxy`` branch, and package releases for ``foxy`` are made from that same branch.
 
 .. note::
     This requires the package maintainers to perform backports or forwardports as appropriate to keep all branches up to date with features.
     The maintainers must also perform general maintenance (bug fixes, etc.) on all branches from which package releases are still made.
 
-    For example, if a feature is merged into the Rolling-specific branch (e.g. `rolling` or `main`), and that feature is also appropriate
+    For example, if a feature is merged into the Rolling-specific branch (e.g. ``rolling`` or ``main``), and that feature is also appropriate
     to the Galactic distribution (does not break API, etc.), then it is good practice to backport the feature to the Galactic-specific branch.
 
     The maintainers may make releases for those older distributions if there are new features or bug fixes available.
 
-**What about `main` and `rolling`?**
+**What about ``main`` and ``rolling``?**
 
-`main` typically targets :doc:`Rolling <../Releases/Release-Rolling-Ridley>` (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a `rolling` branch instead.
+``main`` typically targets :doc:`Rolling <../Releases/Release-Rolling-Ridley>` (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a ``rolling`` branch instead.
 
 Pull requests
 ^^^^^^^^^^^^^

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -297,15 +297,18 @@ Branches
 It is good practice to have **separate branches** in a package's source repository for each ROS distribution it is targeting.
 These branches are typically named after the distribution they target.
 For example, a `humble` branch for development targeted specifically at the Humble distribution.
+
 Releases are also made from these branches, targeting the appropriate distribution.
 Development targeted at a specific ROS distribution can happen on the appropriate branch.
-
 For example: Development commits targeting `foxy` are made to the `foxy` branch, and package releases for `foxy` are made from that same branch.
 
 .. note::
     This requires the package maintainers to perform backports or forwardports as appropriate to keep all branches up to date with features.
     The maintainers must also perform general maintenance (bug fixes, etc.) on all branches from which package releases are still made.
-    For example, if a feature is merged into the Rolling-specific branch (e.g. `rolling` or `main`), and that feature is also appropriate to the Galactic distribution (does not break API, etc.), then it is good practice to backport the feature to the Galactic-specific branch.
+
+    For example, if a feature is merged into the Rolling-specific branch (e.g. `rolling` or `main`), and that feature is also appropriate
+    to the Galactic distribution (does not break API, etc.), then it is good practice to backport the feature to the Galactic-specific branch.
+
     The maintainers may make releases for those older distributions if there are new features or bug fixes available.
 
 **What about `main` and `rolling`?**

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -311,7 +311,7 @@ For example: Development commits targeting ``foxy`` are made to the ``foxy`` bra
 
     The maintainers may make releases for those older distributions if there are new features or bug fixes available.
 
-**What about ``main`` and ``rolling``?**
+**What about** ``main`` **and** ``rolling`` **?**
 
 ``main`` typically targets :doc:`Rolling <../Releases/Release-Rolling-Ridley>` (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a ``rolling`` branch instead.
 

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -286,6 +286,24 @@ When filing an issue please make sure to:
     See `this section <building-from-source>` and follow the instructions to get the "master" branches.
   - Trying with a different RMW implementation.
     See `this page <../How-To-Guides/Working-with-multiple-RMW-implementations>` for how to do that.
+    
+Branches
+^^^^^^^^
+
+.. note::
+    These are really just guidelines though! It’s up to the package maintainers to manage their preferences.
+
+It is good practice to have **separate branches** in a package's source repository for each ros distro it is targeting. Releases are made **FROM** those branches, targeting the appropriate distro. Development can also happen on those branches.
+
+Example: Development commits and releases targeting `foxy` are made from the `foxy` branch.
+
+.. note::
+    This means to keep all branches targeting different distros up to date, maintenance, backporting and upkeep has to be done!
+    You might even need to, where necessary, make independent releases for those distros if there are any changes to be made.
+
+**What about Main and Rolling?**
+
+`main` typically targets the next unreleased ROS distro, though with `rolling` (for rolling releases), you might decide to develop and release from a `rolling` branch instead.
 
 Pull requests
 ^^^^^^^^^^^^^

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -313,7 +313,7 @@ For example: Development commits targeting `foxy` are made to the `foxy` branch,
 
 **What about `main` and `rolling`?**
 
-`main` typically targets `rolling <https://docs.ros.org/en/rolling/Releases/Release-Rolling-Ridley.html/>`_ (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a `rolling` branch instead.
+`main` typically targets :doc:`Rolling <../Releases/Release-Rolling-Ridley>` (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a `rolling` branch instead.
 
 Pull requests
 ^^^^^^^^^^^^^

--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -310,7 +310,7 @@ For example: Development commits targeting `foxy` are made to the `foxy` branch,
 
 **What about `main` and `rolling`?**
 
-`main` typically targets `rolling <https://docs.ros.org/en/rolling/Releases/Release-Rolling-Ridley.html/>` (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a `rolling` branch instead.
+`main` typically targets `rolling <https://docs.ros.org/en/rolling/Releases/Release-Rolling-Ridley.html/>`_ (and so, the next unreleased ROS distribution), though the maintainers may decide to develop and release from a `rolling` branch instead.
 
 Pull requests
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
It is unclear what the branches semantically mean in a source repository for a ROS package. This PR provides some guidelines in the docs.