### PR TITLE
Pin sphinx version to less than 6.0.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 doc8
 docutils==0.16
 pip
-sphinx
+sphinx<6.0.0
 sphinx-copybutton
 sphinx-multiversion
 sphinx-rtd-theme


### PR DESCRIPTION
Apparently there are changes in 6.0.0 that make it not work with sphinx-multiversion, so pin it here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing builds as in https://build.ros.org/job/doc_ros2doc/758