### PR TITLE
Add pytest>=5.3 dependency for pytest-rerunfailures on ubuntu20.04

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -87,6 +87,7 @@ Install packages according to your Ubuntu version.
             flake8-deprecated \
             flake8-import-order \
             flake8-quotes \
+            "pytest>=5.3" \
             pytest-repeat \
             pytest-rerunfailures
 


### PR DESCRIPTION
This PR fixes #3238. I was able to reproduce the original error in a Docker container. After making the change, the error was resolved:
```
root@ubuntu-linux-20-04-desktop:/# python3 -m pip install -U \
>    flake8-blind-except \
>    flake8-builtins \
>    flake8-class-newline \
>    flake8-comprehensions \
>    flake8-deprecated \
>    flake8-import-order \
>    flake8-quotes \
>    "pytest>=5.3" \
>    pytest-repeat \
>    pytest-rerunfailures
Processing /root/.cache/pip/wheels/e1/ae/e7/dd9062f22568a49c419586d7fb7ea983514c4c905c3b985313/flake8_blind_except-0.2.1-py3-none-any.whl
Collecting flake8-builtins
  Using cached flake8_builtins-2.1.0-py3-none-any.whl (13 kB)
Collecting flake8-class-newline
  Using cached flake8_class_newline-1.6.0-py3-none-any.whl (5.2 kB)
Collecting flake8-comprehensions
  Using cached flake8_comprehensions-3.10.1-py3-none-any.whl (7.3 kB)
Collecting flake8-deprecated
  Using cached flake8_deprecated-2.0.1-py3-none-any.whl (11 kB)
Collecting flake8-import-order
  Using cached flake8_import_order-0.18.2-py2.py3-none-any.whl (15 kB)
Processing /root/.cache/pip/wheels/cf/a3/be/7d198244aba238c89cec5574f58a64f47514b6fc9eb5f60ad1/flake8_quotes-3.3.2-py3-none-any.whl
Collecting pytest>=5.3
  Using cached pytest-7.2.1-py3-none-any.whl (317 kB)
Collecting pytest-repeat
  Using cached pytest_repeat-0.9.1-py2.py3-none-any.whl (4.3 kB)
Collecting pytest-rerunfailures
  Using cached pytest_rerunfailures-11.1.1-py3-none-any.whl (12 kB)
Requirement already satisfied, skipping upgrade: flake8 in /usr/local/lib/python3.8/dist-packages (from flake8-builtins) (6.0.0)
Requirement already satisfied, skipping upgrade: pycodestyle in /usr/local/lib/python3.8/dist-packages (from flake8-import-order) (2.10.0)
Requirement already satisfied, skipping upgrade: setuptools in /usr/lib/python3/dist-packages (from flake8-import-order) (45.2.0)
Requirement already satisfied, skipping upgrade: exceptiongroup>=1.0.0rc8; python_version < "3.11" in /usr/local/lib/python3.8/dist-packages (from pytest>=5.3) (1.1.0)
Requirement already satisfied, skipping upgrade: iniconfig in /usr/local/lib/python3.8/dist-packages (from pytest>=5.3) (2.0.0)
Requirement already satisfied, skipping upgrade: packaging in /usr/lib/python3/dist-packages (from pytest>=5.3) (20.3)
Requirement already satisfied, skipping upgrade: pluggy<2.0,>=0.12 in /usr/lib/python3/dist-packages (from pytest>=5.3) (0.13.0)
Requirement already satisfied, skipping upgrade: tomli>=1.0.0; python_version < "3.11" in /usr/local/lib/python3.8/dist-packages (from pytest>=5.3) (2.0.1)
Requirement already satisfied, skipping upgrade: attrs>=19.2.0 in /usr/lib/python3/dist-packages (from pytest>=5.3) (19.3.0)
Requirement already satisfied, skipping upgrade: mccabe<0.8.0,>=0.7.0 in /usr/local/lib/python3.8/dist-packages (from flake8->flake8-builtins) (0.7.0)
Requirement already satisfied, skipping upgrade: pyflakes<3.1.0,>=3.0.0 in /usr/local/lib/python3.8/dist-packages (from flake8->flake8-builtins) (3.0.1)
Installing collected packages: flake8-blind-except, flake8-builtins, flake8-class-newline, flake8-comprehensions, flake8-deprecated, flake8-import-order, flake8-quotes, pytest, pytest-repeat, pytest-rerunfailures
  Attempting uninstall: pytest
    Found existing installation: pytest 4.6.9
    Not uninstalling pytest at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'pytest'. No files were found to uninstall.
Successfully installed flake8-blind-except-0.2.1 flake8-builtins-2.1.0 flake8-class-newline-1.6.0 flake8-comprehensions-3.10.1 flake8-deprecated-2.0.1 flake8-import-order-0.18.2 flake8-quotes-3.3.2 pytest-7.2.1 pytest-repeat-0.9.1 pytest-rerunfailures-11.1.1
```