### PR TITLE
Fix 'Contributing to ROS 2 Documentation' redirect and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The sources from this repository are built and uploaded to the site nightly by a
 ## Contributing to the documentation
 
 Contributions to this site are most welcome.
-Please see the [Contributing to ROS 2 Documentation](https://docs.ros.org/en/rolling/Contributing/Contributing-To-ROS-2-Documentation.html) page to learn more.
+Please see the [Contributing to ROS 2 Documentation](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.html) page to learn more.
 
 ## Contributing to ROS 2
 
-To contribute to the ROS 2 source code project please refer to the [ROS 2 contributing guidelines](https://docs.ros.org/en/rolling/Contributing.html).
+To contribute to the ROS 2 source code project please refer to the [ROS 2 contributing guidelines](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing.html).

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -1,6 +1,6 @@
 .. redirect-from::
 
-  Contributing/Contributing-to-ROS-2-Documentation
+    Contributing/Contributing-To-ROS-2-Documentation
 
 Contributing to ROS 2 Documentation
 ===================================


### PR DESCRIPTION
This link currently results in a 404: https://docs.ros.org/en/rolling/Contributing/Contributing-To-ROS-2-Documentation.html

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>