### PR TITLE
Update Ubuntu-Install-Debians.rst

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -134,6 +134,8 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
    . ~/ros2_{DISTRO}/install/local_setup.bash
 
 .. _rhel_talker-listener:

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -86,13 +86,15 @@ If you would like to use another DDS or RTPS vendor besides the default, you can
 Environment setup
 -----------------
 
-Sourcing the setup script
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Source the setup script
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
 
 Try some examples

--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -135,6 +135,8 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
    . ~/ros2_{DISTRO}/install/local_setup.bash
 
 .. _talker-listener:

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -90,13 +90,15 @@ If you would like to use another DDS or RTPS vendor besides the default, you can
 Environment setup
 -----------------
 
-Sourcing the setup script
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Source the setup script
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
 
 Try some examples

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -78,6 +78,8 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
    source /opt/ros/{DISTRO}/setup.bash
 
 Try some examples

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -76,9 +76,9 @@ Set up your environment by sourcing the following file.
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
    source /opt/ros/{DISTRO}/setup.bash
-   #Replace ".bash" with your shell if you're not using bash
-   #Possible values are: setup.bash, setup.sh, setup.zsh
 
 Try some examples
 -----------------

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -77,6 +77,8 @@ Set up your environment by sourcing the following file.
 .. code-block:: bash
 
    source /opt/ros/{DISTRO}/setup.bash
+   #Replace ".bash" with your shell if you're not using bash
+   #Possible values are: setup.bash, setup.sh, setup.zsh
 
 Try some examples
 -----------------
@@ -91,6 +93,8 @@ In one terminal, source the setup file and then run a C++ ``talker``\ :
 .. code-block:: bash
 
    source /opt/ros/{DISTRO}/setup.bash
+   #replace ".bash" with your shell if you're not using bash
+   #Possible values are: setup.bash, setup.sh, setup.zsh
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :
@@ -98,6 +102,8 @@ In another terminal source the setup file and then run a Python ``listener``\ :
 .. code-block:: bash
 
    source /opt/ros/{DISTRO}/setup.bash
+   #replace ".bash" with your shell if you're not using bash
+   #Possible values are: setup.bash, setup.sh, setup.zsh
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -92,8 +92,6 @@ In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
-   # Replace ".bash" with your shell if you're not using bash
-   # Possible values are: setup.bash, setup.sh, setup.zsh
    source /opt/ros/{DISTRO}/setup.bash
    ros2 run demo_nodes_cpp talker
 
@@ -101,8 +99,6 @@ In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
-   # Replace ".bash" with your shell if you're not using bash
-   # Possible values are: setup.bash, setup.sh, setup.zsh
    source /opt/ros/{DISTRO}/setup.bash
    ros2 run demo_nodes_py listener
 

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -92,9 +92,9 @@ In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
    source /opt/ros/{DISTRO}/setup.bash
-   #replace ".bash" with your shell if you're not using bash
-   #Possible values are: setup.bash, setup.sh, setup.zsh
    ros2 run demo_nodes_cpp talker
 
 In another terminal source the setup file and then run a Python ``listener``\ :

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -101,9 +101,9 @@ In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: bash
 
+   # Replace ".bash" with your shell if you're not using bash
+   # Possible values are: setup.bash, setup.sh, setup.zsh
    source /opt/ros/{DISTRO}/setup.bash
-   #replace ".bash" with your shell if you're not using bash
-   #Possible values are: setup.bash, setup.sh, setup.zsh
    ros2 run demo_nodes_py listener
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.

--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -56,8 +56,10 @@ You will need to run this command on every new shell you open to have access to 
 
    .. group-tab:: Linux
 
-      .. code-block:: console
+      .. code-block:: bash
 
+        # Replace ".bash" with your shell if you're not using bash
+        # Possible values are: setup.bash, setup.sh, setup.zsh
         source /opt/ros/{DISTRO}/setup.bash
 
    .. group-tab:: macOS


### PR DESCRIPTION
Though `.bash` in the file name is quite explicit, hard-coding the `.bash` in this document isn't that good, I think. 

It was not until I used `Tab` to complete the command line that I found there is a `zsh` version, after getting errors sourcing the `bash` version with `zsh`.