### PR TITLE
Update ROS 2 TSC Community Rep.

### DIFF
--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -183,7 +183,7 @@ The current members of the ROS 2 TSC are (23 as of 2022-02-01):
         </tr>
         <tr class="tscclass">
           <td class="tscclass" align="center"><p><img alt="ROS 2 logo" src="../_images/ros2_logo.png" style="height: 60px;" /></p></td>
-          <td class="tscclass" align="center"><p>Community Representative:  <a href="https://www.linkedin.com/in/brett-aldrich-42915b97/">Brett Aldrich </a></p></td>
+          <td class="tscclass" align="center"><p>Community Representative:  <a href="https://github.com/fmrico"> Francisco Martin Rico </a></p></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Remove Brett and add Francisco as per the 2022/12/15 TSC meeting.