### PR TITLE
Deleted all $ signs in code blocks in the "Composing multiple nodes in a single process" tutorial

### DIFF
--- a/source/Tutorials/Intermediate/Composition.rst
+++ b/source/Tutorials/Intermediate/Composition.rst
@@ -34,7 +34,12 @@ To see what components are registered and available in the workspace, execute th
 
 .. code-block:: bash
 
-   $ ros2 component types
+   ros2 component types
+
+The terminal will return the list of all available components:
+
+.. code-block:: bash
+
    (... components of other packages here)
    composition
      composition::Talker
@@ -44,6 +49,7 @@ To see what components are registered and available in the workspace, execute th
      composition::Client
    (... components of other packages here)
 
+
 Run-time composition using ROS services with a publisher and subscriber
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -51,23 +57,31 @@ In the first shell, start the component container:
 
 .. code-block:: bash
 
-   $ ros2 run rclcpp_components component_container
+   ros2 run rclcpp_components component_container
 
-Verify that the container is running via ``ros2`` command line tools:
+Open the second shell and verify that the container is running via ``ros2`` command line tools:
 
 .. code-block:: bash
 
-   $ ros2 component list
+   ros2 component list
+
+You should see a name of the component:
+
+.. code-block:: bash
+
    /ComponentManager
 
 In the second shell load the talker component (see `talker <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/talker_component.cpp>`__ source code):
 
 .. code-block:: bash
 
-   $ ros2 component load /ComponentManager composition composition::Talker
-   Loaded component 1 into '/ComponentManager' container node as '/talker'
+   ros2 component load /ComponentManager composition composition::Talker
 
-The command will return the unique ID of the loaded component as well as the node name.
+The command will return the unique ID of the loaded component as well as the node name:
+
+.. code-block:: bash
+
+   Loaded component 1 into '/ComponentManager' container node as '/talker'
 
 Now the first shell should show a message that the component was loaded as well as repeated message for publishing a message.
 
