### PR TITLE
fix repo filename

### DIFF
--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -38,7 +38,7 @@ The error will be:
   E: Unable to correct problems, you have held broken packages.
 
 To correct this, remove packages.ros.org from your ``sources.list``.
-If you were following the ROS 2 installation guide, simply remove ``/etc/apt/sources.list.d/ros-2-latest.list``
+If you were following the ROS 2 installation guide, simply remove ``/etc/apt/sources.list.d/ros2.list``
 
 For now, to support ``ros1_bridge``, follow the instructions below for building ROS 2 from source.
 

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -23,7 +23,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 1. Make sure you have a working ROS 2 installation from Debian packages (see :doc:`../Installation`).
 
-2. Edit (with sudo) the file ``/etc/apt/sources.list.d/ros2-latest.list`` and change ``ros2`` with ``ros2-testing``.
+2. Edit (with sudo) the file ``/etc/apt/sources.list.d/ros2.list`` and change ``ros2`` with ``ros2-testing``.
    For example, on Ubuntu Jammy the contents should look like the following:
 
    .. code-block:: sh
@@ -49,7 +49,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 
       sudo apt dist-upgrade
 
-6. Once you are finished testing, you can switch back to the normal repository by changing back the contents of ``/etc/apt/sources.list.d/ros2-latest.list``:
+6. Once you are finished testing, you can switch back to the normal repository by changing back the contents of ``/etc/apt/sources.list.d/ros2.list``:
 
    .. code-block:: sh
 


### PR DESCRIPTION
The installation instructions create the repo file as ros2.list. Hence, when the documentation updates that file, it should use the correct name.