### PR TITLE
Small cleanups in the tf2 tutorials

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
@@ -84,12 +84,13 @@ Now open the file called ``fixed_frame_tf2_broadcaster.cpp``.
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/transform_stamped.hpp>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2_ros/transform_broadcaster.h>
-
+   #include <chrono>
+   #include <functional>
    #include <memory>
+
+   #include "geometry_msgs/msg/transform_stamped.hpp"
+   #include "rclcpp/rclcpp.hpp"
+   #include "tf2_ros/transform_broadcaster.h"
 
    using namespace std::chrono_literals;
 
@@ -286,12 +287,13 @@ Now open the file called ``dynamic_frame_tf2_broadcaster.cpp``:
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/transform_stamped.hpp>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2_ros/transform_broadcaster.h>
-
+   #include <chrono>
+   #include <functional>
    #include <memory>
+
+   #include "geometry_msgs/msg/transform_stamped.hpp"
+   #include "rclcpp/rclcpp.hpp"
+   #include "tf2_ros/transform_broadcaster.h"
 
    using namespace std::chrono_literals;
 

--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -331,23 +331,22 @@ Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/point_stamped.hpp>
-   #include <message_filters/subscriber.h>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2_ros/buffer.h>
-   #include <tf2_ros/create_timer_ros.h>
-   #include <tf2_ros/message_filter.h>
-   #include <tf2_ros/transform_listener.h>
-   #ifdef TF2_CPP_HEADERS
-     #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-   #else
-     #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-   #endif
-
    #include <chrono>
    #include <memory>
    #include <string>
+
+   #include "geometry_msgs/msg/point_stamped.hpp"
+   #include "message_filters/subscriber.h"
+   #include "rclcpp/rclcpp.hpp"
+   #include "tf2_ros/buffer.h"
+   #include "tf2_ros/create_timer_ros.h"
+   #include "tf2_ros/message_filter.h"
+   #include "tf2_ros/transform_listener.h"
+   #ifdef TF2_CPP_HEADERS
+     #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+   #else
+     #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+   #endif
 
    using namespace std::chrono_literals;
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -72,17 +72,16 @@ Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/transform_stamped.hpp>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2/LinearMath/Quaternion.h>
-   #include <tf2_ros/transform_broadcaster.h>
-   #include <turtlesim/msg/pose.hpp>
-
+   #include <functional>
    #include <memory>
+   #include <sstream>
    #include <string>
 
-   using std::placeholders::_1;
+   #include "geometry_msgs/msg/transform_stamped.hpp"
+   #include "rclcpp/rclcpp.hpp"
+   #include "tf2/LinearMath/Quaternion.h"
+   #include "tf2_ros/transform_broadcaster.h"
+   #include "turtlesim/msg/pose.hpp"
 
    class FramePublisher : public rclcpp::Node
    {
@@ -106,11 +105,11 @@ Open the file using your preferred text editor.
 
        subscription_ = this->create_subscription<turtlesim::msg::Pose>(
          topic_name, 10,
-         std::bind(&FramePublisher::handle_turtle_pose, this, _1));
+         std::bind(&FramePublisher::handle_turtle_pose, this, std::placeholders::_1));
      }
 
    private:
