### PR TITLE
Include xml and yaml launch files in examples

### DIFF
--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -35,8 +35,9 @@ Each launch file performs the following actions:
 
         import os
 
-        from launch import LaunchDescription
         from ament_index_python import get_package_share_directory
+
+        from launch import LaunchDescription
         from launch.actions import DeclareLaunchArgument
         from launch.actions import GroupAction
         from launch.actions import IncludeLaunchDescription

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -35,17 +35,18 @@ Each launch file performs the following actions:
 
         import os
 
-        from ament_index_python import get_package_share_directory
-
         from launch import LaunchDescription
+        from ament_index_python import get_package_share_directory
         from launch.actions import DeclareLaunchArgument
-        from launch.actions import IncludeLaunchDescription
         from launch.actions import GroupAction
+        from launch.actions import IncludeLaunchDescription
         from launch.launch_description_sources import PythonLaunchDescriptionSource
         from launch.substitutions import LaunchConfiguration
         from launch.substitutions import TextSubstitution
         from launch_ros.actions import Node
-        from launch_ros.actions import PushROSNamespace
+        from launch_ros.actions import PushRosNamespace
+        from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
+        from launch_yaml.launch_description_sources import YAMLLaunchDescriptionSource
 
 
         def generate_launch_description():
@@ -60,8 +61,14 @@ Each launch file performs the following actions:
             background_b_launch_arg = DeclareLaunchArgument(
                 "background_b", default_value=TextSubstitution(text="0")
             )
-            chatter_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_ns", default_value=TextSubstitution(text="my/chatter/ns")
+            chatter_py_ns_launch_arg = DeclareLaunchArgument(
+                "chatter_py_ns", default_value=TextSubstitution(text="chatter/py/ns")
+            )
+            chatter_xml_ns_launch_arg = DeclareLaunchArgument(
+                "chatter_xml_ns", default_value=TextSubstitution(text="chatter/xml/ns")
+            )
+            chatter_yaml_ns_launch_arg = DeclareLaunchArgument(
+                "chatter_yaml_ns", default_value=TextSubstitution(text="chatter/yaml/ns")
             )
 
             # include another launch file
@@ -71,11 +78,11 @@ Each launch file performs the following actions:
                         get_package_share_directory('demo_nodes_cpp'),
                         'launch/topics/talker_listener_launch.py'))
             )