@@ -75,14 +89,24 @@ Run another command in the second shell to load the listener component (see `lis
 
 .. code-block:: bash
 
-   $ ros2 component load /ComponentManager composition composition::Listener
+   ros2 component load /ComponentManager composition composition::Listener
+
+Terminal will return:
+
+.. code-block:: bash
+
    Loaded component 2 into '/ComponentManager' container node as '/listener'
 
 The ``ros2`` command line utility can now be used to inspect the state of the container:
 
 .. code-block:: bash
 
-   $ ros2 component list
+   ros2 component list
+
+You will see the following result:
+
+.. code-block:: bash
+
    /ComponentManager
       1  /talker
       2  /listener
@@ -98,14 +122,14 @@ In the first shell:
 
 .. code-block:: bash
 
-   $ ros2 run rclcpp_components component_container
+   ros2 run rclcpp_components component_container
 
 In the second shell (see `server <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/server_component.cpp>`__ and `client <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/client_component.cpp>`__ source code):
 
 .. code-block:: bash
 
-   $ ros2 component load /ComponentManager composition composition::Server
-   $ ros2 component load /ComponentManager composition composition::Client
+   ros2 component load /ComponentManager composition composition::Server
+   ros2 component load /ComponentManager composition composition::Client
 
 In this case the client sends a request to the server, the server processes the request and replies with a response, and the client prints the received response.
 
@@ -119,7 +143,7 @@ In the shell call (see `source code <https://github.com/ros2/demos/blob/{REPOS_F
 
 .. code-block:: bash
 
-   $ ros2 run composition manual_composition
+   ros2 run composition manual_composition
 
 This should show repeated messages from both pairs, the talker and the listener as well as the server and the client.
 
@@ -139,13 +163,13 @@ The process will open each library and create one instance of each "rclcpp::Node
 
     .. code-block:: bash
 
-       $ ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.so `ros2 pkg prefix composition`/lib/liblistener_component.so
+       ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.so `ros2 pkg prefix composition`/lib/liblistener_component.so
 
   .. group-tab:: macOS
 
     .. code-block:: bash
 
-       $ ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.dylib `ros2 pkg prefix composition`/lib/liblistener_component.dylib
+       ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.dylib `ros2 pkg prefix composition`/lib/liblistener_component.dylib
 
   .. group-tab:: Windows
 
@@ -174,7 +198,7 @@ To automate this action, we can use the functionality in ``ros2 launch``.
 
 .. code-block:: bash
 
-   $ ros2 launch composition composition_demo.launch.py
+   ros2 launch composition composition_demo.launch.py
 
 
 Advanced Topics
@@ -190,29 +214,37 @@ In the first shell, start the component container:
 
 .. code-block:: bash
 
-   $ ros2 run rclcpp_components component_container
+   ros2 run rclcpp_components component_container
 
 Verify that the container is running via ``ros2`` command line tools:
 
 .. code-block:: bash
 
-   $ ros2 component list
+   ros2 component list
+
+You should see a name of the component:
+
+.. code-block:: bash
+
    /ComponentManager
 
 In the second shell load both the talker and listener as we have before:
 
 .. code-block:: bash
 
-   $ ros2 component load /ComponentManager composition composition::Talker
-   Loaded component 1 into '/ComponentManager' container node as '/talker'
-   $ ros2 component load /ComponentManager composition composition::Listener
-   Loaded component 2 into '/ComponentManager' container node as '/listener'
+   ros2 component load /ComponentManager composition composition::Talker
+   ros2 component load /ComponentManager composition composition::Listener
 
 Use the unique ID to unload the node from the component container.
 
 .. code-block:: bash
 
-   $ ros2 component unload /ComponentManager 1 2
+   ros2 component unload /ComponentManager 1 2
+
+The terminal should return:
+
+.. code-block:: bash
+
    Unloaded component 1 from '/ComponentManager' container
    Unloaded component 2 from '/ComponentManager' container
 
@@ -226,13 +258,13 @@ The component manager name and namespace can be remapped via standard command li
 
 .. code-block:: bash
 
-   $ ros2 run rclcpp_components component_container --ros-args -r __node:=MyContainer -r __ns:=/ns
+   ros2 run rclcpp_components component_container --ros-args -r __node:=MyContainer -r __ns:=/ns
 
 In a second shell, components can be loaded by using the updated container name:
 
 .. code-block:: bash
 
-   $ ros2 component load /ns/MyContainer composition composition::Listener
+   ros2 component load /ns/MyContainer composition composition::Listener
 
 .. note::
 
@@ -248,25 +280,39 @@ In the first shell, start the component container:
 
 .. code-block:: bash
 
-   $ ros2 run rclcpp_components component_container
+   ros2 run rclcpp_components component_container
 
 
-Some examples of how to remap names and namespaces:
+Some examples of how to remap names and namespaces.
 
-.. code-block:: bash
-
-   # Remap node name
-   $ ros2 component load /ComponentManager composition composition::Talker --node-name talker2
-   # Remap namespace
-   $ ros2 component load /ComponentManager composition composition::Talker --node-namespace /ns
-   # Remap both
-   $ ros2 component load /ComponentManager composition composition::Talker --node-name talker3 --node-namespace /ns2
-
-The corresponding entries appear in ``ros2 component list``:
+Remap node name:
 
 .. code-block:: bash
 
-   $ ros2 component list
+   ros2 component load /ComponentManager composition composition::Talker --node-name talker2
+
+Remap namespace:
+
+.. code-block:: bash
+
+   ros2 component load /ComponentManager composition composition::Talker --node-namespace /ns
+
+Remap both:
+
+.. code-block:: bash
+
+   ros2 component load /ComponentManager composition composition::Talker --node-name talker3 --node-namespace /ns2
+
+Now use ``ros2`` command line utility:
+
+.. code-block:: bash
+
+   ros2 component list
+
+In the console you should see corresponding entries:
+
+.. code-block:: bash
+
    /ComponentManager
       1  /talker2
       2  /ns/talker
@@ -284,7 +330,7 @@ This functionality can be used as follows:
 
 .. code-block:: bash
 
-   $ ros2 component load /ComponentManager image_tools image_tools::Cam2Image -p burger_mode:=true
+   ros2 component load /ComponentManager image_tools image_tools::Cam2Image -p burger_mode:=true
 
 Passing additional arguments into components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -295,7 +341,7 @@ This functionality can be used as follows:
 
 .. code-block:: bash
 
-   $ ros2 component load /ComponentManager composition composition::Talker -e use_intra_process_comms:=true
+   ros2 component load /ComponentManager composition composition::Talker -e use_intra_process_comms:=true
 
 Composable nodes as shared libraries
 ------------------------------------


### PR DESCRIPTION
$ signs prevent from effective use of "copy to clipboard" button. Previous tutorials don't have them in code blocks