### PR TITLE
Add note about user/system python package installation (linux) in the…

### DIFF
--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -45,12 +45,6 @@ Start by installing requirements located in the ``requirements.txt`` file:
 
        pip3 install --user --upgrade -r requirements.txt
 
-    Or a system install (requires superuser access):
-
-    .. code-block:: console
-
-       pip3 install --upgrade -r requirements.txt
-
   .. group-tab:: macOS
 
     .. code-block:: console

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -39,9 +39,17 @@ Start by installing requirements located in the ``requirements.txt`` file:
 
   .. group-tab:: Linux
 
+    Either do a user-specific install (recommended, requires ``~/.local/bin/`` to be added to ``$PATH``):
+
     .. code-block:: console
 
        pip3 install --user --upgrade -r requirements.txt
+
+    Or a system install (requires superuser access):
+
+    .. code-block:: console
+
+       pip3 install --upgrade -r requirements.txt
 
   .. group-tab:: macOS
 

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -39,7 +39,7 @@ Start by installing requirements located in the ``requirements.txt`` file:
 
   .. group-tab:: Linux
 
-    Either do a user-specific install (recommended, requires ``~/.local/bin/`` to be added to ``$PATH``):
+    The next command does a user-specific install, which requires ``~/.local/bin/`` to be added to ``$PATH``:
 
     .. code-block:: console
 


### PR DESCRIPTION
When following the "Contributing to ROS 2 Documentation" guide with a fresh Ubuntu 22.04 LTS install, ``make test`` fails since ``~/.local/bin`` is not included in ``$PATH`` by default. This is quite confusing for people not familiarized with python's packaging intricacies since the tutorials recommend doing local installs of python packages but fail to mention the aforementioned problem. 

While this is not necessarily a ROS 2 problem, this PR simply adds a note about ``$PATH`` not including ``~/.local/bin`` by default in the "Contributing to ROS 2 Documentation" guide, as well as alternatively suggesting a system-wide install.

Huge thanks to @mjcarroll for helping me with this problem over at the ROS discord server.