### PR TITLE
(Foxy only) Have users install python3-argcomplete.

### DIFF
--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -49,14 +49,14 @@ Desktop Install (Recommended): ROS, RViz, demos, tutorials.
 
 .. code-block:: bash
 
-   sudo apt install ros-{DISTRO}-desktop
+   sudo apt install ros-{DISTRO}-desktop python3-argcomplete
 
 ROS-Base Install (Bare Bones): Communication libraries, message packages, command line tools.
 No GUI tools.
 
 .. code-block:: bash
 
-   sudo apt install ros-{DISTRO}-ros-base
+   sudo apt install ros-{DISTRO}-ros-base python3-argcomplete
 
 Environment setup
 -----------------


### PR DESCRIPTION
This is so that tab completion on the command-line works by default for users.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Closes #3124 