### PR TITLE
Change the branch as appropriate.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -145,7 +145,7 @@ macros = {
     'DISTRO': 'rolling',
     'DISTRO_TITLE': 'Rolling',
     'DISTRO_TITLE_FULL': 'Rolling Ridley',
-    'REPOS_FILE_BRANCH': 'master',
+    'REPOS_FILE_BRANCH': 'rolling',
 }
 
 html_favicon = 'favicon.ico'
@@ -285,7 +285,7 @@ def smv_rewrite_configs(app, config):
             'DISTRO': distro,
             'DISTRO_TITLE': distro.title(),
             'DISTRO_TITLE_FULL': distro_full_names[distro],
-            'REPOS_FILE_BRANCH' : 'master' if distro == 'rolling' else distro,
+            'REPOS_FILE_BRANCH' : distro,
         }
 
 def github_link_rewrite_branch(app, pagename, templatename, context, doctree):

--- a/source/Concepts/About-Build-System.rst
+++ b/source/Concepts/About-Build-System.rst
@@ -114,7 +114,7 @@ This feature essentially replaces the "devel space" from ``catkin`` because it h
 
 Another feature provided by ``ament_cmake_core`` is the |package| resource indexing which is a way for |packages| to indicate that they contain a resource of some type.
 The design of this feature makes it much more efficient to answer simple questions like what |packages| are in this prefix (e.g. ``/usr/local``) because it only requires that you list the files in a single possible location under that prefix.
-You can read more about this feature in the `design docs <https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md>`_ for the resource index.
+You can read more about this feature in the `design docs <https://github.com/ament/ament_cmake/blob/{REPOS_FILE_BRANCH}/ament_cmake_core/doc/resource_index.md>`_ for the resource index.
 
 Like ``catkin``, ``ament_cmake_core`` also provides environment setup files and |package| specific environment hooks.
 The environment setup files, often named something like ``setup.bash``, are a place for |package| developers to define changes to the environment that are needed to utilize their |package|.

--- a/source/Concepts/About-Composition.rst
+++ b/source/Concepts/About-Composition.rst
@@ -36,7 +36,7 @@ Additionally ``ros2 launch`` can be used to automate these actions through speci
 Writing a Component
 -------------------
 
-Since a component is only built into a shared library it doesn't have a ``main`` function (see `Talker source code <https://github.com/ros2/demos/blob/master/composition/src/talker_component.cpp>`__).
+Since a component is only built into a shared library it doesn't have a ``main`` function (see `Talker source code <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/talker_component.cpp>`__).
 A component is commonly a subclass of ``rclcpp::Node``.
 Since it is not in control of the thread it shouldn't perform any long running or blocking tasks in its constructor.
 Instead it can use timers to get periodic notification.
@@ -64,14 +64,14 @@ Additionally, once a component is created, it must be registered with the index 
 Using Components
 ----------------
 
-The `composition <https://github.com/ros2/demos/tree/master/composition>`__ package contains a couple of different approaches on how to use components.
+The `composition <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/composition>`__ package contains a couple of different approaches on how to use components.
 The three most common ones are:
 
 
-#. Start a (`generic container process <https://github.com/ros2/rclcpp/blob/master/rclcpp_components/src/component_container.cpp>`__) and call the ROS service `load_node <https://github.com/ros2/rcl_interfaces/blob/master/composition_interfaces/srv/LoadNode.srv>`__ offered by the container.
+#. Start a (`generic container process <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp_components/src/component_container.cpp>`__) and call the ROS service `load_node <https://github.com/ros2/rcl_interfaces/blob/{REPOS_FILE_BRANCH}/composition_interfaces/srv/LoadNode.srv>`__ offered by the container.
    The ROS service will then load the component specified by the passed package name and library name and start executing it within the running process.
-   Instead of calling the ROS service programmatically you can also use a `command line tool <https://github.com/ros2/ros2cli/tree/master/ros2component>`__ to invoke the ROS service with the passed command line arguments
-#. Create a `custom executable <https://github.com/ros2/demos/blob/master/composition/src/manual_composition.cpp>`__ containing multiple nodes which are known at compile time.
+   Instead of calling the ROS service programmatically you can also use a `command line tool <https://github.com/ros2/ros2cli/tree/{REPOS_FILE_BRANCH}/ros2component>`__ to invoke the ROS service with the passed command line arguments
+#. Create a `custom executable <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/src/manual_composition.cpp>`__ containing multiple nodes which are known at compile time.
    This approach requires that each component has a header file (which is not strictly needed for the first case).
 #. Create a launch file and use ``ros2 launch`` to create a container process with multiple components loaded.
 

--- a/source/Concepts/About-Executors.rst
+++ b/source/Concepts/About-Executors.rst
@@ -11,7 +11,7 @@ Overview
 
 Execution management in ROS 2 is explicated by the concept of Executors.
 An Executor uses one or more threads of the underlying operating system to invoke the callbacks of subscriptions, timers, service servers, action servers, etc. on incoming messages and events.
-The explicit Executor class (in `executor.hpp <https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/executor.hpp>`_ in rclcpp, in `executors.py <https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/executors.py>`_ in rclpy, or in `executor.h <https://github.com/ros2/rclc/blob/master/rclc/include/rclc/executor.h>`_ in rclc) provides more control over execution management than the spin mechanism in ROS 1, although the basic API is very similar.
+The explicit Executor class (in `executor.hpp <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp/include/rclcpp/executor.hpp>`_ in rclcpp, in `executors.py <https://github.com/ros2/rclpy/blob/{REPOS_FILE_BRANCH}/rclpy/rclpy/executors.py>`_ in rclpy, or in `executor.h <https://github.com/ros2/rclc/blob/master/rclc/include/rclc/executor.h>`_ in rclc) provides more control over execution management than the spin mechanism in ROS 1, although the basic API is very similar.
 
 In the following, we focus on the C++ Client Library *rclcpp*.
 
