### PR TITLE
Add a link to API documentation.

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -14,6 +14,7 @@ ROS 2 Documentation
    Tutorials
    How-To-Guides
    Concepts
+   API Documentation <https://docs.ros.org/en/{DISTRO}/p>
    Contributing
    Contact
    ROSCon-Content


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This makes it so that a link to the API documentation is on the sidebar.  The API documentation front page needs some cosmetic work, but it is functional for now.

Note that this should *only* be backported to Humble, as that is the only release besides Rolling that has support for this API documentation.