-            # include another launch file in the chatter_ns namespace
-            launch_include_with_namespace = GroupAction(
+            # include a Python launch file in the chatter_py_ns namespace
+            launch_py_include_with_namespace = GroupAction(
                 actions=[
                     # push_ros_namespace to set namespace of included nodes
-                    PushROSNamespace('chatter_ns'),
+                    PushRosNamespace('chatter_py_ns'),
                     IncludeLaunchDescription(
                         PythonLaunchDescriptionSource(
                             os.path.join(
@@ -85,50 +92,83 @@ Each launch file performs the following actions:
                 ]
             )
 
+            # include a xml launch file in the chatter_xml_ns namespace
+            launch_xml_include_with_namespace = GroupAction(
+                actions=[
+                    # push_ros_namespace to set namespace of included nodes
+                    PushRosNamespace('chatter_xml_ns'),
+                    IncludeLaunchDescription(
+                        XMLLaunchDescriptionSource(
+                            os.path.join(
+                                get_package_share_directory('demo_nodes_cpp'),
+                                'launch/topics/talker_listener_launch.xml'))
+                    ),
+                ]
+            )
+
+            # include a yaml launch file in the chatter_yaml_ns namespace
+            launch_yaml_include_with_namespace = GroupAction(
+                actions=[
+                    # push_ros_namespace to set namespace of included nodes
+                    PushRosNamespace('chatter_yaml_ns'),
+                    IncludeLaunchDescription(
+                        YAMLLaunchDescriptionSource(
+                            os.path.join(
+                                get_package_share_directory('demo_nodes_cpp'),
+                                'launch/topics/talker_listener_launch.yaml'))
+                    ),
+                ]
+            )
+
             # start a turtlesim_node in the turtlesim1 namespace
             turtlesim_node = Node(
-                    package='turtlesim',
-                    namespace='turtlesim1',
-                    executable='turtlesim_node',
-                    name='sim'
-                )
+                package='turtlesim',
+                namespace='turtlesim1',
+                executable='turtlesim_node',
+                name='sim'
+            )
 
             # start another turtlesim_node in the turtlesim2 namespace
             # and use args to set parameters
             turtlesim_node_with_parameters = Node(
-                    package='turtlesim',
-                    namespace='turtlesim2',
-                    executable='turtlesim_node',
-                    name='sim',
-                    parameters=[{
-                        "background_r": LaunchConfiguration('background_r'),
-                        "background_g": LaunchConfiguration('background_g'),
-                        "background_b": LaunchConfiguration('background_b'),
-                    }]
-                )
+                package='turtlesim',
+                namespace='turtlesim2',
+                executable='turtlesim_node',
+                name='sim',
+                parameters=[{
+                    "background_r": LaunchConfiguration('background_r'),
+                    "background_g": LaunchConfiguration('background_g'),
+                    "background_b": LaunchConfiguration('background_b'),
+                }]
+            )
 
             # perform remap so both turtles listen to the same command topic
             forward_turtlesim_commands_to_second_turtlesim_node = Node(
-                    package='turtlesim',
-                    executable='mimic',
-                    name='mimic',
-                    remappings=[
-                        ('/input/pose', '/turtlesim1/turtle1/pose'),
-                        ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                    ]
-                )
+                package='turtlesim',
+                executable='mimic',
+                name='mimic',
+                remappings=[
+                    ('/input/pose', '/turtlesim1/turtle1/pose'),
+                    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+                ]
+            )
 
             return LaunchDescription([
                 background_r_launch_arg,
                 background_g_launch_arg,
                 background_b_launch_arg,
-                chatter_ns_launch_arg,
+                chatter_py_ns_launch_arg,
+                chatter_xml_ns_launch_arg,
+                chatter_yaml_ns_launch_arg,
                 launch_include,
-                launch_include_with_namespace,
+                launch_py_include_with_namespace,
+                launch_xml_include_with_namespace,
+                launch_yaml_include_with_namespace,
                 turtlesim_node,
                 turtlesim_node_with_parameters,
                 forward_turtlesim_commands_to_second_turtlesim_node,
             ])
+
 
    .. group-tab:: XML
 
@@ -138,35 +178,49 @@ Each launch file performs the following actions:
 
         <launch>
 
-          <!-- args that can be set from the command line or a default will be used -->
-          <arg name="background_r" default="0"/>
-          <arg name="background_g" default="255"/>
-          <arg name="background_b" default="0"/>
-          <arg name="chatter_ns" default="my/chatter/ns"/>
+            <!-- args that can be set from the command line or a default will be used -->
+            <arg name="background_r" default="0" />
+            <arg name="background_g" default="255" />
+            <arg name="background_b" default="0" />
+            <arg name="chatter_py_ns" default="chatter/py/ns" />
+            <arg name="chatter_xml_ns" default="chatter/xml/ns" />
+            <arg name="chatter_yaml_ns" default="chatter/yaml/ns" />
 
-          <!-- include another launch file -->
-          <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py"/>
-          <!-- include another launch file in the chatter_ns namespace-->
-          <group>
-            <!-- push_ros_namespace to set namespace of included nodes -->
-            <push_ros_namespace namespace="$(var chatter_ns)"/>
-            <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py"/>
-          </group>
+            <!-- include another launch file -->
+            <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py" />
+            <!-- include a Python launch file in the chatter_py_ns namespace-->
+            <group>
+                <!-- push_ros_namespace to set namespace of included nodes -->
+                <push_ros_namespace namespace="$(var chatter_py_ns)" />
+                <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py" />
+            </group>
+            <!-- include a xml launch file in the chatter_xml_ns namespace-->
+            <group>
+                <!-- push_ros_namespace to set namespace of included nodes -->
+                <push_ros_namespace namespace="$(var chatter_xml_ns)" />
+                <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.xml" />
+            </group>
+            <!-- include a yaml launch file in the chatter_yaml_ns namespace-->
+            <group>
+                <!-- push_ros_namespace to set namespace of included nodes -->
+                <push_ros_namespace namespace="$(var chatter_yaml_ns)" />
+                <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.yaml" />
+            </group>
 
-          <!-- start a turtlesim_node in the turtlesim1 namespace -->
-          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
-          <!-- start another turtlesim_node in the turtlesim2 namespace
-              and use args to set parameters -->
-          <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2">
-            <param name="background_r" value="$(var background_r)"/>
-            <param name="background_g" value="$(var background_g)"/>
-            <param name="background_b" value="$(var background_b)"/>
-          </node>
-          <!-- perform remap so both turtles listen to the same command topic -->
-          <node pkg="turtlesim" exec="mimic" name="mimic">
-            <remap from="/input/pose" to="/turtlesim1/turtle1/pose"/>
-            <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel"/>
-          </node>
+            <!-- start a turtlesim_node in the turtlesim1 namespace -->
+            <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1" />
+            <!-- start another turtlesim_node in the turtlesim2 namespace
+                and use args to set parameters -->
+            <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2">
+                <param name="background_r" value="$(var background_r)" />
+                <param name="background_g" value="$(var background_g)" />
+                <param name="background_b" value="$(var background_b)" />
+            </node>
+            <!-- perform remap so both turtles listen to the same command topic -->
+            <node pkg="turtlesim" exec="mimic" name="mimic">
+                <remap from="/input/pose" to="/turtlesim1/turtle1/pose" />
+                <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel" />
+            </node>
         </launch>
 
    .. group-tab:: YAML
@@ -188,20 +242,40 @@ Each launch file performs the following actions:
             name: "background_b"
             default: "0"
         - arg:
-            name: "chatter_ns"
-            default: "my/chatter/ns"
+            name: "chatter_py_ns"
+            default: "chatter/py/ns"
+        - arg:
+            name: "chatter_xml_ns"
+            default: "chatter/xml/ns"
+        - arg:
+            name: "chatter_yaml_ns"
+            default: "chatter/yaml/ns"
 
 
         # include another launch file
         - include:
             file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py"
 
-        # include another launch file in the chatter_ns namespace
+        # include a Python launch file in the chatter_py_ns namespace
         - group:
             - push_ros_namespace:
-                namespace: "$(var chatter_ns)"
+                namespace: "$(var chatter_py_ns)"
             - include:
                 file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py"
+
+        # include a xml launch file in the chatter_xml_ns namespace
+        - group:
+            - push_ros_namespace:
+                namespace: "$(var chatter_xml_ns)"
+            - include:
+                file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.xml"
+
+        # include a yaml launch file in the chatter_yaml_ns namespace
+        - group:
+            - push_ros_namespace:
+                namespace: "$(var chatter_yaml_ns)"
+            - include:
+                file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.yaml"
 
         # start a turtlesim_node in the turtlesim1 namespace
         - node:


### PR DESCRIPTION
* Add examples on including Python, XML and YAML files in Python/XML/YAML launch files
    Depends on the YAML launch files that were added with a [pull request](https://github.com/ros2/demos/pull/605) in [`ros2/demos`](https://github.com/ros2/demos).
* Renamed example launch files to comply with documentation (as in 19366a0)


Related to #3369
