### PR TITLE
Use remote-literal-include to support references to remote code [wrid22]

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -82,6 +82,7 @@ extensions = [
     'sphinx_tabs.tabs',
     'sphinx_rtd_theme',
     'sphinx_sitemap',
+    'sphinxext.remoteliteralinclude',
 ]
 
 # Intersphinx mapping

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinx-multiversion
 sphinx-rtd-theme
 sphinx-sitemap
 sphinx-tabs
+sphinxext-remoteliteralinclude

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -92,47 +92,10 @@ Now there will be a new file named ``publisher_member_function.py`` adjacent to 
 
 Open the file using your preferred text editor.
 
-.. code-block:: python
-
-  import rclpy
-  from rclpy.node import Node
-
-  from std_msgs.msg import String
-
-
-  class MinimalPublisher(Node):
-
-      def __init__(self):
-          super().__init__('minimal_publisher')
-          self.publisher_ = self.create_publisher(String, 'topic', 10)
-          timer_period = 0.5  # seconds
-          self.timer = self.create_timer(timer_period, self.timer_callback)
-          self.i = 0
-
-      def timer_callback(self):
-          msg = String()
-          msg.data = 'Hello World: %d' % self.i
-          self.publisher_.publish(msg)
-          self.get_logger().info('Publishing: "%s"' % msg.data)
-          self.i += 1
-
-
-  def main(args=None):
-      rclpy.init(args=args)
-
-      minimal_publisher = MinimalPublisher()
-
-      rclpy.spin(minimal_publisher)
-
-      # Destroy the node explicitly
-      # (optional - otherwise it will be done automatically
-      # when the garbage collector destroys the node object)
-      minimal_publisher.destroy_node()
-      rclpy.shutdown()
-
-
-  if __name__ == '__main__':
-      main()
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :caption: `rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py <https://github.com/ros2/examples/blob/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py>`_
+    :language: python
+    :lines: 15-
 
 
 2.1 Examine the code
@@ -140,25 +103,24 @@ Open the file using your preferred text editor.
 
 The first lines of code after the comments import ``rclpy`` so its ``Node`` class can be used.
 
-.. code-block:: python
-
-  import rclpy
-  from rclpy.node import Node
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :language: python
+    :lines: 15-16
 
 The next statement imports the built-in string message type that the node uses to structure the data that it passes on the topic.
 
-.. code-block:: python
-
-  from std_msgs.msg import String
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :language: python
+    :lines: 18
 
 These lines represent the node’s dependencies.
 Recall that dependencies have to be added to ``package.xml``, which you’ll do in the next section.
 
 Next, the ``MinimalPublisher`` class is created, which inherits from (or is a subclass of) ``Node``.
 
-.. code-block:: python
-
-  class MinimalPublisher(Node):
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :language: python
+    :lines: 21
 
 Following is the definition of the class’s constructor.
 ``super().__init__`` calls the ``Node`` class’s constructor and gives it your node name, in this case ``minimal_publisher``.
@@ -169,42 +131,21 @@ Queue size is a required QoS (quality of service) setting that limits the amount
 Next, a timer is created with a callback to execute every 0.5 seconds.
 ``self.i`` is a counter used in the callback.
 
-.. code-block:: python
-
-  def __init__(self):
-      super().__init__('minimal_publisher')
-      self.publisher_ = self.create_publisher(String, 'topic', 10)
-      timer_period = 0.5  # seconds
-      self.timer = self.create_timer(timer_period, self.timer_callback)
-      self.i = 0
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :language: python
+    :lines: 23-28
 
 ``timer_callback`` creates a message with the counter value appended, and publishes it to the console with ``get_logger().info``.
 
-.. code-block:: python
-
-  def timer_callback(self):
-      msg = String()
-      msg.data = 'Hello World: %d' % self.i
-      self.publisher_.publish(msg)
-      self.get_logger().info('Publishing: "%s"' % msg.data)
-      self.i += 1
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :language: python
+    :lines: 30-35
 
 Lastly, the main function is defined.
 
