### PR TITLE
Revert "Revert "adding API change for spin_until_complete""

### DIFF
--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -41,6 +41,13 @@ To come.
 New features in this ROS 2 release
 ----------------------------------
 
+Rename ``spin_until_future_complete`` to ``spin_until_complete``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`PR 1874 <https://github.com/ros2/rclcpp/pull/1874>`_ renames ``spin_until_future_complete`` to ``spin_until_complete`` to represent the semantics of being able to spin on values that are not exclusively futures.
+The API can now spin until arbitrary conditions.
+A deprecation warning will appear for migration.
+
 ros2topic
 ^^^^^^^^^
 

--- a/source/The-ROS2-Project/Contributing/Migration-Guide-Python.rst
+++ b/source/The-ROS2-Project/Contributing/Migration-Guide-Python.rst
@@ -121,4 +121,4 @@ In ROS 2:
    while not add_two_ints.wait_for_service(timeout_sec=1.0):
        node.get_logger().info('service not available, waiting again...')
    resp = add_two_ints.call_async(req)
-   rclpy.spin_until_future_complete(node, resp)
+   rclpy.spin_until_complete(node, resp)

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -679,7 +679,7 @@ Create the client in a file named ``src/ping_client.cpp`` with the following con
         auto result = client->async_send_request(request);
 
         // Wait for the result and log it to the console
-        if (rclcpp::spin_until_future_complete(node, result) ==
+        if (rclcpp::spin_until_complete(node, result) ==
             rclcpp::FutureReturnCode::SUCCESS)
         {
             RCLCPP_INFO(rclcpp::get_logger("ping_client"), "Response received");

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -647,7 +647,7 @@ Client:
 
         auto result = client->async_send_request(request);
         // Wait for the result.
-        if (rclcpp::spin_until_future_complete(node, result) ==
+        if (rclcpp::spin_until_complete(node, result) ==
           rclcpp::FutureReturnCode::SUCCESS)
         {
           RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -228,7 +228,7 @@ Inside the ``ros2_ws/src/cpp_srvcli/src`` directory, create a new file called ``
 
     auto result = client->async_send_request(request);
     // Wait for the result.
-    if (rclcpp::spin_until_future_complete(node, result) ==
+    if (rclcpp::spin_until_complete(node, result) ==
       rclcpp::FutureReturnCode::SUCCESS)
     {
       RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
@@ -197,7 +197,7 @@ Inside the ``ros2_ws/src/py_srvcli/py_srvcli`` directory, create a new file call
           self.req.a = a
           self.req.b = b
           self.future = self.cli.call_async(self.req)
-          rclpy.spin_until_future_complete(self, self.future)
+          rclpy.spin_until_complete(self, self.future)
           return self.future.result()
 
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_0.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_0.py
@@ -27,7 +27,7 @@ def main(args=None):
 
     future = action_client.send_goal(10)
 
-    rclpy.spin_until_future_complete(action_client, future)
+    rclpy.spin_until_complete(action_client, future)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
⚠️ This is waiting on https://github.com/ros2/rclcpp/pull/1957 before being merged

Reverts ros2/ros2_documentation#3333, which originally reverted https://github.com/ros2/ros2_documentation/pull/3328.