### PR TITLE
Add instructions for using ros1_bridge with Jammy

### DIFF
--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -43,6 +43,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/Topics-Services-Actions
    How-To-Guides/Using-Variants
    How-To-Guides/Using-ros2-param
+   How-To-Guides/Using-ros1_bridge-Jammy-upstream
    How-To-Guides/Disabling-ZeroCopy-loaned-messages
    How-To-Guides/Installing-on-Raspberry-Pi
 

--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -7,7 +7,7 @@ Using ``ros1_bridge`` with upstream ROS on Ubuntu 22.04
 
 The release of ROS 2 Humble (and Rolling) on Ubuntu 22.04 Jammy Jellyfish marks the first ROS 2 release on a platform with no official ROS 1 release.
 While ROS 1 Noetic will continue to be supported through the duration of its `long term support window <https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025>`__, it will only target Ubuntu 20.04.
-Alternatively, there are :doc:`upstream variants of ROS 1 packages <metapackages>` in Debian and Ubuntu that are not maintained as an official distribution by the ROS maintainers.
+Alternatively, there are `upstream variants of ROS 1 packages <https://packages.ubuntu.com/jammy/ros-desktop>`__ in Debian and Ubuntu that are not maintained as an official distribution by the ROS maintainers.
 
 This guide outlines the current mechanism for bridging ROS 2 releases with these upstream packages on Ubuntu 22.04 Jammy Jellyfish.
 This provides a migration path for users who still depend on ROS 1, but desire moving to newer ROS 2 and Ubuntu releases.
