### PR TITLE
Make sure to install graphviz for local builds [wrid22]

### DIFF
--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -39,6 +39,17 @@ Firstly, install requirements located in the ``requirements.txt`` file.
 
    pip3 install --user --upgrade -r requirements.txt
 
+In order for Sphinx to be able to generate diagrams, the ``dot`` command must be available.
+
+On Debian/Ubuntu, the ``graphviz`` package provides this:
+
+.. code-block:: console
+
+   sudo apt install graphviz
+
+On Windows download an installer from `the Graphviz Download page <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install it.
+Make sure to allow the installer to add it to the Windows ``%PATH%``, otherwise Sphinx will not be able to find it.
+
 Building the site for one branch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
As per subject.

This should fix #2824.

https://github.com/ros2/ros2_documentation/pull/2253 installs this in the Docker image, but local builds don't necessarily use that image.

As I'm not familiar with macOS, I've only included hints for Linux and Windows.

The Windows link was copied/adapted from `source/Installation/_Windows-Install-Prerequisites.rst`.
