### PR TITLE
Removed `tf_transformation` dependency from `geometry_tutorials`

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Introduction-To-Tf2.rst
+++ b/source/Tutorials/Intermediate/Tf2/Introduction-To-Tf2.rst
@@ -37,12 +37,6 @@ Let's start by installing the demo package and its dependencies.
          # Clone and build the geometry_tutorials repo using the branch that matches your installation
          git clone https://github.com/ros/geometry_tutorials.git -b ros2
 
-Additionally, install a ``transforms3d`` Python package, which provides the quaternion and euler angle transformation functionality for the ``tf_transformations`` package.
-
-.. code-block:: console
-
-   pip3 install transforms3d
-
 Running the demo
 ----------------
 

--- a/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
+++ b/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
@@ -111,6 +111,7 @@ It's easy for us to think of rotations about axes, but hard to think in terms of
 A suggestion is to calculate target rotations in terms of roll (about an X-axis), pitch (about the Y-axis), and yaw (about the Z-axis), and then convert to a quaternion.
 
 .. code-block:: python
+
    # quaternion_from_euler method is available in turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py
    q = quaternion_from_euler(1.5707, 0, -1.5707)
    print(f'The quaternion representation is x: {q[0]} y: {q[1]} z: {q[2]} w: {q[3]}.')

--- a/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
+++ b/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
@@ -111,7 +111,7 @@ It's easy for us to think of rotations about axes, but hard to think in terms of
 A suggestion is to calculate target rotations in terms of roll (about an X-axis), pitch (about the Y-axis), and yaw (about the Z-axis), and then convert to a quaternion.
 
 .. code-block:: python
-
+   # quaternion_from_euler method is available in turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py
    q = quaternion_from_euler(1.5707, 0, -1.5707)
    print(f'The quaternion representation is x: {q[0]} y: {q[1]} z: {q[2]} w: {q[3]}.')
 

--- a/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
+++ b/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
@@ -32,9 +32,6 @@ In this tutorial, you will learn how quaternions and conversion methods work in 
 Prerequisites
 -------------
 
-For this tutorial you may need to install the ``tf_transformations`` ROS 2 package to follow the Python code parts.
-You can find the source code of the ``tf_transformations`` package `here <https://github.com/DLu/tf_transformations>`_.
-
 However, this is not a hard requirement and you can stick to any other geometric transfromation library that suit you best.
 You can take a look at libraries like `transforms3d <https://github.com/matthew-brett/transforms3d>`_, `scipy.spatial.transform <https://github.com/scipy/scipy/tree/master/scipy/spatial/transform>`_, `pytransform3d <https://github.com/rock-learning/pytransform3d>`_, `numpy-quaternion <https://github.com/moble/quaternion>`_ or `blender.mathutils <https://docs.blender.org/api/master/mathutils.html>`_.
 
@@ -115,10 +112,7 @@ A suggestion is to calculate target rotations in terms of roll (about an X-axis)
 
 .. code-block:: python
 
-   import tf_transformations
-   ...
-
-   q = tf_transformations.quaternion_from_euler(1.5707, 0, -1.5707)
+   q = quaternion_from_euler(1.5707, 0, -1.5707)
    print(f'The quaternion representation is x: {q[0]} y: {q[1]} z: {q[2]} w: {q[3]}.')
 
 
@@ -147,13 +141,10 @@ Python
 
 .. code-block:: python
 
-   import tf_transformations
-   ...
-
-   q_orig = tf_transformations.quaternion_from_euler(0, 0, 0)
+   q_orig = quaternion_from_euler(0, 0, 0)
    # Rotate the previous pose by 180* about X
-   q_rot = tf_transformations.quaternion_from_euler(3.14159, 0, 0)
-   q_new = tf_transformations.quaternion_multiply(q_rot, q_orig)
+   q_rot = quaternion_from_euler(3.14159, 0, 0)
+   q_new = quaternion_multiply(q_rot, q_orig)
 
 
 3 Inverting a quaternion
