### PR TITLE
Update throttle logging docs with units and data type hints (re: rclcpp/issues/1929)

### DIFF
--- a/source/Concepts/About-Logging.rst
+++ b/source/Concepts/About-Logging.rst
@@ -53,15 +53,15 @@ These are the APIs that end users of the ROS 2 logging infrastructure should use
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_EXPRESSION`` - output the given printf-style message only if the given expression is true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_FUNCTION`` - output the given printf-style message only if the given function returns true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_SKIPFIRST`` - output the given printf-style message all but the first time this line is hit
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_THROTTLE`` - output the given printf-style message no more than the given rate
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_SKIPFIRST_THROTTLE`` - output the given printf-style message no more than the given rate, but skip the first
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_THROTTLE`` - output the given printf-style message no more than the given rate in integral milliseconds
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_SKIPFIRST_THROTTLE`` - output the given printf-style message no more than the given rate in integral milliseconds, but skip the first
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM`` - output the given C++ stream-style message every time this line is hit
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_ONCE`` - output the given C++ stream-style message only the first time this line is hit
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_EXPRESSION`` - output the given C++ stream-style message only if the given expression is true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_FUNCTION`` - output the given C++ stream-style message only if the given function returns true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_SKIPFIRST`` - output the given C++ stream-style message all but the first time this line is hit
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_THROTTLE`` - output the given C++ stream-style message no more than the given rate
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_SKIPFIRST_THROTTLE`` - output the given C++ stream-style message no more than the given rate, but skip the first
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_THROTTLE`` - output the given C++ stream-style message no more than the given rate in integral milliseconds
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_SKIPFIRST_THROTTLE`` - output the given C++ stream-style message no more than the given rate in integral milliseconds, but skip the first
 
     Each of the above APIs takes an ``rclcpp::Logger`` object as the first argument.
     This can be pulled from the node API by calling ``node->get_logger()`` (recommended), or by constructing a stand-alone ``rclcpp::Logger`` object.

--- a/source/Concepts/About-Logging.rst
+++ b/source/Concepts/About-Logging.rst
@@ -53,15 +53,15 @@ These are the APIs that end users of the ROS 2 logging infrastructure should use
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_EXPRESSION`` - output the given printf-style message only if the given expression is true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_FUNCTION`` - output the given printf-style message only if the given function returns true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_SKIPFIRST`` - output the given printf-style message all but the first time this line is hit
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_THROTTLE`` - output the given printf-style message no more than the given rate in integral milliseconds
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_SKIPFIRST_THROTTLE`` - output the given printf-style message no more than the given rate in integral milliseconds, but skip the first
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_THROTTLE`` - output the given printf-style message no more than the given rate in integer milliseconds
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_SKIPFIRST_THROTTLE`` - output the given printf-style message no more than the given rate in integer milliseconds, but skip the first
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM`` - output the given C++ stream-style message every time this line is hit
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_ONCE`` - output the given C++ stream-style message only the first time this line is hit
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_EXPRESSION`` - output the given C++ stream-style message only if the given expression is true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_FUNCTION`` - output the given C++ stream-style message only if the given function returns true
     * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_SKIPFIRST`` - output the given C++ stream-style message all but the first time this line is hit
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_THROTTLE`` - output the given C++ stream-style message no more than the given rate in integral milliseconds
-    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_SKIPFIRST_THROTTLE`` - output the given C++ stream-style message no more than the given rate in integral milliseconds, but skip the first
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_THROTTLE`` - output the given C++ stream-style message no more than the given rate in integer milliseconds
+    * ``RCLCPP_{DEBUG,INFO,WARN,ERROR,FATAL}_STREAM_SKIPFIRST_THROTTLE`` - output the given C++ stream-style message no more than the given rate in integer milliseconds, but skip the first
 
     Each of the above APIs takes an ``rclcpp::Logger`` object as the first argument.
     This can be pulled from the node API by calling ``node->get_logger()`` (recommended), or by constructing a stand-alone ``rclcpp::Logger`` object.
@@ -73,7 +73,7 @@ These are the APIs that end users of the ROS 2 logging infrastructure should use
 
     * ``logger.{debug,info,warning,error,fatal}`` - output the given Python string to the logging infrastructure.  The calls accept the following keyword args to control behavior:
 
-      * ``throttle_duration_sec`` - if not None, the duration of the throttle interval
+      * ``throttle_duration_sec`` - if not None, the duration of the throttle interval in floating-point seconds
       * ``skip_first`` - if True, output the message all but the first time this line is hit
       * ``once`` - if True, only output the message the first time this line is hit
 

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -91,7 +91,7 @@ The following code will output a log message from a ROS 2 node at ``WARN`` sever
 Logging throttled
 ^^^^^^^^^^^^^^^^^
 
-The following code will output a log message from a ROS 2 node at ``ERROR`` severity, but no more than once per second. 
+The following code will output a log message from a ROS 2 node at ``ERROR`` severity, but no more than once per second.
 
 The interval parameter specifying milliseconds between messages should have an integer data type so it can be converted to a ``rcutils_duration_value_t`` (an ``int64_t``):
 
