### PR TITLE
Add a linkcheck target to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 SOURCE     = source
 OUT        = build
+LINKCHECKDIR  = $(OUT)/linkcheck
 BUILD      = python3 -m sphinx
 OPTS       =-c .
 
@@ -14,9 +15,15 @@ multiversion: Makefile
 	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=humble/index.html\" /></head></html>" > build/html/index.html
 	python3 make_sitemapindex.py
 
-.PHONY: help Makefile multiversion
 %: Makefile
 	@$(BUILD) -M $@ "$(SOURCE)" "$(OUT)" $(OPTS)
 
 test:
 	doc8 --ignore D001 --ignore-path build
+
+linkcheck:
+	$(BUILD) -b linkcheck $(OPTS) $(SOURCE) $(LINKCHECKDIR)
+	@echo
+	@echo "Check finished. Report is in $(LINKCHECKDIR)."
+
+.PHONY: help Makefile multiversion test linkcheck

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -84,6 +84,17 @@ This has two drawbacks:
 To show local changes in the multiversion output, you must first commit the changes to a local branch.
 Then you must edit the `conf.py <https://github.com/ros2/ros2_documentation/blob/rolling/conf.py>`_ file and change the ``smv_branch_whitelist`` variable to point to your branch.
 
+Checking for broken links
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To check for broken links on the site, run:
+
+.. code-block:: console
+
+   make linkcheck
+
+This will check the entire site for broken links, and output the results to the screen and ``build/linkcheck``.
+
 Writing pages
 -------------
 


### PR DESCRIPTION
This makes it easy to run and check all of the links on the
built site.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>