### PR TITLE
Update Windows Symbol Visibility

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -255,7 +255,7 @@ To use it for a package called ``my_library``:
 
     target_compile_definitions(my_library PRIVATE "MY_LIBRARY_BUILDING_LIBRARY")
 
-For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document <../The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
+For more details, see :ref:`Windows Symbol Visibility in the Windows Tips and Tricks document <Windows_Symbol_Visibility>`.
 
 Testing and Linting
 -------------------

--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -255,6 +255,8 @@ To use it for a package called ``my_library``:
 
     target_compile_definitions(my_library PRIVATE "MY_LIBRARY_BUILDING_LIBRARY")
 
+For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document</The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
+
 Testing and Linting
 -------------------
 

--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -255,7 +255,7 @@ To use it for a package called ``my_library``:
 
     target_compile_definitions(my_library PRIVATE "MY_LIBRARY_BUILDING_LIBRARY")
 
-For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document</The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
+For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document <../The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
 
 Testing and Linting
 -------------------

--- a/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
+++ b/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
@@ -23,11 +23,14 @@ This has two practical consequences for ROS 2:
 * Some of the ROS 2 internal path names are fairly long. Because of this, we always recommend using a short path name for the root of your ROS 2 directory, like ``C:\dev``.
 * When building ROS 2 from source, the default isolated build mode of colcon can generate very long path names. To avoid these very long path names, use ``--merge-install`` when building on Windows.
 
-**Note**: It is possible to change Windows to have much longer maximum path lengths.  See `this article <https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later>`__ for more information.
+**Note**: It is possible to change Windows to have much longer maximum path lengths.  
+See `this article <https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later>`__ for more information.
 
 Exporting symbols
 -----------------
-The Microsoft Visual C++ Compiler (MSVC) exposes symbols from a Dynamic Link Library (DLL) only if they are explicitly exported. The clang and gcc compilers have an option to do the same, but it is off by default. As a result, when a library previously built on Linux is built on Windows, other libraries may be unable to resolve the external symbols.
+The Microsoft Visual C++ Compiler (MSVC) exposes symbols from a Dynamic Link Library (DLL) only if they are explicitly exported.
+The clang and gcc compilers have an option to do the same, but it is off by default.
+As a result, when a library previously built on Linux is built on Windows, other libraries may be unable to resolve the external symbols.
 Below are examples of common error messages which can be caused by symbols not being exposed:
 
 .. code-block:: console
@@ -41,24 +44,31 @@ Below are examples of common error messages which can be caused by symbols not b
       Package 'random_numbers' exports the library 'random_numbers' which
       couldn't be found
 
-Symbol Visibility also impacts binary loading. If you are finding that a composible node does not run or a Qt Visualizer isn't working, it may be that the hosting process can not find an expected symbol export from the binary.
-To diagnose this on Windows, the Windows developer tools includes a program called Gflags to enable various options. One of those options is called *Loader Snaps* which enables you to detect load failures while debugging.
-Please visit the Microsoft Documentation for more information on [Gflags](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/setting-and-clearing-image-file-flags) and  [Loaders snaps](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps).
+Symbol Visibility also impacts binary loading.
+If you are finding that a composible node does not run or a Qt Visualizer isn't working, it may be that the hosting process can not find an expected symbol export from the binary.
+To diagnose this on Windows, the Windows developer tools includes a program called Gflags to enable various options.
+One of those options is called *Loader Snaps* which enables you to detect load failures while debugging.
+Please visit the Microsoft Documentation for more information on [Gflags](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/setting-and-clearing-image-file-flags) and [Loaders snaps](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps).
 Two solutions to export symbols on Windows are Visibility Control Headers and the ``WINDOWS_EXPORT_ALL_SYMBOLS`` property.
-Microsoft recommends ROS developers use Visibility Control Headers to control the export of symbols from a binary. Visibility Control Headers provide more control over the symbol export macro and offer other benefits including smaller binary size and reduced link times.
+Microsoft recommends ROS developers use Visibility Control Headers to control the export of symbols from a binary.
+Visibility Control Headers provide more control over the symbol export macro and offer other benefits including smaller binary size and reduced link times.
 
 Visibility Control Headers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-The purpose of Visibility Control Headers headers is to define a macro for each library which correctly declares symbols as dllimport or dllexport. This is decided based on whether the library is being consumed or being built itself. The logic in the macro also takes the compiler into account and includes logic to select the appropriate syntax.
