### PR TITLE
Remove Brief History and  depracated link.

### DIFF
--- a/source/ROSCon-Content.rst
+++ b/source/ROSCon-Content.rst
@@ -7,6 +7,10 @@ The following `ROSCon <https://roscon.ros.org>`__ talks have been given on ROS 2
 
 .. tabs::
 
+  .. group-tab:: 2021
+
+    Videos for ROSCon 2021 are at `ROSCon 2021 <https://roscon.ros.org/world/2021>`__
+
   .. group-tab:: 2020
 
     .. list-table::
@@ -139,15 +143,3 @@ The following `ROSCon <https://roscon.ros.org>`__ talks have been given on ROS 2
          - `slides <https://roscon.ros.org/2015/presentations/ros2_on_small_embedded_systems.pdf>`__ / `video <https://vimeo.com/142150576>`__
        * - Real-time control in ROS and ROS 2
          - `slides <https://roscon.ros.org/2015/presentations/RealtimeROS2.pdf>`__ / `video <https://vimeo.com/142621778>`__
-
-  .. group-tab:: 2014
-
-    .. list-table::
-       :header-rows: 1
-
-       * - Title
-         - Links
-       * - Why you want to use ROS 2
-         - `slides <https://www.osrfoundation.org/wordpress2/wp-content/uploads/2015/04/ROSCON-2014-Why-you-want-to-use-ROS-2.pdf>`__ / `video <https://vimeo.com/107531013>`__
-       * - Next-generation ROS: Building on DDS
-         - `slides <https://roscon.ros.org/2014/wp-content/uploads/2014/07/ROSCON-2014-Next-Generation-of-ROS-on-top-of-DDS.pdf>`__ / `video <https://vimeo.com/106992622>`__

--- a/source/index.rst
+++ b/source/index.rst
@@ -29,11 +29,7 @@ ROS 2 Documentation
 **The Robot Operating System (ROS) is a set of software libraries and tools for building robot applications.**
 From drivers and state-of-the-art algorithms to powerful developer tools, ROS has the open source tools you need for your next robotics project.
 
-Since ROS was started in 2007, a lot has changed in the robotics and ROS community.
-The goal of the ROS 2 project is to adapt to these changes, leveraging what is great about ROS 1 and improving what isn’t.
-
-This site contains the documentation for ROS 2.
-If you are looking for ROS 1 documentation, check out the `ROS wiki <https://wiki.ros.org>`__.
+This site contains the documentation for ROS 2. If you are looking for ROS 1 documentation, check out the `ROS wiki <https://wiki.ros.org>`__.
 
 Getting started
 ---------------
@@ -145,11 +141,6 @@ Other ROS resources
 * `ROS.org <https://www.ros.org/>`__ (ROS 1, ROS 2)
 
   - ROS 1 and ROS 2 product landing page, with high-level description of ROS and links to other ROS sites
-
-Deprecated
-^^^^^^^^^^
-
-The `deprecated ROS 2 docs site <https://docs.ros2.org>`_  has API documentation up to and including Galactic.
 
 Contributing
 ------------


### PR DESCRIPTION
The reference to ROS 1 and the brief history appears unneeded at this point in the landing page

Also, I removed the reference to the deprecated ros2. documentation. One of the most frustrating aspects of the early humble documentation for me as a new user was when I would find myself in a different set of documentation and not realize how I got there.

This is my first pull request. So please let me know if I am doing anything incorrectly.