### PR TITLE
Recommend upgrades before installs

### DIFF
--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -37,7 +37,7 @@ Firstly, install requirements located in the ``requirements.txt`` file.
 
 .. code-block:: console
 
-   pip3 install --user --upgrade -r requirements.txt
+   python -m pip install --user --upgrade -r requirements.txt
 
 In order for Sphinx to be able to generate diagrams, the ``dot`` command must be available.
 
@@ -45,6 +45,7 @@ On Debian/Ubuntu, the ``graphviz`` package provides this:
 
 .. code-block:: console
 
+   sudo apt update
    sudo apt install graphviz
 
 On Windows download an installer from `the Graphviz Download page <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install it.

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -33,23 +33,48 @@ The root directory contains configuration and files required to locally build th
 Building the site locally
 -------------------------
 
-Firstly, install requirements located in the ``requirements.txt`` file.
+Start by installing requirements located in the ``requirements.txt`` file:
 
-.. code-block:: console
+.. tabs::
 
-   python -m pip install --user --upgrade -r requirements.txt
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+       pip3 install --user --upgrade -r requirements.txt
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+       pip3 install --user --upgrade -r requirements.txt
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+      python -m pip install --user --upgrade -r requirements.txt
 
 In order for Sphinx to be able to generate diagrams, the ``dot`` command must be available.
 
-On Debian/Ubuntu, the ``graphviz`` package provides this:
+.. tabs::
 
-.. code-block:: console
+  .. group-tab:: Linux
 
-   sudo apt update
-   sudo apt install graphviz
+    .. code-block:: console
 
-On Windows download an installer from `the Graphviz Download page <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install it.
-Make sure to allow the installer to add it to the Windows ``%PATH%``, otherwise Sphinx will not be able to find it.
+       sudo apt update ; sudo apt install graphviz
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+      brew install graphviz
+
+  .. group-tab:: Windows
+
+      Download an installer from `the Graphviz Download page <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install it.
+      Make sure to allow the installer to add it to the Windows ``%PATH%``, otherwise Sphinx will not be able to find it.
 
 Building the site for one branch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
* Use pip's recommended syntax to install things by invoking through the user's python environment on 20.04
* Reference: https://linuxpip.org/python-is-python3/
* Reference: https://pip.pypa.io/en/stable/getting-started/
* Reference: https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-you-can-run-pip-from-the-command-line

Also, it's good practice to call `apt update` before `apt install`. I bundled these two things together in this PR. 

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>