### PR TITLE
OpenSSL 1.1.1L -> 1.1.1n

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -31,8 +31,8 @@ Open a Command Prompt and type the following to install them via Chocolatey:
 Install OpenSSL
 ^^^^^^^^^^^^^^^
 
-Download the *Win64 OpenSSL v1.1.1L* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
-Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1L*.
+Download the *Win64 OpenSSL v1.1.1n* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
+Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1n*.
 Don't download the Win32 or Light versions.
 
 Run the installer with default parameters, as the following commands assume you used the default installation directory.


### PR DESCRIPTION
I don't see a `1.1.1L` on [this page](https://slproweb.com/products/Win32OpenSSL.html_, but I do see a `1.1.1n`.