### PR TITLE
Fix the inertia values in the URDF tutorials.

### DIFF
--- a/source/Tutorials/URDF/Adding-Physical-and-Collision-Properties-to-a-URDF-Model.rst
+++ b/source/Tutorials/URDF/Adding-Physical-and-Collision-Properties-to-a-URDF-Model.rst
@@ -81,7 +81,7 @@ Here is a simple one.
     </collision>
     <inertial>
       <mass value="10"/>
-      <inertia ixx="0.4" ixy="0.0" ixz="0.0" iyy="0.4" iyz="0.0" izz="0.2"/>
+      <inertia ixx="1e-3" ixy="0.0" ixz="0.0" iyy="1e-3" iyz="0.0" izz="1e-3"/>
     </inertial>
   </link>
 

--- a/source/Tutorials/URDF/Using-Xacro-to-Clean-Up-a-URDF-File.rst
+++ b/source/Tutorials/URDF/Using-Xacro-to-Clean-Up-a-URDF-File.rst
@@ -173,9 +173,9 @@ First, let’s take an example of a simple macro used in R2D2.
     <xacro:macro name="default_inertial" params="mass">
         <inertial>
                 <mass value="${mass}" />
-                <inertia ixx="1.0" ixy="0.0" ixz="0.0"
-                     iyy="1.0" iyz="0.0"
-                     izz="1.0" />
+                <inertia ixx="1e-3" ixy="0.0" ixz="0.0"
+                     iyy="1e-3" iyz="0.0"
+                     izz="1e-3" />
         </inertial>
     </xacro:macro>
 

--- a/source/Tutorials/URDF/r2d2.urdf.xml
+++ b/source/Tutorials/URDF/r2d2.urdf.xml
@@ -23,7 +23,7 @@
   <link name="leg1">
     <inertial>
       <mass value="1"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100" />
+      <inertia ixx="1e-3" ixy="0" ixz="0" iyy="1e-3" iyz="0" izz="1e-3" />
       <origin/>
     </inertial>
 
@@ -55,7 +55,7 @@
   <link name="leg2">
     <inertial>
       <mass value="1"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100" />
+      <inertia ixx="1e-3" ixy="0" ixz="0" iyy="1e-3" iyz="0" izz="1e-3" />
       <origin/>
     </inertial>
 
@@ -87,7 +87,7 @@
   <link name="body">
     <inertial>
       <mass value="1"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100" />
+      <inertia ixx="1e-3" ixy="0" ixz="0" iyy="1e-3" iyz="0" izz="1e-3" />
       <origin/>
     </inertial>
 
@@ -119,7 +119,7 @@
   <link name="head">
     <inertial>
       <mass value="1"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100" />
+      <inertia ixx="1e-3" ixy="0" ixz="0" iyy="1e-3" iyz="0" izz="1e-3" />
       <origin/>
     </inertial>
 
@@ -149,7 +149,7 @@
   <link name="rod">
     <inertial>
       <mass value="1"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100" />
+      <inertia ixx="1e-3" ixy="0" ixz="0" iyy="1e-3" iyz="0" izz="1e-3" />
       <origin/>
     </inertial>
 
@@ -182,7 +182,7 @@
   <link name="box">
     <inertial>
       <mass value="1"/>
-      <inertia ixx="100" ixy="0" ixz="0" iyy="100" iyz="0" izz="100" />
+      <inertia ixx="1e-3" ixy="0" ixz="0" iyy="1e-3" iyz="0" izz="1e-3" />
       <origin/>
     </inertial>
 


### PR DESCRIPTION
In particular, take our own advice and set ixx, iyy, and izz
to 1e-3, which corresponds to a more medium-sized link.
Besides being more reasonable, this also makes it match what
is in https://github.com/ros/urdf_tutorial

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>