### PR TITLE
Fix links to the Governance page.

### DIFF
--- a/source/The-ROS2-Project/Governance/How-To-Start-A-Community-Working-Group.rst
+++ b/source/The-ROS2-Project/Governance/How-To-Start-A-Community-Working-Group.rst
@@ -66,7 +66,7 @@ So what are the steps to making a working group?
 
 #. Now that you have a working group charter, e-mail group, and source
    repository, you can add all of that information to the :doc:`ROS 2 project governance
-   website <index>` by sending a pull request to https://github.com/ros2/ros2_documentation.
+   website <../Governance>` by sending a pull request to https://github.com/ros2/ros2_documentation.
 
 #. Now it is time to schedule your first official working group meeting! We
    recommend announcing the meeting on ROS Discourse approximately one week

--- a/source/The-ROS2-Project/Governance/ROS2-TSC-Intake-process.rst
+++ b/source/The-ROS2-Project/Governance/ROS2-TSC-Intake-process.rst
@@ -17,7 +17,7 @@ Objectives
 Process
 -------
 
-1. Applicant inquires about joining TSC via info@openrobotics.org per :doc:`ROS 2 Governance <index>`.
+1. Applicant inquires about joining TSC via info@openrobotics.org per :doc:`ROS 2 Governance <../Governance>`.
 2. Open Robotics responds with the application questions (below).
 3. Applicant completes and sends application to info@openrobotics.org.
 4. Open Robotics does an initial review and gives applicant feedback if warranted. For example:


### PR DESCRIPTION
Two more pieces of fallout from the revamp.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>