### PR TITLE
add example command to run tests and view results to python testing tutorial

### DIFF
--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -22,3 +22,9 @@ To see the results, simply run the `test-result <https://colcon.readthedocs.io/e
 .. code-block:: console
 
   colcon test-result --all
+  
+To see the exact test cases which fail, use the ``--verbose`` flag:
+
+.. code-block:: console
+
+  colcon test-result --all --verbose

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -22,7 +22,7 @@ To see the results, simply run the `test-result <https://colcon.readthedocs.io/e
 .. code-block:: console
 
   colcon test-result --all
-  
+
 To see the exact test cases which fail, use the ``--verbose`` flag:
 
 .. code-block:: console

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -56,6 +56,15 @@ You can now write tests to your heart's content. There are `plenty of resources 
   def test_math():
       assert 2 + 2 == 5   # This should fail for most mathematical systems
 
+Running Tests
+-------------
+
+You can now run your tests and view the results:
+
+.. code-block:: console
+
+  colcon test --event-handlers console_cohesion+
+
 Special Commands
 ----------------
 

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -59,11 +59,7 @@ You can now write tests to your heart's content. There are `plenty of resources 
 Running Tests
 -------------
 
-You can now run your tests and view the results:
-
-.. code-block:: console
-
-  colcon test --event-handlers console_cohesion+
+See the :doc:`tutorial on how to run tests from the command line <CLI>` for more information on running the tests and inspecting the test results.
 
 Special Commands
 ----------------
@@ -75,3 +71,9 @@ For example, you can specify the name of the function to run with
 .. code-block:: console
 
   colcon test --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
+
+To see the pytest output while running the tests, use these flags:
+
+.. code-block:: console
+
+  colcon test --event-handlers console_cohesion+


### PR DESCRIPTION
I couldn't find any way to actually see the name of the failing test while following the pytest tutorial, this seems to do the trick...

It seems like there should be a better way to do this, but `colcon test-result` does not display any more information and frankly more than one command to run the tests and get any useful feedback on the results seems like too much work for me...
