### PR TITLE
Release note for rclpy Time and Duration comparison fix

### DIFF
--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -448,6 +448,17 @@ Specifying a QoS of KEEP_LAST with a depth of 0 is a nonsensical arrangement, si
 
 See https://github.com/ros2/rclpy/pull/1048 for more information.
 
+Time and Duration no longer raise exception when compared to another type
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+It is now possible to compare ``rclpy.time.Time`` and ``rclpy.duration.Duration`` to other types without getting exceptions. If the types are not comparable, the comparison returns ``False``.
+
+.. code-block:: Python
+
+  print(None in [rclpy.time.Time(), rclpy.duration.Duration()])  # Prints "False" instead of raising TypeError
+
+See https://github.com/ros2/rclpy/pull/1007 for more information.
+
 ``rcutils``
 ^^^^^^^^^^^
 

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -451,7 +451,9 @@ See https://github.com/ros2/rclpy/pull/1048 for more information.
 Time and Duration no longer raise exception when compared to another type
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-It is now possible to compare ``rclpy.time.Time`` and ``rclpy.duration.Duration`` to other types without getting exceptions. If the types are not comparable, the comparison returns ``False``.
+It is now possible to compare ``rclpy.time.Time`` and ``rclpy.duration.Duration`` to other types without getting exceptions.
+If the types are not comparable, the comparison returns ``False``.
+Note that this is a behavior change from previous releases.
 
 .. code-block:: Python
 


### PR DESCRIPTION
Goes along with https://github.com/ros2/rclpy/pull/1007.