### PR TITLE
Switch focal references to jammy.

### DIFF
--- a/source/Contributing/Developer-Guide.rst
+++ b/source/Contributing/Developer-Guide.rst
@@ -651,14 +651,10 @@ Additionally, we test all pull requests against these platforms before merging.
 This is the current set of target platforms and architectures, though it evolves overtime:
 
 
-* Ubuntu 20.04 Focal
+* Ubuntu 22.04 Jammy
 
   * amd64
   * aarch64
-
-* macOS 10.14 Mojave
-
-  * amd64
 
 * Windows 10
 
@@ -672,7 +668,6 @@ There are several categories of jobs on the buildfarm:
   * ci_linux: build + test the code on Ubuntu Xenial
   * ci_linux-aarch64: build + test the code on Ubuntu Xenial on an ARM 64-bit machine (aarch64)
   * ci_linux_coverage: build + test + generation of test coverage
-  * ci_osx: build + test the code on MacOS 10.12
   * ci_windows: build + test the code on Windows 10
   * ci_launcher: trigger all the jobs listed above
 
@@ -682,21 +677,18 @@ There are several categories of jobs on the buildfarm:
 
     * nightly_linux_debug
     * nightly_linux-aarch64_debug
-    * nightly_osx_debug
     * nightly_win_deb
 
   * Release: build + test the code with CMAKE_BUILD_TYPE=Release
 
     * nightly_linux_release
     * nightly_linux-aarch64_release
-    * nightly_osx_release
     * nightly_win_rel
 
   * Repeated: build then run each test up to 20 times or until failed (aka flakiness hunter)
 
     * nightly_linux_repeated
     * nightly_linux-aarch64_repeated
-    * nightly_osx_repeated
     * nightly_win_rep
 
   * Coverage:
@@ -709,7 +701,6 @@ There are several categories of jobs on the buildfarm:
 * packaging (run every night; result is bundled into an archive):
 
   * packaging_linux
-  * packaging_osx
   * packaging_windows
 
 Two additional build farms support the ROS / ROS 2 ecosystem by providing building of source and

--- a/source/Features.rst
+++ b/source/Features.rst
@@ -4,7 +4,7 @@ Features Status
 ===============
 
 The features listed below are available in the current ROS 2 release.
-Unless otherwise specified, the features are available for all supported platforms (Ubuntu 20.04, macOS 10.14.x, Windows 10), DDS implementations (eProsima Fast DDS, RTI Connext DDS, and Eclipse Cyclone DDS) and programming language client libraries (C++ and Python).
+Unless otherwise specified, the features are available for all supported platforms (Ubuntu 22.04 (Jammy), Windows 10), DDS implementations (eProsima Fast DDS, RTI Connext DDS, and Eclipse Cyclone DDS) and programming language client libraries (C++ and Python).
 For planned future development, see the :doc:`Roadmap <Roadmap>`.
 
 .. list-table::

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -24,12 +24,12 @@ For Debian-based operating systems, you can install binary packages from the **r
 1. Make sure you have a working ROS 2 installation from Debian packages (see :doc:`../Installation`).
 
 2. Edit (with sudo) the file ``/etc/apt/sources.list.d/ros2-latest.list`` and change ``ros2`` with ``ros2-testing``.
-   For example, on Ubuntu Focal the contents should look like the following:
+   For example, on Ubuntu Jammy the contents should look like the following:
 
    .. code-block:: sh
 
-      # deb http://packages.ros.org/ros2/ubuntu focal main
-      deb http://packages.ros.org/ros2-testing/ubuntu focal main
+      # deb http://packages.ros.org/ros2/ubuntu jammy main
+      deb http://packages.ros.org/ros2-testing/ubuntu jammy main
 
 3. Update the ``apt`` index:
 
@@ -53,8 +53,8 @@ For Debian-based operating systems, you can install binary packages from the **r
 
    .. code-block:: sh
 
-      deb http://packages.ros.org/ros2/ubuntu focal main
-      # deb http://packages.ros.org/ros2-testing/ubuntu focal main
+      deb http://packages.ros.org/ros2/ubuntu jammy main
+      # deb http://packages.ros.org/ros2-testing/ubuntu jammy main
 
    and doing an update and upgrade:
 

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -16,7 +16,7 @@ System requirements
 -------------------
 The current Debian-based target platforms for {DISTRO_TITLE_FULL} are:
 
