### PR TITLE
fix (howto-launch): namespace on IncludeLaunchDescription

### DIFF
--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -75,7 +75,7 @@ Each launch file performs the following actions:
             launch_include_with_namespace = GroupAction(
                 actions=[
                     # push_ros_namespace to set namespace of included nodes
-                    PushRosNamespace(LaunchConfiguration('chatter_ns')),
+                    PushRosNamespace('chatter_ns'),
                     IncludeLaunchDescription(
                         PythonLaunchDescriptionSource(
                             os.path.join(


### PR DESCRIPTION
Following [the documentation](https://docs.ros.org/en/humble/How-To-Guides/Launch-file-different-formats.html#launch-file-examples) for including another launch file under a specific namespace I encountered an error.  
__Code:__  
```python
pChannel = "vcan0"

ld.add_entity(
        GroupAction(
            actions=[
                PushRosNamespace(LaunchConfiguration(pChannel)), # < -- HERE IS THE ERROR! It has to be: PushRosNamespace(pChannel)
                IncludeLaunchDescription(
                    PythonLaunchDescriptionSource(
                        os.path.join(get_package_share_directory('ros2_socketcan'), 'launch/socket_can_receiver.launch.py')),
                    launch_arguments={
                        'interface': pChannel,
                        'interval_sec': '0.001'
                    }.items(),
                ),
            ]
        ),
    )
```

__Error when launching:__  
```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'vcan0' does not exist
```

__Resolution:__  
Looking at [other code](https://grep.app/search?q=PushRosNamespace) I noticed that people are using it differently instaed and the [implementation of `PushRosNamespace`](https://github.com/ros2/launch_ros/blob/master/launch_ros/launch_ros/actions/push_ros_namespace.py) suggests to me that this is they way to go.