@@ -144,7 +144,7 @@ For tips on how to use callback groups efficiently, see :doc:`Using Callback Gro
 The Executor base class in rclcpp also has the function ``add_callback_group(..)``, which allows distributing callback groups to different Executors.
 By configuring the underlying threads using the operating system scheduler, specific callbacks can be prioritized over other callbacks.
 For example, the subscriptions and timers of a control loop can be prioritized over all other subscriptions and standard services of a node.
-The `examples_rclcpp_cbg_executor package <https://github.com/ros2/examples/tree/master/rclcpp/executors/cbg_executor>`_ provides a demo of this mechanism.
+The `examples_rclcpp_cbg_executor package <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclcpp/executors/cbg_executor>`_ provides a demo of this mechanism.
 
 Scheduling semantics
 --------------------
@@ -180,9 +180,9 @@ The Static Single-Threaded Executor reduces this overhead greatly but it might b
 
 These issues have been partially addressed by the following developments:
 
-* `rclcpp WaitSet <https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/wait_set.hpp>`_: The ``WaitSet`` class of rclcpp allows waiting directly on subscriptions, timers, service servers, action servers, etc. instead of using an Executor.
+* `rclcpp WaitSet <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp/include/rclcpp/wait_set.hpp>`_: The ``WaitSet`` class of rclcpp allows waiting directly on subscriptions, timers, service servers, action servers, etc. instead of using an Executor.
   It can be used to implement deterministic, user-defined processing sequences, possibly processing multiple messages from different subscriptions together.
-  The `examples_rclcpp_wait_set package <https://github.com/ros2/examples/tree/master/rclcpp/wait_set>`_ provides several examples for the use of this user-level wait set mechanism.
+  The `examples_rclcpp_wait_set package <https://github.com/ros2/examples/tree/{REPOS_FILE_BRANCH}/rclcpp/wait_set>`_ provides several examples for the use of this user-level wait set mechanism.
 * `rclc Executor <https://github.com/ros2/rclc/blob/master/rclc/include/rclc/executor.h>`_: This Executor from the C Client Library *rclc* developed for micro-ROS gives the user fine-grained control over the execution order of callbacks and allows for custom trigger conditions to activate callbacks.
   Furthermore, it implements ideas of the Logical Execution Time (LET) semantics.
 

--- a/source/Concepts/About-Logging.rst
+++ b/source/Concepts/About-Logging.rst
@@ -57,5 +57,5 @@ Logging usage
 
   .. group-tab:: Python
 
-    * See the `rclpy examples <https://github.com/ros2/examples/blob/master/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py>`__ for example usage of a node's logger.
-    * See the `rclpy tests <https://github.com/ros2/rclpy/blob/master/rclpy/test/test_logging.py>`__ for example usage of keyword arguments (e.g. ``skip_first``, ``once``).
+    * See the `rclpy examples <https://github.com/ros2/examples/blob/{REPOS_FILE_BRANCH}/rclpy/services/minimal_client/examples_rclpy_minimal_client/client.py>`__ for example usage of a node's logger.
+    * See the `rclpy tests <https://github.com/ros2/rclpy/blob/{REPOS_FILE_BRANCH}/rclpy/test/test_logging.py>`__ for example usage of keyword arguments (e.g. ``skip_first``, ``once``).

--- a/source/Concepts/About-Quality-of-Service-Settings.rst
+++ b/source/Concepts/About-Quality-of-Service-Settings.rst
@@ -114,7 +114,7 @@ The currently defined QoS profiles are:
   This uses the RMW implementation’s default values for all of the policies.
   Different RMW implementations may have different defaults.
 
-`Click here <https://github.com/ros2/rmw/blob/master/rmw/include/rmw/qos_profiles.h>`__ for the specific policies in use for the above profiles.
+`Click here <https://github.com/ros2/rmw/blob/{REPOS_FILE_BRANCH}/rmw/include/rmw/qos_profiles.h>`__ for the specific policies in use for the above profiles.
 The settings in these profiles are subject to further tweaks, based on the feedback from the community.
 
 

--- a/source/Concepts/About-Topic-Statistics.rst
+++ b/source/Concepts/About-Topic-Statistics.rst
@@ -58,7 +58,7 @@ After enabling this feature for a specific node via the subscription configurati
 received message age and received message period measurements are enabled for that specific subscription.
 
 The data is published as a `statistics_msg/msg/MetricsMessage
-<https://github.com/ros2/rcl_interfaces/blob/master/statistics_msgs/msg/MetricsMessage.msg>`__
+<https://github.com/ros2/rcl_interfaces/blob/{REPOS_FILE_BRANCH}/statistics_msgs/msg/MetricsMessage.msg>`__
 at a configurable period (default 1 second) to a configurable topic (default ``/statistics``).
 Note that the publishing period also serves as the sample collection window period.
 

--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -270,7 +270,7 @@ In order to separate testing from building the library with colcon, wrap all cal
 Linting
 ^^^^^^^
 
-It's advised to use the combined call from `ament_lint_auto <https://github.com/ament/ament_lint/blob/master/ament_lint_auto/doc/index.rst#ament_lint_auto>`_:
+It's advised to use the combined call from `ament_lint_auto <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_lint_auto/doc/index.rst#ament_lint_auto>`_:
 
 .. code-block:: cmake
 
@@ -279,10 +279,10 @@ It's advised to use the combined call from `ament_lint_auto <https://github.com/
 
 This will run linters as defined in the ``package.xml``.
 It is recommended to use the set of linters defined by the package ``ament_lint_common``.
-The individual linters included there, as well as their functions, can be seen in the `ament_lint_common docs <https://github.com/ament/ament_lint/blob/master/ament_lint_common/doc/index.rst>`_.
+The individual linters included there, as well as their functions, can be seen in the `ament_lint_common docs <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_lint_common/doc/index.rst>`_.
 
 Linters provided by ament can also be added separately, instead of running ``ament_lint_auto``.
-One example of how to do so can be found in the `ament_cmake_lint_cmake documentation <https://github.com/ament/ament_lint/blob/master/ament_cmake_lint_cmake/doc/index.rst>`_.
+One example of how to do so can be found in the `ament_cmake_lint_cmake documentation <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_cmake_lint_cmake/doc/index.rst>`_.
 
 Testing
 ^^^^^^^