-- Tier 1: Ubuntu Linux - Focal Fossa (20.04) 64-bit
+- Tier 1: Ubuntu Linux - Jammy (22.04) 64-bit
 - Tier 3: Debian Linux - Bullseye (11) 64-bit
 
 

--- a/source/Installation/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Ubuntu-Install-Binary.rst
@@ -22,7 +22,7 @@ There are also :doc:`Debian packages <Ubuntu-Install-Debians>` available.
 System Requirements
 -------------------
 
-We currently support Ubuntu Linux Focal Fossa (20.04) 64-bit x86 and 64-bit ARM.
+We currently support Ubuntu Linux Jammy (22.04) 64-bit x86 and 64-bit ARM.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 Most people will want to use a stable ROS distribution.
 

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -9,7 +9,7 @@ Installing ROS 2 via Debian Packages
    :depth: 2
    :local:
 
-Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Focal.
+Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Jammy.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
 Most people will want to use a stable ROS distribution.
@@ -19,7 +19,7 @@ Resources
 
 * Status Page:
 
-  * ROS 2 {DISTRO_TITLE} (Ubuntu Focal): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_ufv8.html>`__
+  * ROS 2 {DISTRO_TITLE} (Ubuntu Jammy): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_ufv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -123,7 +123,7 @@ have already installed from binaries, run the following command:
 
   sudo apt remove ~nros-{DISTRO}-* && sudo apt autoremove
 
-You may also want to remove the repostiory:
+You may also want to remove the repository:
 
 .. code-block:: bash
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -5,7 +5,7 @@ First, make sure that the `Ubuntu Universe repository <https://help.ubuntu.com/c
 
    apt-cache policy | grep universe
     500 http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
-        release v=20.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=universe,b=amd64
+        release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=universe,b=amd64
 
 If you don't see an output line like the one above, then enable the Universe repository with these instructions.
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -4,8 +4,8 @@ First, make sure that the `Ubuntu Universe repository <https://help.ubuntu.com/c
 .. code-block:: bash
 
    apt-cache policy | grep universe
-    500 http://us.archive.ubuntu.com/ubuntu focal/universe amd64 Packages
-        release v=20.04,o=Ubuntu,a=focal,n=focal,l=Ubuntu,c=universe,b=amd64
+    500 http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
+        release v=20.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=universe,b=amd64
 
 If you don't see an output line like the one above, then enable the Universe repository with these instructions.
 

--- a/source/Installation/_rosdep_Linux_Mint.rst
+++ b/source/Installation/_rosdep_Linux_Mint.rst
@@ -1,1 +1,1 @@
-**Note**: If you're using a distribution that is based on Ubuntu (like Linux Mint) but does not identify itself as such, you'll get an error message like ``Unsupported OS [mint]``. In this case append ``--os=ubuntu:focal`` to the above command.
+**Note**: If you're using a distribution that is based on Ubuntu (like Linux Mint) but does not identify itself as such, you'll get an error message like ``Unsupported OS [mint]``. In this case append ``--os=ubuntu:jammy`` to the above command.

--- a/source/Releases/Release-Rolling-Ridley.rst
+++ b/source/Releases/Release-Rolling-Ridley.rst
@@ -22,14 +22,13 @@ Rolling Ridley is currently supported on the following platforms:
 
 Tier 1 platforms:
 
-* Ubuntu 20.04 (Focal): ``amd64`` and ``arm64``
-* Mac macOS 10.14 (Mojave)
+* Ubuntu 22.04 (Jammy): ``amd64`` and ``arm64``
 * Windows 10 (Visual Studio 2019)
 
 Tier 3 platforms:
 
-* Ubuntu 20.04 (Focal): ``arm32``
 * Debian Buster (10): ``amd64``, ``arm64`` and ``arm32``
+* Mac macOS 10.14 (Mojave)
 * OpenEmbedded Thud (2.6) / webOS OSE: ``arm32`` and ``x86``
 
 Installation


### PR DESCRIPTION
This brings us up-to-date on what is actually supported now.
Note that this should *not* be backported to other branches.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>