+The purpose of Visibility Control Headers headers is to define a macro for each shared library which correctly declares symbols as dllimport or dllexport.
+This is decided based on whether the library is being consumed or being built itself.
+The logic in the macro also takes the compiler into account and includes logic to select the appropriate syntax.
 The following link includes step by step instructions for adding explicit symbol visibility to a library “yielding the highest quality code with the greatest reductions in binary size, load times and link times”: [The GCC visibility documentation](https://gcc.gnu.org/wiki/Visibility).
-A header named ``visibility_control.h`` can be placed in the ``include`` folder for each library as shown in the example below.
+A header named ``visibility_control.h`` can be placed in the ``includes`` folder for each library as shown in the example below.
 The example below shows how a visibility control header would be added for a ``my_lib`` library with a class called ``example_class``.
-Add a visibility header to the include folder for the library. The boiler plate logic is used with the library name used in the macro to make it unique in the project. In another library, ``MY_LIB`` would be replaced with the library name.
+Add a visibility header to the include folder for the library.
+The boiler plate logic is used with the library name used in the macro to make it unique in the project.
+In another library, ``MY_LIB`` would be replaced with the library name.
 
 .. code-block:: c++
 
-   #ifndef MY_LIB__VISIBILITY_CONTROL_HPP_
-   #define MY_LIB__VISIBILITY_CONTROL_HPP_
+   #ifndef MY_LIB__VISIBILITY_CONTROL_H_
+   #define MY_LIB__VISIBILITY_CONTROL_H_
    #if defined _WIN32 || defined __CYGWIN__
    #ifdef __GNUC__
       #define MY_LIB_EXPORT __attribute__ ((dllexport))
@@ -78,7 +88,7 @@ Add a visibility header to the include folder for the library. The boiler plate 
     // Linux visibility settings
    #define MY_LIB_PUBLIC_TYPE
    #endif
-   #endif  // MY_LIB__VISIBILITY_CONTROL_HPP_
+   #endif  // MY_LIB__VISIBILITY_CONTROL_H_
 
 For a complete example of this header, see `rviz_rendering <https://github.com/ros2/rviz/blob/ros2/rviz_rendering/include/rviz_rendering/visibility_control.hpp>`__
 
@@ -90,10 +100,20 @@ To use the macro, add ``MY_LIB_PUBLIC`` before symbols which need to be visible 
 
    MY_LIB_PUBLIC void example_function (){}
 
+In order to build your library with correctly exported symbols, you will need to add the following to your CMakeLists.txt file:
+
+.. code-block:: cmake
+
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "MY_LIB_BUILDING_LIBRARY")
+
+
 WINDOWS_EXPORT_ALL_SYMBOLS Target Property
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CMake implements a macro which will export all symbols on Windows. The ``WINDOWS_EXPORT_ALL_SYMBOLS`` property causes function symbols to be automatically exported on windows. More detail of how it works can be found in the `WINDOWS_EXPORT_ALL_SYMBOLS CMake Documentation <https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html>`__.
+CMake implements a macro which will export all symbols on Windows. 
+The ``WINDOWS_EXPORT_ALL_SYMBOLS`` property causes function symbols to be automatically exported on windows. 
+More detail of how it works can be found in the `WINDOWS_EXPORT_ALL_SYMBOLS CMake Documentation <https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html>`__.
 The property can be implemented by adding the following to the CMakeLists file:
 
 .. code-block:: cmake
