### PR TITLE
Use REPOS_FILE_BRANCH wherever we can.

### DIFF
--- a/source/Tutorials/Actions/Writing-a-Cpp-Action-Server-Client.rst
+++ b/source/Tutorials/Actions/Writing-a-Cpp-Action-Server-Client.rst
@@ -385,6 +385,6 @@ In this tutorial, you put together a C++ action server and action client line by
 Related content
 ---------------
 
-* There are several ways you could write an action server and client in C++; check out the ``minimal_action_server`` and ``minimal_action_client`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/master/rclcpp>`_ repo.
+* There are several ways you could write an action server and client in C++; check out the ``minimal_action_server`` and ``minimal_action_client`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclcpp>`_ repo.
 
 * For more detailed information about ROS actions, please refer to the `design article <http://design.ros2.org/articles/actions.html>`__.

--- a/source/Tutorials/Actions/Writing-a-Py-Action-Server-Client.rst
+++ b/source/Tutorials/Actions/Writing-a-Py-Action-Server-Client.rst
@@ -38,7 +38,7 @@ using the action we created in the :doc:`./Creating-an-Action` tutorial.
 Until now, you've created packages and used ``ros2 run`` to run your nodes.
 To keep things simple in this tutorial, however, we’ll scope the action server to a single file.
 If you'd like to see what a complete package for the actions tutorials looks like, check out
-`action_tutorials <https://github.com/ros2/demos/tree/master/action_tutorials>`__.
+`action_tutorials <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/action_tutorials>`__.
 
 Open a new file in your home directory, let's call it ``fibonacci_action_server.py``,
 and add the following code:
@@ -352,6 +352,6 @@ In this tutorial, you put together a Python action server and action client line
 Related content
 ---------------
 
-* There are several ways you could write an action server and client in Python; check out the ``minimal_action_server`` and ``minimal_action_client`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/master/rclpy/actions>`_ repo.
+* There are several ways you could write an action server and client in Python; check out the ``minimal_action_server`` and ``minimal_action_client`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclpy/actions>`_ repo.
 
 * For more detailed information about ROS actions, please refer to the `design article <http://design.ros2.org/articles/actions.html>`__.

--- a/source/Tutorials/Allocator-Template-Tutorial.rst
+++ b/source/Tutorials/Allocator-Template-Tutorial.rst
@@ -10,7 +10,7 @@ Implement a custom memory allocator
    :local:
 
 This tutorial will teach you how to integrate a custom allocator for publishers and subscribers so that the default heap allocator is never called while your ROS nodes are executing.
-The code for this tutorial is available `here <https://github.com/ros2/demos/blob/master/demo_nodes_cpp/src/topics/allocator_tutorial.cpp>`__.
+The code for this tutorial is available `here <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/demo_nodes_cpp/src/topics/allocator_tutorial.cpp>`__.
 
 Background
 ----------
@@ -205,7 +205,7 @@ You can also override the global new and delete operators:
 
 where the variables we are incrementing are just global static integers, and ``is_running`` is a global static boolean that gets toggled right before the call to ``spin``.
 
-The `example executable <https://github.com/ros2/demos/blob/master/demo_nodes_cpp/src/topics/allocator_tutorial.cpp>`__ prints the value of the variables. To run the example executable, use:
+The `example executable <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/demo_nodes_cpp/src/topics/allocator_tutorial.cpp>`__ prints the value of the variables. To run the example executable, use:
 
 .. code-block:: bash
 
@@ -232,7 +232,7 @@ As a matter of fact, these allocations/deallocations originate in the underlying
 
 Proving this is out of the scope of this tutorial, but you can check out the test for the allocation path that gets run as part of the ROS 2 continuous integration testing, which backtraces through the code and figures out whether certain function calls originate in the rmw implementation or in a DDS implementation:
 
-https://github.com/ros2/realtime_support/blob/master/tlsf_cpp/test/test_tlsf.cpp#L41
+https://github.com/ros2/realtime_support/blob/{REPOS_FILE_BRANCH}/tlsf_cpp/test/test_tlsf.cpp#L41
 
 Note that this test is not using the custom allocator we just created, but the TLSF allocator (see below).
 
@@ -241,11 +241,11 @@ The TLSF allocator
 
 ROS 2 offers support for the TLSF (Two Level Segregate Fit) allocator, which was designed to meet real-time requirements:
 
