### PR TITLE
Fix No module named 'doc8' by invoking it directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ multiversion: Makefile
 	@$(BUILD) -M $@ "$(SOURCE)" "$(OUT)" $(OPTS)
 
 test:
-	doc8 --ignore D001 --ignore-path build
+	python3 -m doc8 --ignore D001 --ignore-path build
 
 linkcheck:
 	$(BUILD) -b linkcheck $(OPTS) $(SOURCE) $(LINKCHECKDIR)


### PR DESCRIPTION
Fixed issue #2947