### PR TITLE
Edit Rolling section on releases page

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -168,14 +168,16 @@ The expectation is to release new ROS 2 distributions once per year.
 Rolling Distribution
 --------------------
 
-The Rolling distribution of ROS 2 serves as a staging area for future stable distributions of ROS 2 and as a collection of the most recent development releases.
-Unlike most stable ROS 2 distributions which have an initial release, a support window during which they are updated, and a definite end of support (see :ref:`list_of_distributions` above) the Rolling distribution is continuously updated and is subject to in-place updates which will at times include breaking changes.
+:doc:`ROS 2 Rolling Ridley <Releases/Release-Rolling-Ridley>` is the rolling development distribution of ROS 2.
+It was proposed in `REP 2002 <https://www.ros.org/reps/rep-2002.html>`_ and was first introduced in June 2020.
+
+The Rolling distribution of ROS 2 serves two purposes:
+
+1. it is a staging area for future stable distributions of ROS 2, and
+2. it is a collection of the most recent development releases.
+
+As the name implies, Rolling is continuously updated and **can have in-place updates that include breaking changes**.
+We recommend that most people use the most recent stable distribution instead (see :ref:`list_of_distributions`).
 
 Packages released into the Rolling distribution will be automatically released into future stable distributions of ROS 2.
 :doc:`Releasing a ROS 2 package <../How-To-Guides/Releasing/Releasing-a-Package>` into the Rolling distribution follows the same procedures as all other ROS 2 distributions.
-
-:doc:`ROS 2 Rolling Ridley <Releases/Release-Rolling-Ridley>` is the rolling development distribution of ROS 2 as proposed in `REP 2002 <https://www.ros.org/reps/rep-2002.html>`_.
-It was first introduced in June 2020.
-
-The Rolling distribution will receive frequent and possibly compatibility-breaking releases in core packages and we recommend most people use the most recent stable distribution instead.
-Since new stable distributions will be created from snapshots of the Rolling distribution, package maintainers who want to make their packages available in future ROS 2 distributions can do so by releasing their packages into the Rolling distribution.

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -169,7 +169,7 @@ Rolling Distribution
 --------------------
 
 :doc:`ROS 2 Rolling Ridley <Releases/Release-Rolling-Ridley>` is the rolling development distribution of ROS 2.
-It was proposed in `REP 2002 <https://www.ros.org/reps/rep-2002.html>`_ and was first introduced in June 2020.
+It is described in `REP 2002 <https://www.ros.org/reps/rep-2002.html>`_ and was first introduced in June 2020.
 
 The Rolling distribution of ROS 2 serves two purposes:
 


### PR DESCRIPTION
I thought the section on rolling was a little confusing and that seemed to repeat itself. I've simplifid the section's text, and I think kept all of the important information.