### PR TITLE
Remove a broken link in Crystal.

### DIFF
--- a/source/Contributing/Inter-Sphinx-Support.rst
+++ b/source/Contributing/Inter-Sphinx-Support.rst
@@ -51,16 +51,6 @@ Class :class:`vcstools.VcsClient` implements the :meth:`vcstools.VcsClient.check
 
 ------------
 
-Links to documentation pages:
-
-.. note::
-
-    Refer to :doc:`vcstools Developer's Guide document<developers_guide>`.
-
-Refer to :doc:`vcstools Developer's Guide document<developers_guide>`.
-
-------------
-
 Links to other pages in this documentation:
 
 .. note::


### PR DESCRIPTION
This is just so sphinx does not warn about it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Yes, you see that correctly; this is a fix for the `crystal` branch.  We normally don't do this, but since this is a warning in e.g. https://build.ros.org/job/doc_ros2doc/602/console , I figure we should fix it up.

Note that we will also need to port this over to `eloquent` once it is approved.