### PR TITLE
Rosidl python incompatability

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
@@ -14,6 +14,13 @@ See the :doc:`ament_cmake user documentation <Ament-CMake-Documentation>` for mo
    To create an ``ament_python`` package, see :doc:`Creating your first ROS 2 package <../Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>`.
    ``ament_cmake_python`` should only be used in cases where that is not possible, like when mixing C/C++ and Python code.
 
+
+.. warning::
+
+   Calling ``rosidl_generate_interfaces`` and ``ament_python_install_package`` in the same CMake project does not work.
+   See this `Github issue <https://github.com/ros2/rosidl_python/issues/141>`_ for more info. It is best practice to instead
+   separate out the message generation into a separate package.
+
 .. contents:: Table of Contents
    :depth: 2
    :local:

--- a/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
@@ -15,12 +15,6 @@ See the :doc:`ament_cmake user documentation <Ament-CMake-Documentation>` for mo
    ``ament_cmake_python`` should only be used in cases where that is not possible, like when mixing C/C++ and Python code.
 
 
-.. warning::
-
-   Calling ``rosidl_generate_interfaces`` and ``ament_python_install_package`` in the same CMake project does not work.
-   See this `Github issue <https://github.com/ros2/rosidl_python/issues/141>`_ for more info. It is best practice to instead
-   separate out the message generation into a separate package.
-
 .. contents:: Table of Contents
    :depth: 2
    :local:
@@ -65,6 +59,12 @@ The ``CMakeLists.txt`` should contain:
 
 The argument to ``ament_python_install_package()`` is the name of the directory alongside the ``CMakeLists.txt`` that contains the Python file.
 In this case, it is ``my_project``, or ``${PROJECT_NAME}``.
+
+.. warning::
+
+   Calling ``rosidl_generate_interfaces`` and ``ament_python_install_package`` in the same CMake project does not work.
+   See this `Github issue <https://github.com/ros2/rosidl_python/issues/141>`_ for more info. It is best practice to instead
+   separate out the message generation into a separate package.
 
 Then, another Python package that correctly depends on ``my_project`` can use it as a normal Python module:
 


### PR DESCRIPTION
This adds a warning to prevent users from running into https://github.com/ros2/rosidl_python/issues/141. 

This is my first contribution to the docs. I followed the guides, had some issues in the developer guide, and cleaned those up in a separate commit. 

If possible, please backport this into `humble` as that is where this issue showed up. It does not happen in `galactic`, at least right now, however it may be a good idea to warn users anyways such that when they move to `humble`, they aren't surprised. 

Here's the new rendered changes:
![image](https://user-images.githubusercontent.com/50461358/179565267-c789b8f5-4147-44f6-8a9f-c9804231077c.png)
![image](https://user-images.githubusercontent.com/50461358/179565371-9e328525-12fb-488f-9c60-fa8fa614aba3.png)
![image](https://user-images.githubusercontent.com/50461358/179565392-6e4bb113-d95d-4adc-b20a-6df700b3ef20.png)
![image](https://user-images.githubusercontent.com/50461358/179565569-dc95747c-5111-4e5e-bc6e-2ddc8f301585.png)

 