### PR TITLE
Renaming Installation doc pages for easier navigation

### DIFF
--- a/source/Installation/DDS-Implementations.rst
+++ b/source/Installation/DDS-Implementations.rst
@@ -1,5 +1,5 @@
-Installing DDS implementations
-==============================
+DDS implementations
+===================
 
 By default, ROS 2 uses DDS as its `middleware <https://design.ros2.org/articles/ros_on_dds.html>`__.
 It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
@@ -8,9 +8,9 @@ See https://ros.org/reps/rep-2000.html for supported DDS vendors by distribution
 
 In Rolling, the default DDS vendor is eProsima's Fast DDS.
 
-* :doc:`Working with Eclipse Cyclone DDS <DDS-Implementations/Working-with-Eclipse-CycloneDDS>` explains how to utilize Cyclone DDS.
-* :doc:`Working with eProsima Fast DDS <DDS-Implementations/Working-with-eProsima-Fast-DDS>` explains how to utilize Fast DDS.
-* :doc:`Working with GurumNetworks GurumDDS <DDS-Implementations/Working-with-GurumNetworks-GurumDDS>` explains how to utilize GurumDDS.
+* :doc:`Eclipse Cyclone DDS <DDS-Implementations/Working-with-Eclipse-CycloneDDS>` explains how to utilize Cyclone DDS.
+* :doc:`eProsima Fast DDS <DDS-Implementations/Working-with-eProsima-Fast-DDS>` explains how to utilize Fast DDS.
+* :doc:`GurumNetworks GurumDDS <DDS-Implementations/Working-with-GurumNetworks-GurumDDS>` explains how to utilize GurumDDS.
 
 .. toctree::
    :hidden:

--- a/source/Installation/DDS-Implementations/Install-Connext-Security-Plugins.rst
+++ b/source/Installation/DDS-Implementations/Install-Connext-Security-Plugins.rst
@@ -1,5 +1,5 @@
-Installing Connext security plugins
-===================================
+Connext security plugins
+========================
 
 The Connext DDS Libraries are included with ROS 2 under a `non-commercial
 license <https://www.rti.com/ncl>`__ and do not include the security

--- a/source/Installation/DDS-Implementations/Install-Connext-University-Eval.rst
+++ b/source/Installation/DDS-Implementations/Install-Connext-University-Eval.rst
@@ -1,5 +1,5 @@
-Installing University or Evaluation versions of RTI Connext DDS
-===============================================================
+RTI Connext DDS (university or evaluation versions)
+===================================================
 
 A libraries-only version of RTI Connext DDS 6.0.1 may be installed per the :doc:`installation instructions <../../Installation>` for
 Debian/Ubuntu Linux (amd64) platforms only, under a `non-commercial license <https://www.rti.com/ncl>`__.

--- a/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
@@ -2,8 +2,8 @@
 
     Working-with-Eclipse-CycloneDDS
 
-Working with Eclipse Cyclone DDS
-================================
+Eclipse Cyclone DDS
+===================
 
 Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation.
 Cyclone DDS is developed completely in the open as an Eclipse IoT project.

--- a/source/Installation/DDS-Implementations/Working-with-GurumNetworks-GurumDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-GurumNetworks-GurumDDS.rst
@@ -2,8 +2,8 @@
 
     Working-with-GurumNetworks-GurumDDS
 
-Working with GurumNetworks GurumDDS
-===================================
+GurumNetworks GurumDDS
+======================
 
 rmw_gurumdds is a implementation of the ROS middleware interface using GurumNetworks GurumDDS.
 More information about GurumDDS is available on our website: https://gurum.cc/index_eng
@@ -13,8 +13,8 @@ Prerequisites
 -------------
 
 The following description assumes that you have completed the 'Environment setup' process
-from the :doc:`Installing ROS 2 via Debian Packages <../Ubuntu-Install-Debians>` or
-from the :doc:`Building ROS 2 on Ubuntu Linux <../Ubuntu-Development-Setup>`.
+from the :doc:`Ubuntu Linux: Build via Debian packages <../Ubuntu-Install-Debians>` or
+from the :doc:`Ubuntu Linux: Build from source <../Ubuntu-Development-Setup>`.
 
 rmw_gurumdds requires version of GurumDDS-2.7.x.
 Debian packages of GurumDDS is provided in the ROS 2 apt repositories on linux.

--- a/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
@@ -1,5 +1,5 @@
-Working with eProsima Fast DDS
-==============================
+eProsima Fast DDS
+=================
 
 eProsima Fast DDS is a complete open-source DDS implementation for real time embedded architectures and operating systems.
 See also: https://www.eprosima.com/index.php/products-all/eprosima-fast-dds

