### PR TITLE
Remove Galactic-specific wording.

### DIFF
--- a/source/Tutorials/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Logging-and-logger-configuration.rst
@@ -170,16 +170,12 @@ Restart the demo including the following command line argument:
 This configures the default severity for any unset logger to the debug severity level.
 You should see debug output from loggers from the demo itself and from the ROS 2 core.
 
-As of the Galactic ROS 2 release, the severity level for individual loggers can be configured from the command-line.
+The severity level for individual loggers can be configured from the command-line.
 Restart the demo including the following command line arguments:
 
-.. tabs::
+.. code-block:: bash
 
-  .. group-tab:: Galactic and newer
-
-    .. code-block:: bash
-
-       ros2 run logging_demo logging_demo_main --ros-args --log-level logger_usage_demo:=debug
+   ros2 run logging_demo logging_demo_main --ros-args --log-level logger_usage_demo:=debug
 
 
 Console output formatting

--- a/source/Tutorials/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Monitoring-For-Parameter-Changes-CPP.rst
@@ -7,8 +7,6 @@ Monitoring for parameter changes (C++)
 
 **Time:** 20 minutes
 
-**Minimum Platform:** Galactic
-
 .. contents:: Contents
    :depth: 2
    :local:
@@ -27,8 +25,6 @@ Before starting this tutorial, you should first complete the following tutorials
 
 - :doc:`./Parameters/Understanding-ROS2-Parameters`
 - :doc:`./Using-Parameters-In-A-Class-CPP`
-
-In addition, you must be running the Galactic distribution of ROS 2.
 
 Tasks
 -----


### PR DESCRIPTION
There is no reason for this wording; we have separate documentation
pages for each of the released distributions.

Because of this, this commit should be backported to the
'galactic' branch, but not the 'foxy' one.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

While this isn't directly connected with the Humble release, it allows us to get rid of some distro-specific wording (which eases that transition).