-https://github.com/ros2/realtime_support/tree/master/tlsf_cpp
+https://github.com/ros2/realtime_support/tree/{REPOS_FILE_BRANCH}/tlsf_cpp
 
 For more information about TLSF, see http://www.gii.upv.es/tlsf/
 
 Note that the TLSF allocator is licensed under a dual-GPL/LGPL license.
 
 A full working example using the TLSF allocator is here:
-https://github.com/ros2/realtime_support/blob/master/tlsf_cpp/example/allocator_example.cpp
+https://github.com/ros2/realtime_support/blob/{REPOS_FILE_BRANCH}/tlsf_cpp/example/allocator_example.cpp

--- a/source/Tutorials/Colcon-Tutorial.rst
+++ b/source/Tutorials/Colcon-Tutorial.rst
@@ -285,9 +285,9 @@ colcon supports multiple build types.
 The recommended build types are ``ament_cmake`` and ``ament_python``.
 Also supported are pure ``cmake`` packages.
 
-An example of an ``ament_python`` build is the `ament_index_python package <https://github.com/ament/ament_index/tree/master/ament_index_python>`__ , where the setup.py is the primary entry point for building.
+An example of an ``ament_python`` build is the `ament_index_python package <https://github.com/ament/ament_index/tree/{REPOS_FILE_BRANCH}/ament_index_python>`__ , where the setup.py is the primary entry point for building.
 
-A package such as `demo_nodes_cpp <https://github.com/ros2/demos/tree/master/demo_nodes_cpp>`__ uses the ``ament_cmake`` build type, and uses CMake as the build tool.
+A package such as `demo_nodes_cpp <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/demo_nodes_cpp>`__ uses the ``ament_cmake`` build type, and uses CMake as the build tool.
 
 For convenience, you can use the tool ``ros2 pkg create`` to create a new package based on a template.
 

--- a/source/Tutorials/Composition.rst
+++ b/source/Tutorials/Composition.rst
@@ -17,7 +17,7 @@ See the :doc:`conceptual article <../Concepts/About-Composition>`.
 Run the demos
 -------------
 
-The demos use executables from `rclcpp_components <https://github.com/ros2/rclcpp/tree/master/rclcpp_components>`__, `ros2component <https://github.com/ros2/ros2cli/tree/master/ros2component>`__, and  `composition <https://github.com/ros2/demos/tree/master/composition>`__ packages, and can be run with the following commands.
+The demos use executables from `rclcpp_components <https://github.com/ros2/rclcpp/tree/{REPOS_FILE_BRANCH}/rclcpp_components>`__, `ros2component <https://github.com/ros2/ros2cli/tree/{REPOS_FILE_BRANCH}/ros2component>`__, and  `composition <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/composition>`__ packages, and can be run with the following commands.
 
 
 Discover available components
@@ -53,7 +53,7 @@ Verify that the container is running via ``ros2`` command line tools:
    $ ros2 component list
    /ComponentManager
 
-In the second shell load the talker component (see `talker <https://github.com/ros2/demos/blob/master/composition/src/talker_component.cpp>`__ source code):
+In the second shell load the talker component (see `talker <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/talker_component.cpp>`__ source code):
 
 .. code-block:: bash
 
@@ -64,7 +64,7 @@ The command will return the unique ID of the loaded component as well as the nod
 
 Now the first shell should show a message that the component was loaded as well as repeated message for publishing a message.
 
-Run another command in the second shell to load the listener component (see `listener <https://github.com/ros2/demos/blob/master/composition/src/listener_component.cpp>`__ source code):
+Run another command in the second shell to load the listener component (see `listener <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/listener_component.cpp>`__ source code):
 
 .. code-block:: bash
 
@@ -93,7 +93,7 @@ In the first shell:
 
    $ ros2 run rclcpp_components component_container
 
-In the second shell (see `server <https://github.com/ros2/demos/blob/master/composition/src/server_component.cpp>`__ and `client <https://github.com/ros2/demos/blob/master/composition/src/client_component.cpp>`__ source code):
+In the second shell (see `server <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/server_component.cpp>`__ and `client <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/client_component.cpp>`__ source code):
 
 .. code-block:: bash
 
