### PR TITLE
Get rid of unnecessary 'launch' subdirectory.

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -133,7 +133,6 @@ The ``PathJoinSubstitution`` substitution is then used to join the path to that 
 
     PathJoinSubstitution([
         FindPackageShare('launch_tutorial'),
-        'launch',
         'example_substitutions.launch.py'
     ])
 


### PR DESCRIPTION
This makes it actually work, and also makes it match the example_main.launch.py right above it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>