### PR TITLE
Install Qt 5.12.X on Windows

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -134,34 +134,22 @@ Now install some additional python dependencies:
 Install Qt5
 ^^^^^^^^^^^
 
-This section is only required if you are building rviz, but it comes with our default set of sources, so if you don't know, then assume you are building it.
+Download the `5.12.X offline installer <https://www.qt.io/offline-installers>`_ from Qt's website.
+Run the installer.
+Make sure to select the ``MSVC 2017 64-bit`` component under the ``Qt`` -> ``Qt 5.12.12`` tree.
 
-First get the installer from Qt's website:
-
-https://www.qt.io/download
-
-Select the Open Source version and then the ``Qt Online Installer for Windows``.
-
-Run the installer and install Qt5.
-
-We recommend you install it to the default location of ``C:\Qt``, but if you choose somewhere else, make sure to update the paths below accordingly.
-When selecting components to install, the only thing you absolutely need is the appropriate MSVC 64-bit component under the ``Qt`` -> ``Qt 5.15.0`` tree.
-We're using ``5.15.0`` as of the writing of this document and that's what we recommend since that's all we test on Windows, but later Qt5 versions will probably work too.
-Be sure to select ``MSVC 2019 64-bit``.
-After that, the default settings are fine.
-
-Finally, set the ``Qt5_DIR`` environment variable in the ``cmd.exe`` where you intend to build so that CMake can find it:
+Finally, in an administrator ``cmd.exe`` window set these environment variables.
+The commands below assume you installed it to the default location of ``C:\Qt``.
 
 .. code-block:: bash
 
-   set Qt5_DIR=C:\Qt\5.15.0\msvc2019_64
-   set QT_QPA_PLATFORM_PLUGIN_PATH=C:\Qt\5.15.0\msvc2019_64\plugins\platforms
+   setx /m Qt5_DIR C:\Qt\Qt5.12.12\5.12.12\msvc2017_64
+   setx /m QT_QPA_PLATFORM_PLUGIN_PATH C:\Qt\Qt5.12.12\5.12.12\msvc2017_64\plugins\platforms
 
-You could set it permanently with ``setx -m Qt5_DIR C:\Qt\5.15.0\msvc2019_64`` and ``setx -m QT_QPA_PLATFORM_PLUGIN_PATH C:\Qt\5.15.0\msvc2019_64\plugins\platforms`` instead, but that requires Administrator.
 
 .. note::
 
-   This path might change based on which MSVC version you're using or if you installed it to a different directory.
+   This path might change based on the installed MSVC version, the directory Qt was installed to, and the version of Qt installed.
 
 RQt dependencies
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This should fix https://github.com/ros/ros_tutorials/issues/126 , and should be backported to Humble.

ROS 2 packaging jobs use Qt 5.12 from an offline installer. The instructions say to use 5.15.0, but turtlesim_node cannot be launched  when 5.15 is installed.

https://github.com/ros2/ci/blob/f76b1a2555373cfaa8e1152e5c1db4223cce1b10/windows_docker_resources/install_ros2_rolling.json#L5-L7

https://github.com/ros-infrastructure/ros2-cookbooks/blob/de9d4cc159f2c4402e4636c458ad4bc535d0610d/cookbooks/ros2_windows/recipes/qt5.rb#L69-L84