### PR TITLE
Update how find ament_cmake_gmock package

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -330,7 +330,7 @@ Similarly, there is a CMake macro to set up GTest including GMock:
 
 .. code-block:: cmake
 
-    find_package(ament_gmock REQUIRED)
+    find_package(ament_cmake_gmock REQUIRED)
     ament_add_gmock(some_test <test_sources>)
 
 It has the same additional parameters as ``ament_add_gtest``.


### PR DESCRIPTION
We will probably need to do this to use the gmock package. If I am not mistaken, could you please merge them?

- update in `source/How-To-Guides/Ament-Cmake-Documentation.rst`