@@ -431,7 +431,7 @@ This can be achieved using the ament index (also called "resource index").
 The ament index explained
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For details on the design and intentions, see `here <https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md>`__
+For details on the design and intentions, see `here <https://github.com/ament/ament_cmake/blob/{REPOS_FILE_BRANCH}/ament_cmake_core/doc/resource_index.md>`__
 
 In principle, the ament index is contained in a folder within the install/share folder of your package.
 It contains shallow subfolders named after different types of resources.

--- a/source/How-To-Guides/Node-arguments.rst
+++ b/source/How-To-Guides/Node-arguments.rst
@@ -109,7 +109,7 @@ Setting parameters from YAML files
 
 Parameters can be set from the command-line in the form of yaml files.
 
-`See here <https://github.com/ros2/rcl/tree/master/rcl_yaml_param_parser>`__ for examples of the yaml file syntax.
+`See here <https://github.com/ros2/rcl/tree/{REPOS_FILE_BRANCH}/rcl_yaml_param_parser>`__ for examples of the yaml file syntax.
 
 As an example, save the following as ``demo_params.yaml``:
 

--- a/source/How-To-Guides/Package-maintainer-guide.rst
+++ b/source/How-To-Guides/Package-maintainer-guide.rst
@@ -27,7 +27,7 @@ The review is looking for:
 * Adds tests for the bug/feature
 * Adds documentation for new features
 * Clean Continuous Integration run
-* Targets default branch (usually "master", "main", or "ros2")
+* Targets default branch (usually "rolling")
 * Has at least one approval from a maintainer that is not the author
 
 Continuous Integration

--- a/source/How-To-Guides/RQt-Source-Install.rst
+++ b/source/How-To-Guides/RQt-Source-Install.rst
@@ -6,7 +6,8 @@
 Building RQt from source
 ========================
 
-We've provided our development setup here to aid future users in easily extending RQt by creating their own plugins. We encourage you to contribute those plugins back to the ``ros-visualization`` GitHub repository!
+We've provided our development setup here to aid future users in easily extending RQt by creating their own plugins.
+We encourage you to contribute those plugins back to the ``ros-visualization`` GitHub repository!
 
 System Requirements
 -------------------

--- a/source/How-To-Guides/Sync-Vs-Async.rst
+++ b/source/How-To-Guides/Sync-Vs-Async.rst
@@ -138,7 +138,7 @@ Since sending a request doesn’t block anything, a loop can be used to both spi
 
 The :doc:`Simple Service and Client <../Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber>` tutorial for Python illustrates how to perform an async service call and retrieve the ``future`` using a loop.
 
-The ``future`` can also be retrieved using a timer or callback, like in `this example <https://github.com/ros2/examples/blob/master/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py>`_, a dedicated thread, or by another method.
+The ``future`` can also be retrieved using a timer or callback, like in `this example <https://github.com/ros2/examples/blob/{REPOS_FILE_BRANCH}/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py>`_, a dedicated thread, or by another method.
 It is up to you, as the caller, to decide how to store ``future``, check on its status, and retrieve your response.
 
 Summary

--- a/source/Releases/Galactic-Geochelone-Complete-Changelog.rst
+++ b/source/Releases/Galactic-Geochelone-Complete-Changelog.rst
@@ -1510,9 +1510,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Alejandro Hernández Cordero, Chris Lalancette, Dirk Thomas, Scott K Logan
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`libstatistics_collector <https://github.com/ros-tooling/libstatistics_collector/tree/master/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`libstatistics_collector <https://github.com/ros-tooling/libstatistics_collector/tree/galactic/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * fix: measured values after the decimal point are truncated `#79 <https://github.com/ros-tooling/libstatistics_collector/issues/79>`__ (`#80 <https://github.com/ros-tooling/libstatistics_collector/issues/80>`__)
 * Update linter to run on rolling+focal (`#81 <https://github.com/ros-tooling/libstatistics_collector/issues/81>`__)
@@ -3105,9 +3105,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Audrow Nash, Claire Wang, Ivan Santiago Paunovic
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`ros2bag <https://github.com/ros2/rosbag2/tree/master/ros2bag/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`ros2bag <https://github.com/ros2/rosbag2/tree/galactic/ros2bag/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * /clock publisher in Player (`#695 <https://github.com/ros2/rosbag2/issues/695>`__)
 * Introducing Reindexer CLI (`#699 <https://github.com/ros2/rosbag2/issues/699>`__)
@@ -3385,9 +3385,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Michel Hidalgo
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2 <https://github.com/ros2/rosbag2/tree/master/rosbag2/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2 <https://github.com/ros2/rosbag2/tree/galactic/rosbag2/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
 * RMW-implementation-searcher converter in rosbag2_cpp (`#670 <https://github.com/ros2/rosbag2/issues/670>`__)
@@ -3399,9 +3399,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Emerson Knapp, Karsten Knese, Mabel Zhang, Michael Jeronimo
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_compression <https://github.com/ros2/rosbag2/tree/master/rosbag2_compression/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_compression <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_compression/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
 * Reindexer core (`#641 <https://github.com/ros2/rosbag2/issues/641>`__) Add a new C++ Reindexer class for reconstructing metadata from bags that are missing it.
@@ -3427,18 +3427,18 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Adam Dąbrowski, Christophe Bedard, Devin Bonnie, Emerson Knapp, Jaison Titus, Karsten Knese, Marwan Taher, Michael Jeronimo, P. J. Reed, jhdcs
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_compression_zstd <https://github.com/ros2/rosbag2/tree/master/rosbag2_compression_zstd/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_compression_zstd <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_compression_zstd/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add test_depend ament_cmake_gmock (`#639 <https://github.com/ros2/rosbag2/issues/639>`__)
 * Move zstd compressor to its own package (`#636 <https://github.com/ros2/rosbag2/issues/636>`__)
 * Contributors: Emerson Knapp, Shane Loretz
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_cpp <https://github.com/ros2/rosbag2/tree/master/rosbag2_cpp/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_cpp <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_cpp/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add set_rate to PlayerClock (`#727 <https://github.com/ros2/rosbag2/issues/727>`__)
 * Enforce non-null now_fn in TimeControllerClock (`#731 <https://github.com/ros2/rosbag2/issues/731>`__)
