### PR TITLE
Update the code in the tf2 tutorials to correspond to the latest.

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
@@ -58,13 +58,13 @@ Download the fixed frame broadcaster code by entering the following command:
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp
 
    .. group-tab:: Windows
 
@@ -72,71 +72,70 @@ Download the fixed frame broadcaster code by entering the following command:
 
       .. code-block:: console
 
-         curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp -o fixed_frame_tf2_broadcaster.cpp
+          curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp -o fixed_frame_tf2_broadcaster.cpp
 
       Or in powershell:
 
       .. code-block:: console
 
-         curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp -o fixed_frame_tf2_broadcaster.cpp
+          curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp -o fixed_frame_tf2_broadcaster.cpp
 
 Now open the file called ``fixed_frame_tf2_broadcaster.cpp``.
 
 .. code-block:: C++
 
-   #include <chrono>
-   #include <functional>
-   #include <memory>
+    #include <chrono>
+    #include <functional>
+    #include <memory>
 
-   #include "geometry_msgs/msg/transform_stamped.hpp"
-   #include "rclcpp/rclcpp.hpp"
-   #include "tf2_ros/transform_broadcaster.h"
+    #include "geometry_msgs/msg/transform_stamped.hpp"
+    #include "rclcpp/rclcpp.hpp"
+    #include "tf2_ros/transform_broadcaster.h"
 
-   using namespace std::chrono_literals;
+    using namespace std::chrono_literals;
 
-   class FixedFrameBroadcaster : public rclcpp::Node
-   {
-   public:
-     FixedFrameBroadcaster()
-     : Node("fixed_frame_tf2_broadcaster")
-     {
-       tf_publisher_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
-       timer_ = this->create_wall_timer(
-         100ms, std::bind(&FixedFrameBroadcaster::broadcast_timer_callback, this));
-     }
+    class FixedFrameBroadcaster : public rclcpp::Node
+    {
+    public:
+      FixedFrameBroadcaster()
+      : Node("fixed_frame_tf2_broadcaster")
+      {
+        tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+        timer_ = this->create_wall_timer(
+          100ms, std::bind(&FixedFrameBroadcaster::broadcast_timer_callback, this));
+      }
 
-   private:
-     void broadcast_timer_callback()
-     {
-       rclcpp::Time now = this->get_clock()->now();
-       geometry_msgs::msg::TransformStamped t;
+    private:
+      void broadcast_timer_callback()
+      {
+        geometry_msgs::msg::TransformStamped t;
 
-       t.header.stamp = now;
-       t.header.frame_id = "turtle1";
-       t.child_frame_id = "carrot1";
-       t.transform.translation.x = 0.0;
-       t.transform.translation.y = 2.0;
-       t.transform.translation.z = 0.0;
-       t.transform.rotation.x = 0.0;
-       t.transform.rotation.y = 0.0;
-       t.transform.rotation.z = 0.0;
-       t.transform.rotation.w = 1.0;
+        t.header.stamp = this->get_clock()->now();
+        t.header.frame_id = "turtle1";
+        t.child_frame_id = "carrot1";
+        t.transform.translation.x = 0.0;
+        t.transform.translation.y = 2.0;
+        t.transform.translation.z = 0.0;
+        t.transform.rotation.x = 0.0;
+        t.transform.rotation.y = 0.0;
+        t.transform.rotation.z = 0.0;
+        t.transform.rotation.w = 1.0;
 
-       tf_publisher_->sendTransform(t);
-     }
-     rclcpp::TimerBase::SharedPtr timer_;
-     std::shared_ptr<tf2_ros::TransformBroadcaster> tf_publisher_;
-   };
+        tf_broadcaster_->sendTransform(t);
+      }
 
-   int main(int argc, char * argv[])
-   {
-     rclcpp::init(argc, argv);
-     rclcpp::spin(std::make_shared<FixedFrameBroadcaster>());
-     rclcpp::shutdown();
-     return 0;
-   }
+    rclcpp::TimerBase::SharedPtr timer_;
+      std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+    };
 
-Don't forget to add the executable in the ``CMakeLists.txt``.
+    int main(int argc, char * argv[])
+    {
+      rclcpp::init(argc, argv);
+      rclcpp::spin(std::make_shared<FixedFrameBroadcaster>());
+      rclcpp::shutdown();
+      return 0;
+    }
+
 The code is very similar to the tf2 broadcaster tutorial example and the only difference is that the transform here does not change over time.
 
 1.1 Examine the code
@@ -148,16 +147,41 @@ The ``carrot1`` frame is 2 meters offset in y axis in terms of the ``turtle1`` f
 
 .. code-block:: C++
 
-   geometry_msgs::msg::TransformStamped t;
+    geometry_msgs::msg::TransformStamped t;
 
-   t.header.stamp = now;
-   t.header.frame_id = "turtle1";
-   t.child_frame_id = "carrot1";
-   t.transform.translation.x = 0.0;
-   t.transform.translation.y = 2.0;
-   t.transform.translation.z = 0.0;
+    t.header.stamp = this->get_clock()->now();
+    t.header.frame_id = "turtle1";
+    t.child_frame_id = "carrot1";
+    t.transform.translation.x = 0.0;
+    t.transform.translation.y = 2.0;
+    t.transform.translation.z = 0.0;
 
-1.2 Write the launch file
+1.2 CMakeLists.txt
+~~~~~~~~~~~~~~~~~~
+
+Navigate one level back to the ``learning_tf2_cpp`` directory, where the ``CMakeLists.txt`` and ``package.xml`` files are located.
+
+Now open the ``CMakeLists.txt`` add the executable and name it ``fixed_frame_tf2_broadcaster``.
+
+.. code-block:: console
+
+    add_executable(fixed_frame_tf2_broadcaster src/fixed_frame_tf2_broadcaster.cpp)
+    ament_target_dependencies(
+        fixed_frame_tf2_broadcaster
+        geometry_msgs
+        rclcpp
+        tf2_ros
+    )
+
+Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
+
+.. code-block:: console
+
+    install(TARGETS
+        fixed_frame_tf2_broadcaster
+        DESTINATION lib/${PROJECT_NAME})
+
+1.3 Write the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now let's create a launch file for this example.
@@ -165,32 +189,32 @@ With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo.la
 
 .. code-block:: python
 
-   import os
+    import os
 
-   from ament_index_python.packages import get_package_share_directory
+    from ament_index_python.packages import get_package_share_directory
 
-   from launch import LaunchDescription
-   from launch.actions import IncludeLaunchDescription
-   from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch import LaunchDescription
+    from launch.actions import IncludeLaunchDescription
+    from launch.launch_description_sources import PythonLaunchDescriptionSource
 
-   from launch_ros.actions import Node
+    from launch_ros.actions import Node
 
 
-   def generate_launch_description():
-      demo_nodes = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-               get_package_share_directory('learning_tf2_cpp'), 'launch'),
-               '/turtle_tf2_demo.launch.py']),
-         )
+    def generate_launch_description():
+        demo_nodes = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([os.path.join(
+                get_package_share_directory('learning_tf2_cpp'), 'launch'),
+                '/turtle_tf2_demo.launch.py']),
+            )
 
-      return LaunchDescription([
-         demo_nodes,
-         Node(
-               package='learning_tf2_cpp',
-               executable='fixed_frame_tf2_broadcaster',
-               name='fixed_broadcaster',
-         ),
-      ])
+        return LaunchDescription([
+            demo_nodes,
+            Node(
+                package='learning_tf2_cpp',
+                executable='fixed_frame_tf2_broadcaster',
+                name='fixed_broadcaster',
+            ),
+        ])
 
 
 This launch file imports the required packages and then creates a ``demo_nodes`` variable that will store nodes that we created in the previous tutorial's launch file.
@@ -199,27 +223,93 @@ The last part of the code will add our fixed ``carrot1`` frame to the turtlesim 
 
 .. code-block:: python
 
-   Node(
-      package='learning_tf2_cpp',
-      executable='fixed_frame_tf2_broadcaster',
-      name='fixed_broadcaster',
-   ),
+    Node(
+        package='learning_tf2_cpp',
+        executable='fixed_frame_tf2_broadcaster',
+        name='fixed_broadcaster',
+    ),
 
-1.3 Build and run
-~~~~~~~~~~~~~~~~~
+1.4 Build
+~~~~~~~~~
 
-Rebuild the package and start the turtle broadcaster demo:
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+From the root of your workspace, build your updated package:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+          colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+          colcon build --merge-install --packages-select learning_tf2_cpp
+
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+          # CMD
+          call install\setup.bat
+
+          # Powershell
+          .\install\setup.ps1
+
+1.5 Run
+~~~~~~~
+
+Now you can start the turtle broadcaster demo:
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch.py
 
 You should notice that the new ``carrot1`` frame appeared in the transformation tree.
 
 .. image:: images/turtlesim_frames_carrot.png
-
-1.4 Checking the results
-~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you drive the first turtle around, you should notice that the behavior didn't change from the previous tutorial, even though we added a new frame.
 That's because adding an extra frame does not affect the other frames and our listener is still using the previously defined frames.
@@ -230,20 +320,20 @@ One way is to pass the ``target_frame`` argument to the launch file directly fro
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch.py target_frame:=carrot1
+    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch.py target_frame:=carrot1
 
 The second way is to update the launch file.
 To do so, open the ``turtle_tf2_fixed_frame_demo.launch.py`` file, and add the ``'target_frame': 'carrot1'`` parameter via ``launch_arguments`` argument.
 
 .. code-block:: python
 
-   def generate_launch_description():
-      demo_nodes = IncludeLaunchDescription(
-         ...,
-         launch_arguments={'target_frame': 'carrot1'}.items(),
-         )
+    def generate_launch_description():
+        demo_nodes = IncludeLaunchDescription(
+            ...,
+            launch_arguments={'target_frame': 'carrot1'}.items(),
+            )
 
-Now just rebuild the package, restart the ``turtle_tf2_fixed_frame_demo.launch.py``, and you'll see the second turtle following the carrot instead of the first turtle!
+Now rebuild the package, restart the ``turtle_tf2_fixed_frame_demo.launch.py``, and you'll see the second turtle following the carrot instead of the first turtle!
 
 .. image:: images/carrot_static.png
 
@@ -261,13 +351,13 @@ Now download the dynamic frame broadcaster code by entering the following comman
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp
 
    .. group-tab:: Windows
 
@@ -275,72 +365,73 @@ Now download the dynamic frame broadcaster code by entering the following comman
 
       .. code-block:: console
 
-         curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp -o dynamic_frame_tf2_broadcaster.cpp
+          curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp -o dynamic_frame_tf2_broadcaster.cpp
 
       Or in powershell:
 
       .. code-block:: console
 
-         curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp -o dynamic_frame_tf2_broadcaster.cpp
+          curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp -o dynamic_frame_tf2_broadcaster.cpp
 
 Now open the file called ``dynamic_frame_tf2_broadcaster.cpp``:
 
 .. code-block:: C++
 
-   #include <chrono>
-   #include <functional>
-   #include <memory>
+    #include <chrono>
+    #include <functional>
+    #include <memory>
 
-   #include "geometry_msgs/msg/transform_stamped.hpp"
-   #include "rclcpp/rclcpp.hpp"
-   #include "tf2_ros/transform_broadcaster.h"
+    #include "geometry_msgs/msg/transform_stamped.hpp"
+    #include "rclcpp/rclcpp.hpp"
+    #include "tf2_ros/transform_broadcaster.h"
 
-   using namespace std::chrono_literals;
+    using namespace std::chrono_literals;
 
-   const double PI = 3.141592653589793238463;
+    const double PI = 3.141592653589793238463;
 
-   class DynamicFrameBroadcaster : public rclcpp::Node
-   {
-   public:
-     DynamicFrameBroadcaster()
-     : Node("dynamic_frame_tf2_broadcaster")
-     {
-       tf_publisher_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
-       timer_ = this->create_wall_timer(
-         100ms, std::bind(&DynamicFrameBroadcaster::broadcast_timer_callback, this));
-     }
+    class DynamicFrameBroadcaster : public rclcpp::Node
+    {
+    public:
+      DynamicFrameBroadcaster()
+      : Node("dynamic_frame_tf2_broadcaster")
+      {
+        tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+        timer_ = this->create_wall_timer(
+          100ms, std::bind(&DynamicFrameBroadcaster::broadcast_timer_callback, this));
+      }
 
-   private:
-     void broadcast_timer_callback()
-     {
-       rclcpp::Time now = this->get_clock()->now();
-       double x = now.seconds() * PI;
-       geometry_msgs::msg::TransformStamped t;
+    private:
+      void broadcast_timer_callback()
+      {
+        rclcpp::Time now = this->get_clock()->now();
+        double x = now.seconds() * PI;
 
-       t.header.stamp = now;
-       t.header.frame_id = "turtle1";
-       t.child_frame_id = "carrot1";
-       t.transform.translation.x = 10 * sin(x);
-       t.transform.translation.y = 10 * cos(x);
-       t.transform.translation.z = 0.0;
-       t.transform.rotation.x = 0.0;
-       t.transform.rotation.y = 0.0;
-       t.transform.rotation.z = 0.0;
-       t.transform.rotation.w = 1.0;
+        geometry_msgs::msg::TransformStamped t;
+        t.header.stamp = now;
+        t.header.frame_id = "turtle1";
+        t.child_frame_id = "carrot1";
+        t.transform.translation.x = 10 * sin(x);
+        t.transform.translation.y = 10 * cos(x);
+        t.transform.translation.z = 0.0;
+        t.transform.rotation.x = 0.0;
+        t.transform.rotation.y = 0.0;
+        t.transform.rotation.z = 0.0;
+        t.transform.rotation.w = 1.0;
 
-       tf_publisher_->sendTransform(t);
-     }
-     rclcpp::TimerBase::SharedPtr timer_;
-     std::shared_ptr<tf2_ros::TransformBroadcaster> tf_publisher_;
-   };
+        tf_broadcaster_->sendTransform(t);
+      }
 
-   int main(int argc, char * argv[])
-   {
-     rclcpp::init(argc, argv);
-     rclcpp::spin(std::make_shared<DynamicFrameBroadcaster>());
-     rclcpp::shutdown();
-     return 0;
-   }
+      rclcpp::TimerBase::SharedPtr timer_;
+      std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+    };
+
+    int main(int argc, char * argv[])
+    {
+      rclcpp::init(argc, argv);
+      rclcpp::spin(std::make_shared<DynamicFrameBroadcaster>());
+      rclcpp::shutdown();
+      return 0;
+    }
 
 2.1 Examine the code
 ~~~~~~~~~~~~~~~~~~~~
@@ -349,52 +440,153 @@ Instead of a fixed definition of our x and y offsets, we are using the ``sin()``
 
 .. code-block:: C++
 
-   double x = now.seconds() * PI;
-   ...
-   t.transform.translation.x = 10 * sin(x);
-   t.transform.translation.y = 10 * cos(x);
+    double x = now.seconds() * PI;
+    ...
+    t.transform.translation.x = 10 * sin(x);
+    t.transform.translation.y = 10 * cos(x);
 
