### PR TITLE
Add Ubuntu 22.04 upgrade requirement to known Humble issues.

### DIFF
--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -49,6 +49,13 @@ Update your apt repository caches after setting up the repositories.
 
 .. include:: _Apt-Upgrade-Admonition.rst
 
+.. warning::
+
+   Due to early updates in Ubuntu 22.04 it is important that ``systemd`` and ``udev``-related packages are updated before installing ROS 2.
+   The installation of ROS 2's dependencies on a freshly installed system without upgrading can trigger the **removal of critical system packages**.
+
+   (Refer to `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_)
+
 Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -54,7 +54,7 @@ Update your apt repository caches after setting up the repositories.
    Due to early updates in Ubuntu 22.04 it is important that ``systemd`` and ``udev``-related packages are updated before installing ROS 2.
    The installation of ROS 2's dependencies on a freshly installed system without upgrading can trigger the **removal of critical system packages**.
 
-   (Refer to `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_)
+   Please refer to `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_ for more information.
 
 Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -815,7 +815,7 @@ These topics will no longer be automatically added to the bag.
 Known Issues
 ------------
 
-When installing ROS 2 on an Ubuntu 22.04 Jammy host it is important to update your system before installing ROS 2 packages.
+When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation.html##install-ros-2-packages>`__ it is important to update your system before installing ROS 2 packages.
 It is *particularly* important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad: #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
 
 Release Timeline

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -816,7 +816,8 @@ Known Issues
 ------------
 
 When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation/Ubuntu-Install-Debians.html>`__ it is important to update your system before installing ROS 2 packages.
-It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1`` could cause the removal of system critical packages. Details can be found in `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
+It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1``, could cause the removal of system critical packages.
+Details can be found in `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
 
 Release Timeline
 ----------------

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -816,7 +816,7 @@ Known Issues
 ------------
 
 When installing ROS 2 on an Ubuntu 22.04 Jammy host it is important to update your system before installing ROS 2 packages.
-It is _particularly_ important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_
+It is *particularly* important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_
 
 Release Timeline
 ----------------

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -815,8 +815,8 @@ These topics will no longer be automatically added to the bag.
 Known Issues
 ------------
 
-When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation.html##install-ros-2-packages>`__ it is important to update your system before installing ROS 2 packages.
-It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1`` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad: #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
+When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation/Ubuntu-Install-Debians.html>`__ it is important to update your system before installing ROS 2 packages.
+It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1`` could cause the removal of system critical packages. Details can be found in `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
 
 Release Timeline
 ----------------

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -816,7 +816,7 @@ Known Issues
 ------------
 
 When installing ROS 2 on an Ubuntu 22.04 Jammy host it is important to update your system before installing ROS 2 packages.
-It is *particularly* important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_
+It is *particularly* important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad: #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
 
 Release Timeline
 ----------------

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -815,7 +815,8 @@ These topics will no longer be automatically added to the bag.
 Known Issues
 ------------
 
-To come.
+When installing ROS 2 on an Ubuntu 22.04 Jammy host it is important to update your system before installing ROS 2 packages.
+It is _particularly_ important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_
 
 Release Timeline
 ----------------

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -816,7 +816,7 @@ Known Issues
 ------------
 
 When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation.html##install-ros-2-packages>`__ it is important to update your system before installing ROS 2 packages.
-It is *particularly* important to make sure that `systemd` and `udev` are updated to the latest available version otherwise installing `ros-humble-desktop`, which depends on `libudev1` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad: #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
+It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1`` could cause the removal of system critical packages. `1272 <https://github.com/ros2/ros2/issues/1272>`_, `Launchpad: #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
 
 Release Timeline
 ----------------


### PR DESCRIPTION
I'm not entirely happy with this. I'm worried it buries the lede.
But it's a start and hopefully we can workshop it a bit.