### PR TITLE
Added explanation to fix error after building a package

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -462,8 +462,8 @@ After making the above edits and saving all the changes, build the package:
     .. code-block:: console
 
       colcon build --merge-install --packages-select py_pubsub
-
-If you have a problem building packet like this :
+      
+If you have the following problem creating the package: :
 
 .. code-block:: console
 

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -469,7 +469,11 @@ If you have the following problem creating the package: :
 
     /usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
 
-Use this command : ``pip install setuptools==58.2.0``
+Use this command  :
+
+.. code-block:: console
+
+    pip install setuptools==58.2.0``
 
 Then open two new terminals, source ``dev_ws`` in each, and run:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -463,7 +463,7 @@ After making the above edits and saving all the changes, build the package:
 
       colcon build --merge-install --packages-select py_pubsub
 
-If you have a problem building packet use this command : pip install setuptools==58.2.0
+If you have a problem building packet use this command : ``pip install setuptools==58.2.0``
 
 Then open two new terminals, source ``dev_ws`` in each, and run:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -466,6 +466,7 @@ After making the above edits and saving all the changes, build the package:
 If you have a problem building packet like this :
 
 .. code-block:: console
+
     /usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
 
 Use this command : ``pip install setuptools==58.2.0``

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -463,6 +463,8 @@ After making the above edits and saving all the changes, build the package:
 
       colcon build --merge-install --packages-select py_pubsub
 
+If you have a problem building packet use this command : pip install setuptools==58.2.0
+
 Then open two new terminals, source ``dev_ws`` in each, and run:
 
 .. tabs::

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -463,7 +463,12 @@ After making the above edits and saving all the changes, build the package:
 
       colcon build --merge-install --packages-select py_pubsub
 
-If you have a problem building packet use this command : ``pip install setuptools==58.2.0``
+If you have a problem building packet like this :
+
+.. code-block:: console
+/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
+
+Use this command : ``pip install setuptools==58.2.0``
 
 Then open two new terminals, source ``dev_ws`` in each, and run:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -466,7 +466,7 @@ After making the above edits and saving all the changes, build the package:
 If you have a problem building packet like this :
 
 .. code-block:: console
-/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
+    /usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
 
 Use this command : ``pip install setuptools==58.2.0``
 


### PR DESCRIPTION
When I use the following command: 
`
colcon build --packages-select py_pubsub
`
I had the following error appearing:

`
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standard-based tools.`

So I created this pull request to indicate in the documentation how to fix this problem.

