### PR TITLE
Small fixes to link in the rosbag with ros1_bridge tutorial.

### DIFF
--- a/source/Tutorials/Demos/Rosbag-with-ROS1-Bridge.rst
+++ b/source/Tutorials/Demos/Rosbag-with-ROS1-Bridge.rst
@@ -6,9 +6,9 @@
 Recording and playing back data with ``rosbag`` using the ROS 1 bridge
 ======================================================================
 
-This tutorial is a follow up to the *Bridge communication between ROS 1 and ROS 2* demo as can be found `here <https://github.com/ros2/ros1_bridge/blob/{REPOS_FILE_BRANCH}/README.md>`__, and in the following it is assumed you have completed that tutorial already.
+This tutorial is a follow up to the *Bridge communication between ROS 1 and ROS 2* demo as can be found `here <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__, and in the following it is assumed you have completed that tutorial already.
 
-The ros1_bridge can either be installed from `binary packages <../../Installation>` or `built from source <https://github.com/ros2/ros1_bridge/blob/{REPOS_FILE_BRANCH}/README.md#building-the-bridge-from-source>`__; both work for these examples.
+The ros1_bridge can be built from :doc:`source <../../How-To-Guides/Using-ros1_bridge-Jammy-upstream>` for these examples.
 
 What follows is a series of additional examples, like that ones that come at the end of the aforementioned *Bridge communication between ROS 1 and ROS 2* demo.
 


### PR DESCRIPTION
Make sure to point at a branch that exists on the ros1_bridge tutorial, and point out how to build the bridge on Ubuntu 22.04