### PR TITLE
Fix typo in 'PyPI' name

### DIFF
--- a/source/How-To-Guides/RQt-Source-Install-Windows10.rst
+++ b/source/How-To-Guides/RQt-Source-Install-Windows10.rst
@@ -26,7 +26,7 @@ Dependencies
 
 The primary dependencies of the RQt package are sip and PyQt5.
 PySide2 may be supported in the future.
-Even though they are provided through PyPi and chocolatey, you must install them by source to get compatible versions.
+Even though they are provided through PyPI and chocolatey, you must install them by source to get compatible versions.
 
 Install sip by source
 ^^^^^^^^^^^^^^^^^^^^^

--- a/source/How-To-Guides/Using-Python-Packages.rst
+++ b/source/How-To-Guides/Using-Python-Packages.rst
@@ -45,13 +45,13 @@ If you don’t want to make a rosdep key, but the package is available in your s
 
     sudo apt install python3-serial
 
-If the package is available on `The Python Package Index (PyPi) <https://pypi.org/>`_ and you want to install globally on your system:
+If the package is available on `The Python Package Index (PyPI) <https://pypi.org/>`_ and you want to install globally on your system:
 
 .. code-block::
 
     python3 -m pip install -U pyserial
 
-If the package is available on PyPi and you want to install locally to your user:
+If the package is available on PyPI and you want to install locally to your user:
 
 .. code-block:: console
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -124,7 +124,7 @@ Other ROS resources
 
 * `ROS Index <https://index.ros.org/>`__ (ROS 1, ROS 2)
 
-  - Indexed list of all packages (i.e. `Python Package Index (PyPi) <https://pypi.org/>`_ for ROS packages)
+  - Indexed list of all packages (i.e. `Python Package Index (PyPI) <https://pypi.org/>`_ for ROS packages)
   - See which ROS distributions a package supports
   - Link to a package's repository, API documentation, or website
   - Inspect a package's license, build type, maintainers, status, and dependencies


### PR DESCRIPTION
See: https://pypi.org/

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>