### PR TITLE
Update Gazebo project name in related projects page.

### DIFF
--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -2,10 +2,10 @@
 Related Projects
 ================
 
-Ignition Gazebo
----------------
+Gazebo
+------
 
-**Gazebo** and its successor **Ignition Gazebo** `(gazebosim.org) <http://gazebosim.org/>`_ are the first open-source choice for 3D physics simulation of ROS-based robots.
+**Gazebo** `(gazebosim.org) <http://gazebosim.org/>`_ and its predecessor Gazebo Classic are the first open-source choice for 3D physics simulation of ROS-based robots.
 
 Large Community Projects
 ------------------------

--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -5,7 +5,7 @@ Related Projects
 Gazebo
 ------
 
-**Gazebo** `(gazebosim.org) <http://gazebosim.org/>`_ and its predecessor Gazebo Classic are the first open-source choice for 3D physics simulation of ROS-based robots.
+**Gazebo** `(gazebosim.org) <http://gazebosim.org/>`_ and its predecessor Gazebo Classic are the first open source choice for 3D physics simulation of ROS-based robots.
 
 Large Community Projects
 ------------------------


### PR DESCRIPTION
I was passing by this document and noted that the new name for the Gazebo project hasn't been updated here yet.

This may be jumping ahead of the renaming project's timeline, in which case this PR can be closed or sit pending further consideration.

There are a few other references to Ignition in the documentation still which I have not touched here.