### PR TITLE
Fix sitemap generation.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -165,6 +165,13 @@ htmlhelp_basename = 'ros2_docsdoc'
 
 html_baseurl = 'https://docs.ros.org/en'
 
+# The sitemap_url_scheme is used by the sitemap generator to figure out how
+# to generate links.  Essentially, the sitemap generator uses the following:
+#
+# url = html_baseurl + '/' + sitemap_url_scheme
+
+sitemap_url_scheme = '{version}/{link}'
+
 class RedirectFrom(Directive):
 
     has_content = True


### PR DESCRIPTION
It turns out that the sphinx sitemap plugin has a configuration variable controlling how it creates the final URL to put into the sitemap.  We always used the default in the past, but for some reason this seems to have changed and no longer works with our scheme.  So add in a custom sitemap scheme, which matches what we actually do.

@Yadunund @audrow It would be great if one of you could confirm that this works with YATM now.