### PR TITLE
[rolling] Add documentation for running tests with colcon when using …

### DIFF
--- a/source/Concepts/About-Executors.rst
+++ b/source/Concepts/About-Executors.rst
@@ -39,7 +39,7 @@ In the simplest case, the main thread is used for processing the incoming messag
       return 0;
    }
 
-The call to ``spin(node)`` basically expands to an instatiation and invokation of the Single-Threaded Executor, which is the simplest Executor:
+The call to ``spin(node)`` basically expands to an instatiation and invocation of the Single-Threaded Executor, which is the simplest Executor:
 
 .. code-block:: cpp
 

--- a/source/Concepts/About-Executors.rst
+++ b/source/Concepts/About-Executors.rst
@@ -39,7 +39,7 @@ In the simplest case, the main thread is used for processing the incoming messag
       return 0;
    }
 
-The call to ``spin(node)`` basically expands to an instatiation and invocation of the Single-Threaded Executor, which is the simplest Executor:
+The call to ``spin(node)`` basically expands to an instantiation and invocation of the Single-Threaded Executor, which is the simplest Executor:
 
 .. code-block:: cpp
 

--- a/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
@@ -84,7 +84,7 @@ The package must declare a test dependency on ``ament_cmake_pytest`` in its ``pa
 
    <test_depend>ament_cmake_pytest</test_depend>
 
-Say the package has a file structure looks like below, with tests in the ``tests`` folder.
+Say the package has a file structure like below, with tests in the ``tests`` folder.
 
 .. code-block::
 

--- a/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
@@ -73,3 +73,54 @@ Then, another Python package that correctly depends on ``my_project`` can use it
    from my_project.my_script import my_function
 
 Assuming ``my_script.py`` contains a function called ``my_function()``.
+
+Using ament_cmake_pytest
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The package ``ament_cmake_pytest`` is used to make tests discoverable to ``cmake``.
+The package must declare a test dependency on ``ament_cmake_pytest`` in its ``package.xml``.
+
+.. code-block:: xml
+
+   <test_depend>ament_cmake_pytest</test_depend>
+
+Say the package have a file structure looks like below, with tests in the ``tests`` folder.
+
+.. code-block::
+
+   awesome_ros_package/
+      awesome_ros_package/
+         __init__.py
+         a.py
+         b.py
+      package.xml
+      CMakeLists.txt
+      tests/
+         test_a.py
+         test_b.py
+
+The ``CMakeLists.txt`` should contain:
+
+.. code-block:: cmake
+
+   if(BUILD_TESTING)
+     find_package(ament_cmake_pytest REQUIRED)
+     set(_pytest_tests
+       tests/test_a.py
+       tests/test_b.py
+       # Add other test files here
+     )
+     foreach(_test_path ${_pytest_tests})
+       get_filename_component(_test_name ${_test_path} NAME_WE)
+       ament_add_pytest_test(${_test_name} ${_test_path}
+         APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+         TIMEOUT 60
+         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+       )
+     endforeach()
+   endif()
+
+Compared to the usage of ament_python, which supports automatic test discovery, ament_cmake_pytest must be called with the path to each test file.
+The timeout can be reduced as needed.
+
+Now, you can invoke your tests with the :doc:`standard colcon testing commands <../Tutorials/Intermediate/Testing/CLI>`.

--- a/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Python-Documentation.rst
@@ -84,20 +84,18 @@ The package must declare a test dependency on ``ament_cmake_pytest`` in its ``pa
 
    <test_depend>ament_cmake_pytest</test_depend>
 
-Say the package have a file structure looks like below, with tests in the ``tests`` folder.
+Say the package has a file structure looks like below, with tests in the ``tests`` folder.
 
 .. code-block::
 
-   awesome_ros_package/
-      awesome_ros_package/
-         __init__.py
-         a.py
-         b.py
-      package.xml
-      CMakeLists.txt
-      tests/
-         test_a.py
-         test_b.py
+   .
+   ├── CMakeLists.txt
+   ├── my_project
+   │   └── my_script.py
+   ├── package.xml
+   └── tests
+       ├── test_a.py
+       └── test_b.py
 
 The ``CMakeLists.txt`` should contain:
 

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -6,7 +6,7 @@ Writing Basic Tests with Python
 Starting point: we'll assume you have a :ref:`basic ament_python package<CreatePkg>` set up already and you want to add some tests to it.
 
 If you are using ament_cmake_python, refer to the the :doc:`ament_cmake_python docs<../../../How-To-Guides/Ament-CMake-Python-Documentation>` for how to make tests dicoverable.
-The test contents and invokation with ``colcon`` remain the same.
+The test contents and invocation with ``colcon`` remain the same.
 
 Package Setup
 -------------

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -5,6 +5,9 @@ Writing Basic Tests with Python
 
 Starting point: we'll assume you have a :ref:`basic ament_python package<CreatePkg>` set up already and you want to add some tests to it.
 
+If you are using ament_cmake_python, refer to the the :doc:`ament_cmake_python docs<../../../How-To-Guides/Ament-CMake-Python-Documentation>` for how to make tests dicoverable.
+The test contents and invokation with ``colcon`` remain the same.
+
 Package Setup
 -------------
 


### PR DESCRIPTION
* Add a reference in Python testing to the less common case of ament_cmake_python
* Add a code example of python testing
* Solves #3215

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>