### PR TITLE
Service Introspection Documentation and Tutorial

### DIFF
--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -52,6 +52,22 @@ This behavior matches that of ROS 1's ``rostopic`` (http://wiki.ros.org/ROS/YAML
 
 Related PR: `ros2/ros2cli#749 <https://github.com/ros2/ros2cli/pull/749>`_
 
+Service Introspection
+^^^^^^^^^^^^^^^^^^^^^
+
+Services can now be echoed using ``ros2 service echo`` and recorded via ``ros2 bag record --services``.
+
+* `REP2012: Service Introspection`_.
+
+   .. _`REP2012: Service Introspection`: https://github.com/ros-infrastructure/rep/pull/360
+
+
+rosidl fixes
+^^^^^^^^^^^^
+
+Packages defining actions no longer need to ``<depend>`` on the action_msgs package.
+
+
 Changes since the Humble release
 ----------------------------------
 
@@ -84,6 +100,31 @@ Later we would like to have support for a full configuration file (see: https://
   Therefore, **this environment variable should be considered experimental and subject to removal without deprecation in the future**, when we add config file support for the ``rcl_logging_spdlog`` logging backend.
 
 See this pull request for more details about the change: https://github.com/ros2/rcl_logging/pull/95
+
+rmw
+^^^
+- RMW_GID_STORAGE_SIZE: Changed from 24 to 16 (`rmw#328`_)
+
+.. _`rmw#328`: https://github.com/ros2/rmw/pull/328
+
+rcl
+^^^
+
+- Services and clients take a clock handle in their respective options struct if service introspection is to be enabled (`rcl#997`_)
+
+.. _`rcl#997`: https://github.com/ros2/rcl/pull/997
+
+rosidl
+^^^^^^
+
+- ``rosidl_defaults`` has been split into ``rosidl_core`` and ``rosidl_defaults`` to correct dependency loops (`rosidl_defaults#22`_)
+- Services now generate a new ``_Event`` message
+
+    - ``rosidl_service_typesupport_t`` now includes methods for creating and destroying said event message (`rosidl#700`_)
+
+.. _`rosidl#700`: https://github.com/ros2/rosidl/pull/700
+.. _`rosidl_defaults#22`: https://github.com/ros2/rosidl_defaults/pull/22
+
 
 Known Issues
 ------------

--- a/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
@@ -200,6 +200,31 @@ You can move the turtle around and press ``Ctrl+C`` when you’re finished.
 
     There is another option you can add to the command, ``-a``, which records all the topics on your system.
 
+3.2 Recording Services
+~~~~~~~~~~~~~~~~~~~~~~
+
+    Note: this feature is avaliable only from in ``rolling ridley`` and ``iron irwini`` onwards.
+
+You can record services as well. 
+
+
+Run the following command:
+
+.. code-block:: console
+
+   ros2 bag record --services <service_name>
+
+
+``ros2 bag record --services`` is a layer of syntactic sugar for ``ros2 bag record`` and will record the service event messages published to ``<service_name>/_service_event``.
+Note that this will only work if service introspection is currently enabled for the services you are recording.
+
+Though one can play back and introspect the service event messages there is currently no support for replaying services i.e. mocking client requests via ``ros2 bag play``.
+
+For more information see REP2012_. 
+
+   .. _REP2012: https://github.com/ros-infrastructure/rep/pull/360
+
+
 4 ros2 bag info
 ^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
@@ -205,7 +205,7 @@ You can move the turtle around and press ``Ctrl+C`` when you’re finished.
 
     Note: this feature is avaliable only from in ``rolling ridley`` and ``iron irwini`` onwards.
 
-You can record services as well. 
+You can record services as well.
 
 
 Run the following command:
@@ -220,7 +220,7 @@ Note that this will only work if service introspection is currently enabled for 
 
 Though one can play back and introspect the service event messages there is currently no support for replaying services i.e. mocking client requests via ``ros2 bag play``.
 
-For more information see REP2012_. 
+For more information see REP2012_.
 
    .. _REP2012: https://github.com/ros-infrastructure/rep/pull/360
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -256,6 +256,84 @@ Your turtlesim window will update with the newly spawned turtle right away:
 
 .. image:: images/spawn.png
 
+7 ros2 service echo
+^^^^^^^^^^^^^^^^^^^
+
+    Note: this feature is avaliable only from in ``rolling ridley`` and ``iron irwini`` onwards.
+
+To see the data communicated between a service client and a service server you can ``echo`` the service using
+
+.. code-block:: console
+   
+  ros2 service echo <service_name | service_type> <arguments>
+
+Since we know from the previous tutorials that turtlesim offers a ``/teleport_relative`` service for teleporting the turtle, let's use it to test out ``echo`` to introspect that service.
+
+
+With ``turtlesim`` running, run
+
+.. code-block:: console
+   
+  ros2 service echo /turtle1/teleport_relative
+
+Nothing will print at first, but that's just because the service hasn't been called yet.
+Next, in another terminal, make a service call with 
+
+.. code-block:: console
+
+   ros2 service call /turtle1/teleport_relative turtlesim/srv/TeleportRelative "{linear: 10.0, angular: 20.0}"
+
+You should now see the service events being printed to the console in the terminal where you ran ``ros2 service echo``.
+
+
+.. code-block:: console
+
+  info:
+    event_type: REQUEST_RECEIVED
+    stamp:
+      sec: 1661567531
+      nanosec: 182051385
+    client_id:
+      uuid: 6ad14b1e-a8b3-e7a4-a516-502f2f1c5de3
+    sequence_number: 1
+  request:
+    linear: 10.0
+    angular: 20.0
+
+  ---------------------------
+  info:
+    event_type: RESPONSE_SENT
+    stamp:
+      sec: 1661567531
+      nanosec: 182179116
+    client_id:
+      uuid: 6ad14b1e-a8b3-e7a4-a516-502f2f1c5de3
+    sequence_number: 1
+  response: {}
+
+  ---------------------------
+
+Breaking it down, ``ros2 service echo`` echoes information about the service call and response logged to a hidden ``<service_name>/_service_event`` topic.
+These service event messages contain a ``service_msgs/ServiceEventInfo`` message containing information about the event as well as the ``request`` and ``response``.
+Though there are a total of four different service event types; ``REQUEST_SENT``, ``REQUEST_RECEIVED``, ``RESPONSE_SENT``, and ``RESPONSE_RECEIVED``, we only see the ``REQUEST_RECEIVED`` and ``RESPONSE_SENT`` events being echoed here because only the turtlesim node had service introspection enabled.
+
+Since echoing service event messages to a hidden topic can incur a performance penalty, you can disable service introspection features during runtime by setting the following boolean parameters
+
+.. code-block:: yaml
+
+   /<node_name>:
+    publish_client_content
+    publish_client_events
+    publish_service_content
+    publish_service_events
+
+
+For more information see REP2012_. 
+
+   .. _REP2012: https://github.com/ros-infrastructure/rep/pull/360
+
+
+
 Summary
 -------
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -264,7 +264,7 @@ Your turtlesim window will update with the newly spawned turtle right away:
 To see the data communicated between a service client and a service server you can ``echo`` the service using
 
 .. code-block:: console
-   
+
   ros2 service echo <service_name | service_type> <arguments>
 
 Since we know from the previous tutorials that turtlesim offers a ``/teleport_relative`` service for teleporting the turtle, let's use it to test out ``echo`` to introspect that service.
@@ -273,11 +273,11 @@ Since we know from the previous tutorials that turtlesim offers a ``/teleport_re
 With ``turtlesim`` running, run
 
 .. code-block:: console
-   
+
   ros2 service echo /turtle1/teleport_relative
 
 Nothing will print at first, but that's just because the service hasn't been called yet.
-Next, in another terminal, make a service call with 
+Next, in another terminal, make a service call with:
 
 .. code-block:: console
 
@@ -328,7 +328,7 @@ Since echoing service event messages to a hidden topic can incur a performance p
     publish_service_events
 
 
-For more information see REP2012_. 
+For more information see REP2012_.
 
    .. _REP2012: https://github.com/ros-infrastructure/rep/pull/360
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -101,7 +101,8 @@ Inside the ``ros2_ws/src/cpp_srvcli/src`` directory, create a new file called ``
       {
         rclcpp::init(argc, argv);
 
-        std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_server");
+        std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_server",
+          rclcpp::NodeOptions().enable_service_introspection(true));
 
         rclcpp::Service<example_interfaces::srv::AddTwoInts>::SharedPtr service =
           node->create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", &add);
@@ -138,11 +139,12 @@ The ``main`` function accomplishes the following, line by line:
 
     rclcpp::init(argc, argv);
 
-* Creates a node named ``add_two_ints_server``:
+* Creates a node named ``add_two_ints_server`` with service introspection enabled:
 
   .. code-block:: C++
 
-    std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_server");
+    std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_two_ints_server",
+      rclcpp::NodeOptions().enable_service_introspection(true));
 
 * Creates a service named ``add_two_ints`` for that node and automatically advertises it over the networks with the ``&add`` method:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
