### PR TITLE
Make the tf2 listener tutorial (C++) more self-contained.

### DIFF
--- a/source/Tutorials/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -22,7 +22,7 @@ After that, following tutorials focus on extending the demo with more advanced t
 Prerequisites
 -------------
 
-This tutorial assumes you have a working knowledge of ROS 2 and you have completed the :doc:`Introduction to tf2 tutorial <./Introduction-To-Tf2>`.
+This tutorial assumes you have a working knowledge of ROS 2 and you have completed the :doc:`Introduction to tf2 tutorial <./Introduction-To-Tf2>` and :doc:`tf2 static broadcaster tutorial (C++) <./Writing-A-Tf2-Static-Broadcaster-Cpp>`.
 In previous tutorials, you learned how to :doc:`create a workspace <../Workspace/Creating-A-Workspace>` and :doc:`create a package <../Creating-Your-First-ROS2-Package>`.
 You also have created the ``learning_tf2_cpp`` :doc:`package <./Writing-A-Tf2-Static-Broadcaster-Cpp>`, which is where we will continue working from.
 
@@ -216,12 +216,6 @@ Finally we take the transform that we constructed and pass it to the ``sendTrans
     // Send the transformation
     tf_broadcaster_->sendTransform(t);
 
-.. note::
-
-    You can also publish static transforms with the same pattern by instantiating a ``tf2_ros::StaticTransformBroadcaster`` instead of a ``tf2_ros::TransformBroadcaster``.
-    The static transforms will be published on the ``/tf_static`` topic and will be sent only when required, not periodically.
-    For more details see :doc:`here <./Writing-A-Tf2-Static-Broadcaster-Cpp>`.
-
 1.2 CMakeLists.txt
 ~~~~~~~~~~~~~~~~~~
 
@@ -328,14 +322,11 @@ Make sure to save the file.
 ~~~~~~~~~~~~~~~~~~
 
 Reopen ``CMakeLists.txt`` and add the line so that the launch files from the ``launch/`` folder would be installed.
-Update the ``install(DIRECTORY…)`` to include the ``launch`` line.
 
 .. code-block:: console
 
-    install(DIRECTORY
-        launch
-        ...
-    )
+    install(DIRECTORY launch
+      DESTINATION share/${PROJECT_NAME})
 
 You can learn more about creating launch files in :doc:`this tutorial <../Launch/Creating-Launch-Files>`.
 
@@ -360,7 +351,27 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
         rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
 
-Build your updated package, and source the setup files.
+From the root of your workspace, build your updated package, and source the setup files.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+         colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+         colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+         colcon build --merge-install --packages-select learning_tf2_cpp
 
 Now run the launch file that will start the turtlesim simulation node and ``turtle_tf2_broadcaster`` node:
 

--- a/source/Tutorials/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -23,7 +23,7 @@ In this tutorial we'll create a tf2 listener to start using tf2.
 Prerequisites
 -------------
 
-This tutorial assumes you have completed the :doc:`tf2 broadcaster tutorial (C++) <./Writing-A-Tf2-Broadcaster-Cpp>`.
+This tutorial assumes you have completed the :doc:`tf2 static broadcaster tutorial (C++) <./Writing-A-Tf2-Static-Broadcaster-Cpp>` and the :doc:`tf2 broadcaster tutorial (C++) <./Writing-A-Tf2-Broadcaster-Cpp>`.
 In the previous tutorial, we created a ``learning_tf2_cpp`` package, which is where we will continue working from.
 
 Tasks
@@ -240,11 +240,38 @@ All this is wrapped in a try-catch block to handle possible exceptions.
     toFrameRel, fromFrameRel,
     tf2::TimePointZero);
 
-2 Build and run
-^^^^^^^^^^^^^^^
+1.2 CMakeLists.txt
+~~~~~~~~~~~~~~~~~~
 
-With your text editor, open the launch file called ``turtle_tf2_demo.launch.py``, and add the following lines after your first ``turtle1`` broadcaster node.
-Additionally, include the imports of ``DeclareLaunchArgument`` and ``LaunchConfiguration`` in the beginning of the file:
+Navigate one level back to the ``learning_tf2_cpp`` directory, where the ``CMakeLists.txt`` and ``package.xml`` files are located.
+
+Now open the ``CMakeLists.txt`` add the executable and name it ``turtle_tf2_listener``, which you'll use later with ``ros2 run``.
+
+.. code-block:: console
+
+    add_executable(turtle_tf2_listener src/turtle_tf2_listener.cpp)
+    ament_target_dependencies(
+        turtle_tf2_listener
+        geometry_msgs
+        rclcpp
+        tf2
+        tf2_ros
+        turtlesim
+    )
+
+Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
+
+.. code-block:: console
+
+    install(TARGETS
+        turtle_tf2_listener
+        DESTINATION lib/${PROJECT_NAME})
+
+2 Update the launch file
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open the launch file called ``turtle_tf2_demo.launch.py`` with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports.
+The resulting file should look like:
 
 .. code-block:: python
 
@@ -254,9 +281,22 @@ Additionally, include the imports of ``DeclareLaunchArgument`` and ``LaunchConfi
 
     from launch_ros.actions import Node
 
+
     def generate_launch_description():
         return LaunchDescription([
-            ...,
+            Node(
+                package='turtlesim',
+                executable='turtlesim_node',
+                name='sim'
+            ),
+            Node(
+                package='learning_tf2_cpp',
+                executable='turtle_tf2_broadcaster',
+                name='broadcaster1',
+                parameters=[
+                    {'turtlename': 'turtle1'}
+                ]
+            ),
             DeclareLaunchArgument(
                 'target_frame', default_value='turtle1',
                 description='Target frame name.'
@@ -280,6 +320,50 @@ Additionally, include the imports of ``DeclareLaunchArgument`` and ``LaunchConfi
         ])
 
 This will declare a ``target_frame`` launch argument, start a broadcaster for second turtle that we will spawn and listener that will subscribe to those transformations.
+
+3 Build and run
+^^^^^^^^^^^^^^^
+
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+        rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+
+From the root of your workspace, build your updated package, and source the setup files.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+         colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+         colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+         colcon build --merge-install --packages-select learning_tf2_cpp
+
 Now you're ready to start your full turtle demo:
 
 .. code-block:: console


### PR DESCRIPTION
That is, make it so that it can be followed if you appropriately
followed the previous tutorials.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #2474 