### PR TITLE
Clarify brace cuddling rules around enum definitions

### DIFF
--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -190,7 +190,7 @@ Always Use Braces
 Open Versus Cuddled Braces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Use open braces for ``function``, ``class``, and ``struct`` definitions, but cuddle braces on ``if``, ``else``, ``while``, ``for``, etc...
+* Use open braces for ``function``, ``class``, ``enum``, and ``struct`` definitions, but cuddle braces on ``if``, ``else``, ``while``, ``for``, etc...
 
   * Exception: when an ``if`` (or ``while``, etc.) condition is long enough to require line-wrapping, then use an open brace (i.e., don't cuddle).
 


### PR DESCRIPTION
It seems like there should be open braces for `enum` definitions, ie:

```c++
// good
enum struct Foo
{
  BAR,
  BAZ,
};

// bad
enum struct Foo {
  BAR,
  BAZ,
};
```

Related: https://github.com/ament/ament_lint/pull/426