@@ -102,7 +102,7 @@ Inside the ``ros2_ws/src/py_srvcli/py_srvcli`` directory, create a new file call
   class MinimalService(Node):
 
       def __init__(self):
-          super().__init__('minimal_service')
+          super().__init__('minimal_service', enable_service_introspection=True)
           self.srv = self.create_service(AddTwoInts, 'add_two_ints', self.add_two_ints_callback)
 
       def add_two_ints_callback(self, request, response):
@@ -138,7 +138,7 @@ The following ``import`` statement imports the ROS 2 Python client library, and 
   import rclpy
   from rclpy.node import Node
 
-The ``MinimalService`` class constructor initializes the node with the name ``minimal_service``.
+The ``MinimalService`` class constructor initializes the node with the name ``minimal_service`` with service introspection enabled.
 Then, it creates a service and defines the type, name, and callback.
 
 .. code-block:: python
@@ -187,7 +187,7 @@ Inside the ``ros2_ws/src/py_srvcli/py_srvcli`` directory, create a new file call
   class MinimalClientAsync(Node):
 
       def __init__(self):
-          super().__init__('minimal_client_async')
+          super().__init__('minimal_client_async', enable_service_introspection=True)
           self.cli = self.create_client(AddTwoInts, 'add_two_ints')
           while not self.cli.wait_for_service(timeout_sec=1.0):
               self.get_logger().info('service not available, waiting again...')


### PR DESCRIPTION
Adding docs for service introspection (https://github.com/ros2/ros2/issues/1285). Leaving as draft until the feature actually gets merged in.

Signed-off-by: Brian Chen <brian.chen@openrobotics.org>