@@ -108,7 +108,7 @@ Compile-time composition using ROS services
 This demos shows that the same shared libraries can be reused to compile a single executable running multiple components.
 The executable contains all four components from above: talker and listener as well as server and client.
 
-In the shell call (see `source code <https://github.com/ros2/demos/blob/master/composition/src/manual_composition.cpp>`__):
+In the shell call (see `source code <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/manual_composition.cpp>`__):
 
 .. code-block:: bash
 
@@ -124,7 +124,7 @@ Run-time composition using dlopen
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This demo presents an alternative to run-time composition by creating a generic container process and explicitly passing the libraries to load without using ROS interfaces.
-The process will open each library and create one instance of each "rclcpp::Node" class in the library `source code <https://github.com/ros2/demos/blob/master/composition/src/dlopen_composition.cpp>`__).
+The process will open each library and create one instance of each "rclcpp::Node" class in the library `source code <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/dlopen_composition.cpp>`__).
 
 .. tabs::
 

--- a/source/Tutorials/Getting-Started-With-Ros2doctor.rst
+++ b/source/Tutorials/Getting-Started-With-Ros2doctor.rst
@@ -191,7 +191,7 @@ Keep in mind, ``ros2doctor`` is not a debug tool; it won’t help with errors in
 Related content
 ---------------
 
-`ros2doctor’s README <https://github.com/ros2/ros2cli/tree/master/ros2doctor>`__ will tell you more about different arguments.
+`ros2doctor’s README <https://github.com/ros2/ros2cli/tree/{REPOS_FILE_BRANCH}/ros2doctor>`__ will tell you more about different arguments.
 You might want to take a look around the ``ros2doctor`` repo as well, since it's fairly beginner friendly and a great place to get started with contributing.
 
 Next steps

--- a/source/Tutorials/Intra-Process-Communication.rst
+++ b/source/Tutorials/Intra-Process-Communication.rst
@@ -39,7 +39,7 @@ This demo is designed to show that the intra process publish/subscribe connectio
 
 First let's take a look at the source:
 
-https://github.com/ros2/demos/blob/master/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
 
 .. code-block:: c++
 
@@ -170,7 +170,7 @@ The cyclic pipeline demo
 This demo is similar to the previous one, but instead of the producer creating a new message for each iteration, this demo only ever uses one message instance.
 This is achieved by creating a cycle in the graph and "kicking off" communication by externally making one of the nodes publish before spinning the executor:
 
-https://github.com/ros2/demos/blob/master/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
+https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
 
 .. code-block:: c++
 

--- a/source/Tutorials/Launch/Launch-system.rst
+++ b/source/Tutorials/Launch/Launch-system.rst
@@ -125,7 +125,7 @@ Or for a standalone launch file:
 Example of ROS 2 launch concepts
 --------------------------------
 
-The launch file in `this example <https://github.com/ros2/launch_ros/blob/master/launch_ros/examples/lifecycle_pub_sub_launch.py>`__
+The launch file in `this example <https://github.com/ros2/launch_ros/blob/{REPOS_FILE_BRANCH}/launch_ros/examples/lifecycle_pub_sub_launch.py>`__
 launches two nodes, one of which is a node with a `managed lifecycle <../Managed-Nodes>` (a "lifecycle node").
 Lifecycle nodes launched through ``launch_ros`` automatically emit *events* when they transition between states.
 The events can then be acted on through the launch framework.
@@ -136,7 +136,7 @@ In the aforementioned example, various transition requests are requested of the 
 Documentation
 -------------
 
-`The launch documentation <https://github.com/ros2/launch/blob/master/launch/doc/source/architecture.rst>`__ provides more details on concepts that are also used in ``launch_ros``.
+`The launch documentation <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`__ provides more details on concepts that are also used in ``launch_ros``.
 
 Additional documentation/examples of launch capabilities are forthcoming.
 See `the source code <https://github.com/ros2/launch>`__ in the meantime.

--- a/source/Tutorials/Launch/Using-Event-Handlers.rst
+++ b/source/Tutorials/Launch/Using-Event-Handlers.rst
@@ -292,7 +292,7 @@ Additionally, it will log messages to the console when:
 Documentation
 -------------
 
-`The launch documentation <https://github.com/ros2/launch/blob/master/launch/doc/source/architecture.rst>`_ provides detailed information about available event handlers.
+`The launch documentation <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`_ provides detailed information about available event handlers.
 
 Summary
 -------

