### PR TITLE
Comment on custom msg / srv definition when using message type from external message package

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -102,6 +102,7 @@ To convert the interfaces you defined into language-specific code (like C++ and 
   rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/Num.msg"
     "srv/AddThreeInts.srv"
+    # DEPENDENCIES geometry_msgs  # Add this line if message types from an external message package (e.g. geometry_msgs) are used.
   )
 
 4 ``package.xml``


### PR DESCRIPTION
If a message contains a type from an external message package (e.g. geometry_msgs) this line is needed.
```
// CMakeLists.txt
  rosidl_generate_interfaces(${PROJECT_NAME}
    "msg/Num.msg"
    "srv/AddThreeInts.srv"
    # DEPENDENCIES geometry_msgs  # Add this line if message types from an external message package (e.g. geometry_msgs) are used.
  )
```

Without this line the message caused errors when it was imported in a python node package.

Maybe this info can be placed somewhere as a hint in the documentation.

See discussion:
https://answers.ros.org/question/326008/ros2-run-symbol-not-found-on-custom-msg/