### PR TITLE
Fix cpp literal block

### DIFF
--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -599,7 +599,7 @@ Example:
     ...
     do_something_with_response(future.get());
     ...
-    do_something_else_with_response(future.get());  # this will throw an exception now!!
+    do_something_else_with_response(future.get());  // this will throw an exception now!!
 
 should be updated to:
 


### PR DESCRIPTION
``WARNING: Could not lex literal_block as "cpp". Highlighting skipped.`` currently arises.

Warning introduced in #2885 