### PR TITLE
Add a bunch of release notes about the ros2cli commands

### DIFF
--- a/source/How-To-Guides/Launch-files-migration-guide.rst
+++ b/source/How-To-Guides/Launch-files-migration-guide.rst
@@ -275,6 +275,8 @@ group
    * ``clear_params`` attribute isn't available.
    * It doesn't accept ``remap`` nor ``param`` tags as children.
 
+.. _launch-prefix-example:
+
 Example
 ~~~~~~~
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -302,6 +302,40 @@ See the associated `pull request <https://github.com/ros2/launch_ros/pull/254>`_
 Relatedly, the ``--launch-prefix-filter`` command-line option was added to selectively add the prefix from ``--launch-prefix`` to executables.
 See the `pull request <https://github.com/ros2/launch_ros/pull/261>`__ for more information.
 
+``ros2 topic echo`` has a ``--flow-style`` argument
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This allows the user to force ``flow style`` for the YAML representation of data on a topic.
+Without this option, the output from ``ros2 topic echo /tf_static`` could look something like:
+
+.. code-block::
+
+  transforms:
+  - header:
+      stamp:
+        sec: 1651172841
+        nanosec: 433705575
+      frame_id: single_rrbot_link3
+    child_frame_id: single_rrbot_camera_link
+    transform:
+      translation:
+        x: 0.05
+        y: 0.0
+        z: 0.9
+      rotation:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+        w: 1.0
+
+With this option, the output would look something like:
+
+.. code-block::
+
+  transforms: [{header: {stamp: {sec: 1651172841, nanosec: 433705575}, frame_id: single_rrbot_link3}, child_frame_id: single_rrbot_camera_link, transform: {translation: {x: 0.05, y: 0.0, z: 0.9}, rotation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}]
+
+See the `PyYAML documentation <https://pyyaml.docsforge.com/master/documentation/#dictionaries-without-nested-collections-are-not-dumped-correctly>`__ for more information.
+
 Changes since the Galactic release
 ----------------------------------
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -549,6 +549,13 @@ Previously, attempting to set a string like "off" to a parameter that was of str
 That's because ``ros2 param set`` interprets the command-line arguments as YAML, and YAML considers "off" to be a boolean type.
 As of https://github.com/ros2/ros2cli/pull/684 , ``ros2 param set`` now accepts the YAML escape sequence of "!!str off" to ensure that the value is considered a string.
 
+``ros2 pkg create`` can automatically generate a LICENSE file
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+If the ``--license`` flag is passed to ``ros2 pkg create``, and the license is one of the known licenses, ``ros2 pkg create`` will now automatically generate a LICENSE file in the root of the package.
+For a list of known licenses, run ``ros2 pkg create --license ? <package_name>``.
+See the associated `pull request <https://github.com/ros2/ros2cli/pull/650>`__ for more information.
+
 robot_state_publisher
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -536,14 +536,14 @@ ros2cli
 ``ros2`` commands disable output buffering by default
 """""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Prior to this release, running a command like:
+Prior to this release, running a command like
 
 .. code-block::
 
   ros2 echo /chatter | grep "Hello"
 
 would not print any data until the output buffer was full.
-Users could work around this by setting PYTHONUNBUFFERED=1, but that was not very user friendly.
+Users could work around this by setting ``PYTHONUNBUFFERED=1``, but that was not very user friendly.
 
 Instead, all ``ros2`` commands now do line-buffering by default, so commands like the above work as soon as a newline is printed.
 To disable this behavior and use default python buffering rules, use the option ``--use-python-default-buffering``.

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -487,6 +487,22 @@ Similar to the feature added to rclcpp.
 ros2cli
 ^^^^^^^
 
+``ros2`` commands disable output buffering by default
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Prior to this release, running a command like:
+
+.. code-block::
+
+  ros2 echo /chatter | grep "Hello"
+
+would not print any data until the output buffer was full.
+Users could work around this by setting PYTHONUNBUFFERED=1, but that was not very user friendly.
+
+Instead, all ``ros2`` commands now do line-buffering by default, so commands like the above work as soon as a newline is printed.
+To disable this behavior and use default python buffering rules, use the option ``--use-python-default-buffering``.
+See the `original issue <https://github.com/ros2/ros2cli/issues/595>`__ and the `pull request <https://github.com/ros2/ros2cli/pull/659>`__ for more information.
+
 ``ros2 topic pub`` will wait for one matching subscription when using ``--times/--once/-1``
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -336,6 +336,18 @@ With this option, the output would look something like:
 
 See the `PyYAML documentation <https://pyyaml.docsforge.com/master/documentation/#dictionaries-without-nested-collections-are-not-dumped-correctly>`__ for more information.
 
+``ros2 topic echo`` can filter data based on message contents
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This allows the user to only print out data on a topic that matches a certain Python expression.
+For instance, using the following argument will only print out string messages that start with 'foo':
+
+.. code-block::
+
+   ros2 topic echo --filter 'm.data.startswith("foo")` /chatter
+
+See the `pull request <https://github.com/ros2/ros2cli/pull/654>`__ for more information.
+
 Changes since the Galactic release
 ----------------------------------
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -290,6 +290,18 @@ To learn more, see the `content_filtering <https://github.com/ros2/examples/blob
 
 Related design PR: `ros2/design#282 <https://github.com/ros2/design/pull/282>`_.
 
+ros2cli
+^^^^^^^
+
+``ros2 launch`` has a ``--launch-prefix`` argument
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This allows passing a prefix to all executables in a launch file, which is useful in many debugging situations.
+See the associated `pull request <https://github.com/ros2/launch_ros/pull/254>`__, as well as the :ref:`tutorial <launch-prefix-example>` for more information.
+
+Relatedly, the ``--launch-prefix-filter`` command-line option was added to selectively add the prefix from ``--launch-prefix`` to executables.
+See the `pull request <https://github.com/ros2/launch_ros/pull/261>`__ for more information.
+
 Changes since the Galactic release
 ----------------------------------
 


### PR DESCRIPTION
Based on the list in https://github.com/ros2/ros2_documentation/issues/2446 , I've added a few release notes.  This isn't a complete list of the changes, but it at least gets us further towards the goal of documenting them all.