-.. code-block:: python
-
-  def main(args=None):
-      rclpy.init(args=args)
-
-      minimal_publisher = MinimalPublisher()
-
-      rclpy.spin(minimal_publisher)
-
-      # Destroy the node explicitly
-      # (optional - otherwise it will be done automatically
-      # when the garbage collector destroys the node object)
-      minimal_publisher.destroy_node()
-      rclpy.shutdown()
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_publisher/examples_rclpy_minimal_publisher/publisher_member_function.py
+    :language: python
+    :lines: 38-49
 
 First the ``rclpy`` library is initialized, then the node is created, and then it “spins” the node so its callbacks are called.
 
@@ -320,57 +261,18 @@ Now the directory should have these files:
 
 Open the ``subscriber_member_function.py`` with your text editor.
 
-.. code-block:: python
-
-  import rclpy
-  from rclpy.node import Node
-
-  from std_msgs.msg import String
-
-
-  class MinimalSubscriber(Node):
-
-      def __init__(self):
-          super().__init__('minimal_subscriber')
-          self.subscription = self.create_subscription(
-              String,
-              'topic',
-              self.listener_callback,
-              10)
-          self.subscription  # prevent unused variable warning
-
-      def listener_callback(self, msg):
-          self.get_logger().info('I heard: "%s"' % msg.data)
-
-
-  def main(args=None):
-      rclpy.init(args=args)
-
-      minimal_subscriber = MinimalSubscriber()
-
-      rclpy.spin(minimal_subscriber)
-
-      # Destroy the node explicitly
-      # (optional - otherwise it will be done automatically
-      # when the garbage collector destroys the node object)
-      minimal_subscriber.destroy_node()
-      rclpy.shutdown()
-
-
-  if __name__ == '__main__':
-      main()
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+    :caption: `rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py <https://github.com/ros2/examples/blob/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py>`_
+    :language: python
+    :lines: 15-
 
 The subscriber node’s code is nearly identical to the publisher’s.
 The constructor creates a subscriber with the same arguments as the publisher.
 Recall from the :doc:`topics tutorial <../Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics>` that the topic name and message type used by the publisher and subscriber must match to allow them to communicate.
 
-.. code-block:: python
-
-  self.subscription = self.create_subscription(
-      String,
-      'topic',
-      self.listener_callback,
-      10)
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+    :language: python
+    :lines: 25-29
 
 The subscriber’s constructor and callback don’t include any timer definition, because it doesn't need one.
 Its callback gets called as soon as it receives a message.
@@ -378,18 +280,15 @@ Its callback gets called as soon as it receives a message.
 The callback definition simply prints an info message to the console, along with the data it received.
 Recall that the publisher defines ``msg.data = 'Hello World: %d' % self.i``
 
-.. code-block:: python
-
-  def listener_callback(self, msg):
-      self.get_logger().info('I heard: "%s"' % msg.data)
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+    :language: python
+    :lines: 32-33
 
 The ``main`` definition is almost exactly the same, replacing the creation and spinning of the publisher with the subscriber.
 
-.. code-block:: python
-
-  minimal_subscriber = MinimalSubscriber()
-
-  rclpy.spin(minimal_subscriber)
+.. rli:: https://github.com/ros2/examples/raw/daa1fcc604e0af5ffecbbb4b3f5e0e4e5c67f653/rclpy/topics/minimal_subscriber/examples_rclpy_minimal_subscriber/subscriber_member_function.py
+    :language: python
+    :lines: 39-41
 
 Since this node has the same dependencies as the publisher, there’s nothing new to add to ``package.xml``.
 The ``setup.cfg`` file can also remain untouched.

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -75,52 +75,11 @@ For more details, see :ref:`Windows Symbol Visibility in the Windows Tips and Tr
 
 Open up ``action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h``, and put the following code in:
 
-.. code-block:: c++
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h
+    :caption: `action_tutorials/action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h <https://github.com/ros2/demos/blob/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h>`_
+    :language: c++
+    :lines: 15-
 