-2.2 Write the launch file
+2.2 CMakeLists.txt
+~~~~~~~~~~~~~~~~~~
+
+Navigate one level back to the ``learning_tf2_cpp`` directory, where the ``CMakeLists.txt`` and ``package.xml`` files are located.
+
+Now open the ``CMakeLists.txt`` add the executable and name it ``dynamic_frame_tf2_broadcaster``.
+
+.. code-block:: console
+
+    add_executable(dynamic_frame_tf2_broadcaster src/dynamic_frame_tf2_broadcaster.cpp)
+    ament_target_dependencies(
+        dynamic_frame_tf2_broadcaster
+        geometry_msgs
+        rclcpp
+        tf2_ros
+    )
+
+Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
+
+.. code-block:: console
+
+    install(TARGETS
+        dynamic_frame_tf2_broadcaster
+        DESTINATION lib/${PROJECT_NAME})
+
+2.3 Write the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo.launch.py`` and paste the following code:
 
 .. code-block:: python
 
-   import os
+    import os
 
-   from ament_index_python.packages import get_package_share_directory
+    from ament_index_python.packages import get_package_share_directory
 
-   from launch import LaunchDescription
-   from launch.actions import IncludeLaunchDescription
-   from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch import LaunchDescription
+    from launch.actions import IncludeLaunchDescription
+    from launch.launch_description_sources import PythonLaunchDescriptionSource
 
-   from launch_ros.actions import Node
+    from launch_ros.actions import Node
 
 
-   def generate_launch_description():
-      demo_nodes = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-               get_package_share_directory('learning_tf2_cpp'), 'launch'),
-               '/turtle_tf2_demo.launch.py']),
-         launch_arguments={'target_frame': 'carrot1'}.items(),
-         )
+    def generate_launch_description():
+        demo_nodes = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([os.path.join(
+                get_package_share_directory('learning_tf2_cpp'), 'launch'),
+                '/turtle_tf2_demo.launch.py']),
+            launch_arguments={'target_frame': 'carrot1'}.items(),
+            )
 
-      return LaunchDescription([
-         demo_nodes,
-         Node(
-               package='learning_tf2_cpp',
-               executable='dynamic_frame_tf2_broadcaster',
-               name='dynamic_broadcaster',
-         ),
-      ])
+        return LaunchDescription([
+            demo_nodes,
+            Node(
+                package='learning_tf2_cpp',
+                executable='dynamic_frame_tf2_broadcaster',
+                name='dynamic_broadcaster',
+            ),
+        ])
 
-2.3 Build and run
-~~~~~~~~~~~~~~~~~
+2.4 Build
+~~~~~~~~~
 
-Rebuild the package, and start the ``turtle_tf2_dynamic_frame_demo.launch.py`` launch file, and now you’ll see that the second turtle is following the carrot's position that is constantly changing.
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+From the root of your workspace, build your updated package:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+          colcon build --packages-select learning_tf2_cpp
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+          colcon build --merge-install --packages-select learning_tf2_cpp
+
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+          # CMD
+          call install\setup.bat
+
+          # Powershell
+          .\install\setup.ps1
+
+2.5 Run
+~~~~~~~
+
+Now you can start the dynamic frame demo:
+
+.. code-block:: console
+
+    ros2 launch learning_tf2_cpp turtle_tf2_dynamic_frame_demo.launch.py
+
+You should see that the second turtle is following the carrot's position that is constantly changing.
 
 .. image:: images/carrot_dynamic.png
+
 
 Summary
 -------

--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
@@ -58,13 +58,13 @@ Download the fixed frame broadcaster code by entering the following command:
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
 
    .. group-tab:: Windows
 
@@ -72,58 +72,59 @@ Download the fixed frame broadcaster code by entering the following command:
 
       .. code-block:: console
 
-         curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py -o fixed_frame_tf2_broadcaster.py
+          curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py -o fixed_frame_tf2_broadcaster.py
 
       Or in powershell:
 
       .. code-block:: console
 
-         curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py -o fixed_frame_tf2_broadcaster.py
+          curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py -o fixed_frame_tf2_broadcaster.py
 
 Now open the file called ``fixed_frame_tf2_broadcaster.py``.
 
 .. code-block:: python
 
-   from geometry_msgs.msg import TransformStamped
+    from geometry_msgs.msg import TransformStamped
 
-   import rclpy
-   from rclpy.node import Node
+    import rclpy
+    from rclpy.node import Node
 
-   from tf2_ros import TransformBroadcaster
-
-
-   class FixedFrameBroadcaster(Node):
-
-      def __init__(self):
-         super().__init__('fixed_frame_tf2_broadcaster')
-         self.br = TransformBroadcaster(self)
-         self.timer = self.create_timer(0.1, self.broadcast_timer_callback)
-
-      def broadcast_timer_callback(self):
-         t = TransformStamped()
-         t.header.stamp = self.get_clock().now().to_msg()
-         t.header.frame_id = 'turtle1'
-         t.child_frame_id = 'carrot1'
-         t.transform.translation.x = 0.0
-         t.transform.translation.y = 2.0
-         t.transform.translation.z = 0.0
-         t.transform.rotation.x = 0.0
-         t.transform.rotation.y = 0.0
-         t.transform.rotation.z = 0.0
-         t.transform.rotation.w = 1.0
-
-         self.br.sendTransform(t)
+    from tf2_ros import TransformBroadcaster
 
 
-   def main():
-      rclpy.init()
-      node = FixedFrameBroadcaster()
-      try:
-         rclpy.spin(node)
-      except KeyboardInterrupt:
-         pass
+    class FixedFrameBroadcaster(Node):
 
-      rclpy.shutdown()
+       def __init__(self):
+           super().__init__('fixed_frame_tf2_broadcaster')
+           self.tf_broadcaster = TransformBroadcaster(self)
+           self.timer = self.create_timer(0.1, self.broadcast_timer_callback)
+
+       def broadcast_timer_callback(self):
+           t = TransformStamped()
+
+           t.header.stamp = self.get_clock().now().to_msg()
+           t.header.frame_id = 'turtle1'
+           t.child_frame_id = 'carrot1'
+           t.transform.translation.x = 0.0
+           t.transform.translation.y = 2.0
+           t.transform.translation.z = 0.0
+           t.transform.rotation.x = 0.0
+           t.transform.rotation.y = 0.0
+           t.transform.rotation.z = 0.0
+           t.transform.rotation.w = 1.0
+
+           self.tf_broadcaster.sendTransform(t)
+
+
+    def main():
+        rclpy.init()
+        node = FixedFrameBroadcaster()
+        try:
+            rclpy.spin(node)
+        except KeyboardInterrupt:
+            pass
+
+        rclpy.shutdown()
 
 The code is very similar to the tf2 broadcaster tutorial example and the only difference is that the transform here does not change over time.
 
@@ -136,13 +137,14 @@ The ``carrot1`` frame is 2 meters offset in y axis in terms of the ``turtle1`` f
 
 .. code-block:: python
 
-   t = TransformStamped()
-   t.header.stamp = self.get_clock().now().to_msg()
-   t.header.frame_id = 'turtle1'
-   t.child_frame_id = 'carrot1'
-   t.transform.translation.x = 0.0
-   t.transform.translation.y = 2.0
-   t.transform.translation.z = 0.0
+    t = TransformStamped()
+
+    t.header.stamp = self.get_clock().now().to_msg()
+    t.header.frame_id = 'turtle1'
+    t.child_frame_id = 'carrot1'
+    t.transform.translation.x = 0.0
+    t.transform.translation.y = 2.0
+    t.transform.translation.z = 0.0
 
 1.2 Add an entry point
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -164,32 +166,32 @@ With your text editor, create a new file called ``launch/turtle_tf2_fixed_frame_
 
 .. code-block:: python
 
-   import os
+    import os
 
-   from ament_index_python.packages import get_package_share_directory
+    from ament_index_python.packages import get_package_share_directory
 
-   from launch import LaunchDescription
-   from launch.actions import IncludeLaunchDescription
-   from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch import LaunchDescription
+    from launch.actions import IncludeLaunchDescription
+    from launch.launch_description_sources import PythonLaunchDescriptionSource
 
-   from launch_ros.actions import Node
+    from launch_ros.actions import Node
 
 
-   def generate_launch_description():
-      demo_nodes = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-               get_package_share_directory('learning_tf2_py'), 'launch'),
-               '/turtle_tf2_demo.launch.py']),
-         )
+    def generate_launch_description():
+        demo_nodes = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([os.path.join(
+                get_package_share_directory('learning_tf2_py'), 'launch'),
+                '/turtle_tf2_demo.launch.py']),
+            )
 
-      return LaunchDescription([
-         demo_nodes,
-         Node(
-               package='learning_tf2_py',
-               executable='fixed_frame_tf2_broadcaster',
-               name='fixed_broadcaster',
-         ),
-      ])
+        return LaunchDescription([
+            demo_nodes,
+            Node(
+                package='learning_tf2_py',
+                executable='fixed_frame_tf2_broadcaster',
+                name='fixed_broadcaster',
+            ),
+        ])
 
 
 This launch file imports the required packages and then creates a ``demo_nodes`` variable that will store nodes that we created in the previous tutorial's launch file.
@@ -198,28 +200,94 @@ The last part of the code will add our fixed ``carrot1`` frame to the turtlesim 
 
 .. code-block:: python
 
-   Node(
-      package='learning_tf2_py',
-      executable='fixed_frame_tf2_broadcaster',
-      name='fixed_broadcaster',
-   ),
+    Node(
+        package='learning_tf2_py',
+        executable='fixed_frame_tf2_broadcaster',
+        name='fixed_broadcaster',
+    ),
 
 
-1.4 Build and run
-~~~~~~~~~~~~~~~~~
+1.4 Build
+~~~~~~~~~
 
-Rebuild the package and start the turtle broadcaster demo:
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+Still in the root of your workspace, build your package:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+        colcon build --packages-select learning_tf2_py
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+        colcon build --packages-select learning_tf2_py
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+        colcon build --merge-install --packages-select learning_tf2_py
+
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+        . install/setup.bash
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+        . install/setup.bash
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+        # CMD
+        call install\setup.bat
+
+        # Powershell
+        .\install\setup.ps1
+
+1.5 Run
+~~~~~~~
+
+Now you are ready to run the launch file:
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo.launch.py
+    ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo.launch.py
 
 You should notice that the new ``carrot1`` frame appeared in the transformation tree.
 
 .. image:: images/turtlesim_frames_carrot.png
-
-1.5 Checking the results
-~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you drive the first turtle around, you should notice that the behavior didn't change from the previous tutorial, even though we added a new frame.
 That's because adding an extra frame does not affect the other frames and our listener is still using the previously defined frames.
@@ -230,18 +298,18 @@ One way is to pass the ``target_frame`` argument to the launch file directly fro
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo.launch.py target_frame:=carrot1
+    ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo.launch.py target_frame:=carrot1
 
 The second way is to update the launch file.
 To do so, open the ``turtle_tf2_fixed_frame_demo.launch.py`` file, and add the ``'target_frame': 'carrot1'`` parameter via ``launch_arguments`` argument.
 
 .. code-block:: python
 
-   def generate_launch_description():
-      demo_nodes = IncludeLaunchDescription(
-         ...,
-         launch_arguments={'target_frame': 'carrot1'}.items(),
-         )
+    def generate_launch_description():
+        demo_nodes = IncludeLaunchDescription(
+            ...,
+            launch_arguments={'target_frame': 'carrot1'}.items(),
+            )
 
 Now just rebuild the package, restart the ``turtle_tf2_fixed_frame_demo.launch.py``, and you'll see the second turtle following the carrot instead of the first turtle!
 
@@ -261,13 +329,13 @@ Now download the dynamic frame broadcaster code by entering the following comman
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
 
    .. group-tab:: Windows
 
@@ -275,63 +343,63 @@ Now download the dynamic frame broadcaster code by entering the following comman
 
       .. code-block:: console
 
-         curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py -o dynamic_frame_tf2_broadcaster.py
+          curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py -o dynamic_frame_tf2_broadcaster.py
 
       Or in powershell:
 
       .. code-block:: console
 
-         curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py -o dynamic_frame_tf2_broadcaster.py
+          curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py -o dynamic_frame_tf2_broadcaster.py
 
 Now open the file called ``dynamic_frame_tf2_broadcaster.py``:
 
 .. code-block:: python
 
-   import math
+    import math
 
-   from geometry_msgs.msg import TransformStamped
+    from geometry_msgs.msg import TransformStamped
 
-   import rclpy
-   from rclpy.node import Node
+    import rclpy
+    from rclpy.node import Node
 
-   from tf2_ros import TransformBroadcaster
-
-
-   class DynamicFrameBroadcaster(Node):
-
-      def __init__(self):
-         super().__init__('dynamic_frame_tf2_broadcaster')
-         self.br = TransformBroadcaster(self)
-         self.timer = self.create_timer(0.1, self.broadcast_timer_callback)
-
-      def broadcast_timer_callback(self):
-         seconds, _ = self.get_clock().now().seconds_nanoseconds()
-         x = seconds * math.pi
-
-         t = TransformStamped()
-         t.header.stamp = self.get_clock().now().to_msg()
-         t.header.frame_id = 'turtle1'
-         t.child_frame_id = 'carrot1'
-         t.transform.translation.x = 10 * math.sin(x)
-         t.transform.translation.y = 10 * math.cos(x)
-         t.transform.translation.z = 0.0
-         t.transform.rotation.x = 0.0
-         t.transform.rotation.y = 0.0
-         t.transform.rotation.z = 0.0
-         t.transform.rotation.w = 1.0
-
-         self.br.sendTransform(t)
+    from tf2_ros import TransformBroadcaster
 
 
-   def main():
-      rclpy.init()
-      node = DynamicFrameBroadcaster()
-      try:
-         rclpy.spin(node)
-      except KeyboardInterrupt:
-         pass
+    class DynamicFrameBroadcaster(Node):
 
-      rclpy.shutdown()
+        def __init__(self):
+            super().__init__('dynamic_frame_tf2_broadcaster')
+            self.tf_broadcaster = TransformBroadcaster(self)
+            self.timer = self.create_timer(0.1, self.broadcast_timer_callback)
+
+        def broadcast_timer_callback(self):
+            seconds, _ = self.get_clock().now().seconds_nanoseconds()
+            x = seconds * math.pi
+
+            t = TransformStamped()
+            t.header.stamp = self.get_clock().now().to_msg()
+            t.header.frame_id = 'turtle1'
+            t.child_frame_id = 'carrot1'
+            t.transform.translation.x = 10 * math.sin(x)
+            t.transform.translation.y = 10 * math.cos(x)
+            t.transform.translation.z = 0.0
+            t.transform.rotation.x = 0.0
+            t.transform.rotation.y = 0.0
+            t.transform.rotation.z = 0.0
+            t.transform.rotation.w = 1.0
+
+            self.tf_broadcaster.sendTransform(t)
+
+
+    def main():
+        rclpy.init()
+        node = DynamicFrameBroadcaster()
+        try:
+            rclpy.spin(node)
+        except KeyboardInterrupt:
+            pass
+
+        rclpy.shutdown()
 
 2.1 Examine the code
 ~~~~~~~~~~~~~~~~~~~~