@@ -101,10 +121,10 @@ The property can be implemented by adding the following to the CMakeLists file:
    set_target_properties(${LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 If there is more than one library in a CMakeLists file you will need to call ``set_target_properties`` on each of them separately.
-
-Note: A binary on Windows can only export 65,536 symbols. If a binary exports more than that, you will get an error and should use the visibility_control headers.
-
-There is an exception to this method in the case of global data symbols. For example, a global static data member like the one below.
+Note: A binary on Windows can only export 65,536 symbols. 
+If a binary exports more than that, you will get an error and should use the visibility_control headers.
+There is an exception to this method in the case of global data symbols. 
+For example, a global static data member like the one below.
 
 .. code-block:: c++
 
@@ -114,7 +134,12 @@ There is an exception to this method in the case of global data symbols. For exa
    static const int Global_data_num;
 
 
-In these cases dllimprort/dllexport must be applied explicitly. This can be done using generate_export_header as described in the following article: `Create dlls on Windows without declspec() using new CMake export all feature <https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/>`__.
+In these cases dllimprort/dllexport must be applied explicitly. 
+This can be done using generate_export_header as described in the following article: `Create dlls on Windows without declspec() using new CMake export all feature <https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/>`__.
+
+Finally, it is important that the header file that exports the symbols be included into at least one of the ``.cpp`` files in the package so that the macros will get expanded and placed into the resulting binary. 
+Otherwise the symbols will still not be callable.
+
 
 
 Debug builds

--- a/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
+++ b/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
@@ -51,7 +51,7 @@ Visibility Control Headers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 The purpose of Visibility Control Headers headers is to define a macro for each library which correctly declares symbols as dllimport or dllexport. This is decided based on whether the library is being consumed or being built itself. The logic in the macro also takes the compiler into account and includes logic to select the appropriate syntax.
 The following link includes step by step instructions for adding explicit symbol visibility to a library “yielding the highest quality code with the greatest reductions in binary size, load times and link times”: [The GCC visibility documentation](https://gcc.gnu.org/wiki/Visibility).
-A header named ``visibility_control.hpp`` can be placed in the ``includes`` folder for each library as shown in the example below.
+A header named ``visibility_control.h`` can be placed in the ``include`` folder for each library as shown in the example below.
 The example below shows how a visibility control header would be added for a ``my_lib`` library with a class called ``example_class``.
 Add a visibility header to the include folder for the library. The boiler plate logic is used with the library name used in the macro to make it unique in the project. In another library, ``MY_LIB`` would be replaced with the library name.
 

--- a/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
+++ b/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
@@ -27,23 +27,95 @@ This has two practical consequences for ROS 2:
 
 Exporting symbols
 -----------------
-All symbols are private by default when building a library on Windows.
-The consequence of this is that without special handling, another library or executable cannot call any symbols in the library.
-This special handling is called `dllexport <https://docs.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-declspec-dllexport?view=msvc-160>`__ and `dllimport <https://docs.microsoft.com/en-us/cpp/build/importing-into-an-application-using-declspec-dllimport?view=msvc-160>`__.
-The ``dllexport`` is used in the library that wants to make a symbol publically callable, and ``dllimport`` is used by the library or application that wants to call the symbol.
-In the ROS 2 core code, packages often have a header called ``visibility_macros.h`` that use macros to define the proper ``dllexport``/``dllimport`` statements.
-With these macros in place, any symbol in header files that needs to be public needs to be decorated with the ``PUBLIC`` version of the macro.
-The CMakeLists.txt of the package should also have a stanza like:
+The Microsoft Visual C++ Compiler (MSVC) exposes symbols from a Dynamic Link Library (DLL) only if they are explicitly exported. The clang and gcc compilers have an option to do the same, but it is off by default. As a result, when a library previously built on Linux is built on Windows, other libraries may be unable to resolve the external symbols.
+Below are examples of common error messages which can be caused by symbols not being exposed:
+
+.. code-block:: console
+
+   error C2448: '__attribute__': function-style initializer appears to be a function definition
+   'visibility': identifier not found
+
+.. code-block:: console
+
+   CMake Error at C:/ws_ros2/install/random_numbers/share/random_numbers/cmake/ament_cmake_export_libraries-extras.cmake:48 (message):
+      Package 'random_numbers' exports the library 'random_numbers' which
+      couldn't be found
+
+Symbol Visibility also impacts binary loading. If you are finding that a composible node does not run or a Qt Visualizer isn't working, it may be that the hosting process can not find an expected symbol export from the binary.
+To diagnose this on Windows, the Windows developer tools includes a program called Gflags to enable various options. One of those options is called *Loader Snaps* which enables you to detect load failures while debugging.
+Please visit the Microsoft Documentation for more information on [Gflags](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/setting-and-clearing-image-file-flags) and  [Loaders snaps](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps).
+Two solutions to export symbols on Windows are Visibility Control Headers and the ``WINDOWS_EXPORT_ALL_SYMBOLS`` property.
+Microsoft recommends ROS developers use Visibility Control Headers to control the export of symbols from a binary. Visibility Control Headers provide more control over the symbol export macro and offer other benefits including smaller binary size and reduced link times.
+
+Visibility Control Headers
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+The purpose of Visibility Control Headers headers is to define a macro for each library which correctly declares symbols as dllimport or dllexport. This is decided based on whether the library is being consumed or being built itself. The logic in the macro also takes the compiler into account and includes logic to select the appropriate syntax.
+The following link includes step by step instructions for adding explicit symbol visibility to a library “yielding the highest quality code with the greatest reductions in binary size, load times and link times”: [The GCC visibility documentation](https://gcc.gnu.org/wiki/Visibility).
+A header named ``visibility_control.hpp`` can be placed in the ``includes`` folder for each library as shown in the example below.
+The example below shows how a visibility control header would be added for a ``my_lib`` library with a class called ``example_class``.
+Add a visibility header to the include folder for the library. The boiler plate logic is used with the library name used in the macro to make it unique in the project. In another library, ``MY_LIB`` would be replaced with the library name.
+
+.. code-block:: c++
+
+   #ifndef MY_LIB__VISIBILITY_CONTROL_HPP_
+   #define MY_LIB__VISIBILITY_CONTROL_HPP_
+   #if defined _WIN32 || defined __CYGWIN__
+   #ifdef __GNUC__
+      #define MY_LIB_EXPORT __attribute__ ((dllexport))
+      #define MY_LIB_IMPORT __attribute__ ((dllimport))
+   #else
+      #define MY_LIB_EXPORT __declspec(dllexport)
+      #define MY_LIB_IMPORT __declspec(dllimport)
+   #endif
+   #ifdef MY_LIB_BUILDING_LIBRARY
+      #define MY_LIB_PUBLIC MY_LIB_EXPORT
+   #else
+      #define MY_LIB_PUBLIC MY_LIB_IMPORT
+   #endif
+   #define MY_LIB_PUBLIC_TYPE MY_LIB_PUBLIC
+   #define MY_LIB_LOCAL
+   #else
+    // Linux visibility settings
+   #define MY_LIB_PUBLIC_TYPE
+   #endif
+   #endif  // MY_LIB__VISIBILITY_CONTROL_HPP_
+
+For a complete example of this header, see `rviz_rendering <https://github.com/ros2/rviz/blob/ros2/rviz_rendering/include/rviz_rendering/visibility_control.hpp>`__
+
+To use the macro, add ``MY_LIB_PUBLIC`` before symbols which need to be visible to external libraries. For example:
+
+.. code-block:: c++
+
+   Class MY_LIB_PUBLIC example_class {}
+
+   MY_LIB_PUBLIC void example_function (){}
+
+WINDOWS_EXPORT_ALL_SYMBOLS Target Property
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+CMake implements a macro which will export all symbols on Windows. The ``WINDOWS_EXPORT_ALL_SYMBOLS`` property causes function symbols to be automatically exported on windows. More detail of how it works can be found in the `WINDOWS_EXPORT_ALL_SYMBOLS CMake Documentation <https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html>`__.
+The property can be implemented by adding the following to the CMakeLists file:
 
 .. code-block:: cmake
 
-  target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "XXX_BUILDING_LIBRARY")
+   set_target_properties(${LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-where "XXX" is replaced with the name of the macro in ``visibility_macros.h``.
+If there is more than one library in a CMakeLists file you will need to call ``set_target_properties`` on each of them separately.
 
-Finally, it is important that the header file that exports the symbols be included into at least one of the ``.cpp`` files in the package so that the macros will get expanded and placed into the resulting binary.
-Otherwise the symbols will still not be callable.
+Note: A binary on Windows can only export 65,536 symbols. If a binary exports more than that, you will get an error and should use the visibility_control headers.
+
+There is an exception to this method in the case of global data symbols. For example, a global static data member like the one below.
+
+.. code-block:: c++
+
+   class Example_class
+   {
+   public:
+   static const int Global_data_num;
+
+
+In these cases dllimprort/dllexport must be applied explicitly. This can be done using generate_export_header as described in the following article: `Create dlls on Windows without declspec() using new CMake export all feature <https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/>`__.
+
 
 Debug builds
 ------------

--- a/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
+++ b/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
@@ -23,7 +23,7 @@ This has two practical consequences for ROS 2:
 * Some of the ROS 2 internal path names are fairly long. Because of this, we always recommend using a short path name for the root of your ROS 2 directory, like ``C:\dev``.
 * When building ROS 2 from source, the default isolated build mode of colcon can generate very long path names. To avoid these very long path names, use ``--merge-install`` when building on Windows.
 
-**Note**: It is possible to change Windows to have much longer maximum path lengths.  
+**Note**: It is possible to change Windows to have much longer maximum path lengths.
 See `this article <https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later>`__ for more information.
 
 Exporting symbols
@@ -111,8 +111,8 @@ In order to build your library with correctly exported symbols, you will need to
 WINDOWS_EXPORT_ALL_SYMBOLS Target Property
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CMake implements a macro which will export all symbols on Windows. 
-The ``WINDOWS_EXPORT_ALL_SYMBOLS`` property causes function symbols to be automatically exported on windows. 
+CMake implements a macro which will export all symbols on Windows.
+The ``WINDOWS_EXPORT_ALL_SYMBOLS`` property causes function symbols to be automatically exported on windows.
 More detail of how it works can be found in the `WINDOWS_EXPORT_ALL_SYMBOLS CMake Documentation <https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html>`__.
 The property can be implemented by adding the following to the CMakeLists file:
 
@@ -121,9 +121,9 @@ The property can be implemented by adding the following to the CMakeLists file:
    set_target_properties(${LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 If there is more than one library in a CMakeLists file you will need to call ``set_target_properties`` on each of them separately.
-Note: A binary on Windows can only export 65,536 symbols. 
+Note: A binary on Windows can only export 65,536 symbols.
 If a binary exports more than that, you will get an error and should use the visibility_control headers.
-There is an exception to this method in the case of global data symbols. 
+There is an exception to this method in the case of global data symbols.
 For example, a global static data member like the one below.
 
 .. code-block:: c++
@@ -134,10 +134,10 @@ For example, a global static data member like the one below.
    static const int Global_data_num;
 
 
-In these cases dllimprort/dllexport must be applied explicitly. 
+In these cases dllimprort/dllexport must be applied explicitly.
 This can be done using generate_export_header as described in the following article: `Create dlls on Windows without declspec() using new CMake export all feature <https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/>`__.
 
-Finally, it is important that the header file that exports the symbols be included into at least one of the ``.cpp`` files in the package so that the macros will get expanded and placed into the resulting binary. 
+Finally, it is important that the header file that exports the symbols be included into at least one of the ``.cpp`` files in the package so that the macros will get expanded and placed into the resulting binary.
 Otherwise the symbols will still not be callable.
 
 

--- a/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
+++ b/source/The-ROS2-Project/Contributing/Windows-Tips-and-Tricks.rst
@@ -6,7 +6,7 @@ Windows Tips and Tricks
 =======================
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 ROS 2 supports Windows 10 as a Tier 1 platform, which means that all code that goes into the ROS 2 core must support Windows.
@@ -26,7 +26,9 @@ This has two practical consequences for ROS 2:
 **Note**: It is possible to change Windows to have much longer maximum path lengths.
 See `this article <https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later>`__ for more information.
 
-Exporting symbols
+.. _Windows_Symbol_Visibility:
+
+Symbol Visibility
 -----------------
 The Microsoft Visual C++ Compiler (MSVC) exposes symbols from a Dynamic Link Library (DLL) only if they are explicitly exported.
 The clang and gcc compilers have an option to do the same, but it is off by default.
@@ -48,7 +50,8 @@ Symbol Visibility also impacts binary loading.
 If you are finding that a composible node does not run or a Qt Visualizer isn't working, it may be that the hosting process can not find an expected symbol export from the binary.
 To diagnose this on Windows, the Windows developer tools includes a program called Gflags to enable various options.
 One of those options is called *Loader Snaps* which enables you to detect load failures while debugging.
-Please visit the Microsoft Documentation for more information on [Gflags](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/setting-and-clearing-image-file-flags) and [Loaders snaps](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps).
+Please visit the Microsoft Documentation for more information on `Gflags <https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/setting-and-clearing-image-file-flags>`__ and `Loaders snaps <https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/show-loader-snaps>`__.
+
 Two solutions to export symbols on Windows are Visibility Control Headers and the ``WINDOWS_EXPORT_ALL_SYMBOLS`` property.
 Microsoft recommends ROS developers use Visibility Control Headers to control the export of symbols from a binary.
 Visibility Control Headers provide more control over the symbol export macro and offer other benefits including smaller binary size and reduced link times.
@@ -58,7 +61,7 @@ Visibility Control Headers
 The purpose of Visibility Control Headers headers is to define a macro for each shared library which correctly declares symbols as dllimport or dllexport.
 This is decided based on whether the library is being consumed or being built itself.
 The logic in the macro also takes the compiler into account and includes logic to select the appropriate syntax.
-The following link includes step by step instructions for adding explicit symbol visibility to a library “yielding the highest quality code with the greatest reductions in binary size, load times and link times”: [The GCC visibility documentation](https://gcc.gnu.org/wiki/Visibility).
+The `GCC visibility documentation <https://gcc.gnu.org/wiki/Visibility>`__ includes step by step instructions for adding explicit symbol visibility to a library “yielding the highest quality code with the greatest reductions in binary size, load times and link times”.
 A header named ``visibility_control.h`` can be placed in the ``includes`` folder for each library as shown in the example below.
 The example below shows how a visibility control header would be added for a ``my_lib`` library with a class called ``example_class``.
 Add a visibility header to the include folder for the library.
@@ -90,7 +93,7 @@ In another library, ``MY_LIB`` would be replaced with the library name.
    #endif
    #endif  // MY_LIB__VISIBILITY_CONTROL_H_
 
-For a complete example of this header, see `rviz_rendering <https://github.com/ros2/rviz/blob/ros2/rviz_rendering/include/rviz_rendering/visibility_control.hpp>`__
+For a complete example of this header, see `rviz_rendering <https://github.com/ros2/rviz/blob/ros2/rviz_rendering/include/rviz_rendering/visibility_control.hpp>`__.
 
 To use the macro, add ``MY_LIB_PUBLIC`` before symbols which need to be visible to external libraries. For example:
 
@@ -110,9 +113,7 @@ In order to build your library with correctly exported symbols, you will need to
 
 WINDOWS_EXPORT_ALL_SYMBOLS Target Property
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-CMake implements a macro which will export all symbols on Windows.
-The ``WINDOWS_EXPORT_ALL_SYMBOLS`` property causes function symbols to be automatically exported on windows.
+CMake implements the ``WINDOWS_EXPORT_ALL_SYMBOLS`` property on Windows, which causes function symbols to be automatically exported.
 More detail of how it works can be found in the `WINDOWS_EXPORT_ALL_SYMBOLS CMake Documentation <https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html>`__.
 The property can be implemented by adding the following to the CMakeLists file:
 
@@ -121,7 +122,8 @@ The property can be implemented by adding the following to the CMakeLists file:
    set_target_properties(${LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 If there is more than one library in a CMakeLists file you will need to call ``set_target_properties`` on each of them separately.
-Note: A binary on Windows can only export 65,536 symbols.
+
+Note that a binary on Windows can only export 65,536 symbols.
 If a binary exports more than that, you will get an error and should use the visibility_control headers.
 There is an exception to this method in the case of global data symbols.
 For example, a global static data member like the one below.
@@ -139,7 +141,6 @@ This can be done using generate_export_header as described in the following arti
 
 Finally, it is important that the header file that exports the symbols be included into at least one of the ``.cpp`` files in the package so that the macros will get expanded and placed into the resulting binary.
 Otherwise the symbols will still not be callable.
-
 
 
 Debug builds

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -71,7 +71,7 @@ Go into the action workspace you created in the :doc:`previous tutorial <../Crea
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to make the package compile and work on Windows, we need to add in some "visibility control".
-For details on why this is needed, see `here <https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport>`_.
+For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document</The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
 
 Open up ``action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h``, and put the following code in:
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -71,7 +71,7 @@ Go into the action workspace you created in the :doc:`previous tutorial <../Crea
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to make the package compile and work on Windows, we need to add in some "visibility control".
-For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document</The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
+For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document <../The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
 
 Open up ``action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h``, and put the following code in:
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -71,7 +71,7 @@ Go into the action workspace you created in the :doc:`previous tutorial <../Crea
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to make the package compile and work on Windows, we need to add in some "visibility control".
-For more details, see :doc:`Windows Symbol Visibility in the Windows Tips and Tricks document <../The-ROS2-Project/Contributing/Windows-Tips-and-Tricks>`.
+For more details, see :ref:`Windows Symbol Visibility in the Windows Tips and Tricks document <Windows_Symbol_Visibility>`.
 
 Open up ``action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h``, and put the following code in:
 


### PR DESCRIPTION
This change adds a dedicated page for symbol visibility on Windows.
The expanded text attempts to clear up confusing around Symbol Visibility on Windows,
In order to improve the porting experience for users.

Signed-off-by: Lou Amadio <lamadio@microsoft.com>