-  #ifndef ACTION_TUTORIALS_CPP__VISIBILITY_CONTROL_H_
-  #define ACTION_TUTORIALS_CPP__VISIBILITY_CONTROL_H_
-
-  #ifdef __cplusplus
-  extern "C"
-  {
-  #endif
-
-  // This logic was borrowed (then namespaced) from the examples on the gcc wiki:
-  //     https://gcc.gnu.org/wiki/Visibility
-
-  #if defined _WIN32 || defined __CYGWIN__
-    #ifdef __GNUC__
-      #define ACTION_TUTORIALS_CPP_EXPORT __attribute__ ((dllexport))
-      #define ACTION_TUTORIALS_CPP_IMPORT __attribute__ ((dllimport))
-    #else
-      #define ACTION_TUTORIALS_CPP_EXPORT __declspec(dllexport)
-      #define ACTION_TUTORIALS_CPP_IMPORT __declspec(dllimport)
-    #endif
-    #ifdef ACTION_TUTORIALS_CPP_BUILDING_DLL
-      #define ACTION_TUTORIALS_CPP_PUBLIC ACTION_TUTORIALS_CPP_EXPORT
-    #else
-      #define ACTION_TUTORIALS_CPP_PUBLIC ACTION_TUTORIALS_CPP_IMPORT
-    #endif
-    #define ACTION_TUTORIALS_CPP_PUBLIC_TYPE ACTION_TUTORIALS_CPP_PUBLIC
-    #define ACTION_TUTORIALS_CPP_LOCAL
-  #else
-    #define ACTION_TUTORIALS_CPP_EXPORT __attribute__ ((visibility("default")))
-    #define ACTION_TUTORIALS_CPP_IMPORT
-    #if __GNUC__ >= 4
-      #define ACTION_TUTORIALS_CPP_PUBLIC __attribute__ ((visibility("default")))
-      #define ACTION_TUTORIALS_CPP_LOCAL  __attribute__ ((visibility("hidden")))
-    #else
-      #define ACTION_TUTORIALS_CPP_PUBLIC
-      #define ACTION_TUTORIALS_CPP_LOCAL
-    #endif
-    #define ACTION_TUTORIALS_CPP_PUBLIC_TYPE
-  #endif
-
-  #ifdef __cplusplus
-  }
-  #endif
-
-  #endif  // ACTION_TUTORIALS_CPP__VISIBILITY_CONTROL_H_
 
 2 Writing an action server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,28 +91,30 @@ Let's focus on writing an action server that computes the Fibonacci sequence usi
 
 Open up ``action_tutorials_cpp/src/fibonacci_action_server.cpp``, and put the following code in:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
+    :caption: `action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp <https://github.com/ros2/demos/blob/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp>`_
     :language: c++
+    :lines: 15-
 
 The first few lines include all of the headers we need to compile.
 
 Next we create a class that is a derived class of ``rclcpp::Node``:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 14
+    :lines: 27
 
 The constructor for the ``FibonacciActionServer`` class initializes the node name as ``fibonacci_action_server``:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 21-22
+    :lines: 34-35
 
 The constructor also instantiates a new action server:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 26-31
+    :lines: 39-47
 
 An action server requires 6 things:
 
@@ -169,33 +130,33 @@ Note that all of the callbacks need to return quickly, otherwise we risk starvin
 
 We start with the callback for handling new goals:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 37-44
+    :lines: 54-59,66-67
 
 This implementation just accepts all goals.
 
 Next up is the callback for dealing with cancellation:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 46-52
+    :lines: 70-76
 
 This implementation just tells the client that it accepted the cancellation.
 
 The last of the callbacks accepts a new goal and starts processing it:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 54-59
+    :lines: 79-84
 
 Since the execution is a long-running operation, we spawn off a thread to do the actual work and return from ``handle_accepted`` quickly.
 
 All further processing and updates are done in the ``execute`` method in the new thread:
 
-.. literalinclude:: scripts/server.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
     :language: c++
-    :lines: 61-95
+    :lines: 87-121
 
 This work thread processes one sequence number of the Fibonacci sequence every second, publishing a feedback update for each step.
 When it has finished processing, it marks the ``goal_handle`` as succeeded, and quits.
