### PR TITLE
Remove MANUAL_BY_NODE liveliness API.

### DIFF
--- a/source/How-To-Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
+++ b/source/How-To-Guides/Overriding-QoS-Policies-For-Recording-And-Playback.rst
@@ -58,7 +58,7 @@ All values are replicated below for reference.
     lifespan:
       sec: int
       nsec: int
-    liveliness: [system_default, automatic, manual_by_node, manual_by_topic, unknown]
+    liveliness: [system_default, automatic, manual_by_topic, unknown]
     liveliness_lease_duration:
       sec: int
       nsec: int


### PR DESCRIPTION
related to https://github.com/ros2/rmw/pull/227

this has been deprecated for more than 2 years, it should not be recommended as `how-to` document.

we need to backport this to humble and foxy.

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>