--- a/source/Tutorials/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Launch/Using-Substitutions.rst
@@ -325,7 +325,7 @@ Now you can pass the desired arguments to the launch file as follows:
 Documentation
 -------------
 
-`The launch documentation <https://github.com/ros2/launch/blob/master/launch/doc/source/architecture.rst>`_ provides detailed information about available substitutions.
+`The launch documentation <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`_ provides detailed information about available substitutions.
 
 Summary
 -------

--- a/source/Tutorials/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Logging-and-logger-configuration.rst
@@ -91,7 +91,7 @@ Logger level configuration: programmatically
 After 10 iterations the level of the logger will be set to ``DEBUG``, which will cause additional messages to be logged.
 
 Some of these debug messages cause additional functions/expressions to be evaluated, which were previously skipped as ``DEBUG`` log calls were not enabled.
-See `the source code <https://github.com/ros2/demos/blob/master/logging_demo/src/logger_usage_component.cpp>`__ of the demo for further explanation of the calls used, and see the rclcpp logging documentation for a full list of supported logging calls.
+See `the source code <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/logging_demo/src/logger_usage_component.cpp>`__ of the demo for further explanation of the calls used, and see the rclcpp logging documentation for a full list of supported logging calls.
 
 Logger level configuration: externally
 --------------------------------------

--- a/source/Tutorials/Managed-Nodes.rst
+++ b/source/Tutorials/Managed-Nodes.rst
@@ -5,5 +5,5 @@
 Management of nodes with managed lifecycles
 ===========================================
 
-This page lives now directly side-by-side with the `code <https://github.com/ros2/demos/blob/master/lifecycle/README.rst>`__.
+This page lives now directly side-by-side with the `code <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/lifecycle/README.rst>`__.
 For more information about the ``lifecycle`` package, refer to `rosindex <https://index.ros.org/p/lifecycle/github-ros2-demos/>`__.

