### PR TITLE
Document tf2::TimePoint vs rclcpp::Time

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
@@ -44,6 +44,15 @@ Open ``turtle_tf2_listener.cpp`` and take a look at the ``lookupTransform()`` ca
       tf2::TimePointZero);
 
 You can see that we specified a time equal to 0 by calling ``tf2::TimePointZero``.
+
+.. note::
+    
+    The ``tf2`` package has it's own time type ``tf2::TimePoint``.
+    This is different from ``rclcpp::Time``.
+    Many APIs in the package ``tf2_ros`` automatically convert between ``rclcpp::Time`` and ``tf2::TimePoint``.
+
+    ``rclcpp::Time(0, 0, this->get_clock()->get_clock_type())`` could have been used here, but it would have been converted to ``tf2::TimePointZero`` anyways.
+
 For tf2, time 0 means "the latest available" transform in the buffer.
 Now, change this line to get the transform at the current time, ``this->get_clock()->now()``:
 

--- a/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
@@ -46,9 +46,8 @@ Open ``turtle_tf2_listener.cpp`` and take a look at the ``lookupTransform()`` ca
 You can see that we specified a time equal to 0 by calling ``tf2::TimePointZero``.
 
 .. note::
-    
-    The ``tf2`` package has it's own time type ``tf2::TimePoint``.
-    This is different from ``rclcpp::Time``.
+
+    The ``tf2`` package has it's own time type ``tf2::TimePoint``, which is different from ``rclcpp::Time``.
     Many APIs in the package ``tf2_ros`` automatically convert between ``rclcpp::Time`` and ``tf2::TimePoint``.
 
     ``rclcpp::Time(0, 0, this->get_clock()->get_clock_type())`` could have been used here, but it would have been converted to ``tf2::TimePointZero`` anyways.


### PR DESCRIPTION
Part of https://github.com/ros2/rviz/issues/894

This documents that `tf2::TimePoint` is different from `rclcpp::Time`, and explains why `tf2::TimePointZero` was used.