### PR TITLE
Update rosdep key skip list for RHEL

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -98,7 +98,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src -y --skip-keys "asio cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 liborocos-kdl-dev python3-babeltrace python3-mypy python3-pykdl rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src -y --skip-keys "asio cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 python3-babeltrace python3-mypy rti-connext-dds-6.0.1 urdfdom_headers"
 
 Install additional DDS implementations (optional)
 -------------------------------------------------

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -80,7 +80,7 @@ Set your rosdistro according to the release you downloaded.
 
 .. code-block:: bash
 
-       rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "asio cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 liborocos-kdl-dev python3-babeltrace python3-mypy python3-pykdl rti-connext-dds-6.0.1 urdfdom_headers"
+       rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "asio cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 python3-babeltrace python3-mypy rti-connext-dds-6.0.1 urdfdom_headers"
 
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There are now Orocos KDL rules for RHEL 8: ros/rosdistro#33277

This should be backported to Humble, but I don't believe it affects Galactic.