@@ -340,11 +408,11 @@ Instead of a fixed definition of our x and y offsets, we are using the ``sin()``
 
 .. code-block:: python
 
-   seconds, _ = self.get_clock().now().seconds_nanoseconds()
-   x = seconds * math.pi
-   ...
-   t.transform.translation.x = 10 * math.sin(x)
-   t.transform.translation.y = 10 * math.cos(x)
+    seconds, _ = self.get_clock().now().seconds_nanoseconds()
+    x = seconds * math.pi
+    ...
+    t.transform.translation.x = 10 * math.sin(x)
+    t.transform.translation.y = 10 * math.cos(x)
 
 2.2 Add an entry point
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -365,38 +433,113 @@ To test this code, create a new launch file ``launch/turtle_tf2_dynamic_frame_de
 
 .. code-block:: python
 
-   import os
+    import os
 
-   from ament_index_python.packages import get_package_share_directory
+    from ament_index_python.packages import get_package_share_directory
 
-   from launch import LaunchDescription
-   from launch.actions import IncludeLaunchDescription
-   from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch import LaunchDescription
+    from launch.actions import IncludeLaunchDescription
+    from launch.launch_description_sources import PythonLaunchDescriptionSource
 
-   from launch_ros.actions import Node
+    from launch_ros.actions import Node
 
 
-   def generate_launch_description():
-      demo_nodes = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-               get_package_share_directory('learning_tf2_py'), 'launch'),
-               '/turtle_tf2_demo.launch.py']),
-         launch_arguments={'target_frame': 'carrot1'}.items(),
-         )
+    def generate_launch_description():
+        demo_nodes = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([os.path.join(
+                get_package_share_directory('learning_tf2_py'), 'launch'),
+                '/turtle_tf2_demo.launch.py']),
+           launch_arguments={'target_frame': 'carrot1'}.items(),
+           )
 
-      return LaunchDescription([
-         demo_nodes,
-         Node(
-               package='learning_tf2_py',
-               executable='dynamic_frame_tf2_broadcaster',
-               name='dynamic_broadcaster',
-         ),
-      ])
+        return LaunchDescription([
+            demo_nodes,
+            Node(
+                package='learning_tf2_py',
+                executable='dynamic_frame_tf2_broadcaster',
+                name='dynamic_broadcaster',
+            ),
+        ])
 
-2.4 Build and run
-~~~~~~~~~~~~~~~~~
+2.4 Build
+~~~~~~~~~
 
-Rebuild the package, and start the ``turtle_tf2_dynamic_frame_demo.launch.py`` launch file, and now you’ll see that the second turtle is following the carrot's position that is constantly changing.
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+Still in the root of your workspace, build your package:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+        colcon build --packages-select learning_tf2_py
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+        colcon build --packages-select learning_tf2_py
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+        colcon build --merge-install --packages-select learning_tf2_py
+
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+        . install/setup.bash
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+        . install/setup.bash
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+        # CMD
+        call install\setup.bat
+
+        # Powershell
+        .\install\setup.ps1
+
+1.5 Run
+~~~~~~~
+
+Now you are ready to run the launch file:
+
+.. code-block:: console
+
+    ros2 launch learning_tf2_py turtle_tf2_dynamic_frame_demo.launch.py
+
+You should see that the second turtle is following the carrot's position that is constantly changing.
 
 .. image:: images/carrot_dynamic.png
 

--- a/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Py.rst
@@ -42,7 +42,7 @@ It should look like shown below:
       from_frame_rel,
       now)
 
-Moreover, import additional exceptions that we will handle in the beggining of the file:
+Moreover, import additional exceptions that we will handle in the beginning of the file:
 
 .. code-block:: python
 

--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -20,7 +20,8 @@ Using stamped datatypes with ``tf2_ros::MessageFilter``
 Background
 ----------
 
-This tutorial explains how to use sensor data with tf2. Some real-world examples of sensor data are:
+This tutorial explains how to use sensor data with tf2.
+Some real-world examples of sensor data are:
 
     * cameras, both mono and stereo
 
@@ -34,8 +35,8 @@ To do this ``turtle1`` must listen to the topic where ``turtle3``'s pose is bein
 To make this easier the ``tf2_ros::MessageFilter`` is very useful.
 The ``tf2_ros::MessageFilter`` will take a subscription to any ROS 2 message with a header and cache it until it is possible to transform it into the target frame.
 
-Setting up the example
-----------------------
+Tasks
+-----
 
 1 Write the broadcaster node of PointStamped messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,13 +54,13 @@ Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the exampl
 
     .. code-block:: console
 
-       wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
+        wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
 
   .. group-tab:: macOS
 
     .. code-block:: console
 
-       wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
+        wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
 
   .. group-tab:: Windows
 
@@ -67,101 +68,101 @@ Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the exampl
 
     .. code-block:: console
 
-       curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py -o turtle_tf2_message_broadcaster.py
+        curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py -o turtle_tf2_message_broadcaster.py
 
     Or in powershell:
 
     .. code-block:: console
 
-       curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py -o turtle_tf2_message_broadcaster.py
+        curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py -o turtle_tf2_message_broadcaster.py
 
 Open the file using your preferred text editor.
 
 .. code-block:: python
 
-   from geometry_msgs.msg import PointStamped
-   from geometry_msgs.msg import Twist
+    from geometry_msgs.msg import PointStamped
+    from geometry_msgs.msg import Twist
 
-   import rclpy
-   from rclpy.node import Node
+    import rclpy
+    from rclpy.node import Node
 
-   from turtlesim.msg import Pose
-   from turtlesim.srv import Spawn
-
-
-   class PointPublisher(Node):
-
-       def __init__(self):
-           super().__init__('turtle_tf2_message_broadcaster')
-
-           # Create a client to spawn a turtle
-           self.spawner = self.create_client(Spawn, 'spawn')
-           # Boolean values to store the information
-           # if the service for spawning turtle is available
-           self.turtle_spawning_service_ready = False
-           # if the turtle was successfully spawned
-           self.turtle_spawned = False
-           # if the topics of turtle3 can be subscribed
-           self.turtle_pose_cansubscribe = False
-
-           self.timer = self.create_timer(1.0, self.on_timer)
-
-       def on_timer(self):
-           if self.turtle_spawning_service_ready:
-               if self.turtle_spawned:
-                   self.turtle_pose_cansubscribe = True
-               else:
-                   if self.result.done():
-                       self.get_logger().info(
-                           f'Successfully spawned {self.result.result().name}')
-                       self.turtle_spawned = True
-                   else:
-                       self.get_logger().info('Spawn is not finished')
-           else:
-               if self.spawner.service_is_ready():
-                   # Initialize request with turtle name and coordinates
-                   # Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
-                   request = Spawn.Request()
-                   request.name = 'turtle3'
-                   request.x = float(4)
-                   request.y = float(2)
-                   request.theta = float(0)
-                   # Call request
-                   self.result = self.spawner.call_async(request)
-                   self.turtle_spawning_service_ready = True
-               else:
-                   # Check if the service is ready
-                   self.get_logger().info('Service is not ready')
-
-           if self.turtle_pose_cansubscribe:
-               self.vel_pub = self.create_publisher(Twist, 'turtle3/cmd_vel', 10)
-               self.sub = self.create_subscription(Pose, 'turtle3/pose', self.handle_turtle_pose, 10)
-               self.pub = self.create_publisher(PointStamped, 'turtle3/turtle_point_stamped', 10)
-
-       def handle_turtle_pose(self, msg):
-           vel_msg = Twist()
-           vel_msg.linear.x = 1.0
-           vel_msg.angular.z = 1.0
-           self.vel_pub.publish(vel_msg)
-
-           ps = PointStamped()
-           ps.header.stamp = self.get_clock().now().to_msg()
-           ps.header.frame_id = 'world'
-           ps.point.x = msg.x
-           ps.point.y = msg.y
-           ps.point.z = 0.0
-           self.pub.publish(ps)
+    from turtlesim.msg import Pose
+    from turtlesim.srv import Spawn
 
 
-   def main():
-       rclpy.init()
-       node = PointPublisher()
-       try:
-           rclpy.spin(node)
-       except KeyboardInterrupt:
-           pass
+    class PointPublisher(Node):
 
-       rclpy.shutdown()
+        def __init__(self):
+            super().__init__('turtle_tf2_message_broadcaster')
+
+            # Create a client to spawn a turtle
+            self.spawner = self.create_client(Spawn, 'spawn')
+            # Boolean values to store the information
+            # if the service for spawning turtle is available
+            self.turtle_spawning_service_ready = False
+            # if the turtle was successfully spawned
+            self.turtle_spawned = False
+            # if the topics of turtle3 can be subscribed
+            self.turtle_pose_cansubscribe = False
+
+            self.timer = self.create_timer(1.0, self.on_timer)
+
+        def on_timer(self):
+            if self.turtle_spawning_service_ready:
+                if self.turtle_spawned:
+                    self.turtle_pose_cansubscribe = True
+                else:
+                    if self.result.done():
+                        self.get_logger().info(
+                            f'Successfully spawned {self.result.result().name}')
+                        self.turtle_spawned = True
+                    else:
+                        self.get_logger().info('Spawn is not finished')
+            else:
+                if self.spawner.service_is_ready():
+                    # Initialize request with turtle name and coordinates
+                    # Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
+                    request = Spawn.Request()
+                    request.name = 'turtle3'
+                    request.x = 4.0
+                    request.y = 2.0
+                    request.theta = 0.0
+                    # Call request
+                    self.result = self.spawner.call_async(request)
+                    self.turtle_spawning_service_ready = True
+                else:
+                    # Check if the service is ready
+                    self.get_logger().info('Service is not ready')
+
+            if self.turtle_pose_cansubscribe:
+                self.vel_pub = self.create_publisher(Twist, 'turtle3/cmd_vel', 10)
+                self.sub = self.create_subscription(Pose, 'turtle3/pose', self.handle_turtle_pose, 10)
+                self.pub = self.create_publisher(PointStamped, 'turtle3/turtle_point_stamped', 10)
+
+        def handle_turtle_pose(self, msg):
+            vel_msg = Twist()
+            vel_msg.linear.x = 1.0
+            vel_msg.angular.z = 1.0
+            self.vel_pub.publish(vel_msg)
+
+            ps = PointStamped()
+            ps.header.stamp = self.get_clock().now().to_msg()
+            ps.header.frame_id = 'world'
+            ps.point.x = msg.x
+            ps.point.y = msg.y
+            ps.point.z = 0.0
+            self.pub.publish(ps)
+
+
+    def main():
+        rclpy.init()
+        node = PointPublisher()
+        try:
+            rclpy.spin(node)
+        except KeyboardInterrupt:
+            pass
+
+        rclpy.shutdown()
 
 
 1.1 Examine the code
@@ -172,41 +173,41 @@ First, in the ``on_timer`` callback function, we spawn the ``turtle3`` by asynch
 
 .. code-block:: python
 
-   # Initialize request with turtle name and coordinates
-   # Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
-   request = Spawn.Request()
-   request.name = 'turtle3'
-   request.x = float(4)
-   request.y = float(2)
-   request.theta = float(0)
-   Call request
-   self.result = self.spawner.call_async(request)
+    # Initialize request with turtle name and coordinates
+    # Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
+    request = Spawn.Request()
+    request.name = 'turtle3'
+    request.x = 4.0
+    request.y = 2.0
+    request.theta = 0.0
+    # Call request
+    self.result = self.spawner.call_async(request)
 
 Afterward, the node publishes the topic ``turtle3/cmd_vel``, topic ``turtle3/turtle_point_stamped``, and subscribes to topic ``turtle3/pose`` and runs callback function ``handle_turtle_pose`` on every incoming message.
 
 .. code-block:: python
 
-   self.vel_pub = self.create_publisher(Twist, '/turtle3/cmd_vel', 10)
-   self.sub = self.create_subscription(Pose, '/turtle3/pose', self.handle_turtle_pose, 10)
-   self.pub = self.create_publisher(PointStamped, '/turtle3/turtle_point_stamped', 10)
+    self.vel_pub = self.create_publisher(Twist, '/turtle3/cmd_vel', 10)
+    self.sub = self.create_subscription(Pose, '/turtle3/pose', self.handle_turtle_pose, 10)
+    self.pub = self.create_publisher(PointStamped, '/turtle3/turtle_point_stamped', 10)
 
 Finally, in the callback function ``handle_turtle_pose``, we initialize the ``Twist`` messages of ``turtle3`` and publish them, which will make the ``turtle3`` move along a circle.
 Then we fill up the ``PointStamped`` messages of ``turtle3`` with incoming ``Pose`` messages and publish them.
 
 .. code-block:: python
 
-   vel_msg = Twist()
-   vel_msg.linear.x = 1.0
-   vel_msg.angular.z = 1.0
-   self.vel_pub.publish(vel_msg)
+    vel_msg = Twist()
+    vel_msg.linear.x = 1.0
+    vel_msg.angular.z = 1.0
+    self.vel_pub.publish(vel_msg)
 
-   ps = PointStamped()
-   ps.header.stamp = self.get_clock().now().to_msg()
-   ps.header.frame_id = 'world'
-   ps.point.x = msg.x
-   ps.point.y = msg.y
-   ps.point.z = 0.0
-   self.pub.publish(ps)
+    ps = PointStamped()
+    ps.header.stamp = self.get_clock().now().to_msg()
+    ps.header.frame_id = 'world'
+    ps.point.x = msg.x
+    ps.point.y = msg.y
+    ps.point.z = 0.0
+    self.pub.publish(ps)
 
 1.2 Write the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -215,58 +216,78 @@ In order to run this demo, we need to create a launch file ``turtle_tf2_sensor_m
 
 .. code-block:: python
 
