### PR TITLE
Fix links to installation instructions.

### DIFF
--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -33,7 +33,7 @@ For more information about RMW implementations, compiler / interpreter versions,
 Installation
 ------------
 
-`Install Dashing Diademata <../dashing/Installation/Summary.html>`__
+`Install Dashing Diademata <../../dashing/Installation.html>`__
 
 New features in this ROS 2 release
 ----------------------------------

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -33,7 +33,7 @@ For more information about RMW implementations, compiler / interpreter versions,
 Installation
 ------------
 
-`Install Eloquent Elusor <../eloquent/Installation/Summary.html>`__
+`Install Eloquent Elusor <../../eloquent/Installation.html>`__
 
 New features in this ROS 2 release
 ----------------------------------

--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -31,7 +31,7 @@ For more information about RMW implementations, compiler / interpreter versions,
 Installation
 ------------
 
-`Install Foxy Fitzroy <../foxy/Installation/Summary.htmk>`__
+`Install Foxy Fitzroy <../../foxy/Installation.html>`__
 
 New features in this ROS 2 release
 ----------------------------------


### PR DESCRIPTION
That is, since we've switched to one-distro-per-branch,
these links were broken.

This is kind of a silly fix since this is to a long EOL
distribution, but we may as well have all of the links
working.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>