@@ -186,17 +177,53 @@ Here's an example to get the relative rotation from the previous robot pose to t
 
 .. code-block:: python
 
-   q1_inv[0] = prev_pose.pose.orientation.x
-   q1_inv[1] = prev_pose.pose.orientation.y
-   q1_inv[2] = prev_pose.pose.orientation.z
-   q1_inv[3] = -prev_pose.pose.orientation.w # Negate for inverse
+  def quaternion_multiply(q0, q1):
+      """
+      Multiplies two quaternions.
 
-   q2[0] = current_pose.pose.orientation.x
-   q2[1] = current_pose.pose.orientation.y
-   q2[2] = current_pose.pose.orientation.z
-   q2[3] = current_pose.pose.orientation.w
+      Input
+      :param q0: A 4 element array containing the first quaternion (q01, q11, q21, q31)
+      :param q1: A 4 element array containing the second quaternion (q02, q12, q22, q32)
 
-   qr = tf_transformations.quaternion_multiply(q2, q1_inv)
+      Output
+      :return: A 4 element array containing the final quaternion (q03,q13,q23,q33)
+
+      """
+      # Extract the values from q0
+      w0 = q0[0]
+      x0 = q0[1]
+      y0 = q0[2]
+      z0 = q0[3]
+
+      # Extract the values from q1
+      w1 = q1[0]
+      x1 = q1[1]
+      y1 = q1[2]
+      z1 = q1[3]
+
+      # Computer the product of the two quaternions, term by term
+      q0q1_w = w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1
+      q0q1_x = w0 * x1 + x0 * w1 + y0 * z1 - z0 * y1
+      q0q1_y = w0 * y1 - x0 * z1 + y0 * w1 + z0 * x1
+      q0q1_z = w0 * z1 + x0 * y1 - y0 * x1 + z0 * w1
+
+      # Create a 4 element array containing the final quaternion
+      final_quaternion = np.array([q0q1_w, q0q1_x, q0q1_y, q0q1_z])
+
+      # Return a 4 element array containing the final quaternion (q02,q12,q22,q32)
+      return final_quaternion
+
+  q1_inv[0] = prev_pose.pose.orientation.x
+  q1_inv[1] = prev_pose.pose.orientation.y
+  q1_inv[2] = prev_pose.pose.orientation.z
+  q1_inv[3] = -prev_pose.pose.orientation.w # Negate for inverse
+
+  q2[0] = current_pose.pose.orientation.x
+  q2[1] = current_pose.pose.orientation.y
+  q2[2] = current_pose.pose.orientation.z
+  q2[3] = current_pose.pose.orientation.w
+
+  qr = quaternion_multiply(q2, q1_inv)
 
 Summary
 -------

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -349,11 +349,11 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
    .. group-tab:: macOS
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
    .. group-tab:: Windows
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
 From the root of your workspace, build your updated package, and source the setup files.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -79,8 +79,6 @@ Open the file using your preferred text editor.
 
     from tf2_ros import TransformBroadcaster
 
-    import tf_transformations
-
     from turtlesim.msg import Pose
 
 
@@ -124,7 +122,7 @@ Open the file using your preferred text editor.
             # For the same reason, turtle can only rotate around one axis
             # and this why we set rotation in x and y to 0 and obtain
             # rotation in z axis from the message
-            q = tf_transformations.quaternion_from_euler(0, 0, msg.theta)
+            q = quaternion_from_euler(0, 0, msg.theta)
             t.transform.rotation.x = q[0]
             t.transform.rotation.y = q[1]
             t.transform.rotation.z = q[2]
@@ -199,7 +197,7 @@ Here we copy the information from the 3D turtle pose into the 3D transform.
     # For the same reason, turtle can only rotate around one axis
     # and this why we set rotation in x and y to 0 and obtain
     # rotation in z axis from the message
