### PR TITLE
Clearing up command vs response in install instructions

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -4,10 +4,13 @@ First, make sure that the `Ubuntu Universe repository <https://help.ubuntu.com/c
 .. code-block:: bash
 
    apt-cache policy | grep universe
+
+If you don't see an output line like the one below, then enable the Universe repository with the instructions in this section.
+
+.. code-block:: bash
+
     500 http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
         release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=universe,b=amd64
-
-If you don't see an output line like the one above, then enable the Universe repository with these instructions.
 
 .. code-block:: bash
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -12,8 +12,8 @@ This should output a line like the one below:
     500 http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
         release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=universe,b=amd64
 
- If you don't see an output line like the one above, then enable the Universe repository with these instructions.
- 
+If you don't see an output line like the one above, then enable the Universe repository with these instructions.
+
 .. code-block:: bash
 
    sudo apt install software-properties-common

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -5,7 +5,7 @@ First, make sure that the `Ubuntu Universe repository <https://help.ubuntu.com/c
 
    apt-cache policy | grep universe
 
-If you don't see an output line like the one below, then enable the Universe repository with the instructions in this section.
+This should output a line like the one below:
 
 .. code-block:: bash
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -12,11 +12,12 @@ This should output a line like the one below:
     500 http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
         release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=universe,b=amd64
 
+ If you don't see an output line like the one above, then enable the Universe repository with these instructions.
+ 
 .. code-block:: bash
 
    sudo apt install software-properties-common
    sudo add-apt-repository universe
-
 
 Now add the ROS 2 apt repository to your system.
 First authorize our GPG key with apt.


### PR DESCRIPTION
Also should be backported to Humble. If you're just scanning through, that looks like a full command versus being a command and then a response to look for. I separated them to be more clear what's the command and what's the response. 