@@ -3479,17 +3479,17 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Adam Dąbrowski, Alexander, Chris Lalancette, Dirk Thomas, Emerson Knapp, Ivan Santiago Paunovic, Jacob Perron, Jaison Titus, Karsten Knese, Marwan Taher, Michael Jeronimo, P. J. Reed, Patrick Spieler, Tomoya Fujita, jhdcs
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_interfaces <https://github.com/ros2/rosbag2/tree/master/rosbag2_interfaces/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_interfaces <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_interfaces/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add rosbag2_interfaces package with playback service definitions (`#728 <https://github.com/ros2/rosbag2/issues/728>`__)
 * Contributors: Emerson Knapp
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_performance_benchmarking <https://github.com/ros2/rosbag2/tree/master/rosbag2_performance/rosbag2_performance_benchmarking/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_performance_benchmarking <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_performance/rosbag2_performance_benchmarking/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * fixed a memory leak in no-transport benchmark (`#674 <https://github.com/ros2/rosbag2/issues/674>`__)
 * report of performance improvements in rosbag2 (roughly since Foxy) (`#651 <https://github.com/ros2/rosbag2/issues/651>`__)
@@ -3503,9 +3503,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Adam Dąbrowski, Karsten Knese, Michael Jeronimo, Piotr Jaroszek
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_py <https://github.com/ros2/rosbag2/tree/master/rosbag2_py/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_py <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_py/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Remove -Werror from builds, enable it in Action CI (`#722 <https://github.com/ros2/rosbag2/issues/722>`__)
 * Split Rosbag2Transport into Player and Recorder classes - first pass to enable further progress (`#721 <https://github.com/ros2/rosbag2/issues/721>`__)
@@ -3530,9 +3530,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Emerson Knapp, Ivan Santiago Paunovic, Karsten Knese, Mabel Zhang, Michael Jeronimo, P. J. Reed, jhdcs
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_storage <https://github.com/ros2/rosbag2/tree/master/rosbag2_storage/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_storage <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_storage/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Remove -Werror from builds, enable it in Action CI (`#722 <https://github.com/ros2/rosbag2/issues/722>`__)
 * PlayerClock initial implementation - Player functionally unchanged (`#689 <https://github.com/ros2/rosbag2/issues/689>`__)
@@ -3550,9 +3550,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Adam Dąbrowski, Barry Xu, Emerson Knapp, Josh Langsfeld, Karsten Knese, Michael Jeronimo, Scott K Logan, jhdcs
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_storage_default_plugins <https://github.com/ros2/rosbag2/tree/master/rosbag2_storage_default_plugins/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_storage_default_plugins <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_storage_default_plugins/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Remove -Werror from builds, enable it in Action CI (`#722 <https://github.com/ros2/rosbag2/issues/722>`__)
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
@@ -3566,9 +3566,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Adam Dąbrowski, Emerson Knapp, Karsten Knese, Michael Jeronimo, P. J. Reed, jhdcs
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_test_common <https://github.com/ros2/rosbag2/tree/master/rosbag2_test_common/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_test_common <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_test_common/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Remove -Werror from builds, enable it in Action CI (`#722 <https://github.com/ros2/rosbag2/issues/722>`__)
 * Fix bad_function_call by replacing rclcpp::spin_some with SingleThreadedExecutor (`#705 <https://github.com/ros2/rosbag2/issues/705>`__)
@@ -3579,9 +3579,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Emerson Knapp, Michael Jeronimo
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_tests <https://github.com/ros2/rosbag2/tree/master/rosbag2_tests/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_tests <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_tests/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Remove -Werror from builds, enable it in Action CI (`#722 <https://github.com/ros2/rosbag2/issues/722>`__)
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
@@ -3608,9 +3608,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Adam Dąbrowski, Alexander, Emerson Knapp, Jaison Titus, Karsten Knese, Marwan Taher, Michael Jeronimo, jhdcs
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`rosbag2_transport <https://github.com/ros2/rosbag2/tree/master/rosbag2_transport/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`rosbag2_transport <https://github.com/ros2/rosbag2/tree/galactic/rosbag2_transport/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * cleanup cmakelists (`#726 <https://github.com/ros2/rosbag2/issues/726>`__)
 * turn recorder into a node (`#724 <https://github.com/ros2/rosbag2/issues/724>`__)
@@ -4453,9 +4453,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michel Hidalgo, Stephen Brawner, brawner, shonigmann
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`shared_queues_vendor <https://github.com/ros2/rosbag2/tree/master/shared_queues_vendor/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`shared_queues_vendor <https://github.com/ros2/rosbag2/tree/galactic/shared_queues_vendor/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
 * Update the package.xml files with the latest Open Robotics maintainers (`#535 <https://github.com/ros2/rosbag2/issues/535>`__)
@@ -4478,9 +4478,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Alejandro Hernández Cordero, Chris Lalancette, Dirk Thomas, Scott K Logan, shonigmann
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`sqlite3_vendor <https://github.com/ros2/rosbag2/tree/master/sqlite3_vendor/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`sqlite3_vendor <https://github.com/ros2/rosbag2/tree/galactic/sqlite3_vendor/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
 * Always preserve source permissions in vendor packages (`#645 <https://github.com/ros2/rosbag2/issues/645>`__)
@@ -4564,9 +4564,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michel Hidalgo, Stephen Brawner, brawner, shonigmann
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`tango_icons_vendor <https://github.com/ros-visualization/tango_icons_vendor/tree/master/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`tango_icons_vendor <https://github.com/ros-visualization/tango_icons_vendor/tree/galactic/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add exec_depend on tango-icon-theme system package (`#8 <https://github.com/ros-visualization/tango_icons_vendor/issues/8>`__)
 * Added common linters (`#7 <https://github.com/ros-visualization/tango_icons_vendor/issues/7>`__) * Added common linters * Fixed license in package.xml
