### PR TITLE
Update script examples to match new ament_python package template

### DIFF
--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -103,7 +103,7 @@ and a ``setup.py`` file that looks like:
 
    import os
    from glob import glob
-   from setuptools import setup
+   from setuptools import find_packages, setup
 
    package_name = 'my_package'
 
@@ -111,7 +111,7 @@ and a ``setup.py`` file that looks like:
        name=package_name,
        version='0.0.0',
        # Packages to export
-       packages=[package_name],
+       packages=find_packages(exclude=['test']),
        # Files we want to install, specifically launch files
        data_files=[
            # Install marker file in the package index

--- a/source/Tutorials/Advanced/Simulators/Code/setup.py
+++ b/source/Tutorials/Advanced/Simulators/Code/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 package_name = 'my_package'
 data_files = []
@@ -11,7 +11,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 setup(
     name=package_name,
     version='0.0.0',
-    packages=[package_name],
+    packages=find_packages(exclude=['test']),
     data_files=data_files,
     install_requires=['setuptools'],
     zip_safe=True,

--- a/source/Tutorials/Advanced/Simulators/Code/setup_sensor.py
+++ b/source/Tutorials/Advanced/Simulators/Code/setup_sensor.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 package_name = 'my_package'
 data_files = []
@@ -11,7 +11,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 setup(
     name=package_name,
     version='0.0.0',
-    packages=[package_name],
+    packages=find_packages(exclude=['test']),
     data_files=data_files,
     install_requires=['setuptools'],
     zip_safe=True,

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
@@ -474,14 +474,14 @@ This is where your ``package.xml`` would list its dependencies on other packages
 
       .. code-block:: python
 
-       from setuptools import setup
+       from setuptools import find_packages, setup
 
        package_name = 'my_py_pkg'
 
        setup(
         name=package_name,
         version='0.0.0',
-        packages=[package_name],
+        packages=find_packages(exclude=['test']),
         data_files=[
             ('share/ament_index/resource_index/packages',
                     ['resource/' + package_name]),

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -107,7 +107,7 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
 
       import os
       from glob import glob
-      from setuptools import setup
+      from setuptools import find_packages, setup
 
       package_name = 'py_launch_example'
 

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -74,7 +74,7 @@ Finally, make sure to add in changes to the ``setup.py`` of the package so that 
 
   import os
   from glob import glob
-  from setuptools import setup
+  from setuptools import find_packages, setup
 
   package_name = 'launch_tutorial'
 


### PR DESCRIPTION
[A change](https://github.com/ros2/ros2cli/pull/801) ~~is being~~ has been made in the ament_python package template used to generate a package via ``ros2 pkg create --build-type ament_python ...``. This updates the documentation to match the new template. 