### PR TITLE
Mistake in article: Not YAML, but JSON

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
@@ -243,7 +243,7 @@ Now that you have the message structure, you can publish data onto a topic direc
 
 The ``'<args>'`` argument is the actual data you’ll pass to the topic, in the structure you just discovered in the previous section.
 
-It’s important to note that this argument needs to be input in YAML syntax.
+It’s important to note that this argument needs to be input in JSON syntax.
 Input the full command like so:
 
 .. code-block:: console


### PR DESCRIPTION
The data in the example command
```js
{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}
```
isn't `YAML` but `JSON`. The original text was wrong. 

**Note**: my changed supposes that the example command is correct, but I haven't verified yet.