@@ -5123,9 +5123,9 @@ This page is a list of the complete changes in all ROS 2 core packages since the
 * Contributors: Ivan Santiago Paunovic, Scott K Logan, Sean Yen
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`zstd_vendor <https://github.com/ros2/rosbag2/tree/master/zstd_vendor/CHANGELOG.rst>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`zstd_vendor <https://github.com/ros2/rosbag2/tree/galactic/zstd_vendor/CHANGELOG.rst>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Explicitly add emersonknapp as maintainer (`#692 <https://github.com/ros2/rosbag2/issues/692>`__)
 * Always preserve source permissions in vendor packages (`#645 <https://github.com/ros2/rosbag2/issues/645>`__)

--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -39,9 +39,9 @@ New features in this ROS 2 release
 
 A few features and improvements we would like to highlight:
 
-* `Components <https://index.ros.org/doc/ros2/Tutorials/Composition/>`__ are now the recommended way to write your node.
+* :doc:`Components <../Tutorials/Intermediate/Composition>` are now the recommended way to write your node.
   They can be used standalone as well as being composed within a process and both ways are fully support from ``launch`` files.
-* The `intra-process communication <https://github.com/ros2/ros2_documentation/edit/master/source/Tutorials/Intra-Process-Communication.rst>`__ (C++ only) has been improved - both in terms of latency as well as minimizing copies.
+* The :doc:`intra-process communication <../Tutorials/Demos/Intra-Process-Communication>` (C++ only) has been improved - both in terms of latency as well as minimizing copies.
 * The Python client library has been updated to match most of the C++ equivalent and some important bug fixes and improvements have landed related to memory usage and performance.
 * Parameters are now a complete alternative to ``dynamic_reconfigure`` from ROS 1 including constraints like ranges or being read-only.
 * By relying on (a subset of) `IDL 4.2 <https://www.omg.org/spec/IDL/4.2>`__ for the message generation pipeline it is now possible to use ``.idl`` files (beside ``.msg`` / ``.srv`` / ``.action`` files).
@@ -697,7 +697,7 @@ launch
 The ``launch_testing`` package caught up with the ``launch`` package redesign done in Bouncy Bolson.
 The legacy Python API, already moved into the ``launch.legacy`` submodule, has thus been deprecated and removed.
 
-See ``launch`` `examples <https://github.com/ros2/launch/tree/master/launch/examples>`__ and `documentation <https://github.com/ros2/launch/tree/master/launch/doc>`__ for reference on how to use its new API.
+See ``launch`` `examples <https://github.com/ros2/launch/tree/dashing/launch/examples>`__ and `documentation <https://github.com/ros2/launch/tree/dashing/launch/doc>`__ for reference on how to use its new API.
 
 See `demos tests <https://github.com/ros2/demos>`__ for reference on how to use the new ``launch_testing`` API.
 

--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -218,7 +218,7 @@ Change in Serialized Message Callback Signature
 """""""""""""""""""""""""""""""""""""""""""""""
 
 The pull request `ros2/rclcpp#1081 <https://github.com/ros2/rclcpp/pull/1081>`_ introduces a new signature of the callbacks for retrieving ROS messages in serialized form.
-The previously used C-Struct `rcl_serialized_message_t <https://github.com/ros2/rmw/blob/master/rmw/include/rmw/serialized_message.h>`_ is being superseded by a C++ data type `rclcpp::SerializedMessage <https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/serialized_message.hpp>`_.
+The previously used C-Struct `rcl_serialized_message_t <https://github.com/ros2/rmw/blob/foxy/rmw/include/rmw/serialized_message.h>`_ is being superseded by a C++ data type `rclcpp::SerializedMessage <https://github.com/ros2/rclcpp/blob/foxy/rclcpp/include/rclcpp/serialized_message.hpp>`_.
 
 The example nodes in ``demo_nodes_cpp``, namely ``talker_serialized_message`` as well as ``listener_serialized_message`` reflect these changes.
 

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -400,7 +400,7 @@ performance testing package and performance improvements
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 A thorough performance analysis project was performed on rosbag2 since the Foxy release.
-The full initial report is available at https://github.com/ros2/rosbag2/blob/master/rosbag2_performance/rosbag2_performance_benchmarking/docs/rosbag2_performance_improvements.pdf .
+The full initial report is available at https://github.com/ros2/rosbag2/blob/galactic/rosbag2_performance/rosbag2_performance_benchmarking/docs/rosbag2_performance_improvements.pdf .
 The package ``rosbag2_performance_benchmarking`` provides tools to run performance analyses, especially on recording, which helps us maintain and improve the performance of rosbag2.
 
 Following this report, key work was done do improve the performance to a much more usable state for actual robot workflows.
@@ -698,7 +698,7 @@ If the previous dynamic behavior is desired, there is an mechanism to opt it in 
     descriptor.dynamic_typing = true;
     node->declare_parameter("dynamically_typed_param", rclcpp::ParameterValue{}, descriptor);
 
-For more details see https://github.com/ros2/rclcpp/blob/master/rclcpp/doc/notes_on_statically_typed_parameters.md.
+For more details see https://github.com/ros2/rclcpp/blob/galactic/rclcpp/doc/notes_on_statically_typed_parameters.md.
 
 New API for checking QoS profile compatibility
 """"""""""""""""""""""""""""""""""""""""""""""
@@ -774,7 +774,7 @@ Run these commands to see how statically and dynamically typed parameters are di
     $ ros2 param set /static_param_example static_param 42
     Setting parameter failed: Wrong parameter type, expected 'Type.STRING' got 'Type.INTEGER'
 