--- a/source/Tutorials/Quality-of-Service.rst
+++ b/source/Tutorials/Quality-of-Service.rst
@@ -172,11 +172,11 @@ Enforcing reliability on a lossy channel means that the publisher (in this case,
 Let's now try running both programs, but with more suitable settings.
 First of all, we'll use the ``-p reliability:=best_effort`` option to enable best effort communication.
 The publisher will now just attempt to deliver the network packets, and don't expect acknowledgement from the consumer.
-We see now that some of the frame on the ``showimage`` side were dropped, the frame numbers in the shell running ``showimage`` won't be consecutive anymore:
+We see now that some of the frames on the ``showimage`` side were dropped, so the frame numbers in the shell running ``showimage`` won't be consecutive anymore:
 
 
-.. image:: https://raw.githubusercontent.com/ros2/demos/master/image_tools/doc/qos-best-effort.png
-   :target: https://raw.githubusercontent.com/ros2/demos/master/image_tools/doc/qos-best-effort.png
+.. image:: https://raw.githubusercontent.com/ros2/demos/{REPOS_FILE_BRANCH}/image_tools/doc/qos-best-effort.png
+   :target: https://raw.githubusercontent.com/ros2/demos/{REPOS_FILE_BRANCH}/image_tools/doc/qos-best-effort.png
    :alt: Best effort image transfer
 
 

--- a/source/Tutorials/Ros2bag/Recording-A-Bag-From-Your-Own-Node-Python.rst
+++ b/source/Tutorials/Ros2bag/Recording-A-Bag-From-Your-Own-Node-Python.rst
@@ -142,7 +142,7 @@ Note the importation of the ``rosbag2_py`` package for the functions and structu
 
 In the class constructor, we begin by creating the writer object that we will use to write to the bag.
 We are creating a ``SequentialWriter``, which writes messages into the bag in the order received.
-Other writers with different behaviours may be available in the [``rosbag2`` source](https://github.com/ros2/rosbag2/tree/master/rosbag2_cpp/include/rosbag2_cpp/writers).
+Other writers with different behaviours may be available in the `rosbag2 <https://github.com/ros2/rosbag2/tree/{REPOS_FILE_BRANCH}/rosbag2_cpp/include/rosbag2_cpp/writers>`__.
 
 .. code-block:: Python
 

--- a/source/Tutorials/Rosbag-with-ROS1-Bridge.rst
+++ b/source/Tutorials/Rosbag-with-ROS1-Bridge.rst
@@ -7,7 +7,7 @@ Recording and playback of topic data with rosbag using the ROS 1 bridge
 
 This tutorial is a follow up to the *Bridge communication between ROS 1 and ROS 2* demo as can be found listed with the other `demos <../Tutorials>`, and in the following it is assumed you have completed that tutorial already.
 
-The ros1_bridge can either be installed from `binary packages <../Installation>` or `built from source <https://github.com/ros2/ros1_bridge/blob/master/README.md#building-the-bridge-from-source>`__; both work for these examples.
+The ros1_bridge can either be installed from `binary packages <../Installation>` or `built from source <https://github.com/ros2/ros1_bridge/blob/{REPOS_FILE_BRANCH}/README.md#building-the-bridge-from-source>`__; both work for these examples.
 
 What follows is a series of additional examples, like that ones that come at the end of the aforementioned *Bridge communication between ROS 1 and ROS 2* demo.
 

--- a/source/Tutorials/Security/Access-Controls.rst
+++ b/source/Tutorials/Security/Access-Controls.rst
@@ -135,7 +135,7 @@ Use the templates
 ^^^^^^^^^^^^^^^^^
 
 Security policies can quickly become confusing, so the ``sros2`` utilities add the ability to create policies from templates.
-Do this by using the `sample policy file <https://github.com/ros2/sros2/blob/master/sros2/test/policies/sample.policy.xml#L1>`_ provided in the ``sros2`` repository.
+Do this by using the `sample policy file <https://github.com/ros2/sros2/blob/{REPOS_FILE_BRANCH}/sros2/test/policies/sample.policy.xml#L1>`_ provided in the ``sros2`` repository.
 Let's creates a policy for both the ``talker`` and the ``listener`` to only use the ``chatter`` topic.
 
 Begin by downloading the ``sros2`` repository with the sample policy files:

--- a/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Single-Package-Define-And-Use-Interface.rst
@@ -25,7 +25,7 @@ In a :doc:`previous tutorial <./Custom-ROS2-Interfaces>`, you learned how to cre
 While best practice is to declare interfaces in dedicated interface packages, sometimes it can be convenient to declare, create and use an interface all in one package.
 
 Recall that interfaces can currently only be defined in CMake packages.
-It is possible, however, to have Python libraries and nodes in CMake packages (using `ament_cmake_python <https://github.com/ament/ament_cmake/tree/master/ament_cmake_python>`_), so you could define interfaces and Python nodes together in one package.
+It is possible, however, to have Python libraries and nodes in CMake packages (using `ament_cmake_python <https://github.com/ament/ament_cmake/tree/{REPOS_FILE_BRANCH}/ament_cmake_python>`_), so you could define interfaces and Python nodes together in one package.
 We'll use a CMake package and C++ nodes here for the sake of simplicity.
 
 This tutorial will focus on the msg interface type, but the steps here are applicable to all interface types.

--- a/source/Tutorials/Topics/Topic-Statistics-Tutorial.rst
+++ b/source/Tutorials/Topics/Topic-Statistics-Tutorial.rst
@@ -52,19 +52,19 @@ download the example talker code by entering the following command:
 
       .. code-block:: console
 
-            wget -O member_function_with_topic_statistics.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
+            wget -O member_function_with_topic_statistics.cpp https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-            wget -O member_function_with_topic_statistics.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
+            wget -O member_function_with_topic_statistics.cpp https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
 
    .. group-tab:: Windows
 
       Right click this link and select Save As ``publisher_member_function.cpp``:
 
-      https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
+      https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function_with_topic_statistics.cpp
 
 Now there will be a new file named ``member_function_with_topic_statistics.cpp``.
 Open the file using your preferred text editor.
@@ -300,7 +300,7 @@ The terminal should start publishing statistics messages every 10 seconds, becau
       data: 0.4463309283488427
     ---
 
-From the `message definition <https://github.com/ros2/rcl_interfaces/tree/master/statistics_msgs>`__
+From the `message definition <https://github.com/ros2/rcl_interfaces/tree/{REPOS_FILE_BRANCH}/statistics_msgs>`__
 the ``data_types`` are as follows
 
 ===============    ===================
@@ -331,4 +331,4 @@ Related content
 ---------------
 
 To observe how the ``message_age`` period is calculated please see the
-`ROS 2 Topic Statistics demo <https://github.com/ros2/demos/tree/master/topic_statistics_demo>`__.
+`ROS 2 Topic Statistics demo <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/topic_statistics_demo>`__.

--- a/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -20,7 +20,7 @@ Background
 In this tutorial, the nodes will pass information in the form of string messages to each other over a :doc:`topic <./Topics/Understanding-ROS2-Topics>`.
 The example used here is a simple “talker” and “listener” system; one node publishes data and the other subscribes to the topic so it can receive that data.
 
-The code used in these examples can be found `here <https://github.com/ros2/examples/tree/master/rclcpp/topics>`__.
+The code used in these examples can be found `here <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclcpp/topics>`__.
 
 Prerequisites
 -------------
@@ -61,13 +61,13 @@ Download the example talker code by entering the following command:
 
       .. code-block:: console
 
-            wget -O publisher_member_function.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp
+            wget -O publisher_member_function.cpp https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_publisher/member_function.cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-            wget -O publisher_member_function.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp
+            wget -O publisher_member_function.cpp https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_publisher/member_function.cpp
 
    .. group-tab:: Windows
 
@@ -75,13 +75,13 @@ Download the example talker code by entering the following command:
 
       .. code-block:: console
 
-            curl -sk https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp -o publisher_member_function.cpp
+            curl -sk https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_publisher/member_function.cpp -o publisher_member_function.cpp
 
       Or in powershell:
 
       .. code-block:: console
 
-            curl https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_publisher/member_function.cpp -o publisher_member_function.cpp
+            curl https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_publisher/member_function.cpp -o publisher_member_function.cpp
 
 Now there will be a new file named ``publisher_member_function.cpp``.
 Open the file using your preferred text editor.
@@ -307,13 +307,13 @@ Enter the following code in your terminal:
 
       .. code-block:: console
 
-            wget -O subscriber_member_function.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp
+            wget -O subscriber_member_function.cpp https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function.cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-            wget -O subscriber_member_function.cpp https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp
+            wget -O subscriber_member_function.cpp https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function.cpp
 
    .. group-tab:: Windows
 
@@ -321,13 +321,13 @@ Enter the following code in your terminal:
 
       .. code-block:: console
 
-            curl -sk https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp -o subscriber_member_function.cpp
+            curl -sk https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function.cpp -o subscriber_member_function.cpp
 
       Or in powershell:
 
       .. code-block:: console
 
-            curl https://raw.githubusercontent.com/ros2/examples/master/rclcpp/topics/minimal_subscriber/member_function.cpp -o subscriber_member_function.cpp
+            curl https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/member_function.cpp -o subscriber_member_function.cpp
 
 Entering ``ls`` in the console will now return:
 
@@ -545,4 +545,4 @@ Again, you can choose to write it in either :doc:`C++ <./Writing-A-Simple-Cpp-Se
 Related content
 ---------------
 
-There are several ways you could write a publisher and subscriber in C++; check out the ``minimal_publisher`` and ``minimal_subscriber`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/master/rclcpp/topics>`_ repo.
+There are several ways you could write a publisher and subscriber in C++; check out the ``minimal_publisher`` and ``minimal_subscriber`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclcpp/topics>`_ repo.

--- a/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -47,7 +47,7 @@ Navigate into ``dev_ws/src`` and create a new package:
 Your terminal will return a message verifying the creation of your package ``cpp_srvcli`` and all its necessary files and folders.
 
 The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml`` and ``CMakeLists.txt``.
-``example_interfaces`` is the package that includes `the .srv file <https://github.com/ros2/example_interfaces/blob/master/srv/AddTwoInts.srv>`__ you will need to structure your requests and responses:
+``example_interfaces`` is the package that includes `the .srv file <https://github.com/ros2/example_interfaces/blob/{REPOS_FILE_BRANCH}/srv/AddTwoInts.srv>`__ you will need to structure your requests and responses:
 
 .. code-block:: console
 
@@ -423,4 +423,4 @@ Next, you'll learn how to :doc:`create custom interfaces <./Custom-ROS2-Interfac
 Related content
 ---------------
 
-* There are several ways you could write a service and client in C++; check out the ``minimal_service`` and ``minimal_client`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/master/rclcpp/services>`_ repo.
+* There are several ways you could write a service and client in C++; check out the ``minimal_service`` and ``minimal_client`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclcpp/services>`_ repo.

--- a/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -20,7 +20,7 @@ In this tutorial, you will create :doc:`nodes <./Understanding-ROS2-Nodes>` that
 The example used here is a simple “talker” and “listener” system;
 one node publishes data and the other subscribes to the topic so it can receive that data.
 
-The code used in these examples can be found `here <https://github.com/ros2/examples/tree/master/rclpy/topics>`__.
+The code used in these examples can be found `here <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclpy/topics>`__.
 
 Prerequisites
 -------------
@@ -62,13 +62,13 @@ Download the example talker code by entering the following command:
 
       .. code-block:: console
 
-        wget https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+        wget https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-        wget https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+        wget https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
 
    .. group-tab:: Windows
 
@@ -76,13 +76,13 @@ Download the example talker code by entering the following command:
 
       .. code-block:: console
 
-            curl -sk https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py -o publisher_member_function.py
+            curl -sk https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py -o publisher_member_function.py
 
       Or in powershell:
 
       .. code-block:: console
 
-            curl https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py -o publisher_member_function.py
+            curl https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py -o publisher_member_function.py
 
 Now there will be a new file named ``publisher_member_function.py`` adjacent to ``__init__.py``.
 
@@ -283,13 +283,13 @@ Enter the following code in your terminal:
 
       .. code-block:: console
 
-        wget https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+        wget https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-        wget https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+        wget https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
 
    .. group-tab:: Windows
 
@@ -297,13 +297,13 @@ Enter the following code in your terminal:
 
       .. code-block:: console
 
-            curl -sk https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py -o subscriber_member_function.py
+            curl -sk https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py -o subscriber_member_function.py
 
       Or in powershell:
 
       .. code-block:: console
 
-            curl https://raw.githubusercontent.com/ros2/examples/master/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py -o subscriber_member_function.py
+            curl https://raw.githubusercontent.com/ros2/examples/{REPOS_FILE_BRANCH}/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py -o subscriber_member_function.py
 
 Now the directory should have these files:
 
@@ -525,4 +525,4 @@ Again, you can choose to write it in either :doc:`C++ <./Writing-A-Simple-Cpp-Se
 Related content
 ---------------
 
-There are several ways you could write a publisher and subscriber in Python; check out the ``minimal_publisher`` and ``minimal_subscriber`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/master/rclpy/topics>`_ repo.
+There are several ways you could write a publisher and subscriber in Python; check out the ``minimal_publisher`` and ``minimal_subscriber`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclpy/topics>`_ repo.

--- a/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Writing-A-Simple-Py-Service-And-Client.rst
@@ -46,7 +46,7 @@ Navigate into ``dev_ws/src`` and create a new package:
 Your terminal will return a message verifying the creation of your package ``py_srvcli`` and all its necessary files and folders.
 
 The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml``.
-``example_interfaces`` is the package that includes `the .srv file <https://github.com/ros2/example_interfaces/blob/master/srv/AddTwoInts.srv>`__ you will need to structure your requests and responses:
+``example_interfaces`` is the package that includes `the .srv file <https://github.com/ros2/example_interfaces/blob/{REPOS_FILE_BRANCH}/srv/AddTwoInts.srv>`__ you will need to structure your requests and responses:
 
 .. code-block:: console
 
@@ -354,7 +354,7 @@ Next, you'll learn how to :doc:`create custom interfaces <./Custom-ROS2-Interfac
 Related content
 ---------------
 
-* There are several ways you could write a service and client in Python; check out the ``minimal_client`` and ``minimal_service`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/master/rclpy/services>`_ repo.
+* There are several ways you could write a service and client in Python; check out the ``minimal_client`` and ``minimal_service`` packages in the `ros2/examples <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclpy/services>`_ repo.
 
 * In this tutorial, you used the ``call_async()`` API in your client node to call the service.
   There is another service call API available for Python called synchronous calls.


### PR DESCRIPTION
That way, once we backport this most of the tutorials will
point to the correct branch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #2451, at least for the Tutorials.  @fujitatomoya FYI.