### PR TITLE
Remove action_msgs dependency

### DIFF
--- a/source/Tutorials/Intermediate/Creating-an-Action.rst
+++ b/source/Tutorials/Intermediate/Creating-an-Action.rst
@@ -146,11 +146,7 @@ We should also add the required dependencies to our ``package.xml``:
 
     <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-    <depend>action_msgs</depend>
-
     <member_of_group>rosidl_interface_packages</member_of_group>
-
-Note, we need to depend on ``action_msgs`` since action definitions include additional metadata (e.g. goal IDs).
 
 We should now be able to build the package containing the ``Fibonacci`` action definition:
 


### PR DESCRIPTION
It is now properly included in the rosidl dependency chain.

**This should not be backported to Humble or earlier.** It is only available in Rolling, pending https://github.com/ros2/rosidl_defaults/pull/22