-   from launch import LaunchDescription
-   from launch.actions import DeclareLaunchArgument
-   from launch_ros.actions import Node
+    from launch import LaunchDescription
+    from launch.actions import DeclareLaunchArgument
+    from launch_ros.actions import Node
 
 
-   def generate_launch_description():
-       return LaunchDescription([
-           DeclareLaunchArgument(
-               'target_frame', default_value='turtle1',
-               description='Target frame name.'
-           ),
-           Node(
-               package='turtlesim',
-               executable='turtlesim_node',
-               name='sim',
-               output='screen'
-           ),
-           Node(
-               package='turtle_tf2_py',
-               executable='turtle_tf2_broadcaster',
-               name='broadcaster1',
-               parameters=[
-                   {'turtlename': 'turtle1'}
-               ]
-           ),
-           Node(
-               package='turtle_tf2_py',
-               executable='turtle_tf2_broadcaster',
-               name='broadcaster2',
-               parameters=[
-                   {'turtlename': 'turtle3'}
-               ]
-           ),
-           Node(
-               package='turtle_tf2_py',
-               executable='turtle_tf2_message_broadcaster',
-               name='message_broadcaster',
-           ),
-       ])
+    def generate_launch_description():
+        return LaunchDescription([
+            DeclareLaunchArgument(
+                'target_frame', default_value='turtle1',
+                description='Target frame name.'
+            ),
+            Node(
+                package='turtlesim',
+                executable='turtlesim_node',
+                name='sim',
+                output='screen'
+            ),
+            Node(
+                package='turtle_tf2_py',
+                executable='turtle_tf2_broadcaster',
+                name='broadcaster1',
+                parameters=[
+                    {'turtlename': 'turtle1'}
+                ]
+            ),
+            Node(
+                package='turtle_tf2_py',
+                executable='turtle_tf2_broadcaster',
+                name='broadcaster2',
+                parameters=[
+                    {'turtlename': 'turtle3'}
+                ]
+            ),
+            Node(
+                package='turtle_tf2_py',
+                executable='turtle_tf2_message_broadcaster',
+                name='message_broadcaster',
+            ),
+        ])
 
 
-1.3 Add an entry point and build the package
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1.3 Add an entry point
+~~~~~~~~~~~~~~~~~~~~~~
 
-Don't forget to add the executable in the ``setup.py`` file of the package:
+To allow the ``ros2 run`` command to run your node, you must add the entry point to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
+
+Add the following line between the ``'console_scripts':`` brackets:
 
 .. code-block:: python
 
-   'console_scripts': [
-       ...
-       'turtle_tf2_message_broadcaster = learning_tf2_py.turtle_tf2_message_broadcaster:main',
-   ],
+    'turtle_tf2_message_broadcaster = learning_tf2_py.turtle_tf2_message_broadcaster:main',
+
+1.4 Build
+~~~~~~~~~
+
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
 And then we can build the package:
 
@@ -276,19 +297,19 @@ And then we can build the package:
 
     .. code-block:: console
 
-       colcon build --packages-select learning_tf2_py
+        colcon build --packages-select learning_tf2_py
 
   .. group-tab:: macOS
 
     .. code-block:: console
 
-       colcon build --packages-select learning_tf2_py
+        colcon build --packages-select learning_tf2_py
 
   .. group-tab:: Windows
 
     .. code-block:: console
 
-       colcon build --merge-install --packages-select learning_tf2_py
+        colcon build --merge-install --packages-select learning_tf2_py
 
 
 2 Writing the message filter/listener node
@@ -305,13 +326,13 @@ Inside the ``src/learning_tf2_cpp/src`` directory download file ``turtle_tf2_mes
 
     .. code-block:: console
 
-       wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
+        wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
 
   .. group-tab:: macOS
 
     .. code-block:: console
 
-       wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
+        wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
 
   .. group-tab:: Windows
 
@@ -319,99 +340,98 @@ Inside the ``src/learning_tf2_cpp/src`` directory download file ``turtle_tf2_mes
 
     .. code-block:: console
 
-       curl -sk wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp -o turtle_tf2_message_filter.cpp
+        curl -sk wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp -o turtle_tf2_message_filter.cpp
 
     Or in powershell:
 
     .. code-block:: console
 
-       curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp -o turtle_tf2_message_filter.cpp
+        curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp -o turtle_tf2_message_filter.cpp
 
 Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <chrono>
-   #include <memory>
-   #include <string>
+    #include <chrono>
+    #include <memory>
+    #include <string>
 
-   #include "geometry_msgs/msg/point_stamped.hpp"
-   #include "message_filters/subscriber.h"
-   #include "rclcpp/rclcpp.hpp"
-   #include "tf2_ros/buffer.h"
-   #include "tf2_ros/create_timer_ros.h"
-   #include "tf2_ros/message_filter.h"
-   #include "tf2_ros/transform_listener.h"
-   #ifdef TF2_CPP_HEADERS
-     #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-   #else
-     #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-   #endif
+    #include "geometry_msgs/msg/point_stamped.hpp"
+    #include "message_filters/subscriber.h"
+    #include "rclcpp/rclcpp.hpp"
+    #include "tf2_ros/buffer.h"
+    #include "tf2_ros/create_timer_ros.h"
+    #include "tf2_ros/message_filter.h"
+    #include "tf2_ros/transform_listener.h"
+    #ifdef TF2_CPP_HEADERS
+      #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+    #else
+      #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+    #endif
 
-   using namespace std::chrono_literals;
+    using namespace std::chrono_literals;
 
-   class PoseDrawer : public rclcpp::Node
-   {
-   public:
-     PoseDrawer()
-     : Node("turtle_tf2_pose_drawer")
-     {
-       // Declare and acquire `target_frame` parameter
-       this->declare_parameter<std::string>("target_frame", "turtle1");
-       this->get_parameter("target_frame", target_frame_);
+    class PoseDrawer : public rclcpp::Node
+    {
+    public:
+      PoseDrawer()
+      : Node("turtle_tf2_pose_drawer")
+      {
+        // Declare and acquire `target_frame` parameter
+        target_frame_ = this->declare_parameter<std::string>("target_frame", "turtle1");
 
-       typedef std::chrono::duration<int> seconds_type;
-       seconds_type buffer_timeout(1);
+        std::chrono::duration<int> buffer_timeout(1);
 
-       tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-       // Create the timer interface before call to waitForTransform,
-       // to avoid a tf2_ros::CreateTimerInterfaceException exception
-       auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-         this->get_node_base_interface(),
-         this->get_node_timers_interface());
-       tf2_buffer_->setCreateTimerInterface(timer_interface);
-       tf2_listener_ =
-         std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
+        tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+        // Create the timer interface before call to waitForTransform,
+        // to avoid a tf2_ros::CreateTimerInterfaceException exception
+        auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+          this->get_node_base_interface(),
+          this->get_node_timers_interface());
+        tf2_buffer_->setCreateTimerInterface(timer_interface);
+        tf2_listener_ =
+          std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
 
-       point_sub_.subscribe(this, "/turtle3/turtle_point_stamped");
-       tf2_filter_ = std::make_shared<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>>(
-         point_sub_, *tf2_buffer_, target_frame_, 100, this->get_node_logging_interface(),
-         this->get_node_clock_interface(), buffer_timeout);
-       // Register a callback with tf2_ros::MessageFilter to be called when transforms are available
-       tf2_filter_->registerCallback(&PoseDrawer::msgCallback, this);
-     }
+        point_sub_.subscribe(this, "/turtle3/turtle_point_stamped");
+        tf2_filter_ = std::make_shared<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>>(
+          point_sub_, *tf2_buffer_, target_frame_, 100, this->get_node_logging_interface(),
+          this->get_node_clock_interface(), buffer_timeout);
+        // Register a callback with tf2_ros::MessageFilter to be called when transforms are available
+        tf2_filter_->registerCallback(&PoseDrawer::msgCallback, this);
+      }
 
-   private:
-     void msgCallback(const geometry_msgs::msg::PointStamped::SharedPtr point_ptr)
-     {
-       geometry_msgs::msg::PointStamped point_out;
-       try {
-         tf2_buffer_->transform(*point_ptr, point_out, target_frame_);
-         RCLCPP_INFO(
-           this->get_logger(), "Point of turtle3 in frame of turtle1: x:%f y:%f z:%f\n",
-           point_out.point.x,
-           point_out.point.y,
-           point_out.point.z);
-       } catch (tf2::TransformException & ex) {
-         RCLCPP_WARN(
-           // Print exception which was caught
-           this->get_logger(), "Failure %s\n", ex.what());
-       }
-     }
-     std::string target_frame_;
-     std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
-     std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
-     message_filters::Subscriber<geometry_msgs::msg::PointStamped> point_sub_;
-     std::shared_ptr<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>> tf2_filter_;
-   };
+    private:
+      void msgCallback(const geometry_msgs::msg::PointStamped::SharedPtr point_ptr)
+      {
+        geometry_msgs::msg::PointStamped point_out;
+        try {
+          tf2_buffer_->transform(*point_ptr, point_out, target_frame_);
+          RCLCPP_INFO(
+            this->get_logger(), "Point of turtle3 in frame of turtle1: x:%f y:%f z:%f\n",
+            point_out.point.x,
+            point_out.point.y,
+            point_out.point.z);
+        } catch (const tf2::TransformException & ex) {
+          RCLCPP_WARN(
+            // Print exception which was caught
+            this->get_logger(), "Failure %s\n", ex.what());
+        }
+      }
 
-   int main(int argc, char * argv[])
-   {
-     rclcpp::init(argc, argv);
-     rclcpp::spin(std::make_shared<PoseDrawer>());
-     rclcpp::shutdown();
-     return 0;
-   }
+      std::string target_frame_;
+      std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
+      std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
+      message_filters::Subscriber<geometry_msgs::msg::PointStamped> point_sub_;
+      std::shared_ptr<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>> tf2_filter_;
+    };
+
+    int main(int argc, char * argv[])
+    {
+      rclcpp::init(argc, argv);
+      rclcpp::spin(std::make_shared<PoseDrawer>());
+      rclcpp::shutdown();
+      return 0;
+    }
 
 
 2.1 Examine the code
@@ -421,30 +441,29 @@ First, you must include the ``tf2_ros::MessageFilter`` headers from the ``tf2_ro
 
 .. code-block:: C++
 
-   #include <geometry_msgs/msg/point_stamped.hpp>
-   #include <message_filters/subscriber.h>
-
-   #include <rclcpp/rclcpp.hpp>
-   #include <tf2_ros/buffer.h>
-   #include <tf2_ros/create_timer_ros.h>
-   #include <tf2_ros/message_filter.h>
-   #include <tf2_ros/transform_listener.h>
-   #ifdef TF2_CPP_HEADERS
-     #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-   #else
-     #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-   #endif
+    #include "geometry_msgs/msg/point_stamped.hpp"
+    #include "message_filters/subscriber.h"
+    #include "rclcpp/rclcpp.hpp"
+    #include "tf2_ros/buffer.h"
+    #include "tf2_ros/create_timer_ros.h"
+    #include "tf2_ros/message_filter.h"
+    #include "tf2_ros/transform_listener.h"
+    #ifdef TF2_CPP_HEADERS
+      #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+    #else
+      #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+    #endif
 
 
 Second, there needs to be persistent instances of ``tf2_ros::Buffer``, ``tf2_ros::TransformListener`` and ``tf2_ros::MessageFilter``.
 
 .. code-block:: C++
 
-   std::string target_frame_;
-   std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
-   std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
-   message_filters::Subscriber<geometry_msgs::msg::PointStamped> point_sub_;
-   std::shared_ptr<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>> tf2_filter_;
+    std::string target_frame_;
+    std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
+    message_filters::Subscriber<geometry_msgs::msg::PointStamped> point_sub_;
+    std::shared_ptr<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>> tf2_filter_;
 
 
 Third, the ROS 2 ``message_filters::Subscriber`` must be initialized with the topic.
@@ -455,109 +474,140 @@ And the callback function is the function that will be called when the data is r
 
 .. code-block:: C++
 
-   PoseDrawer()
-   : Node("turtle_tf2_pose_drawer")
-   {
-     // Declare and acquire `target_frame` parameter
-     this->declare_parameter<std::string>("target_frame", "turtle1");
-     this->get_parameter("target_frame", target_frame_);
+    PoseDrawer()
+    : Node("turtle_tf2_pose_drawer")
+    {
+      // Declare and acquire `target_frame` parameter
+      target_frame_ = this->declare_parameter<std::string>("target_frame", "turtle1");
 
-     typedef std::chrono::duration<int> seconds_type;
-     seconds_type buffer_timeout(1);
+      std::chrono::duration<int> buffer_timeout(1);
 
-     tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-     // Create the timer interface before call to waitForTransform,
-     // to avoid a tf2_ros::CreateTimerInterfaceException exception
-     auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-       this->get_node_base_interface(),
-       this->get_node_timers_interface());
-     tf2_buffer_->setCreateTimerInterface(timer_interface);
-     tf2_listener_ =
-       std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
+      tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+      // Create the timer interface before call to waitForTransform,
+      // to avoid a tf2_ros::CreateTimerInterfaceException exception
+      auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+        this->get_node_base_interface(),
+        this->get_node_timers_interface());
+      tf2_buffer_->setCreateTimerInterface(timer_interface);
+      tf2_listener_ =
+        std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
 
-     point_sub_.subscribe(this, "/turtle3/turtle_point_stamped");
-     tf2_filter_ = std::make_shared<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>>(
-       point_sub_, *tf2_buffer_, target_frame_, 100, this->get_node_logging_interface(),
-       this->get_node_clock_interface(), buffer_timeout);
-     // Register a callback with tf2_ros::MessageFilter to be called when transforms are available
-     tf2_filter_->registerCallback(&PoseDrawer::msgCallback, this);
-   }
+      point_sub_.subscribe(this, "/turtle3/turtle_point_stamped");
+      tf2_filter_ = std::make_shared<tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped>>(
+        point_sub_, *tf2_buffer_, target_frame_, 100, this->get_node_logging_interface(),
+        this->get_node_clock_interface(), buffer_timeout);
+      // Register a callback with tf2_ros::MessageFilter to be called when transforms are available
+      tf2_filter_->registerCallback(&PoseDrawer::msgCallback, this);
+    }
 
 
 And last, the callback method will call ``tf2_buffer_->transform`` when the data is ready and print output to the console.
 
 .. code-block:: C++
 
-   private:
-   void msgCallback(const geometry_msgs::msg::PointStamped::SharedPtr point_ptr)
-   {
-     geometry_msgs::msg::PointStamped point_out;
-     try {
-       tf2_buffer_->transform(*point_ptr, point_out, target_frame_);
-       RCLCPP_INFO(
-         this->get_logger(), "Point of turtle3 in frame of turtle1: x:%f y:%f z:%f\n",
-         point_out.point.x,
-         point_out.point.y,
-         point_out.point.z);
-     } catch (tf2::TransformException & ex) {
-       RCLCPP_WARN(
-         // Print exception which was caught
-         this->get_logger(), "Failure %s\n", ex.what());
-     }
-   }
+    private:
+      void msgCallback(const geometry_msgs::msg::PointStamped::SharedPtr point_ptr)
+      {
+        geometry_msgs::msg::PointStamped point_out;
+        try {
+          tf2_buffer_->transform(*point_ptr, point_out, target_frame_);
+          RCLCPP_INFO(
+            this->get_logger(), "Point of turtle3 in frame of turtle1: x:%f y:%f z:%f\n",
+            point_out.point.x,
+            point_out.point.y,
+            point_out.point.z);
+        } catch (const tf2::TransformException & ex) {
+          RCLCPP_WARN(
+            // Print exception which was caught
+            this->get_logger(), "Failure %s\n", ex.what());
+        }
+      }
 
 
-2.2 Build the package
-~~~~~~~~~~~~~~~~~~~~~
+2.2 Add dependencies
+~~~~~~~~~~~~~~~~~~~~
 
 Before building the package ``learning_tf2_cpp``, please add two another dependencies in the ``package.xml`` file of this package:
 
 .. code-block:: xml
 