@@ -22,6 +22,7 @@ If the ROS 2 apt repository is in the available apt repositories (``/etc/apt/sou
 The error will be:
 
 .. code-block:: bash
+
   $ apt install ros-core-dev
   Reading package lists... Done
   Building dependency tree... Done
@@ -35,17 +36,16 @@ The error will be:
   The following packages have unmet dependencies:
    ros-core-dev : Depends: catkin but it is not installable
   E: Unable to correct problems, you have held broken packages.
-.. _ros1-bridge-apt-error:
 
 To correct this, remove packages.ros.org from your ``sources.list``.
-If you were following the ROS 2 installation guide, tsimplem remove ``/etc/apt/sources.list.d/ros-2-latest.list``
+If you were following the ROS 2 installation guide, simply remove ``/etc/apt/sources.list.d/ros-2-latest.list``
 
 For now, to support ``ros1_bridge``, follow the instructions below for building ROS 2 from source.
 
 ROS 2 from source
 -----------------
 
-Installing :doc:`ROS 2 from Source <../Installation/Alternatives/Ubuntu-Development-Setup` is the only configuration that works for ROS 2 on Ubuntu Jammy.
+Installing :doc:`ROS 2 from Source <../Installation/Alternatives/Ubuntu-Development-Setup>` is the only configuration that works for ROS 2 on Ubuntu Jammy.
 
 Below is a summary of the necessary instructions from the source build instructions.
 The substantial deviation is that we skip using the ROS 2 apt repositories because of conflicting packages.
@@ -82,10 +82,7 @@ Since we aren't using the ROS 2 apt repositories, ``colcon`` must be installed v
    # Install colcon from PyPI, rather than apt packages
    python3 -m pip install -U colcon-common-extensions vcstool
 
-.. _linux-dev-get-ros2-code:
-
-
-From here, continue with the source install guide to build ROS 2.
+From here, continue with the :doc:`source install guide <../Installation/Alternatives/Ubuntu-Development-Setup>` to build ROS 2.
 
 Install ROS 1 from Ubuntu packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,8 +90,6 @@ Install ROS 1 from Ubuntu packages
 .. code-block:: bash
 
    sudo apt update && sudo apt install -y ros-core-dev
-
-.. _linux-dev-install-ros1:
 
 
 Build ``ros1_bridge``
@@ -114,7 +109,5 @@ Build ``ros1_bridge``
     # Build
     colcon build
 
-.. _linux-dev-build-ros1:
-
-After building all of ``ros1_bridge``, the remainder of the :doc:`ros1_bridge examples <https://github.com/ros2/ros1_bridge#example-1-run-the-bridge-and-the-example-talker-and-listener>` should work with your new installation
+After building all of ``ros1_bridge``, the remainder of the `ros1_bridge examples <https://github.com/ros2/ros1_bridge#example-1-run-the-bridge-and-the-example-talker-and-listener>`__ should work with your new installation
 

--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -19,22 +19,22 @@ Installing :doc:`ROS 2 from Debian packages <../Installation/Ubuntu-Install-Debi
 The version of ``catkin-pkg-modules`` available in the Ubuntu repository conflicts with that in the ROS 2 package repository.
 
 If the ROS 2 apt repository is in the available apt repositories (``/etc/apt/sources.list.d``), no ROS 1 packages will be installable.
-The error will be: 
+The error will be:
 
 .. code-block:: bash
-$ apt install ros-core-dev
-Reading package lists... Done
-Building dependency tree... Done
-Reading state information... Done
-Some packages could not be installed. This may mean that you have
-requested an impossible situation or if you are using the unstable
-distribution that some required packages have not yet been created
-or been moved out of Incoming.
-The following information may help to resolve the situation:
+  $ apt install ros-core-dev
+  Reading package lists... Done
+  Building dependency tree... Done
+  Reading state information... Done
+  Some packages could not be installed. This may mean that you have
+  requested an impossible situation or if you are using the unstable
+  distribution that some required packages have not yet been created
+  or been moved out of Incoming.
+  The following information may help to resolve the situation:
 
-The following packages have unmet dependencies:
- ros-core-dev : Depends: catkin but it is not installable
-E: Unable to correct problems, you have held broken packages.
+  The following packages have unmet dependencies:
+   ros-core-dev : Depends: catkin but it is not installable
+  E: Unable to correct problems, you have held broken packages.
 .. _ros1-bridge-apt-error:
 
 To correct this, remove packages.ros.org from your ``sources.list``.

--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -5,25 +5,47 @@ Using ``ros1_bridge`` with upstream ROS on Ubuntu 22.04
    :depth: 1
    :local:
 
-The release of ROS 2 Humble on Ubuntu 22.04 Jammy Jellyfish marks the first ROS 2 release on a platform with no official ROS 1 release.
+The release of ROS 2 Humble (and Rolling) on Ubuntu 22.04 Jammy Jellyfish marks the first ROS 2 release on a platform with no official ROS 1 release.
 While ROS 1 Noetic will continue to be supported through the duration of its `long term support window <https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025>`__, it will only target Ubuntu 20.04.
 Alternatively, there are :doc:`upstream variants of ROS 1 packages <metapackages>` in Debian and Ubuntu that are not maintained as an official distribution by the ROS maintainers.
 
-This guide outlines the current mechanism for bridging ROS 2 Humble with these upstream packages on Ubuntu 22.04 Jammy Jellyfish.
-This provides a migration path for users who still depend on ROS 1, but desire moving to Humble/Jammy.
+This guide outlines the current mechanism for bridging ROS 2 releases with these upstream packages on Ubuntu 22.04 Jammy Jellyfish.
+This provides a migration path for users who still depend on ROS 1, but desire moving to newer ROS 2 and Ubuntu releases.
 
 ROS 2 via Debian packages
 -------------------------
 
-Installing :doc:`ROS 2 from Debian packages <../Installation/Ubuntu-Install-Debians>` currently does not work for ROS 2 Humble on Ubuntu Jammy.
+Installing :doc:`ROS 2 from Debian packages <../Installation/Ubuntu-Install-Debians>` currently does not work for ROS 2 on Ubuntu Jammy.
 The version of ``catkin-pkg-modules`` available in the Ubuntu repository conflicts with that in the ROS 2 package repository.
+
+If the ROS 2 apt repository is in the available apt repositories (``/etc/apt/sources.list.d``), no ROS 1 packages will be installable.
+The error will be: 
+
+.. code-block:: bash
+$ apt install ros-core-dev
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+Some packages could not be installed. This may mean that you have
+requested an impossible situation or if you are using the unstable
+distribution that some required packages have not yet been created
+or been moved out of Incoming.
+The following information may help to resolve the situation:
+
+The following packages have unmet dependencies:
+ ros-core-dev : Depends: catkin but it is not installable
+E: Unable to correct problems, you have held broken packages.
+.. _ros1-bridge-apt-error:
+
+To correct this, remove packages.ros.org from your ``sources.list``.
+If you were following the ROS 2 installation guide, tsimplem remove ``/etc/apt/sources.list.d/ros-2-latest.list``
 
 For now, to support ``ros1_bridge``, follow the instructions below for building ROS 2 from source.
 
 ROS 2 from source
 -----------------
 
-Installing :doc:`ROS 2 from Source <../Installation/Alternatives/Ubuntu-Development-Setup` is the only configuration that works for ROS 2 Humble on Ubuntu Jammy.
+Installing :doc:`ROS 2 from Source <../Installation/Alternatives/Ubuntu-Development-Setup` is the only configuration that works for ROS 2 on Ubuntu Jammy.
 
 Below is a summary of the necessary instructions from the source build instructions.
 The substantial deviation is that we skip using the ROS 2 apt repositories because of conflicting packages.
@@ -63,7 +85,7 @@ Since we aren't using the ROS 2 apt repositories, ``colcon`` must be installed v
 .. _linux-dev-get-ros2-code:
 
 
-From here, continue with the source install guide to build ROS 2 Humble.
+From here, continue with the source install guide to build ROS 2.
 
 Install ROS 1 from Ubuntu packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -1,0 +1,98 @@
+Using ``ros1_bridge`` with Debian upstream ROS on Jammy
+=======================================================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+The release of ROS 2 Humble on Ubuntu 22.04 Jammy Jellyfish marks the first ROS 2 release on a platform with no official ROS 1 release.
+While, ROS 1 Noetic will continue to be supported through the duration of it's :doc:`long term support window <https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025>`, it will only target Ubuntu 20.04.
+Alternatively, there are :doc:`upstream variants of ROS 1 packages <metapackages>` in Debian that are not maintained as an official distribution by the ROS maintainers.
+
+This guide outlines the current mechanism for bridging ROS 2 Humble with these upstream Debian packages on Jammy Jellyfish.
+This provides a migration path for users who still depend on ROS 1, but desire moving to Humble/Jammy.
+
+ROS 2 via Debian packages
+-------------------------
+
+Installing :doc:`ROS 2 from Debian packages <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html>` currently does not work for ROS 2 Humble on Ubuntu Jammy.
+The version of ``catkin-pkg-modules`` available in the Ubuntu repository conflicts with that in the ROS 2 package repository.
+
+For now, to support ``ros1_bridge``, follow the instructions below for building ROS 2 from source.
+
+ROS 2 from source
+-----------------
+
+Installing :doc:`ROS 2 from Source <https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html` is the only configuration that works for ROS 2 Humble on Ubuntu Jammy.
+
+Below is a summary of the necessary instructions from the source build instructions.
+The substantial deviation is that we skip using the ROS 2 apt repositories because of conflicting packages.
+
+Install development tools and ROS tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since we aren't using the ROS 2 apt repositories, ``colcon`` must be installed via ``pip``.
+
+.. code-block:: bash
+
+   sudo apt update && sudo apt install -y \
+     build-essential \
+     cmake \
+     git \
+     python3-flake8 \
+     python3-flake8-blind-except \
+     python3-flake8-builtins \
+     python3-flake8-class-newline \
+     python3-flake8-comprehensions \
+     python3-flake8-deprecated \
+     python3-flake8-docstrings \
+     python3-flake8-import-order \
+     python3-flake8-quotes \
+     python3-pip \
+     python3-pytest \
+     python3-pytest-cov \
+     python3-pytest-repeat \
+     python3-pytest-rerunfailures \
+     python3-rosdep \
+     python3-setuptools \
+     wget
+
+   # Install colcon from PyPI, rather than apt packages
+   python3 -m pip install -U colcon-common-extensions vcstool
+
+.. _linux-dev-get-ros2-code:
+
+
+From here, continue with the source install guide to build ROS 2 Humble.
+
+Install ROS 1 from Ubuntu packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   sudo apt update && sudo apt install -y ros-core-dev
+
+.. _linux-dev-install-ros1:
+
+
+Build ``ros1_bridge``
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    # Create a workspace for the ros1_bridge
+    mkdir -p ~/ros1_bridge/src
+    cd ~/ros1_bridge/src
+    git clone https://github.com/ros2/ros1_bridge
+    cd ~/ros1_bridge
+
+    # Source the ROS 2 workspace
+    . ~/ros2_humble/install/local_setup.bash
+
+    # Build
+    colcon build
+
+.. _linux-dev-build-ros1:
+
+After building all of ``ros1_bridge``, the remainder of the :doc:`ros1_bridge examples <https://github.com/ros2/ros1_bridge#example-1-run-the-bridge-and-the-example-talker-and-listener>` should work with your new installation
+

--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -1,4 +1,4 @@
-Using ``ros1_bridge`` with Debian upstream ROS on Jammy
+Using ``ros1_bridge`` with upstream ROS on Ubuntu 22.04
 =======================================================
 
 .. contents:: Table of Contents
@@ -6,16 +6,16 @@ Using ``ros1_bridge`` with Debian upstream ROS on Jammy
    :local:
 
 The release of ROS 2 Humble on Ubuntu 22.04 Jammy Jellyfish marks the first ROS 2 release on a platform with no official ROS 1 release.
-While, ROS 1 Noetic will continue to be supported through the duration of it's :doc:`long term support window <https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025>`, it will only target Ubuntu 20.04.
-Alternatively, there are :doc:`upstream variants of ROS 1 packages <metapackages>` in Debian that are not maintained as an official distribution by the ROS maintainers.
+While ROS 1 Noetic will continue to be supported through the duration of its `long term support window <https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025>`__, it will only target Ubuntu 20.04.
+Alternatively, there are :doc:`upstream variants of ROS 1 packages <metapackages>` in Debian and Ubuntu that are not maintained as an official distribution by the ROS maintainers.
 
-This guide outlines the current mechanism for bridging ROS 2 Humble with these upstream Debian packages on Jammy Jellyfish.
+This guide outlines the current mechanism for bridging ROS 2 Humble with these upstream packages on Ubuntu 22.04 Jammy Jellyfish.
 This provides a migration path for users who still depend on ROS 1, but desire moving to Humble/Jammy.
 
 ROS 2 via Debian packages
 -------------------------
 
-Installing :doc:`ROS 2 from Debian packages <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html>` currently does not work for ROS 2 Humble on Ubuntu Jammy.
+Installing :doc:`ROS 2 from Debian packages <../Installation/Ubuntu-Install-Debians>` currently does not work for ROS 2 Humble on Ubuntu Jammy.
 The version of ``catkin-pkg-modules`` available in the Ubuntu repository conflicts with that in the ROS 2 package repository.
 
 For now, to support ``ros1_bridge``, follow the instructions below for building ROS 2 from source.
@@ -23,7 +23,7 @@ For now, to support ``ros1_bridge``, follow the instructions below for building 
 ROS 2 from source
 -----------------
 
-Installing :doc:`ROS 2 from Source <https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html` is the only configuration that works for ROS 2 Humble on Ubuntu Jammy.
+Installing :doc:`ROS 2 from Source <../Installation/Alternatives/Ubuntu-Development-Setup` is the only configuration that works for ROS 2 Humble on Ubuntu Jammy.
 
 Below is a summary of the necessary instructions from the source build instructions.
 The substantial deviation is that we skip using the ROS 2 apt repositories because of conflicting packages.

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -821,11 +821,11 @@ These topics will no longer be automatically added to the bag.
 Known Issues
 ------------
 
-When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation/Ubuntu-Install-Debians.html>`__ it is important to update your system before installing ROS 2 packages.
-It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1``, could cause the removal of system critical packages.
-Details can be found in `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
+* When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation/Ubuntu-Install-Debians.html>`__ it is important to update your system before installing ROS 2 packages.
+  It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1``, could cause the removal of system critical packages.
+  Details can be found in `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
 
-When ROS 2 apt repositories are available, ROS 1 packages in Ubuntu are not installable.
+* When ROS 2 apt repositories are available, ROS 1 packages in Ubuntu are not installable.  See the :doc:`ros1_bridge on Ubuntu Jammy <../How-To-Guides/Using-ros1_bridge-Jammy-upstream>` document for more information.
 
 
 Release Timeline

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -610,6 +610,12 @@ Two new methods were added to allow sleeping on a particular clock in `ros2/rclp
 ``sleep_for`` will suspend the current thread until the clock advances a certain amount of time from when the method was called.
 Both methods will wake early if the ``Context`` is shutdown.
 
+ros1_bridge
+^^^^^^^^^^^
+
+Since there is no official ROS 1 distribution on Ubuntu Jammy and forward, ``ros1_bridge`` is now compatible with the Ubuntu-packaged versions of ROS 1.
+More details about using ``ros1_bridge`` with Jammy packages are avilable in `the how-to guides <../How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst>`__.
+
 ros2cli
 ^^^^^^^
 
@@ -818,6 +824,9 @@ Known Issues
 When `installing ROS 2 on an Ubuntu 22.04 Jammy host <../../humble/Installation/Ubuntu-Install-Debians.html>`__ it is important to update your system before installing ROS 2 packages.
 It is *particularly* important to make sure that ``systemd`` and ``udev`` are updated to the latest available version otherwise installing ``ros-humble-desktop``, which depends on ``libudev1``, could cause the removal of system critical packages.
 Details can be found in `ros2/ros2#1272 <https://github.com/ros2/ros2/issues/1272>`_ and `Launchpad #1974196 <https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1974196>`_
+
+When ROS 2 apt repositories are available, ROS 1 packages in Ubuntu are not installable.
+
 
 Release Timeline
 ----------------


### PR DESCRIPTION
Address installing `ros-core-dev` from Jammy upstream packages and building the `ros1_bridge` against them.

Signed-off-by: Michael Carroll <michael@openrobotics.org>