### PR TITLE
added rclc to list of community-supported client libraries

### DIFF
--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -32,16 +32,20 @@ Supported client libraries
 
 The C++ client library (``rclcpp``) and the Python client library (``rclpy``) are both client libraries which utilize common functionality in the RCL.
 
-While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community have created additional client libraries:
+While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community maintain additional client libraries:
 
-* `C programming language <https://github.com/ros2/rclc>`__  developed for microcontrollers in `micro.ros.org <https://micro.ros.org/>`__
+* `Ada <https://github.com/ada-ros/ada4ros2>`__ Ada binding and tools for ROS2 - workspace overlay
+* `C programming language <https://github.com/ros2/rclc>`__  ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in C. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials.
+* `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__ This is a collection of projects (bindings, code generator, examples and more) for writing ROS2 applications for .NET Core and .NET Standard.
+* `Node.js <https://www.npmjs.com/package/rclnodejs>`__ rclnodejs is a Node.js client for the Robot Operating System (ROS 2). It provides a simple and easy JavaScript API for ROS 2 programming.
+* `Rust <https://github.com/ros2-rust/ros2_rust>`__ This is a set of projects (the rclrs client library, code generator, examples and more) that enables developers to write ROS 2 applications in Rust.
+
+Older, unmaintained client libraries are:
+
+* `C# <https://github.com/firesurfer/rclcs>`__
 * `JVM and Android <https://github.com/esteve/ros2_java>`__
 * `Objective C and iOS <https://github.com/esteve/ros2_objc>`__
-* `C# <https://github.com/firesurfer/rclcs>`__
-* `Node.js <https://www.npmjs.com/package/rclnodejs>`__
-* `Ada <https://github.com/ada-ros/ada4ros2>`__
-* `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__
-* `Rust <https://github.com/ros2-rust/ros2_rust>`__
+
 
 Common functionality: the RCL
 -----------------------------

--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -42,6 +42,7 @@ While the C++ and Python client libraries are maintained by the core ROS 2 team,
 * `Ada <https://github.com/ada-ros/ada4ros2>`__
 * `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__
 * `Rust <https://github.com/ros2-rust/ros2_rust>`__
+* `rclc for C <https://github.com/ros2/rclc>`__ . ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in the C programming language. It has been developed particularly for micro-ROS and therefore limits dynamic memory operations to the initialization phase. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials on programming with rclc. `API Documentation <http://docs.ros.org/en/humble/p/rclc/>`__
 
 Common functionality: the RCL
 -----------------------------

--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -34,7 +34,7 @@ The C++ client library (``rclcpp``) and the Python client library (``rclpy``) ar
 
 While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community have created additional client libraries:
 
-* `rclc for C <https://github.com/ros2/rclc>`__ . ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in the C programming language. It has been developed particularly for micro-ROS and therefore limits dynamic memory operations to the initialization phase. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials on programming with rclc. `API Documentation <http://docs.ros.org/en/humble/p/rclc/>`__
+* `C programming language <https://github.com/ros2/rclc>`__  developed for microcontrollers in `micro.ros.org <https://micro.ros.org/>`__
 * `JVM and Android <https://github.com/esteve/ros2_java>`__
 * `Objective C and iOS <https://github.com/esteve/ros2_objc>`__
 * `C# <https://github.com/firesurfer/rclcs>`__

--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -35,7 +35,7 @@ The C++ client library (``rclcpp``) and the Python client library (``rclpy``) ar
 While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community maintain additional client libraries:
 
 * `Ada <https://github.com/ada-ros/ada4ros2>`__ Ada binding and tools for ROS2 - workspace overlay
-* `C programming language <https://github.com/ros2/rclc>`__  ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in C. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials.
+* `C <https://github.com/ros2/rclc>`__  ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in C. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials.
 * `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__ This is a collection of projects (bindings, code generator, examples and more) for writing ROS2 applications for .NET Core and .NET Standard.
 * `Node.js <https://www.npmjs.com/package/rclnodejs>`__ rclnodejs is a Node.js client for the Robot Operating System (ROS 2). It provides a simple and easy JavaScript API for ROS 2 programming.
 * `Rust <https://github.com/ros2-rust/ros2_rust>`__ This is a set of projects (the rclrs client library, code generator, examples and more) that enables developers to write ROS 2 applications in Rust.

--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -34,16 +34,16 @@ The C++ client library (``rclcpp``) and the Python client library (``rclpy``) ar
 
 While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community maintain additional client libraries:
 
-* `Ada <https://github.com/ada-ros/ada4ros2>`__ Ada binding and tools for ROS2 - workspace overlay
+* `Ada <https://github.com/ada-ros/ada4ros2>`__ Ada binding and tools for ROS 2 - workspace overlay.
 * `C <https://github.com/ros2/rclc>`__  ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in C. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials.
-* `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__ This is a collection of projects (bindings, code generator, examples and more) for writing ROS2 applications for .NET Core and .NET Standard.
+* `JVM and Android <https://github.com/ros2-java>`__ Java and Android bindings for ROS 2.
+* `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__ This is a collection of projects (bindings, code generator, examples and more) for writing ROS 2 applications for .NET Core and .NET Standard.
 * `Node.js <https://www.npmjs.com/package/rclnodejs>`__ rclnodejs is a Node.js client for the Robot Operating System (ROS 2). It provides a simple and easy JavaScript API for ROS 2 programming.
 * `Rust <https://github.com/ros2-rust/ros2_rust>`__ This is a set of projects (the rclrs client library, code generator, examples and more) that enables developers to write ROS 2 applications in Rust.
 
 Older, unmaintained client libraries are:
 
 * `C# <https://github.com/firesurfer/rclcs>`__
-* `JVM and Android <https://github.com/esteve/ros2_java>`__
 * `Objective C and iOS <https://github.com/esteve/ros2_objc>`__
 
 

--- a/source/Concepts/About-ROS-2-Client-Libraries.rst
+++ b/source/Concepts/About-ROS-2-Client-Libraries.rst
@@ -34,7 +34,7 @@ The C++ client library (``rclcpp``) and the Python client library (``rclpy``) ar
 
 While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community have created additional client libraries:
 
-
+* `rclc for C <https://github.com/ros2/rclc>`__ . ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in the C programming language. It has been developed particularly for micro-ROS and therefore limits dynamic memory operations to the initialization phase. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials on programming with rclc. `API Documentation <http://docs.ros.org/en/humble/p/rclc/>`__
 * `JVM and Android <https://github.com/esteve/ros2_java>`__
 * `Objective C and iOS <https://github.com/esteve/ros2_objc>`__
 * `C# <https://github.com/firesurfer/rclcs>`__
@@ -42,7 +42,6 @@ While the C++ and Python client libraries are maintained by the core ROS 2 team,
 * `Ada <https://github.com/ada-ros/ada4ros2>`__
 * `_.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__
 * `Rust <https://github.com/ros2-rust/ros2_rust>`__
-* `rclc for C <https://github.com/ros2/rclc>`__ . ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in the C programming language. It has been developed particularly for micro-ROS and therefore limits dynamic memory operations to the initialization phase. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials on programming with rclc. `API Documentation <http://docs.ros.org/en/humble/p/rclc/>`__
 
 Common functionality: the RCL
 -----------------------------


### PR DESCRIPTION
- added rclc to the list of community maintained client libraries
- related PR: https://github.com/ros2/ros2_documentation/pull/2886