-   <depend>message_filters</depend>
-   <depend>tf2_geometry_msgs</depend>
+    <depend>message_filters</depend>
+    <depend>tf2_geometry_msgs</depend>
 
+2.3 CMakeLists.txt
+~~~~~~~~~~~~~~~~~~
 
 And in the ``CMakeLists.txt`` file, add two lines below the existing dependencies:
 
 .. code-block:: console
 
-   find_package(message_filters REQUIRED)
-   find_package(tf2_geometry_msgs REQUIRED)
+    find_package(message_filters REQUIRED)
+    find_package(tf2_geometry_msgs REQUIRED)
 
-Most importantly, add these lines below the dependencies:
+The lines below will deal with differences between ROS distributions:
 
 .. code-block:: console
 
-   find_file(TF2_CPP_HEADERS
-     NAMES tf2_geometry_msgs.hpp
-     PATHS ${tf2_geometry_msgs_INCLUDE_DIRS}
-     NO_CACHE
-     PATH_SUFFIXES tf2_geometry_msgs
-   )
+    if(TARGET tf2_geometry_msgs::tf2_geometry_msgs)
+      get_target_property(_include_dirs tf2_geometry_msgs::tf2_geometry_msgs INTERFACE_INCLUDE_DIRECTORIES)
+    else()
+      set(_include_dirs ${tf2_geometry_msgs_INCLUDE_DIRS})
+    endif()
+
+    find_file(TF2_CPP_HEADERS
+      NAMES tf2_geometry_msgs.hpp
+      PATHS ${_include_dirs}
+      NO_CACHE
+      PATH_SUFFIXES tf2_geometry_msgs
+    )
 
 After that, add the executable and name it ``turtle_tf2_message_filter``, which you'll use later with ``ros2 run``.
 
 .. code-block:: console
 
-   add_executable(turtle_tf2_message_filter src/turtle_tf2_message_filter.cpp)
-   ament_target_dependencies(
-     turtle_tf2_message_filter
-     geometry_msgs
-     message_filters
-     rclcpp
-     tf2
-     tf2_geometry_msgs
-     tf2_ros
-   )
+    add_executable(turtle_tf2_message_filter src/turtle_tf2_message_filter.cpp)
+    ament_target_dependencies(
+      turtle_tf2_message_filter
+      geometry_msgs
+      message_filters
+      rclcpp
+      tf2
+      tf2_geometry_msgs
+      tf2_ros
+    )
+
+    if(EXISTS ${TF2_CPP_HEADERS})
+      target_compile_definitions(turtle_tf2_message_filter PUBLIC -DTF2_CPP_HEADERS)
+    endif()
 
 Finally, add the ``install(TARGETS…)`` section (below other existing nodes) so ``ros2 run`` can find your executable:
 
 .. code-block:: console
 
-   install(TARGETS
-     turtle_tf2_message_filter
-     DESTINATION lib/${PROJECT_NAME})
+    install(TARGETS
+      turtle_tf2_message_filter
+      DESTINATION lib/${PROJECT_NAME})
+
+2.4 Build
+~~~~~~~~~
+
+Run ``rosdep`` in the root of your workspace to check for missing dependencies.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
+
+   .. group-tab:: macOS
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
+
+   .. group-tab:: Windows
+
+        rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
 Now open a new terminal, navigate to the root of your workspace, and rebuild the package with command:
 
@@ -567,37 +617,61 @@ Now open a new terminal, navigate to the root of your workspace, and rebuild the
 
     .. code-block:: console
 
-       colcon build --packages-select learning_tf2_cpp
+        colcon build --packages-select learning_tf2_cpp
 
   .. group-tab:: macOS
 
     .. code-block:: console
 
-       colcon build --packages-select learning_tf2_cpp
+        colcon build --packages-select learning_tf2_cpp
 
   .. group-tab:: Windows
 
     .. code-block:: console
 
-       colcon build --merge-install --packages-select learning_tf2_cpp
+        colcon build --merge-install --packages-select learning_tf2_cpp
 
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
 
+.. tabs::
 
-Running and results
--------------------
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+          # CMD
+          call install\setup.bat
+
+          # Powershell
+          .\install\setup.ps1
+
+3 Run
+^^^^^
 
 First we need to run several nodes (including the broadcaster node of PointStamped messages) by launching the launch file ``turtle_tf2_sensor_message.launch.py``:
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_py turtle_tf2_sensor_message.launch.py
+    ros2 launch learning_tf2_py turtle_tf2_sensor_message.launch.py
 
 This will bring up the ``turtlesim`` window with two turtles, where ``turtle3`` is moving along a circle, while ``turtle1`` isn't moving at first.
 But you can run the ``turtle_teleop_key`` node in another terminal to drive ``turtle1`` to move:
 
 .. code-block:: console
 
-   ros2 run turtlesim turtle_teleop_key
+    ros2 run turtlesim turtle_teleop_key
 
 .. image:: images/turtlesim_messagefilter.png
 
@@ -605,60 +679,60 @@ Now if you echo the topic ``turtle3/turtle_point_stamped``:
 
 .. code-block:: console
 
-   ros2 topic echo /turtle3/turtle_point_stamped
+    ros2 topic echo /turtle3/turtle_point_stamped
 
 Then there will be output like this:
 
 .. code-block:: console
 
-   header:
-     stamp:
-       sec: 1629877510
-       nanosec: 902607040
-     frame_id: world
-   point:
-     x: 4.989276885986328
-     y: 3.073937177658081
-     z: 0.0
-   ---
-   header:
-     stamp:
-       sec: 1629877510
-       nanosec: 918389395
-     frame_id: world
-   point:
-     x: 4.987966060638428
-     y: 3.089883327484131
-     z: 0.0
-   ---
-   header:
-     stamp:
-       sec: 1629877510
-       nanosec: 934186680
-     frame_id: world
-   point:
-     x: 4.986400127410889
-     y: 3.105806589126587
-     z: 0.0
-   ---
+    header:
+      stamp:
+        sec: 1629877510
+        nanosec: 902607040
+      frame_id: world
+    point:
+      x: 4.989276885986328
+      y: 3.073937177658081
+      z: 0.0
+    ---
+    header:
+      stamp:
+        sec: 1629877510
+        nanosec: 918389395
+      frame_id: world
+    point:
+      x: 4.987966060638428
+      y: 3.089883327484131
+      z: 0.0
+    ---
+    header:
+      stamp:
+        sec: 1629877510
+        nanosec: 934186680
+      frame_id: world
+    point:
+      x: 4.986400127410889
+      y: 3.105806589126587
+      z: 0.0
+    ---
 
 When the demo is running, open another terminal and run the message filter/listener node:
 
 .. code-block:: console
 
-   ros2 run learning_tf2_cpp turtle_tf2_message_filter
+    ros2 run learning_tf2_cpp turtle_tf2_message_filter
 
 If it's running correctly you should see streaming data like this:
 
 .. code-block:: console
 
-   [INFO] [1630016162.006173900] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.493231 y:-2.961614 z:0.000000
+    [INFO] [1630016162.006173900] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.493231 y:-2.961614 z:0.000000
 
-   [INFO] [1630016162.006291983] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.472169 y:-3.004742 z:0.000000
+    [INFO] [1630016162.006291983] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.472169 y:-3.004742 z:0.000000
 
-   [INFO] [1630016162.006326234] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.479420 y:-2.990479 z:0.000000
+    [INFO] [1630016162.006326234] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.479420 y:-2.990479 z:0.000000
 
-   [INFO] [1630016162.006355644] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.486441 y:-2.976102 z:0.000000
+    [INFO] [1630016162.006355644] [turtle_tf2_pose_drawer]: Point of turtle3 in frame of turtle1: x:-6.486441 y:-2.976102 z:0.000000
 
 
 Summary

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -60,13 +60,13 @@ Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the exampl
 
         .. code-block:: console
 
-                curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py -o turtle_tf2_broadcaster.py
+            curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py -o turtle_tf2_broadcaster.py
 
         Or in powershell:
 
         .. code-block:: console
 
-                curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py -o turtle_tf2_broadcaster.py
+            curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py -o turtle_tf2_broadcaster.py
 
 Open the file using your preferred text editor.
 
@@ -116,12 +116,11 @@ Open the file using your preferred text editor.
             super().__init__('turtle_tf2_frame_publisher')
 
             # Declare and acquire `turtlename` parameter
-            self.declare_parameter('turtlename', 'turtle')
-            self.turtlename = self.get_parameter(
-                'turtlename').get_parameter_value().string_value
+            self.turtlename = self.declare_parameter(
+              'turtlename', 'turtle').get_parameter_value().string_value
 
             # Initialize the transform broadcaster
-            self.br = TransformBroadcaster(self)
+            self.tf_broadcaster = TransformBroadcaster(self)
 
             # Subscribe to a turtle{1}{2}/pose topic and call handle_turtle_pose
             # callback function on each message
@@ -157,7 +156,7 @@ Open the file using your preferred text editor.
             t.transform.rotation.w = q[3]
 
             # Send the transformation
-            self.br.sendTransform(t)
+            self.tf_broadcaster.sendTransform(t)
 
 
     def main():
@@ -178,19 +177,18 @@ Firstly, we define and acquire a single parameter ``turtlename``, which specifie
 
 .. code-block:: python
 
-    self.declare_parameter('turtlename', 'turtle')
-    self.turtlename = self.get_parameter(
-        'turtlename').get_parameter_value().string_value
+    self.turtlename = self.declare_parameter(
+      'turtlename', 'turtle').get_parameter_value().string_value
 
 Afterward, the node subscribes to topic ``turtleX/pose`` and runs function ``handle_turtle_pose`` on every incoming message.
 
 .. code-block:: python
 
-    self .subscription = self.create_subscription(
-        Pose,
-        f'/{self.turtlename}/pose',
-        self.handle_turtle_pose,
-        1)
+     self .subscription = self.create_subscription(
+         Pose,
+         f'/{self.turtlename}/pose',
+         self.handle_turtle_pose,
+         1)
 
 Now, we create a ``TransformStamped`` object and give it the appropriate metadata.
 
@@ -236,7 +234,7 @@ Finally we take the transform that we constructed and pass it to the ``sendTrans
 .. code-block:: python
 
     # Send the transformation
-    self.br.sendTransform(t)
+    self.tf_broadcaster.sendTransform(t)
 
 .. note::
 
@@ -353,8 +351,8 @@ Also add the appropriate imports at the top of the file:
 
 You can learn more about creating launch files in :doc:`this tutorial <../Launch/Creating-Launch-Files>`.
 
-3 Build and run
-^^^^^^^^^^^^^^^
+3 Build
+^^^^^^^
 
 Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
@@ -364,7 +362,7 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro {DISTRO} -y
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 
@@ -374,7 +372,56 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
         rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
-Build your updated package, and source the setup files.
+Still in the root of your workspace, build your package:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+        colcon build --packages-select learning_tf2_py
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+        colcon build --packages-select learning_tf2_py
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+        colcon build --merge-install --packages-select learning_tf2_py
+
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+        . install/setup.bash
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+        . install/setup.bash
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+        # CMD
+        call install\setup.bat
+
+        # Powershell
+        .\install\setup.ps1
+
+4 Run
+^^^^^
 
 Now run the launch file that will start the turtlesim simulation node and ``turtle_tf2_broadcaster`` node:
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -71,141 +71,141 @@ Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <chrono>
-   #include <functional>
-   #include <memory>
-   #include <string>
+    #include <chrono>
+    #include <functional>
+    #include <memory>
+    #include <string>
 
-   #include "geometry_msgs/msg/transform_stamped.hpp"
-   #include "geometry_msgs/msg/twist.hpp"
-   #include "rclcpp/rclcpp.hpp"
-   #include "tf2/exceptions.h"
-   #include "tf2_ros/transform_listener.h"
-   #include "tf2_ros/buffer.h"
-   #include "turtlesim/srv/spawn.hpp"
+    #include "geometry_msgs/msg/transform_stamped.hpp"
+    #include "geometry_msgs/msg/twist.hpp"
+    #include "rclcpp/rclcpp.hpp"
+    #include "tf2/exceptions.h"
+    #include "tf2_ros/transform_listener.h"
+    #include "tf2_ros/buffer.h"
+    #include "turtlesim/srv/spawn.hpp"
 
-   using namespace std::chrono_literals;
+    using namespace std::chrono_literals;
 
