### PR TITLE
Install pip and setuptools first in Windows instructions

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -125,13 +125,11 @@ First upgrade pip and setuptools:
 
    python -m pip install -U pip setuptools==59.6.0
 
-
 Now install some additional python dependencies:
 
 .. code-block:: bash
 
    python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro
-
 
 Install Qt5
 ^^^^^^^^^^^

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -119,11 +119,18 @@ Once these packages are downloaded, open an administrative shell and execute the
 
 Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 
-You must also install some additional python dependencies:
+First upgrade pip and setuptools:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro setuptools==59.6.0
+   python -m pip install -U pip setuptools==59.6.0
+
+
+Now install some additional python dependencies:
+
+.. code-block:: bash
+
+   python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro
 
 
 Install Qt5


### PR DESCRIPTION
This fixes an error I saw following the Windows Binary Installation instructions on a fresh Windows 10 machine

To reproduce the error this PR fixes

Uninstall all python packages

```
pip freeze
# Copy freeze output into freeze.txt
python -m pip uninstall -y -r C:\path\to\freeze.txt
```

Install old versions of pip and setuptools

```
python -m pip install pip==19.2.3 setuptools==41.2.0
```

Try the existing install command in the documentation

```
python -m pip install -U catkin_pkg cryptography empy importlib-metadata lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pip pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro setuptools==59.6.0
```

Installation of PyQt5 will fail

```
Collecting catkin_pkg
  Using cached https://files.pythonhosted.org/packages/33/ac/66c1a11fcfa5f6aeffd4a08209ae77eb19b6a26311e26871e0ddd8d844d3/catkin_pkg-0.4.24-py3-none-any.whl
Collecting cryptography
  Downloading https://files.pythonhosted.org/packages/10/a7/51953e73828deef2b58ba1604de9167843ee9cd4185d8aaffcb45dd1932d/cryptography-36.0.2.tar.gz (572kB)
     |████████████████████████████████| 573kB 6.8MB/s
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting empy
  Using cached https://files.pythonhosted.org/packages/3b/95/88ed47cb7da88569a78b7d6fb9420298df7e99997810c844a924d96d3c08/empy-3.3.4.tar.gz
Collecting importlib-metadata
  Using cached https://files.pythonhosted.org/packages/92/f2/c48787ca7d1e20daa185e1b6b2d4e16acd2fb5e0320bc50ffc89b91fa4d7/importlib_metadata-4.11.3-py3-none-any.whl
Collecting lark==1.1.1
  Using cached https://files.pythonhosted.org/packages/f3/8d/5e0efe24fee5677e230e5402b004f8d00b39e2026a5959ba865e2cb32bc0/lark-1.1.1-py2.py3-none-any.whl
Collecting lxml
  Using cached https://files.pythonhosted.org/packages/e5/21/e21acad8935d260e313bce95b586ae07d8bea853b11f8e9942b330260804/lxml-4.8.0-cp38-cp38-win_amd64.whl
Collecting matplotlib
  Using cached https://files.pythonhosted.org/packages/83/a5/d079d2287ac7a6389059a0e52537dc2e2ff342580512f42f6c7844c451a0/matplotlib-3.5.1-cp38-cp38-win_amd64.whl
Collecting netifaces
  Using cached https://files.pythonhosted.org/packages/d7/6c/d24d9973e385fde1440f6bb83b481ac8d1627902021c6b405f9da3951348/netifaces-0.11.0-cp38-cp38-win_amd64.whl
Collecting numpy
  Using cached https://files.pythonhosted.org/packages/fa/f2/f4ec28f935f980167740c5af5a1908090a48a564bed5e689f4b92386d7d9/numpy-1.22.3-cp38-cp38-win_amd64.whl
Collecting opencv-python
  Downloading https://files.pythonhosted.org/packages/3c/61/ee4496192ed27f657532fdf0d814b05b9787e7fc5122ed3ca57282bae69c/opencv-python-4.5.5.64.tar.gz (89.9MB)
     |████████████████████████████████| 89.9MB 6.4MB/s
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting PyQt5
  Downloading https://files.pythonhosted.org/packages/3b/27/fd81188a35f37be9b3b4c2db1654d9439d1418823916fe702ac3658c9c41/PyQt5-5.15.6.tar.gz (3.2MB)
     |████████████████████████████████| 3.2MB 6.8MB/s
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: 'C:\Python38\python.exe' 'C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py' prepare_metadata_for_build_wheel 'C:\Users\IEUser\AppData\Local\Temp\tmpx4zzzi32'
         cwd: C:\Users\IEUser\AppData\Local\Temp\pip-install-h6fwrv2h\PyQt5
    Complete output (31 lines):
    Traceback (most recent call last):
      File "C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 64, in prepare_metadata_for_build_wheel
        hook = backend.prepare_metadata_for_build_wheel
    AttributeError: module 'sipbuild.api' has no attribute 'prepare_metadata_for_build_wheel'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 207, in <module>
        main()
      File "C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 197, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 66, in prepare_metadata_for_build_wheel
        return _get_wheel_metadata_from_wheel(backend, metadata_directory,
      File "C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 95, in _get_wheel_metadata_from_wheel
        whl_basename = backend.build_wheel(metadata_directory, config_settings)
      File "C:\Users\IEUser\AppData\Local\Temp\pip-build-env-g1ymfwl2\overlay\Lib\site-packages\sipbuild\api.py", line 51, in build_wheel
        project = AbstractProject.bootstrap('pep517')
      File "C:\Users\IEUser\AppData\Local\Temp\pip-build-env-g1ymfwl2\overlay\Lib\site-packages\sipbuild\abstract_project.py", line 83, in bootstrap
        project.setup(pyproject, tool, tool_description)
      File "C:\Users\IEUser\AppData\Local\Temp\pip-build-env-g1ymfwl2\overlay\Lib\site-packages\sipbuild\project.py", line 594, in setup
        self.apply_user_defaults(tool)
      File "project.py", line 63, in apply_user_defaults
        super().apply_user_defaults(tool)
      File "C:\Users\IEUser\AppData\Local\Temp\pip-build-env-g1ymfwl2\overlay\Lib\site-packages\pyqtbuild\project.py", line 70, in apply_user_defaults
        super().apply_user_defaults(tool)
      File "C:\Users\IEUser\AppData\Local\Temp\pip-build-env-g1ymfwl2\overlay\Lib\site-packages\sipbuild\project.py", line 241, in apply_user_defaults
        self.builder.apply_user_defaults(tool)
      File "C:\Users\IEUser\AppData\Local\Temp\pip-build-env-g1ymfwl2\overlay\Lib\site-packages\pyqtbuild\builder.py", line 67, in apply_user_defaults
        raise PyProjectOptionException('qmake',
    sipbuild.pyproject.PyProjectOptionException
    ----------------------------------------
ERROR: Command errored out with exit status 1: 'C:\Python38\python.exe' 'C:\Python38\lib\site-packages\pip\_vendor\pep517\_in_process.py' prepare_metadata_for_build_wheel 'C:\Users\IEUser\AppData\Local\Temp\tmpx4zzzi32' Check the logs for full command output.
WARNING: You are using pip version 19.2.3, however version 22.0.4 is available.
You should consider upgrading via the 'python -m pip install --upgrade pip' command.
```

Installing newer versions of pip and setuptools first resolves the issue.