-    q = tf_transformations.quaternion_from_euler(0, 0, msg.theta)
+    q = quaternion_from_euler(0, 0, msg.theta)
     t.transform.rotation.x = q[0]
     t.transform.rotation.y = q[1]
     t.transform.rotation.z = q[2]
@@ -342,11 +340,11 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
    .. group-tab:: macOS
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
    .. group-tab:: Windows
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
 Build your updated package, and source the setup files.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -340,11 +340,11 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
    .. group-tab:: macOS
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
    .. group-tab:: Windows
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
 From the root of your workspace, build your updated package, and source the setup files.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
@@ -285,11 +285,11 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
    .. group-tab:: macOS
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
    .. group-tab:: Windows
 
-        rosdep only runs on Linux, so you will need to install ``geometry_msgs``, ``tf_transformations`` and ``turtlesim`` dependencies yourself
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
 Build your updated package, and source the setup files.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -101,8 +101,6 @@ Open the file using your preferred text editor.
 
    from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 
-   import tf_transformations
-
 
    class StaticFramePublisher(Node):
       """
@@ -129,7 +127,7 @@ Open the file using your preferred text editor.
          static_transformStamped.transform.translation.x = float(sys.argv[2])
          static_transformStamped.transform.translation.y = float(sys.argv[3])
          static_transformStamped.transform.translation.z = float(sys.argv[4])
-         quat = tf_transformations.quaternion_from_euler(
+         quat = quaternion_from_euler(
                float(sys.argv[5]), float(sys.argv[6]), float(sys.argv[7]))
          static_transformStamped.transform.rotation.x = quat[0]
          static_transformStamped.transform.rotation.y = quat[1]
@@ -183,13 +181,10 @@ Afterward, ``rclpy`` is imported so its ``Node`` class can be used.
 
 The ``tf2_ros`` package provides a ``StaticTransformBroadcaster`` to make the publishing of static transforms easy.
 To use the ``StaticTransformBroadcaster``, we need to import it from the ``tf2_ros`` module.
-``tf_transformations`` provides functions for converting Euler angles to quaternions and vice versa.
 
 .. code-block:: python
 
    from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
-
-   import tf_transformations
 
 The ``StaticFramePublisher`` class constructor initializes the node with the name ``static_turtle_tf2_broadcaster``.
 Then, ``StaticTransformBroadcaster`` is created, which will send one static transformation upon the startup.
@@ -222,7 +217,7 @@ Here we populate the 6D pose (translation and rotation) of the turtle.
    static_transformStamped.transform.translation.x = float(sys.argv[2])
    static_transformStamped.transform.translation.y = float(sys.argv[3])
    static_transformStamped.transform.translation.z = float(sys.argv[4])
-   quat = tf_transformations.quaternion_from_euler(
+   quat = quaternion_from_euler(
       float(sys.argv[5]), float(sys.argv[6]), float(sys.argv[7]))
    static_transformStamped.transform.rotation.x = quat[0]
    static_transformStamped.transform.rotation.y = quat[1]
@@ -256,11 +251,10 @@ After the lines above, add the following dependencies corresponding to your node
 
    <exec_depend>geometry_msgs</exec_depend>
    <exec_depend>rclpy</exec_depend>
-   <exec_depend>tf_transformations</exec_depend>
    <exec_depend>tf2_ros</exec_depend>
    <exec_depend>turtlesim</exec_depend>
 
-This declares the required ``geometry_msgs``, ``tf_transformations``, ``rclpy``, ``tf2_ros``, and ``turtlesim`` dependencies when its code is executed.
+This declares the required ``geometry_msgs``, ``rclpy``, ``tf2_ros``, and ``turtlesim`` dependencies when its code is executed.
 
 Make sure to save the file.
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

the `tf_transformation` dependency was removed from `geometry_tutorials` in this PR https://github.com/ros/geometry_tutorials/pull/69. Removing the dependency in the tutorials too.