-   class FrameListener : public rclcpp::Node
-   {
-   public:
-     FrameListener()
-     : Node("turtle_tf2_frame_listener"),
-       turtle_spawning_service_ready_(false),
-       turtle_spawned_(false)
-     {
-       // Declare and acquire `target_frame` parameter
-       this->declare_parameter<std::string>("target_frame", "turtle1");
-       this->get_parameter("target_frame", target_frame_);
+    class FrameListener : public rclcpp::Node
+    {
+    public:
+      FrameListener()
+      : Node("turtle_tf2_frame_listener"),
+        turtle_spawning_service_ready_(false),
+        turtle_spawned_(false)
+      {
+        // Declare and acquire `target_frame` parameter
+        target_frame_ = this->declare_parameter<std::string>("target_frame", "turtle1");
 
-       tf_buffer_ =
-         std::make_unique<tf2_ros::Buffer>(this->get_clock());
-       transform_listener_ =
-         std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+        tf_buffer_ =
+          std::make_unique<tf2_ros::Buffer>(this->get_clock());
+        tf_listener_ =
+          std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
-       // Create a client to spawn a turtle
-       spawner_ =
-         this->create_client<turtlesim::srv::Spawn>("spawn");
+        // Create a client to spawn a turtle
+        spawner_ =
+          this->create_client<turtlesim::srv::Spawn>("spawn");
 
-       // Create turtle2 velocity publisher
-       publisher_ =
-         this->create_publisher<geometry_msgs::msg::Twist>("turtle2/cmd_vel", 1);
+        // Create turtle2 velocity publisher
+        publisher_ =
+          this->create_publisher<geometry_msgs::msg::Twist>("turtle2/cmd_vel", 1);
 
-       // Call on_timer function every second
-       timer_ = this->create_wall_timer(
-         1s, std::bind(&FrameListener::on_timer, this));
-     }
+        // Call on_timer function every second
+        timer_ = this->create_wall_timer(
+          1s, std::bind(&FrameListener::on_timer, this));
+      }
 
-   private:
-     void on_timer()
-     {
-       // Store frame names in variables that will be used to
-       // compute transformations
-       std::string fromFrameRel = target_frame_.c_str();
-       std::string toFrameRel = "turtle2";
+    private:
+      void on_timer()
+      {
+        // Store frame names in variables that will be used to
+        // compute transformations
+        std::string fromFrameRel = target_frame_.c_str();
+        std::string toFrameRel = "turtle2";
 
-       if (turtle_spawning_service_ready_) {
-         if (turtle_spawned_) {
-           geometry_msgs::msg::TransformStamped transformStamped;
+        if (turtle_spawning_service_ready_) {
+          if (turtle_spawned_) {
+            geometry_msgs::msg::TransformStamped t;
 
-           // Look up for the transformation between target_frame and turtle2 frames
-           // and send velocity commands for turtle2 to reach target_frame
-           try {
-             transformStamped = tf_buffer_->lookupTransform(
-               toFrameRel, fromFrameRel,
-               tf2::TimePointZero);
-           } catch (tf2::TransformException & ex) {
-             RCLCPP_INFO(
-               this->get_logger(), "Could not transform %s to %s: %s",
-               toFrameRel.c_str(), fromFrameRel.c_str(), ex.what());
-             return;
-           }
+            // Look up for the transformation between target_frame and turtle2 frames
+            // and send velocity commands for turtle2 to reach target_frame
+            try {
+              t = tf_buffer_->lookupTransform(
+                toFrameRel, fromFrameRel,
+                tf2::TimePointZero);
+            } catch (const tf2::TransformException & ex) {
+              RCLCPP_INFO(
+                this->get_logger(), "Could not transform %s to %s: %s",
+                toFrameRel.c_str(), fromFrameRel.c_str(), ex.what());
+              return;
+            }
 
-           geometry_msgs::msg::Twist msg;
+            geometry_msgs::msg::Twist msg;
 
-           static const double scaleRotationRate = 1.0;
-           msg.angular.z = scaleRotationRate * atan2(
-             transformStamped.transform.translation.y,
-             transformStamped.transform.translation.x);
+            static const double scaleRotationRate = 1.0;
+            msg.angular.z = scaleRotationRate * atan2(
+              t.transform.translation.y,
+              t.transform.translation.x);
 
-           static const double scaleForwardSpeed = 0.5;
-           msg.linear.x = scaleForwardSpeed * sqrt(
-             pow(transformStamped.transform.translation.x, 2) +
-             pow(transformStamped.transform.translation.y, 2));
+            static const double scaleForwardSpeed = 0.5;
+            msg.linear.x = scaleForwardSpeed * sqrt(
+              pow(t.transform.translation.x, 2) +
+              pow(t.transform.translation.y, 2));
 
-           publisher_->publish(msg);
-         } else {
-           RCLCPP_INFO(this->get_logger(), "Successfully spawned");
-           turtle_spawned_ = true;
-         }
-       } else {
-         // Check if the service is ready
-         if (spawner_->service_is_ready()) {
-           // Initialize request with turtle name and coordinates
-           // Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
-           auto request = std::make_shared<turtlesim::srv::Spawn::Request>();
-           request->x = 4.0;
-           request->y = 2.0;
-           request->theta = 0.0;
-           request->name = "turtle2";
+            publisher_->publish(msg);
+          } else {
+            RCLCPP_INFO(this->get_logger(), "Successfully spawned");
+            turtle_spawned_ = true;
+          }
+        } else {
+          // Check if the service is ready
+          if (spawner_->service_is_ready()) {
+            // Initialize request with turtle name and coordinates
+            // Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
+            auto request = std::make_shared<turtlesim::srv::Spawn::Request>();
+            request->x = 4.0;
+            request->y = 2.0;
+            request->theta = 0.0;
+            request->name = "turtle2";
 
-           // Call request
-           using ServiceResponseFuture =
-             rclcpp::Client<turtlesim::srv::Spawn>::SharedFuture;
-           auto response_received_callback = [this](ServiceResponseFuture future) {
-               auto result = future.get();
-               if (strcmp(result->name.c_str(), "turtle2") == 0) {
-                 turtle_spawning_service_ready_ = true;
-               } else {
-                 RCLCPP_ERROR(this->get_logger(), "Service callback result mismatch");
-               }
-             };
-           auto result = spawner_->async_send_request(request, response_received_callback);
-         } else {
-           RCLCPP_INFO(this->get_logger(), "Service is not ready");
-         }
-       }
-     }
-     // Boolean values to store the information
-     // if the service for spawning turtle is available
-     bool turtle_spawning_service_ready_;
-     // if the turtle was successfully spawned
-     bool turtle_spawned_;
-     rclcpp::Client<turtlesim::srv::Spawn>::SharedPtr spawner_{nullptr};
-     rclcpp::TimerBase::SharedPtr timer_{nullptr};
-     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_{nullptr};
-     std::shared_ptr<tf2_ros::TransformListener> transform_listener_{nullptr};
-     std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-     std::string target_frame_;
-   };
+            // Call request
+            using ServiceResponseFuture =
+              rclcpp::Client<turtlesim::srv::Spawn>::SharedFuture;
+            auto response_received_callback = [this](ServiceResponseFuture future) {
+                auto result = future.get();
+                if (strcmp(result->name.c_str(), "turtle2") == 0) {
+                  turtle_spawning_service_ready_ = true;
+                } else {
+                  RCLCPP_ERROR(this->get_logger(), "Service callback result mismatch");
+                }
+              };
+            auto result = spawner_->async_send_request(request, response_received_callback);
+          } else {
+            RCLCPP_INFO(this->get_logger(), "Service is not ready");
+          }
+        }
+      }
 
-   int main(int argc, char * argv[])
-   {
-     rclcpp::init(argc, argv);
-     rclcpp::spin(std::make_shared<FrameListener>());
-     rclcpp::shutdown();
-     return 0;
-   }
+      // Boolean values to store the information
+      // if the service for spawning turtle is available
+      bool turtle_spawning_service_ready_;
+      // if the turtle was successfully spawned
+      bool turtle_spawned_;
+      rclcpp::Client<turtlesim::srv::Spawn>::SharedPtr spawner_{nullptr};
+      rclcpp::TimerBase::SharedPtr timer_{nullptr};
+      rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_{nullptr};
+      std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
+      std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+      std::string target_frame_;
+    };
+
+    int main(int argc, char * argv[])
+    {
+      rclcpp::init(argc, argv);
+      rclcpp::spin(std::make_shared<FrameListener>());
+      rclcpp::shutdown();
+      return 0;
+    }
 
 1.1 Examine the code
 ~~~~~~~~~~~~~~~~~~~~
@@ -217,13 +217,13 @@ The ``tf2_ros`` contains a ``TransformListener`` header file implementation that
 
 .. code-block:: C++
 
-    #include <tf2_ros/transform_listener.h>
+    #include "tf2_ros/transform_listener.h"
 
 Here, we create a ``TransformListener`` object. Once the listener is created, it starts receiving tf2 transformations over the wire, and buffers them for up to 10 seconds.
 
 .. code-block:: C++
 
-    transform_listener_ =
+    tf_listener_ =
       std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
 Finally, we query the listener for a specific transformation. We call ``lookup_transform`` method with following arguments:
@@ -239,9 +239,9 @@ All this is wrapped in a try-catch block to handle possible exceptions.
 
 .. code-block:: C++
 
-  transformStamped = tf_buffer_->lookupTransform(
-    toFrameRel, fromFrameRel,
-    tf2::TimePointZero);
+    t = tf_buffer_->lookupTransform(
+      toFrameRel, fromFrameRel,
+      tf2::TimePointZero);
 
 1.2 CMakeLists.txt
 ~~~~~~~~~~~~~~~~~~
@@ -324,8 +324,8 @@ The resulting file should look like:
 
 This will declare a ``target_frame`` launch argument, start a broadcaster for second turtle that we will spawn and listener that will subscribe to those transformations.
 
-3 Build and run
-^^^^^^^^^^^^^^^
+3 Build
+^^^^^^^
 
 Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
@@ -335,7 +335,7 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro {DISTRO} -y
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 
@@ -345,7 +345,7 @@ Run ``rosdep`` in the root of your workspace to check for missing dependencies.
 
         rosdep only runs on Linux, so you will need to install ``geometry_msgs`` and ``turtlesim`` dependencies yourself
 
-From the root of your workspace, build your updated package, and source the setup files.
+From the root of your workspace, build your updated package:
 
 .. tabs::
 
@@ -353,35 +353,61 @@ From the root of your workspace, build your updated package, and source the setu
 
       .. code-block:: console
 
-         colcon build --packages-select learning_tf2_cpp
+          colcon build --packages-select learning_tf2_cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         colcon build --packages-select learning_tf2_cpp
+          colcon build --packages-select learning_tf2_cpp
 
    .. group-tab:: Windows
 
       .. code-block:: console
 
-         colcon build --merge-install --packages-select learning_tf2_cpp
+          colcon build --merge-install --packages-select learning_tf2_cpp
+
+Open a new terminal, navigate to the root of your workspace, and source the setup files:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+          . install/setup.bash
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+          # CMD
+          call install\setup.bat
+
+          # Powershell
+          .\install\setup.ps1
+
+4 Run
+^^^^^
 
 Now you're ready to start your full turtle demo:
 
 .. code-block:: console
 
-  ros2 launch learning_tf2_cpp turtle_tf2_demo.launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_demo.launch.py
 
 You should see the turtle sim with two turtles.
 In the second terminal window type the following command:
 
 .. code-block:: console
 
-  ros2 run turtlesim turtle_teleop_key
-
-4 Checking the results
-^^^^^^^^^^^^^^^^^^^^^^
+    ros2 run turtlesim turtle_teleop_key
 
 To see if things work, simply drive around the first turtle using the arrow keys (make sure your terminal window is active, not your simulator window), and you'll see the second turtle following the first one!
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -42,7 +42,7 @@ Tasks
 ^^^^^^^^^^^^^^^^^^
 
 First we will create a package that will be used for this tutorial and the following ones.
-The package called ``learning_tf2_cpp`` will depend on ``rclcpp``, ``tf2``, ``tf2_ros``, ``geometry_msgs``, and ``turtlesim``.
+The package called ``learning_tf2_cpp`` will depend on ``geometry_msgs``, ``rclcpp``, ``tf2``, ``tf2_ros``, and ``turtlesim``.
 Code for this tutorial is stored `here <https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp>`_.
 
 Open a new terminal and :doc:`source your ROS 2 installation <../../Beginner-CLI-Tools/Configuring-ROS2-Environment>` so that ``ros2`` commands will work.
@@ -50,7 +50,7 @@ Navigate to workspace's ``src`` folder and create a new package:
 
 .. code-block:: console
 
-   ros2 pkg create --build-type ament_cmake learning_tf2_cpp
+   ros2 pkg create --build-type ament_cmake --dependencies geometry_msgs rclcpp tf2 tf2_ros turtlesim -- learning_tf2_cpp
 
 Your terminal will return a message verifying the creation of your package ``learning_tf2_cpp`` and all its necessary files and folders.
 
@@ -66,13 +66,13 @@ Inside the ``src/learning_tf2_cpp/src`` directory download the example static br
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp
+          wget https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp
 
    .. group-tab:: Windows
 
@@ -80,91 +80,91 @@ Inside the ``src/learning_tf2_cpp/src`` directory download the example static br
 
       .. code-block:: console
 
-         curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp -o static_turtle_tf2_broadcaster.py
+          curl -sk https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp -o static_turtle_tf2_broadcaster.py
 
       Or in powershell:
 
       .. code-block:: console
 
-         curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp -o static_turtle_tf2_broadcaster.py
+          curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp -o static_turtle_tf2_broadcaster.py
 
 Open the file using your preferred text editor.
 
 .. code-block:: C++
 
-   #include <memory>
+    #include <memory>
 
-   #include "geometry_msgs/msg/transform_stamped.hpp"
-   #include "rclcpp/rclcpp.hpp"
-   #include "tf2/LinearMath/Quaternion.h"
-   #include "tf2_ros/static_transform_broadcaster.h"
+    #include "geometry_msgs/msg/transform_stamped.hpp"
+    #include "rclcpp/rclcpp.hpp"
+    #include "tf2/LinearMath/Quaternion.h"
+    #include "tf2_ros/static_transform_broadcaster.h"
 
-   class StaticFramePublisher : public rclcpp::Node
-   {
-   public:
-     explicit StaticFramePublisher(char * transformation[])
-     : Node("static_turtle_tf2_broadcaster")
-     {
-       tf_publisher_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+    class StaticFramePublisher : public rclcpp::Node
+    {
+    public:
+      explicit StaticFramePublisher(char * transformation[])
+      : Node("static_turtle_tf2_broadcaster")
+      {
+        tf_static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
 
-       // Publish static transforms once at startup
-       this->make_transforms(transformation);
-     }
+        // Publish static transforms once at startup
+        this->make_transforms(transformation);
+      }
 
-   private:
-     void make_transforms(char * transformation[])
-     {
-       rclcpp::Time now = this->get_clock()->now();
-       geometry_msgs::msg::TransformStamped t;
+    private:
+      void make_transforms(char * transformation[])
+      {
+        geometry_msgs::msg::TransformStamped t;
 
-       t.header.stamp = now;
-       t.header.frame_id = "world";
-       t.child_frame_id = transformation[1];
+        t.header.stamp = this->get_clock()->now();
+        t.header.frame_id = "world";
+        t.child_frame_id = transformation[1];
 
-       t.transform.translation.x = atof(transformation[2]);
-       t.transform.translation.y = atof(transformation[3]);
-       t.transform.translation.z = atof(transformation[4]);
-       tf2::Quaternion q;
-       q.setRPY(
-         atof(transformation[5]),
-         atof(transformation[6]),
-         atof(transformation[7]));
-       t.transform.rotation.x = q.x();
-       t.transform.rotation.y = q.y();
-       t.transform.rotation.z = q.z();
-       t.transform.rotation.w = q.w();
+        t.transform.translation.x = atof(transformation[2]);
+        t.transform.translation.y = atof(transformation[3]);
+        t.transform.translation.z = atof(transformation[4]);
+        tf2::Quaternion q;
+        q.setRPY(
+          atof(transformation[5]),
+          atof(transformation[6]),
+          atof(transformation[7]));
+        t.transform.rotation.x = q.x();
+        t.transform.rotation.y = q.y();
+        t.transform.rotation.z = q.z();
+        t.transform.rotation.w = q.w();
 
-       tf_publisher_->sendTransform(t);
-     }
-     std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_publisher_;
-   };
+        tf_static_broadcaster_->sendTransform(t);
+      }
 
-   int main(int argc, char * argv[])
-   {
-     auto logger = rclcpp::get_logger("logger");
+      std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_static_broadcaster_;
+    };
 
-     // Obtain parameters from command line arguments
-     if (argc != 8) {
-       RCLCPP_INFO(
-         logger, "Invalid number of parameters\nusage: "
-         "ros2 run learning_tf2_cpp static_turtle_tf2_broadcaster "
-         "child_frame_name x y z roll pitch yaw");
-       return 1;
-     }
+    int main(int argc, char * argv[])
+    {
+      auto logger = rclcpp::get_logger("logger");
 
-     // As the parent frame of the transform is `world`, it is
-     // necessary to check that the frame name passed is different
-     if (strcmp(argv[1], "world") == 0) {
-       RCLCPP_INFO(logger, "Your static turtle name cannot be 'world'");
-       return 1;
-     }
+      // Obtain parameters from command line arguments
+      if (argc != 8) {
+        RCLCPP_INFO(
+          logger, "Invalid number of parameters\nusage: "
+          "$ ros2 run learning_tf2_cpp static_turtle_tf2_broadcaster "
+          "child_frame_name x y z roll pitch yaw");
+        return 1;
+      }
 
-     // Pass parameters and initialize node
-     rclcpp::init(argc, argv);
-     rclcpp::spin(std::make_shared<StaticFramePublisher>(argv));
-     rclcpp::shutdown();
-     return 0;
-   }
+      // As the parent frame of the transform is `world`, it is
+      // necessary to check that the frame name passed is different
+      if (strcmp(argv[1], "world") == 0) {
+        RCLCPP_INFO(logger, "Your static turtle name cannot be 'world'");
+        return 1;
+      }
+
+      // Pass parameters and initialize node
+      rclcpp::init(argc, argv);
+      rclcpp::spin(std::make_shared<StaticFramePublisher>(argv));
+      rclcpp::shutdown();
+      return 0;
+    }
 
 2.1 Examine the code
 ~~~~~~~~~~~~~~~~~~~~
