### PR TITLE
Include link to docs contribution guide

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -159,3 +159,4 @@ Contributing
 
 We're always working to improve our documentation.
 You can help by submitting pull requests for fixes or issues for suggestions on `our GitHub repository <https://github.com/ros2/ros2_documentation>`__.
+See the :doc:`contribution guide <Contributing/Contributing-To-ROS-2-Documentation>`.


### PR DESCRIPTION
I thought it would be good to directly link to the documentation contribution guide, even if the repo's README links to it.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>