--- a/source/Installation/Fedora-Development-Setup.rst
+++ b/source/Installation/Fedora-Development-Setup.rst
@@ -1,5 +1,5 @@
-Building ROS 2 on Fedora Linux
-==============================
+Fedora Linux: Build from source
+===============================
 
 How to setup the development environment?
 -----------------------------------------

--- a/source/Installation/Latest-Development-Setup.rst
+++ b/source/Installation/Latest-Development-Setup.rst
@@ -1,5 +1,5 @@
-Installing the latest ROS 2 development
-=======================================
+Latest ROS 2 development
+========================
 
 If you plan to contribute directly to the latest ROS 2 development, you can install ROS 2 by building it from source or installing testing binaries.
 This will give you the latest bug fixes and features.

--- a/source/Installation/Maintaining-a-Source-Checkout.rst
+++ b/source/Installation/Maintaining-a-Source-Checkout.rst
@@ -1,14 +1,14 @@
 .. _MaintainingSource:
 
-Maintaining a source checkout of ROS 2 {DISTRO_TITLE}
-=====================================================
+Maintaining a source checkout
+=============================
 
 .. ifconfig:: smv_current_version != '' and smv_current_version != 'rolling'
 
   .. note::
 
      For instructions on maintaining a source checkout of the **latest development version** of ROS 2, refer to
-     `Maintaining a source checkout of ROS 2 Rolling <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
+     `Maintaining a source checkout <../../rolling/Installation/Maintaining-a-Source-Checkout.html>`__
 
 .. contents::
    :depth: 2

--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -1,7 +1,7 @@
 .. _rhel-latest:
 
-Building ROS 2 on RHEL
-======================
+RHEL: Build from source
+=======================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/RHEL-Install-Binary.rst
+++ b/source/Installation/RHEL-Install-Binary.rst
@@ -1,5 +1,5 @@
-Installing ROS 2 on RHEL
-========================
+RHEL: Install from binary
+=========================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -1,5 +1,5 @@
-Installing ROS 2 via RPM Packages
-=================================
+RHEL: Install via RPM packages
+==============================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -2,8 +2,8 @@
 
    Installation/Prerelease-Testing
 
-Alternative Installation Sources for Testing
-============================================
+Testing alternatives 
+====================
 
 Many ROS packages are provided as pre-built binaries.
 Usually, you will get the released version of binaries when following :doc:`../Installation`.

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -4,8 +4,8 @@
 
    Installation/Linux-Development-Setup
 
-Building ROS 2 on Ubuntu Linux
-==============================
+Ubuntu Linux: Build from source
+===============================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Ubuntu-Install-Binary.rst
@@ -2,8 +2,8 @@
 
    Installation/Linux-Install-Binary
 
-Installing ROS 2 on Ubuntu Linux
-================================
+Ubuntu Linux: Install from binary
+=================================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -2,8 +2,8 @@
 
    Installation/Linux-Install-Debians
 
-Installing ROS 2 via Debian Packages
-====================================
+Ubuntu Linux: Install via Debian packages
+=========================================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/Windows-Development-Setup.rst
+++ b/source/Installation/Windows-Development-Setup.rst
@@ -1,7 +1,7 @@
 .. _windows-latest:
 
-Building ROS 2 on Windows
-=========================
+Windows: Build from source
+==========================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -1,5 +1,5 @@
-Installing ROS 2 on Windows
-===========================
+Windows: Install from binary
+============================
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -4,8 +4,8 @@
 
 .. _macOS-latest:
 
-Building ROS 2 on macOS
-=======================
+macOS: Build from source
+========================
 
 .. contents:: Table of Contents
    :depth: 2


### PR DESCRIPTION
- Edit page titles for conciseness (no unnecessarily repetitive prefixes like "Building ROS 2 for....")
- Prepend all installation pages with the platform name
- No pages were moved, so no reroutes necessary
- No audits of the pages' actual content were yet considered

@clalancette - Would love your thoughts re: 

- Consolidating any pages
- Getting rid of any pages (Fedora?)
- Adding subfolders for each platform like in previous PR – "Windows", "RHEL", "Ubuntu Linux", etc.


<img width="305" alt="Screen Shot 2022-05-02 at 1 54 58 PM" src="https://user-images.githubusercontent.com/6993359/166326317-3e069e91-7eea-4730-ac8c-81bcf78fa46b.png">

cc: @amacneil