### PR TITLE
Add a reference to the new source entry requirement for ros2-gbp repository creation.

### DIFF
--- a/source/How-To-Guides/Releasing/Release-Team-Repository.rst
+++ b/source/How-To-Guides/Releasing/Release-Team-Repository.rst
@@ -61,6 +61,8 @@ Having a release repository separate from your source code repository is a requi
 Create a new release repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+If your repository is new to the ROS community, you should first open a pull request on `ros/rosdistro <https://github.com/ros/rosdistro>`_ adding a ``source`` entry for your repository.
+The review process for the rosdistro database will ensure your repository and packages conform to the `REP 144 package naming conventions <https://www.ros.org/reps/rep-0144.html>`_ and other requirements before release.
 Fill the `Add New Release Repositories issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_repository.md&title=Add+new+release+repositories>`_ issue template
 if you don't have a release repo for your project yet.
 

--- a/source/How-To-Guides/Releasing/Release-Team-Repository.rst
+++ b/source/How-To-Guides/Releasing/Release-Team-Repository.rst
@@ -63,7 +63,7 @@ Create a new release repository
 
 If your repository is new to the ROS community, you should first open a pull request on `ros/rosdistro <https://github.com/ros/rosdistro>`_ adding a ``source`` entry for your repository.
 The review process for the rosdistro database will ensure your repository and packages conform to the `REP 144 package naming conventions <https://www.ros.org/reps/rep-0144.html>`_ and other requirements before release.
-Fill the `Add New Release Repositories issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_repository.md&title=Add+new+release+repositories>`_ issue template
+Once your package name has been approved and merged, fill in the `Add New Release Repositories issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_repository.md&title=Add+new+release+repositories>`_ issue template
 if you don't have a release repo for your project yet.
 
 What if my existing release repo isn't on ros2-gbp?


### PR DESCRIPTION
As discussed, we're adding a requirement to the release repository creation process to add a source stanza, ensuring that the packages in the new repository undergo rosdistro review before a release repository is created.
This is particularly important for naming convention review since that review could affect the name of the source, and by extension, release repository created.

Connects to https://github.com/ros2-gbp/ros2-gbp-github-org/issues/106