-For more details see https://github.com/ros2/rclcpp/blob/master/rclcpp/doc/notes_on_statically_typed_parameters.md.
+For more details see https://github.com/ros2/rclcpp/blob/galactic/rclcpp/doc/notes_on_statically_typed_parameters.md.
 
 New API for checking QoS profile compatibility
 """"""""""""""""""""""""""""""""""""""""""""""

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -129,7 +129,7 @@ launch_pytest
 We've added a new package, ``launch_pytest``, that acts as an alternative to ``launch_testing``.
 ``launch_pytest`` is a simple pytest plugin that provides pytest fixtures to manage the lifetime of a launch service.
 
-Check out the `package README for details and examples. <https://github.com/ros2/launch/tree/master/launch_pytest>`_
+Check out the `package README for details and examples. <https://github.com/ros2/launch/tree/humble/launch_pytest>`_
 
 Related PR: `ros2/launch#528 <https://github.com/ros2/launch/pull/528>`_
 
@@ -308,7 +308,7 @@ SROS2 Security enclaves now support Certificate Revocation Lists
 
 Certificate Revocation Lists (CRLs) are a concept where particular certificates can be revoked before their expiration.
 As of Humble, it is now possible to put a CRL in an SROS2 security enclave and have it be honored.
-See `the SROS2 tutorials <https://github.com/ros2/sros2/blob/master/SROS2_Linux.md#certificate-revocation-lists>`__ for an example of how to use it.
+See `the SROS2 tutorials <https://github.com/ros2/sros2/blob/humble/SROS2_Linux.md#certificate-revocation-lists>`__ for an example of how to use it.
 
 Content Filtered Topics
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -326,7 +326,7 @@ Content Filtered Topics can be used to request content-based subscriptions when 
    * - rmw_cyclonedds
      - not supported
 
-To learn more, see the `content_filtering <https://github.com/ros2/examples/blob/master/rclcpp/topics/minimal_subscriber/content_filtering.cpp>`_ examples.
+To learn more, see the `content_filtering <https://github.com/ros2/examples/blob/humble/rclcpp/topics/minimal_subscriber/content_filtering.cpp>`_ examples.
 
 Related design PR: `ros2/design#282 <https://github.com/ros2/design/pull/282>`_.
 

--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -17,7 +17,7 @@ For other things like package layout or documentation layout we will need to com
 Additionally, wherever possible, developers should use integrated tools to allow them to check that these guidelines are followed in their editors.
 For example, everyone should have a PEP8 checker built into their editor to cut down on review iterations related to style.
 
-Also where possible, packages should check style as part of their unit tests to help with the automated detection of style issues (see `ament_lint_auto <https://github.com/ament/ament_lint/blob/master/ament_lint_auto/doc/index.rst>`__).
+Also where possible, packages should check style as part of their unit tests to help with the automated detection of style issues (see `ament_lint_auto <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_lint_auto/doc/index.rst>`__).
 
 C
 -
@@ -305,9 +305,9 @@ We check these styles with a combination of Google's `cpplint.py <https://github
 
 We provide command line tools with custom configurations:
 
-* `ament_clang_format <https://github.com/ament/ament_lint/blob/master/ament_clang_format/doc/index.rst>`__: `configuration <https://github.com/ament/ament_lint/blob/master/ament_clang_format/ament_clang_format/configuration/.clang-format>`__
-* `ament_cpplint <https://github.com/ament/ament_lint/blob/master/ament_cpplint/doc/index.rst>`__
-* `ament_uncrustify <https://github.com/ament/ament_lint/blob/master/ament_uncrustify/doc/index.rst>`__: `configuration <https://github.com/ament/ament_lint/blob/master/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg>`__
+* `ament_clang_format <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_clang_format/doc/index.rst>`__: `configuration <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_clang_format/ament_clang_format/configuration/.clang-format>`__
+* `ament_cpplint <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_cpplint/doc/index.rst>`__
+* `ament_uncrustify <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_uncrustify/doc/index.rst>`__: `configuration <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_uncrustify/ament_uncrustify/configuration/ament_code_style.cfg>`__
 
 Some formatters such as ament_uncrustify and ament_clang_format support ``--reformat`` options to apply changes in place.
 
@@ -315,7 +315,7 @@ We also run other tools to detect and eliminate as many warnings as possible.
 Here's a non-exhaustive list of additional things we try to do on all of our packages:
 
 * use compiler flags like ``-Wall -Wextra -Wpedantic``
-* run static code analysis like ``cppcheck``, which we have integrated in `ament_cppcheck <https://github.com/ament/ament_lint/blob/master/ament_cppcheck/doc/index.rst>`__.
+* run static code analysis like ``cppcheck``, which we have integrated in `ament_cppcheck <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_cppcheck/doc/index.rst>`__.
 
 Python
 ------
@@ -338,7 +338,7 @@ We chose the following more precise rule where PEP 8 leaves some freedom:
 
 Tools like the ``(ament_)pycodestyle`` Python package should be used in unit-test and/or editor integration for checking Python code style.
 
-The pycodestyle configuration used in the linter is `here <https://github.com/ament/ament_lint/blob/master/ament_pycodestyle/ament_pycodestyle/configuration/ament_pycodestyle.ini>`__.
+The pycodestyle configuration used in the linter is `here <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_pycodestyle/ament_pycodestyle/configuration/ament_pycodestyle.ini>`__.
 
 Integration with editors:
 

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -267,7 +267,7 @@ Use                    Becomes (for Rolling)  Example
 \{DISTRO\}             rolling                ros-\{DISTRO\}-pkg
 \{DISTRO_TITLE\}       Rolling                ROS 2 \{DISTRO_TITLE\}
 \{DISTRO_TITLE_FULL\}  Rolling Ridley         ROS 2 \{DISTRO_TITLE_FULL\}
-\{REPOS_FILE_BRANCH\}  master                 git checkout \{REPOS_FILE_BRANCH\}
+\{REPOS_FILE_BRANCH\}  rolling                git checkout \{REPOS_FILE_BRANCH\}
 =====================  =====================  ==================================
 
 The same file can be used on multiple branches (i.e., for multiple distros) and the generated content will be distro-specific.

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -50,7 +50,7 @@ We will also adhere to some ROS-specific rules built on top of ``semver's`` full
   * Patch (interface-preserving) and minor (non-breaking) version increments do not break compatibility, so these sorts of changes *are* allowed within a release.
 
   * Major ROS releases are the best time to release breaking changes.
-    If a core package needs multiple breaking changes, they should be merged into their integration branch (e.g. master) to allow catching problems in CI quickly, but released together to reduce the number of major releases for ROS users.
+    If a core package needs multiple breaking changes, they should be merged into their integration branch (e.g. rolling) to allow catching problems in CI quickly, but released together to reduce the number of major releases for ROS users.
 
   * Though major increments require a new distribution, a new distribution does not necessarily require a major bump (if development and release can happen without breaking API).
 
@@ -158,7 +158,7 @@ Guidelines for backporting PRs
 
 When changing an older version of ROS:
 
-* Make sure the features or fixes are accepted and merged in the master branch before opening a PR to backport the changes to older versions.
+* Make sure the features or fixes are accepted and merged in the rolling branch before opening a PR to backport the changes to older versions.
 * When backporting to older versions, also consider backporting to any other :doc:`still supported versions <../../Releases>`, even non-LTS versions.
 * If you are backporting a single PR in its entirety, title the backport PR "[Distro] <name of original PR>".
   If backporting a subset of changes from one or multiple PRs, the title should be "[Distro] <description of changes>".
@@ -243,10 +243,10 @@ We will also require justification for merging a change or making a release that
 Linters and static analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We will use :doc:`ROS code style <Code-Style-Language-Versions>` and enforce it with linters from `ament_lint_common <https://github.com/ament/ament_lint/tree/master/ament_lint_common/doc/index.rst>`_.
+We will use :doc:`ROS code style <Code-Style-Language-Versions>` and enforce it with linters from `ament_lint_common <https://github.com/ament/ament_lint/tree/{REPOS_FILE_BRANCH}/ament_lint_common/doc/index.rst>`_.
 All linters/static analysis that are part of ``ament_lint_common`` must be used.
 
-The `ament_lint_auto <https://github.com/ament/ament_lint/blob/master/ament_lint_auto/doc/index.rst>`_ documentation provides information on running ``ament_lint_common``.
+The `ament_lint_auto <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_lint_auto/doc/index.rst>`_ documentation provides information on running ``ament_lint_common``.
 
 General Practices
 -----------------
@@ -284,7 +284,7 @@ When filing an issue please make sure to:
 - Mention troubleshooting steps that have been tried already, including:
 
   - Upgrading to the latest version of the code, which may include bug fixes that have not been released yet.
-    See `this section <building-from-source>` and follow the instructions to get the "master" branches.
+    See `this section <building-from-source>` and follow the instructions to get the "rolling" branches.
   - Trying with a different RMW implementation.
     See `this page <../../How-To-Guides/Working-with-multiple-RMW-implementations>` for how to do that.
 
@@ -357,7 +357,7 @@ If you need libraries to have different versions then consider splitting them in
 Development process
 ^^^^^^^^^^^^^^^^^^^
 
-* The default branch (in most cases the master branch) must always build, pass all tests and compile without warnings.
+* The default branch (in most cases the rolling branch) must always build, pass all tests and compile without warnings.
   If at any time there is a regression it is the top priority to restore at least the previous state.
 * Always build with tests enabled.
 * Always run tests locally after changes and before proposing them in a pull request.

--- a/source/The-ROS2-Project/Contributing/Migration-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Migration-Guide.rst
@@ -15,7 +15,7 @@ There are two different kinds of package migrations:
 * Migrating the source code of an existing package from ROS 1 to ROS 2 with the intent that a significant part of the source code will stay the same or at least similar.
   An example for this could be `pluginlib <https://github.com/ros/pluginlib>`_ where the source code is maintained in different branches within the same repository and commonly patches can be ported between those branches when necessary.
 * Implementing the same or similar functionality of a ROS 1 package for ROS 2 but with the assumption that the source code will be significantly different.
-  An example for this could be `roscpp <https://github.com/ros/ros_comm/tree/melodic-devel/clients/roscpp>`_ in ROS 1 and `rclcpp <https://github.com/ros2/rclcpp/tree/master/rclcpp>`_ in ROS 2 which are separate repositories and don't share any code.
+  An example for this could be `roscpp <https://github.com/ros/ros_comm/tree/melodic-devel/clients/roscpp>`_ in ROS 1 and `rclcpp <https://github.com/ros2/rclcpp/tree/rolling/rclcpp>`_ in ROS 2 which are separate repositories and don't share any code.
 
 This article focuses on the former case and describes the high-level steps to migrate a ROS 1 package to ROS 2.
 It does not aim to be a step-by-step migration instruction and is not considered the *final* "solution".
@@ -57,7 +57,7 @@ Service files must end in ``.srv`` and must be located in the subfolder ``srv``.
 Actions files must end in ``.action`` and must be located in the subfolder ``action``.
 
 These files might need to be updated to comply with the `ROS Interface definition <https://design.ros2.org/articles/interface_definition.html>`__.
-Some primitive types have been removed and the types ``duration`` and ``time`` which were builtin types in ROS 1 have been replaced with normal message definitions and must be used from the `builtin_interfaces <https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces>`__ package.
+Some primitive types have been removed and the types ``duration`` and ``time`` which were builtin types in ROS 1 have been replaced with normal message definitions and must be used from the `builtin_interfaces <https://github.com/ros2/rcl_interfaces/tree/{REPOS_FILE_BRANCH}/builtin_interfaces>`__ package.
 Also some naming conventions are stricter than in ROS 1.
 
 In your ``package.xml``:
@@ -150,7 +150,7 @@ Apply the following changes to use ``ament_cmake`` instead of ``catkin``:
     Invoke ``ament_package`` instead but **after** all targets have been registered.
 
   *
-    The only valid argument for `ament_package <https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/cmake/core/ament_package.cmake>`__ is ``CONFIG_EXTRAS``.
+    The only valid argument for `ament_package <https://github.com/ament/ament_cmake/blob/{REPOS_FILE_BRANCH}/ament_cmake_core/cmake/core/ament_package.cmake>`__ is ``CONFIG_EXTRAS``.
     All other arguments are covered by separate functions which all need to be invoked *before* ``ament_package``:
 
     * Instead of passing ``CATKIN_DEPENDS ...`` call ``ament_export_dependencies(...)`` before.
@@ -161,7 +161,7 @@ Apply the following changes to use ``ament_cmake`` instead of ``catkin``:
     **TODO document ament_export_targets (``ament_export_interfaces`` in Eloquent and older)?**
 
 *
-  Replace the invocation of ``add_message_files``, ``add_service_files`` and ``generate_messages`` with `rosidl_generate_interfaces <https://github.com/ros2/rosidl/blob/master/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake>`__.
+  Replace the invocation of ``add_message_files``, ``add_service_files`` and ``generate_messages`` with `rosidl_generate_interfaces <https://github.com/ros2/rosidl/blob/{REPOS_FILE_BRANCH}/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake>`__.
 
 
   *
@@ -189,7 +189,7 @@ Apply the following changes to use ``ament_cmake`` instead of ``catkin``:
   Related CMake variables like ``CATKIN_DEVEL_PREFIX`` do not exist anymore.
 
 
-  * The ``CATKIN_DEPENDS`` and ``DEPENDS`` arguments are passed to the new function `ament_export_dependencies <https://github.com/ament/ament_cmake/blob/master/ament_cmake_export_dependencies/cmake/ament_export_dependencies.cmake>`__.
+  * The ``CATKIN_DEPENDS`` and ``DEPENDS`` arguments are passed to the new function `ament_export_dependencies <https://github.com/ament/ament_cmake/blob/{REPOS_FILE_BRANCH}/ament_cmake_export_dependencies/cmake/ament_export_dependencies.cmake>`__.
   * ``CATKIN_GLOBAL_BIN_DESTINATION``: ``bin``
   * ``CATKIN_GLOBAL_INCLUDE_DESTINATION``: ``include``
   * ``CATKIN_GLOBAL_LIB_DESTINATION``: ``lib``
@@ -415,7 +415,7 @@ In ROS 2, parameters are associated per node and are configurable at runtime wit
 Launch files
 ------------
 
-While launch files in ROS 1 are always specified using `.xml <https://wiki.ros.org/roslaunch/XML>`__ files, ROS 2 supports Python scripts to enable more flexibility (see `launch package <https://github.com/ros2/launch/tree/master/launch>`__) as well as XML and YAML files.
+While launch files in ROS 1 are always specified using `.xml <https://wiki.ros.org/roslaunch/XML>`__ files, ROS 2 supports Python scripts to enable more flexibility (see `launch package <https://github.com/ros2/launch/tree/{REPOS_FILE_BRANCH}/launch>`__) as well as XML and YAML files.
 See `separate tutorial <../../How-To-Guides/Launch-files-migration-guide>` on migrating launch files from ROS 1 to ROS 2.
 
 Example: Converting an existing ROS 1 package to use ROS 2

--- a/source/The-ROS2-Project/Contributing/Quality-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Quality-Guide.rst
@@ -72,13 +72,13 @@ Static code analysis as part of the ament package build
 
 * ``rclcpp``:
 
-  * `rclcpp/rclcpp/CMakeLists.txt <https://github.com/ros2/rclcpp/blob/master/rclcpp/CMakeLists.txt>`__
-  * `rclcpp/rclcpp/package.xml <https://github.com/ros2/rclcpp/blob/master/rclcpp/package.xml>`__
+  * `rclcpp/rclcpp/CMakeLists.txt <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp/CMakeLists.txt>`__
+  * `rclcpp/rclcpp/package.xml <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp/package.xml>`__
 
 * ``rclcpp_lifecycle``:
 
-  * `rclcpp/rclcpp_lifecycle/CMakeLists.txt <https://github.com/ros2/rclcpp/blob/master/rclcpp_lifecycle/CMakeLists.txt>`__
-  * `rclcpp/rclcpp_lifecycle/package.xml <https://github.com/ros2/rclcpp/blob/master/rclcpp_lifecycle/package.xml>`__
+  * `rclcpp/rclcpp_lifecycle/CMakeLists.txt <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp_lifecycle/CMakeLists.txt>`__
+  * `rclcpp/rclcpp_lifecycle/package.xml <https://github.com/ros2/rclcpp/blob/{REPOS_FILE_BRANCH}/rclcpp_lifecycle/package.xml>`__
 
 **Resulting context**:
 
@@ -110,7 +110,7 @@ Static Thread Safety Analysis via Code Annotation
 
 To enable Thread Safety Analysis, code must be annotated to let the compiler know more about the semantics of the code. These annotations are Clang-specific attributes - e.g. ``__attribute__(capability()))``. Instead of using those attributes directly, ROS 2 provides preprocessor macros that are erased when using other compilers.
 
-These macros can be found in `rcpputils/thread_safety_annotations.h <https://github.com/ros2/rcpputils/blob/{REPOS_FILE_BRANCH}/include/rcpputils/thread_safety_annotations.hpp>`__
+These macros can be found in `rcpputils/thread_safety_annotations.hpp <https://github.com/ros2/rcpputils/blob/{REPOS_FILE_BRANCH}/include/rcpputils/thread_safety_annotations.hpp>`__
 
 The Thread Safety Analysis documentation states
   Thread safety analysis can be used with any threading library, but it does require that the threading API be wrapped in classes and methods which have the appropriate annotations

--- a/source/Tutorials/Demos/Content-Filtering-Subscription.rst
+++ b/source/Tutorials/Demos/Content-Filtering-Subscription.rst
@@ -304,5 +304,5 @@ You can see the message ``Content filter is not enabled`` because underlying RMW
 Related content
 ---------------
 
-- `content filtering examples <https://github.com/ros2/examples/blob/master/rclcpp/topics/minimal_subscriber/content_filtering.cpp>`__ that covers all interfaces for content filtering subscription.
+- `content filtering examples <https://github.com/ros2/examples/blob/{REPOS_FILE_BRANCH}/rclcpp/topics/minimal_subscriber/content_filtering.cpp>`__ that covers all interfaces for content filtering subscription.
 - `content filtering design PR <https://github.com/ros2/design/pull/282>`__


### PR DESCRIPTION
In many cases, this turns out to be the REPOS_FILE_BRANCH.
In some cases, we fix up hardcoded branches that are actually
pointing to the wrong place.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This isn't quite ready to merge, as we still need to branch https://github.com/ros2/ros2/blob/master/ros2.repos into rolling.  Once that is done, this should be good to go.