### PR TITLE
Add mirror sites for rosdep

### DIFF
--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -68,6 +68,11 @@ Be sure to use the same Python interpreter as the one used to build the binary.
 
 For example, such a mismatch can crop up after an update of the OS. Then, rebuilding the workspace may fix the issue.
 
+Unable to rosdep init/update
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you experience ``socket.timeout: The read operation timed out`` or other network errors caused by accessing ``raw.githubusercontent.com`` when ``rosdep init``, you may use a mirror site like `TUNA <https://mirrors.tuna.tsinghua.edu.cn/help/rosdistro/>`_ and `BFSU <https://mirrors.bfsu.edu.cn/help/rosdistro/>`_.
+
 .. _linux-troubleshooting:
 
 Linux


### PR DESCRIPTION
The discussion on mirror sites is at https://github.com/ros-infrastructure/rosdep/pull/839#issuecomment-1164655530.

Similar guide has already been added at http://wiki.ros.org/rosdep