### PR TITLE
Remove Galactic from the top-level Distributions tab.

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -24,7 +24,6 @@ Rows in the table marked in green are the currently supported distributions.
    :hidden:
 
    Releases/Release-Humble-Hawksbill.rst
-   Releases/Release-Galactic-Geochelone.rst
    Releases/Release-Foxy-Fitzroy.rst
    Releases/Release-Rolling-Ridley.rst
    Releases/Development.rst


### PR DESCRIPTION
It was added to the End-of-Life Distributions, so it should be removed from the top-level one to keep it tidy.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>