### PR TITLE
Add note to ensure the wrong OpenSSL version isn't downloaded

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -33,7 +33,7 @@ Install OpenSSL
 
 Download the *Win64 OpenSSL v1.1.1n* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
 Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1n*.
-Don't download the Win32 or Light versions, or the v3.0.X installers.
+Don't download the Win32 or Light versions, or the v3.X.Y installers.
 
 Run the installer with default parameters, as the following commands assume you used the default installation directory.
 

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -33,7 +33,7 @@ Install OpenSSL
 
 Download the *Win64 OpenSSL v1.1.1n* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
 Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1n*.
-Don't download the Win32 or Light versions.
+Don't download the Win32 or Light versions, or the v3.0.X installers.
 
 Run the installer with default parameters, as the following commands assume you used the default installation directory.
 


### PR DESCRIPTION
I encountered some issues running the demo when I downloaded the wrong version of OpenSSL. As this seems like a common mistake as explained [this article](https://qiita.com/comocc/items/f9dd3130acdff798d4f9), it'd be good to add a note.