### PR TITLE
Add section about packages containing both C++ and Python

### DIFF
--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -150,7 +150,5 @@ and a ``setup.py`` file that looks like:
 Combined C++ and Python Packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When writing a package with both C++ and Python code, the
-``setup.py`` file and ``setup.cfg`` file are not used.
+When writing a package with both C++ and Python code, the ``setup.py`` file and ``setup.cfg`` file are not used.
 Instead, use :doc:`ament_cmake_python <./Ament-CMake-Python-Documentation>`.
-

--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -153,3 +153,4 @@ Combined C++ and Python Packages
 When writing a package with both C++ and Python code, the
 ``setup.py`` file and ``setup.cfg`` file are not used.
 Instead, use :doc:`ament_cmake_python <./Ament-CMake-Python-Documentation>`.
+

--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -145,3 +145,11 @@ and a ``setup.py`` file that looks like:
            ],
        },
    )
+
+
+Combined C++ and Python Packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When writing a package with both C++ and Python code, the
+``setup.py`` file and ``setup.cfg`` file are not used.
+Instead, use :doc:`ament_cmake_python <./Ament-CMake-Python-Documentation>`.


### PR DESCRIPTION
* link out to combined C++/Python in the "Developing a ROS2 Package" as it's a valid third option