### PR TITLE
Update versions of certain packages in the install instructions.

### DIFF
--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -50,6 +50,8 @@ Install development tools and ROS tools
      python3-pip \
      python3-pydocstyle \
      python3-pytest \
+     python3-pytest-repeat \
+     python3-pytest-rerunfailures \
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
@@ -65,9 +67,7 @@ Install development tools and ROS tools
      flake8-docstrings \
      flake8-import-order \
      flake8-quotes \
-     mypy==0.931 \
-     pytest-repeat \
-     pytest-rerunfailures
+     mypy==0.931
 
 .. _Rolling_rhel-dev-get-ros2-code:
 

--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -48,6 +48,8 @@ Install development tools and ROS tools
      patch \
      python3-colcon-common-extensions \
      python3-pip \
+     python3-pydocstyle \
+     python3-pytest \
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
@@ -55,7 +57,7 @@ Install development tools and ROS tools
    # install some pip packages needed for testing and
    # not available as RPMs
    python3 -m pip install -U --user \
-     flake8-blind-except \
+     flake8-blind-except==0.1.1 \
      flake8-builtins \
      flake8-class-newline \
      flake8-comprehensions \
@@ -63,12 +65,9 @@ Install development tools and ROS tools
      flake8-docstrings \
      flake8-import-order \
      flake8-quotes \
-     mypy==0.761 \
-     pydocstyle \
+     mypy==0.931 \
      pytest-repeat \
-     pytest-rerunfailures \
-     pytest \
-     setuptools
+     pytest-rerunfailures
 
 .. _Rolling_rhel-dev-get-ros2-code:
 

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -17,6 +17,7 @@ System requirements
 The current Debian-based target platforms for {DISTRO_TITLE_FULL} are:
 
 - Tier 1: Ubuntu Linux - Jammy (22.04) 64-bit
+- Tier 3: Ubuntu Linux - Focal (20.04) 64-bit
 - Tier 3: Debian Linux - Bullseye (11) 64-bit
 
 
@@ -52,31 +53,23 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-flake8 \
+     python3-flake8-blind-except \
+     python3-flake8-builtins \
+     python3-flake8-class-newline \
+     python3-flake8-comprehensions \
+     python3-flake8-deprecated \
+     python3-flake8-docstrings \
+     python3-flake8-import-order \
+     python3-flake8-quotes
      python3-pip \
+     python3-pytest \
      python3-pytest-cov \
+     python3-pytest-repeat \
+     python3-pytest-rerunfailures \
      python3-rosdep \
      python3-setuptools \
      python3-vcstool \
      wget
-   # install some pip packages needed for testing
-   python3 -m pip install -U \
-     flake8-blind-except \
-     flake8-builtins \
-     flake8-class-newline \
-     flake8-comprehensions \
-     flake8-deprecated \
-     flake8-docstrings \
-     flake8-import-order \
-     flake8-quotes \
-     pytest-repeat \
-     pytest-rerunfailures \
-     pytest
-
-Ubuntu 18.04 is not an officially supported platform, but may still work.  You'll need at least the following additional dependencies:
-
-.. code-block:: bash
-
-   python3 -m pip install -U importlib-metadata importlib-resources
 
 .. _Rolling_linux-dev-get-ros2-code:
 

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -123,7 +123,7 @@ You must also install some additional python dependencies:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark-parser lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing pyyaml rosdistro setuptools==59.6.0
+   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro setuptools==59.6.0
 
 
 Install Qt5

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -123,7 +123,7 @@ You must also install some additional python dependencies:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark-parser lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing pyyaml rosdistro setuptools
+   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark-parser lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing pyyaml rosdistro setuptools==59.6.0
 
 
 Install Qt5

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -106,11 +106,11 @@ You need the following things installed to build ROS 2:
 
        python3 -m pip install -U \
         argcomplete catkin_pkg colcon-common-extensions coverage \
-        cryptography empy flake8 flake8-blind-except flake8-builtins \
+        cryptography empy flake8 flake8-blind-except==0.1.1 flake8-builtins \
         flake8-class-newline flake8-comprehensions flake8-deprecated \
         flake8-docstrings flake8-import-order flake8-quotes \
-        importlib-metadata lark-parser lxml matplotlib mock mypy==0.931 netifaces \
-        nose pep8 psutil pydocstyle pydot pygraphviz "pyparsing>=2.4,<3" \
+        importlib-metadata lark==1.1.1 lxml matplotlib mock mypy==0.931 netifaces \
+        nose pep8 psutil pydocstyle pydot pygraphviz pyparsing==2.4.7 \
         pytest-mock rosdep rosdistro setuptools==59.6.0 vcstool
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -111,7 +111,7 @@ You need the following things installed to build ROS 2:
         flake8-docstrings flake8-import-order flake8-quotes \
         importlib-metadata lark-parser lxml matplotlib mock mypy==0.931 netifaces \
         nose pep8 psutil pydocstyle pydot pygraphviz "pyparsing>=2.4,<3" \
-        pytest-mock rosdep rosdistro setuptools vcstool
+        pytest-mock rosdep rosdistro setuptools==59.6.0 vcstool
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (default: ``$HOME/Library/Python/<version>/bin``)
 


### PR DESCRIPTION
In short, this change makes the package versions match what we
use in CI.

In long, there are various problems with upstream packages, and
it is best if we instruct users to use the versions of dependencies
that we are actually testing.  The immediate reason for this is
to avoid some of the upstream setuptools changes post 59.6.0,
but while in here I did a small audit to make sure most of our
pip dependencies are the same as what we are testing in CI.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>