-     void handle_turtle_pose(const turtlesim::msg::Pose & msg)
+     void handle_turtle_pose(const std::shared_ptr<turtlesim::msg::Pose> msg)
      {
        rclcpp::Time now = this->get_clock()->now();
        geometry_msgs::msg::TransformStamped t;
@@ -123,15 +122,15 @@ Open the file using your preferred text editor.
 
        // Turtle only exists in 2D, thus we get x and y translation
        // coordinates from the message and set the z coordinate to 0
-       t.transform.translation.x = msg.x;
-       t.transform.translation.y = msg.y;
+       t.transform.translation.x = msg->x;
+       t.transform.translation.y = msg->y;
        t.transform.translation.z = 0.0;
 
        // For the same reason, turtle can only rotate around one axis
        // and this why we set rotation in x and y to 0 and obtain
        // rotation in z axis from the message
        tf2::Quaternion q;
-       q.setRPY(0, 0, msg.theta);
+       q.setRPY(0, 0, msg->theta);
        t.transform.rotation.x = q.x();
        t.transform.rotation.y = q.y();
        t.transform.rotation.z = q.z();
@@ -199,15 +198,15 @@ Here we copy the information from the 3D turtle pose into the 3D transform.
 
     // Turtle only exists in 2D, thus we get x and y translation
     // coordinates from the message and set the z coordinate to 0
-    t.transform.translation.x = msg.x;
-    t.transform.translation.y = msg.y;
+    t.transform.translation.x = msg->x;
+    t.transform.translation.y = msg->y;
     t.transform.translation.z = 0.0;
 
     // For the same reason, turtle can only rotate around one axis
     // and this why we set rotation in x and y to 0 and obtain
     // rotation in z axis from the message
     tf2::Quaternion q;
-    q.setRPY(0, 0, msg.theta);
+    q.setRPY(0, 0, msg->theta);
     t.transform.rotation.x = q.x();
     t.transform.rotation.y = q.y();
     t.transform.rotation.z = q.z();

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -72,7 +72,11 @@ Open the file using your preferred text editor.
 
 .. code-block:: python
 
+    import math
+
     from geometry_msgs.msg import TransformStamped
+
+    import numpy as np
 
     import rclpy
     from rclpy.node import Node
@@ -80,6 +84,30 @@ Open the file using your preferred text editor.
     from tf2_ros import TransformBroadcaster
 
     from turtlesim.msg import Pose
+
+
+    def quaternion_from_euler(ai, aj, ak):
+        ai /= 2.0
+        aj /= 2.0
+        ak /= 2.0
+        ci = math.cos(ai)
+        si = math.sin(ai)
+        cj = math.cos(aj)
+        sj = math.sin(aj)
+        ck = math.cos(ak)
+        sk = math.sin(ak)
+        cc = ci*ck
+        cs = ci*sk
+        sc = si*ck
+        ss = si*sk
+
+        q = np.empty((4, ))
+        q[0] = cj*sc - sj*cs
+        q[1] = cj*ss + sj*cc
+        q[2] = cj*cs - sj*sc
+        q[3] = cj*cc + sj*ss
+
+        return q
 
 
     class FramePublisher(Node):

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -71,20 +71,19 @@ Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/transform_stamped.hpp>
-   #include <geometry_msgs/msg/twist.hpp>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2/exceptions.h>
-   #include <tf2_ros/transform_listener.h>
-   #include <tf2_ros/buffer.h>
-   #include <turtlesim/srv/spawn.hpp>
-
    #include <chrono>
+   #include <functional>
    #include <memory>
    #include <string>
 
-   using std::placeholders::_1;
+   #include "geometry_msgs/msg/transform_stamped.hpp"
+   #include "geometry_msgs/msg/twist.hpp"
+   #include "rclcpp/rclcpp.hpp"
+   #include "tf2/exceptions.h"
+   #include "tf2_ros/transform_listener.h"
+   #include "tf2_ros/buffer.h"
+   #include "turtlesim/srv/spawn.hpp"
+
    using namespace std::chrono_literals;
 
    class FrameListener : public rclcpp::Node

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -92,15 +92,12 @@ Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/transform_stamped.hpp>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2/LinearMath/Quaternion.h>
-   #include <tf2_ros/static_transform_broadcaster.h>
-
    #include <memory>
 
-   using std::placeholders::_1;
+   #include "geometry_msgs/msg/transform_stamped.hpp"
+   #include "rclcpp/rclcpp.hpp"
+   #include "tf2/LinearMath/Quaternion.h"
+   #include "tf2_ros/static_transform_broadcaster.h"
 
    class StaticFramePublisher : public rclcpp::Node
    {
@@ -178,21 +175,21 @@ First we include ``geometry_msgs/msg/transform_stamped.hpp`` to access the ``Tra
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/transform_stamped.hpp>
+   #include "geometry_msgs/msg/transform_stamped.hpp"
 
 Afterward, ``rclcpp`` is included so its ``rclcpp::Node`` class can be used.
 
 .. code-block:: C++
 
-   #include <rclcpp/rclcpp.hpp>
+   #include "rclcpp/rclcpp.hpp"
 
 ``tf2::Quaternion`` is a class for a quaternion that provides convenient functions for converting Euler angles to quaternions and vice versa.
 We also include ``tf2_ros/static_transform_broadcaster.h`` to use the ``StaticTransformBroadcaster`` to make the publishing of static transforms easy.
 
 .. code-block:: C++
 
-   #include <tf2/LinearMath/Quaternion.h>
-   #include <tf2_ros/static_transform_broadcaster.h>
+   #include "tf2/LinearMath/Quaternion.h"
+   #include "tf2_ros/static_transform_broadcaster.h"
 
 The ``StaticFramePublisher`` class constructor initializes the node with the name ``static_turtle_tf2_broadcaster``.
 Then, ``StaticTransformBroadcaster`` is created, which will send one static transformation upon the startup.

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -92,14 +92,41 @@ Open the file using your preferred text editor.
 
 .. code-block:: python
 
+   import math
    import sys
 
    from geometry_msgs.msg import TransformStamped
+
+   import numpy as np
 
    import rclpy
    from rclpy.node import Node
 
    from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
+
+
+    def quaternion_from_euler(ai, aj, ak):
+        ai /= 2.0
+        aj /= 2.0
+        ak /= 2.0
+        ci = math.cos(ai)
+        si = math.sin(ai)
+        cj = math.cos(aj)
+        sj = math.sin(aj)
+        ck = math.cos(ak)
+        sk = math.sin(ak)
+        cc = ci*ck
+        cs = ci*sk
+        sc = si*ck
+        ss = si*sk
+
+        q = np.empty((4, ))
+        q[0] = cj*sc - sj*cs
+        q[1] = cj*ss + sj*cc
+        q[2] = cj*cs - sj*sc
+        q[3] = cj*cc + sj*ss
+
+        return q
 
 
    class StaticFramePublisher(Node):
@@ -250,11 +277,12 @@ After the lines above, add the following dependencies corresponding to your node
 .. code-block:: xml
 
    <exec_depend>geometry_msgs</exec_depend>
+   <exec_depend>python3-numpy</exec_depend>
    <exec_depend>rclpy</exec_depend>
    <exec_depend>tf2_ros</exec_depend>
    <exec_depend>turtlesim</exec_depend>
 
-This declares the required ``geometry_msgs``, ``rclpy``, ``tf2_ros``, and ``turtlesim`` dependencies when its code is executed.
+This declares the required ``geometry_msgs``, ``python3-numpy``, ``rclpy``, ``tf2_ros``, and ``turtlesim`` dependencies when its code is executed.
 
 Make sure to save the file.
 


### PR DESCRIPTION
This PR fixes both the C++ and the Python tutorials.

For the C++ ones, it just synchronizes what we have here with what is in upstream https://github.com/ros/geometry_tutorials/tree/ros2/turtle_tf2_cpp .  These are small fixes, but it is good to keep them in sync.

For the Python tutorials, it adds in the missing `quaternion_from_euler` methods so that the tutorials are complete.

This partially addresses #3015.