@@ -175,30 +175,30 @@ First we include ``geometry_msgs/msg/transform_stamped.hpp`` to access the ``Tra
 
 .. code-block:: C++
 
-   #include "geometry_msgs/msg/transform_stamped.hpp"
+    #include "geometry_msgs/msg/transform_stamped.hpp"
 
 Afterward, ``rclcpp`` is included so its ``rclcpp::Node`` class can be used.
 
 .. code-block:: C++
 
-   #include "rclcpp/rclcpp.hpp"
+    #include "rclcpp/rclcpp.hpp"
 
 ``tf2::Quaternion`` is a class for a quaternion that provides convenient functions for converting Euler angles to quaternions and vice versa.
 We also include ``tf2_ros/static_transform_broadcaster.h`` to use the ``StaticTransformBroadcaster`` to make the publishing of static transforms easy.
 
 .. code-block:: C++
 
-   #include "tf2/LinearMath/Quaternion.h"
-   #include "tf2_ros/static_transform_broadcaster.h"
+    #include "tf2/LinearMath/Quaternion.h"
+    #include "tf2_ros/static_transform_broadcaster.h"
 
 The ``StaticFramePublisher`` class constructor initializes the node with the name ``static_turtle_tf2_broadcaster``.
 Then, ``StaticTransformBroadcaster`` is created, which will send one static transformation upon the startup.
 
 .. code-block:: C++
 
-   tf_publisher_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+    tf_static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
 
-   this->make_transforms(transformation);
+    this->make_transforms(transformation);
 
 Here we create a ``TransformStamped`` object, which will be the message we will send over once populated.
 Before passing the actual transform values we need to give it the appropriate metadata.
@@ -211,35 +211,34 @@ Before passing the actual transform values we need to give it the appropriate me
 
 .. code-block:: C++
 
-   rclcpp::Time now = this->get_clock()->now();
-   geometry_msgs::msg::TransformStamped t;
+    geometry_msgs::msg::TransformStamped t;
 
-   t.header.stamp = now;
-   t.header.frame_id = "world";
-   t.child_frame_id = transformation[1];
+    t.header.stamp = this->get_clock()->now();
+    t.header.frame_id = "world";
+    t.child_frame_id = transformation[1];
 
 Here we populate the 6D pose (translation and rotation) of the turtle.
 
 .. code-block:: C++
 
-   t.transform.translation.x = atof(transformation[2]);
-   t.transform.translation.y = atof(transformation[3]);
-   t.transform.translation.z = atof(transformation[4]);
-   tf2::Quaternion q;
-   q.setRPY(
-     atof(transformation[5]),
-     atof(transformation[6]),
-     atof(transformation[7]));
-   t.transform.rotation.x = q.x();
-   t.transform.rotation.y = q.y();
-   t.transform.rotation.z = q.z();
-   t.transform.rotation.w = q.w();
+    t.transform.translation.x = atof(transformation[2]);
+    t.transform.translation.y = atof(transformation[3]);
+    t.transform.translation.z = atof(transformation[4]);
+    tf2::Quaternion q;
+    q.setRPY(
+      atof(transformation[5]),
+      atof(transformation[6]),
+      atof(transformation[7]));
+    t.transform.rotation.x = q.x();
+    t.transform.rotation.y = q.y();
+    t.transform.rotation.z = q.z();
+    t.transform.rotation.w = q.w();
 
 Finally, we broadcast static transform using the ``sendTransform()`` function.
 
 .. code-block:: C++
 
-   tf_publisher_->sendTransform(t);
+    tf_static_broadcaster_->sendTransform(t);
 
 2.2 Add dependencies
 ~~~~~~~~~~~~~~~~~~~~
@@ -252,61 +251,38 @@ As mentioned in the :doc:`Create a package <../../Beginner-Client-Libraries/Crea
 
 .. code-block:: xml
 
-  <description>Learning tf2 with rclcpp</description>
-  <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
-
-After the lines above, add the following dependencies corresponding to your node’s include statements:
-
-.. code-block:: xml
-
-   <depend>geometry_msgs</depend>
-   <depend>rclcpp</depend>
-   <depend>tf2</depend>
-   <depend>tf2_ros</depend>
-   <depend>turtlesim</depend>
-
-This declares the required ``geometry_msgs``, ``rclcpp``, ``tf2``, ``tf2_ros``, and ``turtlesim`` dependencies when its code is built and executed.
+    <description>Learning tf2 with rclcpp</description>
+    <maintainer email="you@email.com">Your Name</maintainer>
+    <license>Apache License 2.0</license>
 
 Make sure to save the file.
 
 2.3 CMakeLists.txt
 ~~~~~~~~~~~~~~~~~~
 
-Now open the CMakeLists.txt file. Below the existing dependency ``find_package(ament_cmake REQUIRED)``, add the lines:
+Add the executable to the CMakeLists.txt and name it ``static_turtle_tf2_broadcaster``, which you'll use later with ``ros2 run``.
 
 .. code-block:: console
 
-   find_package(geometry_msgs REQUIRED)
-   find_package(rclcpp REQUIRED)
-   find_package(tf2 REQUIRED)
-   find_package(tf2_ros REQUIRED)
-   find_package(turtlesim REQUIRED)
-
-After that, add the executable and name it ``static_turtle_tf2_broadcaster``, which you'll use later with ``ros2 run``.
-
-.. code-block:: console
-
-   add_executable(static_turtle_tf2_broadcaster src/static_turtle_tf2_broadcaster.cpp)
-   ament_target_dependencies(
-      static_turtle_tf2_broadcaster
-      geometry_msgs
-      rclcpp
-      tf2
-      tf2_ros
-      turtlesim
-   )
+    add_executable(static_turtle_tf2_broadcaster src/static_turtle_tf2_broadcaster.cpp)
+    ament_target_dependencies(
+       static_turtle_tf2_broadcaster
+       geometry_msgs
+       rclcpp
+       tf2
+       tf2_ros
+    )
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
 
 .. code-block:: console
 
-   install(TARGETS
-      static_turtle_tf2_broadcaster
-      DESTINATION lib/${PROJECT_NAME})
+    install(TARGETS
+       static_turtle_tf2_broadcaster
+       DESTINATION lib/${PROJECT_NAME})
 
-3 Build and run
-^^^^^^^^^^^^^^^
+3 Build
+^^^^^^^
 
 It's good practice to run ``rosdep`` in the root of your workspace to check for missing dependencies before building:
 
@@ -316,7 +292,7 @@ It's good practice to run ``rosdep`` in the root of your workspace to check for 
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro {DISTRO} -y
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 
@@ -334,19 +310,19 @@ Still in the root of your workspace, build your new package:
 
       .. code-block:: console
 
-         colcon build --packages-select learning_tf2_cpp
+          colcon build --packages-select learning_tf2_cpp
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         colcon build --packages-select learning_tf2_cpp
+          colcon build --packages-select learning_tf2_cpp
 
    .. group-tab:: Windows
 
       .. code-block:: console
 
-         colcon build --merge-install --packages-select learning_tf2_cpp
+          colcon build --merge-install --packages-select learning_tf2_cpp
 
 Open a new terminal, navigate to the root of your workspace, and source the setup files:
 
@@ -356,29 +332,32 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 
       .. code-block:: console
 
-         . install/setup.bash
+          . install/setup.bash
 
    .. group-tab:: macOS
 
       .. code-block:: console
 
-         . install/setup.bash
+          . install/setup.bash
 
    .. group-tab:: Windows
 
       .. code-block:: console
 
-         # CMD
-         call install\setup.bat
+          # CMD
+          call install\setup.bat
 
-         # Powershell
-         .\install\setup.ps1
+          # Powershell
+          .\install\setup.ps1
+
+4 Run
+^^^^^
 
 Now run the ``static_turtle_tf2_broadcaster`` node:
 
 .. code-block:: console
 
-   ros2 run learning_tf2_cpp static_turtle_tf2_broadcaster mystaticturtle 0 0 1 0 0 0
+    ros2 run learning_tf2_cpp static_turtle_tf2_broadcaster mystaticturtle 0 0 1 0 0 0
 
 This sets a turtle pose broadcast for ``mystaticturtle`` to float 1 meter above the ground.
 
@@ -386,29 +365,29 @@ We can now check that the static transform has been published by echoing the ``t
 
 .. code-block:: console
 
-   ros2 topic echo /tf_static
+    ros2 topic echo /tf_static
 
 If everything went well you should see a single static transform
 
 .. code-block:: console
 
-   transforms:
-   - header:
-      stamp:
-         sec: 1622908754
-         nanosec: 208515730
-      frame_id: world
-   child_frame_id: mystaticturtle
-   transform:
-      translation:
-         x: 0.0
-         y: 0.0
-         z: 1.0
-      rotation:
-         x: 0.0
-         y: 0.0
-         z: 0.0
-         w: 1.0
+    transforms:
+    - header:
+       stamp:
+          sec: 1622908754
+          nanosec: 208515730
+       frame_id: world
+    child_frame_id: mystaticturtle
+    transform:
+       translation:
+          x: 0.0
+          y: 0.0
+          z: 1.0
+       rotation:
+          x: 0.0
+          y: 0.0
+          z: 0.0
+          w: 1.0
 
 The proper way to publish static transforms
 -------------------------------------------
@@ -422,29 +401,29 @@ In our case, roll/pitch/yaw refers to rotation about the x/y/z-axis, respectivel
 
 .. code-block:: console
 
-   ros2 run tf2_ros static_transform_publisher --x x --y y --z z --yaw yaw --pitch pitch --roll roll --frame-id frame_id --child-frame-id child_frame_id
+    ros2 run tf2_ros static_transform_publisher --x x --y y --z z --yaw yaw --pitch pitch --roll roll --frame-id frame_id --child-frame-id child_frame_id
 
 Publish a static coordinate transform to tf2 using an x/y/z offset in meters and quaternion.
 
 .. code-block:: console
 
-   ros2 run tf2_ros static_transform_publisher --x x --y y --z z --qx qx --qy qy --qz qz --qw qw --frame-id frame_id --child-frame-id child_frame_id
+    ros2 run tf2_ros static_transform_publisher --x x --y y --z z --qx qx --qy qy --qz qz --qw qw --frame-id frame_id --child-frame-id child_frame_id
 
 ``static_transform_publisher`` is designed both as a command-line tool for manual use, as well as for use within ``launch`` files for setting static transforms. For example:
 
 .. code-block:: console
 
-   from launch import LaunchDescription
-   from launch_ros.actions import Node
+    from launch import LaunchDescription
+    from launch_ros.actions import Node
 
-   def generate_launch_description():
-      return LaunchDescription([
-         Node(
-               package='tf2_ros',
-               executable='static_transform_publisher',
-               arguments = ['--x', '0', '--y', '0', '--z', '1', '--yaw', '0', '--pitch', '0', '--roll', '0', '--frame-id', 'world', '--child-frame-id', 'mystaticturtle']
-         ),
-      ])
+    def generate_launch_description():
+        return LaunchDescription([
+            Node(
+                 package='tf2_ros',
+                 executable='static_transform_publisher',
+                 arguments = ['--x', '0', '--y', '0', '--z', '1', '--yaw', '0', '--pitch', '0', '--roll', '0', '--frame-id', 'world', '--child-frame-id', 'mystaticturtle']
+            ),
+        ])
 
 Note that all arguments except for ``--frame-id`` and ``--child-frame-id`` are optional; if a particular option isn't specified, then the identity will be assumed.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -42,7 +42,7 @@ Tasks
 ^^^^^^^^^^^^^^^^^^
 
 First we will create a package that will be used for this tutorial and the following ones.
-The package called ``learning_tf2_py`` will depend on ``rclpy``, ``tf2_ros``, ``geometry_msgs``, and ``turtlesim``.
+The package called ``learning_tf2_py`` will depend on ``geometry_msgs``, ``python3-numpy``, ``rclpy``, ``tf2_ros_py``, and ``turtlesim``.
 Code for this tutorial is stored `here <https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/static_turtle_tf2_broadcaster.py>`_.
 
 Open a new terminal and :doc:`source your ROS 2 installation <../../Beginner-CLI-Tools/Configuring-ROS2-Environment>` so that ``ros2`` commands will work.
@@ -92,17 +92,17 @@ Open the file using your preferred text editor.
 
 .. code-block:: python
 
-   import math
-   import sys
+    import math
+    import sys
 
-   from geometry_msgs.msg import TransformStamped
+    from geometry_msgs.msg import TransformStamped
 
-   import numpy as np
+    import numpy as np
 
-   import rclpy
-   from rclpy.node import Node
+    import rclpy
+    from rclpy.node import Node
 
-   from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
+    from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 
 
     def quaternion_from_euler(ai, aj, ak):
@@ -129,64 +129,66 @@ Open the file using your preferred text editor.
         return q
 
 
-   class StaticFramePublisher(Node):
-      """
-      Broadcast transforms that never change.
+    class StaticFramePublisher(Node):
+        """
+        Broadcast transforms that never change.
 
-      This example publishes transforms from `world` to a static turtle frame.
-      The transforms are only published once at startup, and are constant for all
-      time.
-      """
+        This example publishes transforms from `world` to a static turtle frame.
+        The transforms are only published once at startup, and are constant for all
+        time.
+        """
 
-      def __init__(self, transformation):
-         super().__init__('static_turtle_tf2_broadcaster')
+        def __init__(self, transformation):
+            super().__init__('static_turtle_tf2_broadcaster')
 
-         self._tf_publisher = StaticTransformBroadcaster(self)
+            self.tf_static_broadcaster = StaticTransformBroadcaster(self)
 
-         # Publish static transforms once at startup
-         self.make_transforms(transformation)
+            # Publish static transforms once at startup
+            self.make_transforms(transformation)
 
-      def make_transforms(self, transformation):
-         static_transformStamped = TransformStamped()
-         static_transformStamped.header.stamp = self.get_clock().now().to_msg()
-         static_transformStamped.header.frame_id = 'world'
-         static_transformStamped.child_frame_id = sys.argv[1]
-         static_transformStamped.transform.translation.x = float(sys.argv[2])
-         static_transformStamped.transform.translation.y = float(sys.argv[3])
-         static_transformStamped.transform.translation.z = float(sys.argv[4])
-         quat = quaternion_from_euler(
-               float(sys.argv[5]), float(sys.argv[6]), float(sys.argv[7]))
-         static_transformStamped.transform.rotation.x = quat[0]
-         static_transformStamped.transform.rotation.y = quat[1]
-         static_transformStamped.transform.rotation.z = quat[2]
-         static_transformStamped.transform.rotation.w = quat[3]
+        def make_transforms(self, transformation):
+            t = TransformStamped()
 
-         self._tf_publisher.sendTransform(static_transformStamped)
+            t.header.stamp = self.get_clock().now().to_msg()
+            t.header.frame_id = 'world'
+            t.child_frame_id = transformation[1]
+
+            t.transform.translation.x = float(transformation[2])
+            t.transform.translation.y = float(transformation[3])
+            t.transform.translation.z = float(transformation[4])
+            quat = quaternion_from_euler(
+                float(transformation[5]), float(transformation[6]), float(transformation[7]))
+            t.transform.rotation.x = quat[0]
+            t.transform.rotation.y = quat[1]
+            t.transform.rotation.z = quat[2]
+            t.transform.rotation.w = quat[3]
+
+            self.tf_static_broadcaster.sendTransform(t)
 
 
-   def main():
-      logger = rclpy.logging.get_logger('logger')
+    def main():
+        logger = rclpy.logging.get_logger('logger')
 
-      # obtain parameters from command line arguments
-      if len(sys.argv) < 8:
-         logger.info('Invalid number of parameters. Usage: \n'
-                     '$ ros2 run learning_tf2_py static_turtle_tf2_broadcaster'
-                     'child_frame_name x y z roll pitch yaw')
-         sys.exit(0)
-      else:
-         if sys.argv[1] == 'world':
-               logger.info('Your static turtle name cannot be "world"')
-               sys.exit(0)
+        # obtain parameters from command line arguments
+        if len(sys.argv) != 8:
+            logger.info('Invalid number of parameters. Usage: \n'
+                        '$ ros2 run learning_tf2_py static_turtle_tf2_broadcaster'
+                        'child_frame_name x y z roll pitch yaw')
+            sys.exit(1)
 
-      # pass parameters and initialize node
-      rclpy.init()
-      node = StaticFramePublisher(sys.argv)
-      try:
-         rclpy.spin(node)
-      except KeyboardInterrupt:
-         pass
+        if sys.argv[1] == 'world':
+            logger.info('Your static turtle name cannot be "world"')
+            sys.exit(2)
 
-      rclpy.shutdown()
+        # pass parameters and initialize node
+        rclpy.init()
+        node = StaticFramePublisher(sys.argv)
+        try:
+            rclpy.spin(node)
+        except KeyboardInterrupt:
+            pass
+
+        rclpy.shutdown()
 
 2.1 Examine the code
 ~~~~~~~~~~~~~~~~~~~~
@@ -197,29 +199,29 @@ First we import the ``TransformStamped`` from the ``geometry_msgs``, which provi
 
 .. code-block:: python
 
-   from geometry_msgs.msg import TransformStamped
+    from geometry_msgs.msg import TransformStamped
 
 Afterward, ``rclpy`` is imported so its ``Node`` class can be used.
 
 .. code-block:: python
 
-   import rclpy
-   from rclpy.node import Node
+    import rclpy
+    from rclpy.node import Node
 
 The ``tf2_ros`` package provides a ``StaticTransformBroadcaster`` to make the publishing of static transforms easy.
 To use the ``StaticTransformBroadcaster``, we need to import it from the ``tf2_ros`` module.
 
 .. code-block:: python
 
-   from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
+    from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 
 The ``StaticFramePublisher`` class constructor initializes the node with the name ``static_turtle_tf2_broadcaster``.
 Then, ``StaticTransformBroadcaster`` is created, which will send one static transformation upon the startup.
 
 .. code-block:: python
 
-   self._tf_publisher = StaticTransformBroadcaster(self)
-   self.make_transforms(transformation)
+    self.tf_static_broadcaster = StaticTransformBroadcaster(self)
+    self.make_transforms(transformation)
 
 Here we create a ``TransformStamped`` object, which will be the message we will send over once populated.
 Before passing the actual transform values we need to give it the appropriate metadata.
@@ -232,30 +234,31 @@ Before passing the actual transform values we need to give it the appropriate me
 
 .. code-block:: python
 
-   static_transformStamped = TransformStamped()
-   static_transformStamped.header.stamp = self.get_clock().now().to_msg()
-   static_transformStamped.header.frame_id = 'world'
-   static_transformStamped.child_frame_id = sys.argv[1]
+    t = TransformStamped()
+
+    t.header.stamp = self.get_clock().now().to_msg()
+    t.header.frame_id = 'world'
+    t.child_frame_id = transformation[1]
 
 Here we populate the 6D pose (translation and rotation) of the turtle.
 
 .. code-block:: python
 
-   static_transformStamped.transform.translation.x = float(sys.argv[2])
-   static_transformStamped.transform.translation.y = float(sys.argv[3])
-   static_transformStamped.transform.translation.z = float(sys.argv[4])
-   quat = quaternion_from_euler(
-      float(sys.argv[5]), float(sys.argv[6]), float(sys.argv[7]))
-   static_transformStamped.transform.rotation.x = quat[0]
-   static_transformStamped.transform.rotation.y = quat[1]
-   static_transformStamped.transform.rotation.z = quat[2]
-   static_transformStamped.transform.rotation.w = quat[3]
+    t.transform.translation.x = float(transformation[2])
+    t.transform.translation.y = float(transformation[3])
+    t.transform.translation.z = float(transformation[4])
+    quat = quaternion_from_euler(
+        float(transformation[5]), float(transformation[6]), float(transformation[7]))
+    t.transform.rotation.x = quat[0]
+    t.transform.rotation.y = quat[1]
+    t.transform.rotation.z = quat[2]
+    t.transform.rotation.w = quat[3]
 
 Finally, we broadcast static transform using the ``sendTransform()`` function.
 
 .. code-block:: python
 
-   self._tf_publisher.sendTransform(static_transformStamped)
+    self.tf_static_broadcaster.sendTransform(t)
 
 2.2 Add dependencies
 ~~~~~~~~~~~~~~~~~~~~
@@ -268,21 +271,21 @@ As mentioned in the :doc:`Create a package <../../Beginner-Client-Libraries/Crea
 
 .. code-block:: xml
 
