### PR TITLE
Fix FastDDS-Configuration.rst to work

### DIFF
--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -230,7 +230,7 @@ Create a file with name ``SyncAsync.xml`` and the following content:
             <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
         </publisher>
 
-        <!-- subscriber profile for topic sync_topic -->
+        <!-- default subscriber profile -->
         <subscriber profile_name="default_subscriber" is_default_profile="true">
             <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
         </subscriber>
@@ -257,7 +257,7 @@ Create a file with name ``SyncAsync.xml`` and the following content:
 
      </profiles>
 
-Note that several publisher profiles are defined.
+Note that several profiles for publisher and subscriber are defined.
 A default profile which is defined setting the ``is_default_profile`` to ``true``, and two profiles with names that coincide with those of the previously defined topics: ``sync_topic`` and another one for ``async_topic``.
 These last two profiles set the publication mode to ``SYNCHRONOUS`` or ``ASYNCHRONOUS`` accordingly.
 Note also that all profiles specify a ``historyMemoryPolicy`` value, which is needed for the example to work, and the reason will be explained later on this tutorial.

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -230,6 +230,11 @@ Create a file with name ``SyncAsync.xml`` and the following content:
             <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
         </publisher>
 
+        <!-- subscriber profile for topic sync_topic -->
+        <subscriber profile_name="default_subscriber" is_default_profile="true">
+            <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+        </subscriber>
+
         <!-- publisher profile for topic sync_topic -->
         <publisher profile_name="/sync_topic">
             <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
@@ -379,22 +384,6 @@ Open the ``CMakeLists.txt`` file and add a new executable and name it ``SyncAsyn
     install(TARGETS
         SyncAsyncReader
         DESTINATION lib/${PROJECT_NAME})
-
-
-Add the subscriber profiles to the the XML
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Configuration profiles for the subscribers can be added in the same XML file ``SyncAsync.xml``.
-For the moment, only the default profile will be set.
-The subscriber profiles will be extended later on.
-Open the ``SyncAsync.xml`` file and add the following profiles inside the ``<profiles>`` tag:
-
-.. code-block:: XML
-
-    <!-- subscriber profile for topic sync_topic -->
-    <subscriber profile_name="default_subscriber" is_default_profile="true">
-        <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
-    </subscriber>
 
 
 Execute the subscriber node
@@ -576,7 +565,6 @@ Their profiles should now look like this:
         </qos>
     </subscriber>
 
-Also be sure to remove the "default_subscriber" subscriber profile.
 Open two terminals.
 Do not forget to source the setup files and to set the required environment variables.
 On the first terminal run the publisher node, and the subscriber node on the other one.

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -258,7 +258,7 @@ Create a file with name ``SyncAsync.xml`` and the following content:
      </profiles>
 
 Note that several profiles for publisher and subscriber are defined.
-A default profile which is defined setting the ``is_default_profile`` to ``true``, and two profiles with names that coincide with those of the previously defined topics: ``sync_topic`` and another one for ``async_topic``.
+Two default profiles which are defined setting the ``is_default_profile`` to ``true``, and two profiles with names that coincide with those of the previously defined topics: ``sync_topic`` and another one for ``async_topic``.
 These last two profiles set the publication mode to ``SYNCHRONOUS`` or ``ASYNCHRONOUS`` accordingly.
 Note also that all profiles specify a ``historyMemoryPolicy`` value, which is needed for the example to work, and the reason will be explained later on this tutorial.
 


### PR DESCRIPTION
The `SyncAsyncWriter` in the following tutorial outputs error messages.

* [Unlocking the potential of Fast DDS middleware](https://docs.ros.org/en/humble/Tutorials/Advanced/FastDDS-Configuration.html)

```
$ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
$ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
$ export FASTRTPS_DEFAULT_PROFILES_FILE=SyncAsync.xml
$ source install/setup.bash
$ ros2 run sync_async_node_example_cpp SyncAsyncWriter
2023-01-26 11:45:23.579 [RTPS_READER_HISTORY Error] Change payload size of '76' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts
2023-01-26 11:45:23.580 [RTPS_READER_HISTORY Error] Change payload size of '100' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts
...
```

Adding "default subscriber profile" to the SyncAsync.xml file prevents error messages.

I believe that a default subscriber profile is also necessary for publishers.

This pull request changes the SyncAsync.xml file to always include a default subscriber profile

The following pull request is also relevant.

* https://github.com/ros2/rmw_fastrtps/pull/663