### PR TITLE
Minor fixes to the Release-Process linking.

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -29,6 +29,7 @@ Rows in the table marked in green are the currently supported distributions.
    Releases/Release-Rolling-Ridley.rst
    Releases/Development.rst
    Releases/End-of-Life.rst
+   Releases/Release-Process.rst
 
 .. raw:: html
 

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -99,4 +99,4 @@ Development progress
 
 For progress on the development and release of Iron Irwini, see `the tracking GitHub issue <https://github.com/ros2/ros2/issues/1298>`__.
 
-For the broad process followed by Iron Irwini, see the :doc:`process description page <Releases/Release-Process.rst>`.
+For the broad process followed by Iron Irwini, see the :doc:`process description page <Release-Process>`.


### PR DESCRIPTION
This makes it build without warnings.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>