-  <description>Learning tf2 with rclpy</description>
-  <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+    <description>Learning tf2 with rclpy</description>
+    <maintainer email="you@email.com">Your Name</maintainer>
+    <license>Apache License 2.0</license>
 
 After the lines above, add the following dependencies corresponding to your node’s import statements:
 
 .. code-block:: xml
 
-   <exec_depend>geometry_msgs</exec_depend>
-   <exec_depend>python3-numpy</exec_depend>
-   <exec_depend>rclpy</exec_depend>
-   <exec_depend>tf2_ros</exec_depend>
-   <exec_depend>turtlesim</exec_depend>
+    <exec_depend>geometry_msgs</exec_depend>
+    <exec_depend>python3-numpy</exec_depend>
+    <exec_depend>rclpy</exec_depend>
+    <exec_depend>tf2_ros_py</exec_depend>
+    <exec_depend>turtlesim</exec_depend>
 
-This declares the required ``geometry_msgs``, ``python3-numpy``, ``rclpy``, ``tf2_ros``, and ``turtlesim`` dependencies when its code is executed.
+This declares the required ``geometry_msgs``, ``python3-numpy``, ``rclpy``, ``tf2_ros_py``, and ``turtlesim`` dependencies when its code is executed.
 
 Make sure to save the file.
 
@@ -291,14 +294,14 @@ Make sure to save the file.
 
 To allow the ``ros2 run`` command to run your node, you must add the entry point to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
 
-Finally, add the following line between the ``'console_scripts':`` brackets:
+Add the following line between the ``'console_scripts':`` brackets:
 
 .. code-block:: python
 
-   'static_turtle_tf2_broadcaster = learning_tf2_py.static_turtle_tf2_broadcaster:main',
+    'static_turtle_tf2_broadcaster = learning_tf2_py.static_turtle_tf2_broadcaster:main',
 
-3 Build and run
-^^^^^^^^^^^^^^^
+3 Build
+^^^^^^^
 
 It's good practice to run ``rosdep`` in the root of your workspace to check for missing dependencies before building:
 
@@ -308,7 +311,7 @@ It's good practice to run ``rosdep`` in the root of your workspace to check for 
 
       .. code-block:: console
 
-        rosdep install -i --from-path src --rosdistro {DISTRO} -y
+          rosdep install -i --from-path src --rosdistro {DISTRO} -y
 
    .. group-tab:: macOS
 
@@ -326,19 +329,19 @@ Still in the root of your workspace, build your new package:
 
     .. code-block:: console
 
-      colcon build --packages-select learning_tf2_py
+        colcon build --packages-select learning_tf2_py
 
   .. group-tab:: macOS
 
     .. code-block:: console
 
-      colcon build --packages-select learning_tf2_py
+        colcon build --packages-select learning_tf2_py
 
   .. group-tab:: Windows
 
     .. code-block:: console
 
-      colcon build --merge-install --packages-select learning_tf2_py
+        colcon build --merge-install --packages-select learning_tf2_py
 
 Open a new terminal, navigate to the root of your workspace, and source the setup files:
 
@@ -348,29 +351,32 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 
     .. code-block:: console
 
-      . install/setup.bash
+        . install/setup.bash
 
   .. group-tab:: macOS
 
     .. code-block:: console
 
-      . install/setup.bash
+        . install/setup.bash
 
   .. group-tab:: Windows
 
     .. code-block:: console
 
-      # CMD
-      call install\setup.bat
+        # CMD
+        call install\setup.bat
 
-      # Powershell
-      .\install\setup.ps1
+        # Powershell
+        .\install\setup.ps1
+
+4 Run
+^^^^^
 
 Now run the ``static_turtle_tf2_broadcaster`` node:
 
 .. code-block:: console
 
-   ros2 run learning_tf2_py static_turtle_tf2_broadcaster mystaticturtle 0 0 1 0 0 0
+    ros2 run learning_tf2_py static_turtle_tf2_broadcaster mystaticturtle 0 0 1 0 0 0
 
 This sets a turtle pose broadcast for ``mystaticturtle`` to float 1 meter above the ground.
 
@@ -378,29 +384,29 @@ We can now check that the static transform has been published by echoing the ``t
 
 .. code-block:: console
 
-   ros2 topic echo /tf_static
+    ros2 topic echo /tf_static
 
 If everything went well you should see a single static transform
 
 .. code-block:: console
 
-   transforms:
-   - header:
-      stamp:
-         sec: 1622908754
-         nanosec: 208515730
-      frame_id: world
-   child_frame_id: mystaticturtle
-   transform:
-      translation:
-         x: 0.0
-         y: 0.0
-         z: 1.0
-      rotation:
-         x: 0.0
-         y: 0.0
-         z: 0.0
-         w: 1.0
+    transforms:
+    - header:
+       stamp:
+          sec: 1622908754
+          nanosec: 208515730
+       frame_id: world
+    child_frame_id: mystaticturtle
+    transform:
+       translation:
+          x: 0.0
+          y: 0.0
+          z: 1.0
+       rotation:
+          x: 0.0
+          y: 0.0
+          z: 0.0
+          w: 1.0
 
 The proper way to publish static transforms
 -------------------------------------------
@@ -414,29 +420,29 @@ In our case, roll/pitch/yaw refers to rotation about the x/y/z-axis, respectivel
 
 .. code-block:: console
 
-   ros2 run tf2_ros static_transform_publisher --x x --y y --z z --yaw yaw --pitch pitch --roll roll --frame-id frame_id --child-frame-id child_frame_id
+    ros2 run tf2_ros static_transform_publisher --x x --y y --z z --yaw yaw --pitch pitch --roll roll --frame-id frame_id --child-frame-id child_frame_id
 
 Publish a static coordinate transform to tf2 using an x/y/z offset in meters and quaternion.
 
 .. code-block:: console
 
-   ros2 run tf2_ros static_transform_publisher --x x --y y --z z --qx qx --qy qy --qz qz --qw qw --frame-id frame_id --child-frame-id child_frame_id
+    ros2 run tf2_ros static_transform_publisher --x x --y y --z z --qx qx --qy qy --qz qz --qw qw --frame-id frame_id --child-frame-id child_frame_id
 
 ``static_transform_publisher`` is designed both as a command-line tool for manual use, as well as for use within ``launch`` files for setting static transforms. For example:
 
 .. code-block:: console
 
-   from launch import LaunchDescription
-   from launch_ros.actions import Node
+    from launch import LaunchDescription
+    from launch_ros.actions import Node
 
-   def generate_launch_description():
-      return LaunchDescription([
-         Node(
-               package='tf2_ros',
-               executable='static_transform_publisher',
-               arguments = ['--x', '0', '--y', '0', '--z', '1', '--yaw', '0', '--pitch', '0', '--roll', '0', '--frame-id', 'world', '--child-frame-id', 'mystaticturtle']
-         ),
-      ])
+    def generate_launch_description():
+        return LaunchDescription([
+            Node(
+                package='tf2_ros',
+                executable='static_transform_publisher',
+                arguments = ['--x', '0', '--y', '0', '--z', '1', '--yaw', '0', '--pitch', '0', '--roll', '0', '--frame-id', 'world', '--child-frame-id', 'mystaticturtle']
+            ),
+        ])
 
 Note that all arguments except for ``--frame-id`` and ``--child-frame-id`` are optional; if a particular option isn't specified, then the identity will be assumed.
 


### PR DESCRIPTION
This commit actually does a full audit of the Tf2 tutorials to do a number of things in them:

1.  Synchronizes the code in here with what is in https://github.com/ros/geometry_tutorials.  In the process of doing this, it fixes some small bugs.
2.  It makes the tutorials far more internally consistent, so that we have the same set of steps for each tutorial and each step is well-defined.
3.  It splits the "Build and run" sections into separate "Build" and "Run" sections, as that just seemed to make more sense.
4.  It fixes up the spacing so that it is all internally consistent within the tutorials.  This makes up the bulk of the changes, but I think it is worthwhile to do.

One thing I did not do is revamp the "Time" parts of the Tf2 tutorials. Those need to be rethought, but that will be a separate effort.

I retested all of these tutorials with these changes in place, and they all seem to work for me.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I apologize for the size of this PR; I just started changing things, and it just got larger and larger.  If you'd prefer I split this up somehow, please let me know and I can think about a way to make this easier to review.