### PR TITLE
(quick fix) instructions update for ZSH users

### DIFF
--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -77,7 +77,7 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    source /opt/ros/{DISTRO}/setup.bash
- 
+
 Note for ZSH users, replace all instances of the above with the following:
 
 .. code-block:: bash

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -77,6 +77,12 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    source /opt/ros/{DISTRO}/setup.bash
+ 
+Note for ZSH users, replace all instances of the above with the following:
+
+.. code-block:: bash
+
+   source /opt/ros/{DISTRO}/setup.zsh
 
 Try some examples
 -----------------


### PR DESCRIPTION
avoids annoying/cryptic "setup.sh" not found error

follows explanations in Ros Noetic
http://wiki.ros.org/noetic/Installation/Ubuntu#noetic.2FInstallation.2FDebEnvironment.Environment_setup