### PR TITLE
Change the Sphinx configured language to 'en'.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ default_role = 'any'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Modern versions of Sphinx (>= 5.0.0) expect this to be a string,
so set it.  The good news is that this is backwards compatible
all the way to Sphinx 1.7.9, so this should work across the
board.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>