### PR TITLE
Add in an end-of-life page for distributions.

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -23,22 +23,12 @@ Rows in the table marked in green are the currently supported distributions.
 .. toctree::
    :hidden:
 
-   Releases/Alpha-Overview.rst
-   Releases/Beta1-Overview.rst
-   Releases/Beta2-Overview.rst
-   Releases/Beta3-Overview.rst
-   Releases/Release-Ardent-Apalone.rst
-   Releases/Release-Bouncy-Bolson.rst
-   Releases/Release-Crystal-Clemmys.rst
-   Releases/Release-Dashing-Diademata.rst
-   Releases/Release-Eloquent-Elusor.rst
-   Releases/Release-Foxy-Fitzroy.rst
-   Releases/Release-Galactic-Geochelone.rst
-   Releases/Galactic-Geochelone-Complete-Changelog.rst
    Releases/Release-Humble-Hawksbill.rst
-   Releases/Humble-Hawksbill-Complete-Changelog.rst
-   Releases/Release-Iron-Irwini.rst
+   Releases/Release-Galactic-Geochelone.rst
+   Releases/Release-Foxy-Fitzroy.rst
    Releases/Release-Rolling-Ridley.rst
+   Releases/Development.rst
+   Releases/End-of-Life.rst
 
 .. raw:: html
 

--- a/source/Releases/Development.rst
+++ b/source/Releases/Development.rst
@@ -1,0 +1,9 @@
+Development Distribution
+========================
+
+Below is the ROS 2 distribution that is currently in development.
+
+.. toctree::
+   :maxdepth: 1
+
+   Release-Iron-Irwini.rst

--- a/source/Releases/End-of-Life.rst
+++ b/source/Releases/End-of-Life.rst
@@ -1,0 +1,17 @@
+End-of-Life Distributions
+=========================
+
+Below is a list of historic ROS 2 distributions that are no longer supported.
+
+.. toctree::
+   :maxdepth: 1
+
+   Release-Eloquent-Elusor.rst
+   Release-Dashing-Diademata.rst
+   Release-Crystal-Clemmys.rst
+   Release-Bouncy-Bolson.rst
+   Release-Ardent-Apalone.rst
+   Beta3-Overview.rst
+   Beta2-Overview.rst
+   Beta1-Overview.rst
+   Alpha-Overview.rst

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -3,6 +3,11 @@
 ROS 2 Galactic Geochelone (codename 'galactic'; May, 2021)
 ==========================================================
 
+.. toctree::
+   :hidden:
+
+   Galactic-Geochelone-Complete-Changelog.rst
+
 .. contents:: Table of Contents
    :depth: 2
    :local:

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -7,6 +7,11 @@
 ROS 2 Humble Hawksbill (codename 'humble'; May, 2022)
 =====================================================
 
+.. toctree::
+   :hidden:
+
+   Humble-Hawksbill-Complete-Changelog.rst
+
 .. contents:: Table of Contents
    :depth: 2
    :local:


### PR DESCRIPTION
That way we effectively hide these from top-level navigation
while still making them available.  This should make it
significantly easier to understand what is going on within
the Distribution tab when navigating.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@esthersweon @kscottz @sumedhreddy90 FYI.  This is a partial replacement for #2465