### PR TITLE
:books: Adding some documentation suggestions following issue #1487

### DIFF
--- a/source/Concepts/About-Composition.rst
+++ b/source/Concepts/About-Composition.rst
@@ -65,15 +65,16 @@ Using Components
 ----------------
 
 The `composition <https://github.com/ros2/demos/tree/master/composition>`__ package contains a couple of different approaches on how to use components.
-The three most common ones are:
+The three most common ones happen during:
 
+#. *Compile Time*.- Create a `custom executable <https://github.com/ros2/demos/blob/master/composition/src/manual_composition.cpp>`__ containing multiple nodes which are known at compile time.
+   This approach requires that each component has a header file (which is not strictly needed for the first case).
 
-#. Start a (`generic container process <https://github.com/ros2/rclcpp/blob/master/rclcpp_components/src/component_container.cpp>`__) and call the ROS service `load_node <https://github.com/ros2/rcl_interfaces/blob/master/composition_interfaces/srv/LoadNode.srv>`__ offered by the container.
+#. *Launch Time*.- Create a launch file and use ``ros2 launch`` to create a container process with multiple components loaded.
+
+#. *Run Time*.- Start a (`generic container process <https://github.com/ros2/rclcpp/blob/master/rclcpp_components/src/component_container.cpp>`__) and call the ROS service `load_node <https://github.com/ros2/rcl_interfaces/blob/master/composition_interfaces/srv/LoadNode.srv>`__ offered by the container.
    The ROS service will then load the component specified by the passed package name and library name and start executing it within the running process.
    Instead of calling the ROS service programmatically you can also use a `command line tool <https://github.com/ros2/ros2cli/tree/master/ros2component>`__ to invoke the ROS service with the passed command line arguments
-#. Create a `custom executable <https://github.com/ros2/demos/blob/master/composition/src/manual_composition.cpp>`__ containing multiple nodes which are known at compile time.
-   This approach requires that each component has a header file (which is not strictly needed for the first case).
-#. Create a launch file and use ``ros2 launch`` to create a container process with multiple components loaded.
 
 Practical application
 ---------------------

--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -34,6 +34,8 @@ All ROS 2 packages begin by running the command
 
 in your workspace (usually ``~/ros2_ws/src``).
 
+Note that it is recommended to name your workspace after your project. For example, "nav2_ws" or "carma_ws" instead of simply "ros2_ws."
+
 To create a package for a specific client library:
 
 .. tabs::

--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -43,7 +43,7 @@ If the first command did not return a response similar to:
 
    Received from xx.xxx.xxx.xx:43751: 'Hello World!'
 
-then you will need to update your firewall configuration to allow multicast using `ufw <https://help.ubuntu.com/community/UFW>`__.
+then you will need to update your firewall configuration to allow multicast using `ufw <https://help.ubuntu.com/community/UFW>`__. Note that this step is not applicable to Windows systems.
 
 .. code-block:: bash
 

--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -22,12 +22,10 @@ Background
 
 ROS 2 relies on the notion of combining workspaces using the shell environment.
 "Workspace" is a ROS term for the location on your system where you're developing with ROS 2.
-The core ROS 2 workspace is called the underlay.
-Subsequent local workspaces are called overlays.
-When developing with ROS 2, you will typically have several workspaces active concurrently.
 
 Combining workspaces makes developing against different versions of ROS 2, or against different sets of packages, easier.
-It also allows the installation of several ROS 2 distributions (or “distros”, e.g. Dashing and Eloquent) on the same computer and switching between them.
+
+When developing with ROS 2, you will typically have several workspaces active concurrently. This also allows for the installation of several ROS 2 distributions (or “distros”, e.g. Dashing and Eloquent) on the same computer and switching between them.
 
 This is accomplished by sourcing setup files every time you open a new shell, or by adding the source command to your shell startup script once.
 Without sourcing the setup files, you won’t be able to access ROS 2 commands, or find or use ROS 2 packages.


### PR DESCRIPTION
Changes made based on the following [comment](https://github.com/ros2/ros2_documentation/issues/1487#issue-885201422) in issue #1487.

Tutorials/Configuring-ROS2-Environment.html
-------------------------------------------------------------
Removed the lines calling the core ROS 2 workspace underlay and the other local workspaces overlays to avoid the possible confusion as explained in [comment](https://github.com/ros2/ros2_documentation/issues/1487#issue-885201422).

Guides/Installation-Troubleshooting.html
-----------------------------------------------------
Added a note about the firewall configuration not being applicable to Windows.

Guides/Developing-a-ROS-2-Package.html
---------------------------------------------------------
Added a note recommending to name workspaces based on project specifics instead of simply ros2_ws.

Concepts/About-Composition.html
----------------------------------------------
Following this [comment](https://github.com/ros2/ros2_documentation/issues/1487#issue-885201422), I further divided the most common components based on when they are being used (during compile time, launch time or run time).
