### PR TITLE
Remove references to Rolling in Humble install instructions

### DIFF
--- a/source/Installation/DDS-Implementations.rst
+++ b/source/Installation/DDS-Implementations.rst
@@ -6,7 +6,7 @@ It is compatible with multiple DDS or RTPS (the DDS wire protocol) vendors.
 There is currently support for eProsima's Fast DDS, RTI's Connext DDS, Eclipse Cyclone DDS, and GurumNetworks GurumDDS.
 See https://ros.org/reps/rep-2000.html for supported DDS vendors by distribution.
 
-In Rolling, the default DDS vendor is eProsima's Fast DDS.
+In Humble, the default DDS vendor is eProsima's Fast DDS.
 
 * :doc:`Working with Eclipse Cyclone DDS <DDS-Implementations/Working-with-Eclipse-CycloneDDS>` explains how to utilize Cyclone DDS.
 * :doc:`Working with eProsima Fast DDS <DDS-Implementations/Working-with-eProsima-Fast-DDS>` explains how to utilize Fast DDS.

--- a/source/Installation/Fedora-Development-Setup.rst
+++ b/source/Installation/Fedora-Development-Setup.rst
@@ -43,5 +43,5 @@ The following system dependencies are required to build ROS 2 on Fedora. They ca
      wget
 
 
-With this done, you can follow the rest of the :ref:`instructions <Rolling_linux-dev-get-ros2-code>` to fetch and build ROS 2.
+With this done, you can follow the rest of the :ref:`instructions <_linux-dev-get-ros2-code>` to fetch and build ROS 2.
 

--- a/source/Installation/RHEL-Development-Setup.rst
+++ b/source/Installation/RHEL-Development-Setup.rst
@@ -69,7 +69,7 @@ Install development tools and ROS tools
      flake8-quotes \
      mypy==0.931
 
-.. _Rolling_rhel-dev-get-ros2-code:
+.. _rhel-dev-get-ros2-code:
 
 Get ROS 2 code
 --------------

--- a/source/Installation/RHEL-Install-Binary.rst
+++ b/source/Installation/RHEL-Install-Binary.rst
@@ -19,8 +19,6 @@ System Requirements
 -------------------
 
 We currently support RHEL 8 64-bit.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-Most people will want to use a stable ROS distribution.
 
 Enable required repositories
 ----------------------------
@@ -45,9 +43,7 @@ There are a few packages that must be installed in order to get and unpack the b
 Downloading ROS 2
 -----------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for RHEL; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -6,9 +6,6 @@ Installing ROS 2 via RPM Packages
    :local:
 
 RPM packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for RHEL 8.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
-Most people will want to use a stable ROS distribution.
 
 Resources
 ---------

--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -71,7 +71,7 @@ Install development tools and ROS tools
      python3-vcstool \
      wget
 
-.. _Rolling_linux-dev-get-ros2-code:
+.. _linux-dev-get-ros2-code:
 
 Get ROS 2 code
 --------------

--- a/source/Installation/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Ubuntu-Install-Binary.rst
@@ -23,8 +23,6 @@ System Requirements
 -------------------
 
 We currently support Ubuntu Linux Jammy (22.04) 64-bit x86 and 64-bit ARM.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-Most people will want to use a stable ROS distribution.
 
 Add the ROS 2 apt repository
 ----------------------------
@@ -34,9 +32,7 @@ Add the ROS 2 apt repository
 Downloading ROS 2
 -----------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for Ubuntu; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -10,9 +10,6 @@ Installing ROS 2 via Debian Packages
    :local:
 
 Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Jammy.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
-Most people will want to use a stable ROS distribution.
 
 Resources
 ---------

--- a/source/Installation/macOS-Development-Setup.rst
+++ b/source/Installation/macOS-Development-Setup.rst
@@ -1,7 +1,3 @@
-.. redirect-from::
-
-  Installation/Rolling/OSX-Development-Setup
-
 .. _macOS-latest:
 
 Building ROS 2 on macOS
@@ -15,8 +11,6 @@ System requirements
 -------------------
 
 We currently support macOS Mojave (10.14).
-The Rolling Ridley distribution will change target platforms from time to time as new platforms become available.
-Most people will want to use a stable ROS distribution.
 
 Install prerequisites
 ---------------------


### PR DESCRIPTION
I didn't do a thorough review of content, which might be warranted. E.g. I don't know if we want to keep the macOS instructions the way they are since it makes it sound like a supported platform.