### PR TITLE
Update link to RViz package

### DIFF
--- a/source/Tutorials/URDF/Using-URDF-with-Robot-State-Publisher.rst
+++ b/source/Tutorials/URDF/Using-URDF-with-Robot-State-Publisher.rst
@@ -26,7 +26,7 @@ We then use ``robot_state_publisher`` to publish the entire robot state to ``/tf
 Prerequisites
 -------------
 
-- `rviz2 <https://index.ros.org/r/rviz/>`__
+- `rviz2 <https://index.ros.org/p/rviz2/>`__
 
 As always, don’t forget to source ROS 2 in :doc:`every new terminal you open <../Configuring-ROS2-Environment>`.
 


### PR DESCRIPTION
The link pointing to RViz repository containing all ROS 1 and ROS 2 packages rather than RViz2 package is confusing. 

Mentioned here: https://github.com/ros2/ros2_documentation/issues/2401