### PR TITLE
Add default subscriber profile to FastDDS example

### DIFF
--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -230,6 +230,11 @@ Create a file with name ``SyncAsync.xml`` and the following content:
             <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
         </publisher>
 
+        <!-- Default subscriber profile -->
+        <subscriber profile_name="default_subscriber" is_default_profile="true">
+            <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+        </subscriber>
+
         <!-- publisher profile for topic sync_topic -->
         <publisher profile_name="/sync_topic">
             <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>


### PR DESCRIPTION
Running the tutorial as-is, I ran into the following error:

2023-02-08 18:56:54.513 [RTPS_READER_HISTORY Error] Change payload size of '76' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts

I resolved this using a solution based on:
https://github.com/ros2/rmw_fastrtps/pull/663