@@ -107,7 +107,7 @@ The interval parameter specifying milliseconds between messages should have an i
             // C++ stream style
             RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_lock(), 1000, "My log message " << 4);
 
-            // For now, use the nanoseconds() method to use an existing rclcpp::Duration value, see https://github.com/ros2/rclcpp/issues/1929 
+            // For now, use the nanoseconds() method to use an existing rclcpp::Duration value, see https://github.com/ros2/rclcpp/issues/1929
             RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), msg_interval.nanoseconds()/1000000, "My log message " << 4);
 
     .. group-tab:: Python

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -105,6 +105,31 @@ The following code will output a log message from a ROS 2 node at ``ERROR`` seve
             // C++ stream style
             RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_lock(), 1000, "My log message " << 4);
 
+        .. note::
+          The time between messages is in milliseconds. 
+          
+          Due to limitations in the way ``rclcpp`` C++ logging macros 
+          currently use the underlying ``rcutils`` C macros, the data type of the interval parameter 
+          needs to be implicitly convertible to ``rcutils_duration_value_t``. 
+          
+          See the 
+          `discussion at rclcpp/issues/1929 <https://github.com/ros2/rclcpp/issues/1929>`_ for work to make these
+          macros accept a ``rclcpp::Duration``. 
+          
+          In the meantime, if you have a duration value ``message_interval`` that you'd like to use instead of an integer 
+          literal, you can use code like the following:
+        
+        .. code-block:: C++
+
+          // If you have a duration you'd like to use, probably coming from other code
+          rclcpp::Duration message_interval = rclcpp::Duration::from_seconds(1.2345);
+          
+          // Convert it with rclcpp::Duration::nanoseconds()
+          RCLCPP_ERROR_THROTTLE(node->get_logger(), 
+                                *node->get_clock(), 
+                                message_interval.nanoseconds()/(1'000'000), 
+                                "My log message %d", 4);
+
     .. group-tab:: Python
 
         .. code-block:: python

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -91,7 +91,9 @@ The following code will output a log message from a ROS 2 node at ``WARN`` sever
 Logging throttled
 ^^^^^^^^^^^^^^^^^
 
-The following code will output a log message from a ROS 2 node at ``ERROR`` severity, but no more than once per second:
+The following code will output a log message from a ROS 2 node at ``ERROR`` severity, but no more than once per second. 
+
+The interval parameter specifying milliseconds between messages should have an integer data type so it can be converted to a ``rcutils_duration_value_t`` (an ``int64_t``):
 
 .. tabs::
 
@@ -105,30 +107,8 @@ The following code will output a log message from a ROS 2 node at ``ERROR`` seve
             // C++ stream style
             RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_lock(), 1000, "My log message " << 4);
 
-        .. note::
-          The time between messages is in milliseconds. 
-          
-          Due to limitations in the way ``rclcpp`` C++ logging macros 
-          currently use the underlying ``rcutils`` C macros, the data type of the interval parameter 
-          needs to be implicitly convertible to ``rcutils_duration_value_t``. 
-          
-          See the 
-          `discussion at rclcpp/issues/1929 <https://github.com/ros2/rclcpp/issues/1929>`_ for work to make these
-          macros accept a ``rclcpp::Duration``. 
-          
-          In the meantime, if you have a duration value ``message_interval`` that you'd like to use instead of an integer 
-          literal, you can use code like the following:
-        
-        .. code-block:: C++
-
-          // If you have a duration you'd like to use, probably coming from other code
-          rclcpp::Duration message_interval = rclcpp::Duration::from_seconds(1.2345);
-          
-          // Convert it with rclcpp::Duration::nanoseconds()
-          RCLCPP_ERROR_THROTTLE(node->get_logger(), 
-                                *node->get_clock(), 
-                                message_interval.nanoseconds()/(1'000'000), 
-                                "My log message %d", 4);
+            // For now, use the nanoseconds() method to use an existing rclcpp::Duration value, see https://github.com/ros2/rclcpp/issues/1929 
+            RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), msg_interval.nanoseconds()/1000000, "My log message %d" << 4);
 
     .. group-tab:: Python
 

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -108,7 +108,7 @@ The interval parameter specifying milliseconds between messages should have an i
             RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_lock(), 1000, "My log message " << 4);
 
             // For now, use the nanoseconds() method to use an existing rclcpp::Duration value, see https://github.com/ros2/rclcpp/issues/1929 
-            RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), msg_interval.nanoseconds()/1000000, "My log message %d" << 4);
+            RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), msg_interval.nanoseconds()/1000000, "My log message " << 4);
 
     .. group-tab:: Python
 


### PR DESCRIPTION
Relates to the discussion in https://github.com/ros2/rclcpp/issues/1929 about changing the throttled macros.

In the interim, since `RCLCPP_INFO_THROTTLE` and related macros are pretty basic functionality that newer C++/ROS2 users might want, it's worth adding an explicit note about how to convert a `rclcpp::Duration` to a usable type for the message interval in those macros.