### PR TITLE
Remove Iron as current and past distro

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -88,10 +88,6 @@ Rows in the table marked in green are the currently supported distributions.
      - Release date
      - Logo
      - EOL date
-   * - :doc:`Iron Irwini <Releases/Release-Iron-Irwini>`
-     - May 23rd, 2023
-     - TBD
-     - November 2024
    * - :doc:`Humble Hawksbill <Releases/Release-Humble-Hawksbill>`
      - May 23rd, 2022
      - |humble|


### PR DESCRIPTION
I noticed that Iron is listed both in the current and past section and in the future section. Perhaps we should remove it from the current and past section until it is released?