### PR TITLE
Fix missing .py in tf2 tutorials

### DIFF
--- a/source/Tutorials/Tf2/Debugging-Tf2-Problems.rst
+++ b/source/Tutorials/Tf2/Debugging-Tf2-Problems.rst
@@ -191,7 +191,7 @@ If you like to get a graphical representation of this, use ``view_frames`` tool.
 
 .. code-block:: console
 
-   ros2 run tf2_tools view_frames
+   ros2 run tf2_tools view_frames.py
 
 Open the generated ``frames.pdf`` file to see the following output:
 


### PR DESCRIPTION
Hi everyone!

This PR brings a small fix for the tf2 tutorials. The `.py` extension is missing in the view_frames code snippet.

Running the current code will cause a `No executable found` error (as discussed [here](https://get-help.robotigniteacademy.com/t/ros2-debugging-tools-t2tools-view-frames-executable-not-found/14835))

This problem was partially solved in the foxy and galactic versions of the Introduction-To-Tf2 page, but the rolling version was not updated, thus the partial solution was cherry-picked into this PR