@@ -258,28 +219,30 @@ Source the workspace we just built (``ros2_ws``), and try to run the action serv
 
 Open up ``action_tutorials_cpp/src/fibonacci_action_client.cpp``, and put the following code in:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
+    :caption: `action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp <https://github.com/ros2/demos/blob/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp>`_
     :language: c++
+    :lines: 15-
 
 The first few lines include all of the headers we need to compile.
 
 Next we create a class that is a derived class of ``rclcpp::Node``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 15
+    :lines: 29
 
 The constructor for the ``FibonacciActionClient`` class initializes the node name as ``fibonacci_action_client``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 20-22
+    :lines: 36-37
 
 The constructor also instantiates a new action client:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 24-26
+    :lines: 39-44
 
 An action client requires 3 things:
 
@@ -289,15 +252,15 @@ An action client requires 3 things:
 
 We also instantiate a ROS timer that will kick off the one and only call to ``send_goal``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 27-30
+    :lines: 46-48
 
 When the timer expires, it will call ``send_goal``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 32-57
+    :lines: 52-77
 
 This function does the following:
 
@@ -310,23 +273,23 @@ This function does the following:
 When the server receives and accepts the goal, it will send a response to the client.
 That response is handled by ``goal_response_callback``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 62-71
+    :lines: 84-92
 
 Assuming the goal was accepted by the server, it will start processing.
 Any feedback to the client will be handled by the ``feedback_callback``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 72-83
+    :lines: 95-105
 
 When the server is finished processing, it will return a result to the client.
 The result is handled by the ``result_callback``:
 
-.. literalinclude:: scripts/client.cpp
+.. rli:: https://github.com/ros2/demos/raw/9c4ced3c5be392145312e0c0d3653140a2e29cc0/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
     :language: c++
-    :lines: 84-107
+    :lines: 108-130
 
 We now have a fully functioning action client.  Let's get it built and running.
 


### PR DESCRIPTION
As per subject.

Should fix #2444.

This uses the [sphinxext-remoteliteralinclude](https://pypi.org/project/sphinxext-remoteliteralinclude) (Github repository: [wpilibsuite/sphinxext-remoteliteralinclude](https://github.com/wpilibsuite/sphinxext-remoteliteralinclude)) Sphinx extension to directly include code / resources hosted remotely, instead of having to copy whole sections of code verbatim into the `.rst`. This extension is essentially identical to `literalinclude` and supports [all the configuration options of that extension](https://devopstutodoc.readthedocs.io/en/stable/documentation/doc_generators/sphinx/rest_sphinx/code/literalinclude/literalinclude.html).

Screenshot showing how this renders (current version for comparison: [here](http://docs.ros.org/en/rolling/Tutorials/Demos/Intra-Process-Communication.html#the-two-node-pipeline-demo)):

![image](https://user-images.githubusercontent.com/4550046/177534203-a28940da-cce8-4e81-9f70-44be2236b1e2.png)

This is the first code section in [Setting up efficient intra-process communication](https://github.com/ros2/ros2_documentation/blob/68c12c48a24698026d9eaf6f354174bbf325e232/source/Tutorials/Demos/Intra-Process-Communication.rst). I edited that page as it's mentioned in https://github.com/ros2/ros2_documentation/issues/2444#issuecomment-1115146117.

See d08758fb7b84f1b4c9e29c9dfba8489e00eee272 and 39c44db8bdac7752fbfbc35cc6515e79f81a5547 for two example 'styles': the former uses an actual permalink (as suggested in #2444), the latter uses the currently used link, which includes `REPOS_FILE_BRANCH`.

Both have their pros and cons.

Before updating all pages which reference code, decisions should be made whether:

 1. depending on `remoteliteralinclude` for this is acceptable
 1. to use permalinks or not
 1. which specific settings for each `rli::` directive we'd like to standardise on

Once we reach consensus about this, other pages should be updated to migrate to `remoteliteralinclude` where applicable, `literalinclude` should be removed as well as any local copies of sources that accompany pages using that directive.
