### PR TITLE
Update default WORKING_DIRECTORY for ament_add_gtest()

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -326,7 +326,7 @@ The macros have additional parameters:
 
 - ``WORKING_DIRECTORY``: set the working directory for the test.
 
-The default working directory otherwise is the ``CMAKE_SOURCE_DIR``, which will be evaluated to the directory of the top-level ``CMakeLists.txt``.
+The default working directory otherwise is the ``CMAKE_CURRENT_BINARY_DIR``, which is described in the `CMake documentation <https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_BINARY_DIR.html>`_.
 
 Similarly, there is a CMake macro to set up GTest including GMock:
 


### PR DESCRIPTION
Part of #3116, if this PR is approved, I'll open other PRs into foxy, galactic, and humble with the same diff.

What's the consensus on hyperlinks in these docs? Are they sorta avoided in case they go stale? I figured it was best in this case since the CMake docs should be reliable and the "best source of truth" for variables that they define.