### PR TITLE
Add Draft PR and Dependent PR Guidelines to Contributing

### DIFF
--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -341,7 +341,7 @@ Pull requests
   When that change is ready for review, move the pull request out of the draft state.
   Note that if you want early feedback from specific people on a draft pull request, you can @ mention them in the pull request's description or in a comment on the pull request.
 
-* If your pull request depends on other pull requests, link to each depended on pull requests by adding "Depends on <link>" at the top of your pull request's description.
+* If your pull request depends on other pull requests, link to each depended on pull request by adding ``- Depends on <link>`` at the top of your pull request's description.
   Doing so helps reviewers understand the context of the pull request.
 
 * When you start reviewing a pull request, comment on the pull request so that other developers know that you're reviewing it.

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -341,7 +341,7 @@ Pull requests
   When that change is ready for review, move the pull request out of the draft state.
   Note that if you want early feedback from specific people on a draft pull request, you can @ mention them in the pull request's description or in a comment on the pull request.
 
-* If your pull request depends on other pull requests, link to those pull requests in the pull request's description.
+* If your pull request depends on other pull requests, link to each depended on pull requests by adding "Depends on <link>" at the top of your pull request's description.
   Doing so helps reviewers understand the context of the pull request.
 
 * When you start reviewing a pull request, comment on the pull request so that other developers know that you're reviewing it.

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -337,6 +337,13 @@ Pull requests
 
 * Any developer is welcome to review and approve a pull request (see `General Principles`_).
 
+* When you are working on a change that is not ready for review or to be merged, use a draft pull request.
+  When that change is ready for review, move the pull request out of the draft state.
+  Note that if you want early feedback from specific people on a draft pull request, you can @ mention them in the pull request's description or in a comment on the pull request.
+
+* If your pull request depends on other pull requests, link to those pull requests in the pull request's description.
+  Doing so helps reviewers understand the context of the pull request.
+
 * When you start reviewing a pull request, comment on the pull request so that other developers know that you're reviewing it.
 
 * Pull-request review is not read-only, with the reviewer making comments and then waiting for the author to address them.


### PR DESCRIPTION
This is after discussion in the weekly ROS 2 meeting. I think it will be helpful as something we can point to if people ask and helpful to refer to if things are being done in a different way, which may cause confusion.