### PR TITLE
Make sure to add Galactic to the EOL list of distros.

### DIFF
--- a/source/Releases/End-of-Life.rst
+++ b/source/Releases/End-of-Life.rst
@@ -6,6 +6,7 @@ Below is a list of historic ROS 2 distributions that are no longer supported.
 .. toctree::
    :maxdepth: 1
 
+   Release-Galactic-Geochelone.rst
    Release-Eloquent-Elusor.rst
    Release-Dashing-Diademata.rst
    Release-Crystal-Clemmys.rst


### PR DESCRIPTION
This makes it visible, and also gets rid of a Sphinx warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>