### PR TITLE
Fix indentation in the concept and tutorial cli pages

### DIFF
--- a/source/Concepts/About-Build-System.rst
+++ b/source/Concepts/About-Build-System.rst
@@ -30,16 +30,16 @@ Parsing of the :term:`package.xml` files is provided by ``catkin_pkg`` (as in RO
 
 .. glossary::
 
-   package.xml
-       Package manifest file which marks the root of a :term:`package` and contains meta information about the :term:`package` including its name, version, description, maintainer, license, dependencies, and more.
-       The contents of the manifest are in machine readable XML format and the contents are described in the |REPs| `127 <http://www.ros.org/reps/rep-0127.html>`_ and `140 <http://www.ros.org/reps/rep-0140.html>`_, with the possibility of further modifications in future |REPs|.
+  package.xml
+      Package manifest file which marks the root of a :term:`package` and contains meta information about the :term:`package` including its name, version, description, maintainer, license, dependencies, and more.
+      The contents of the manifest are in machine readable XML format and the contents are described in the |REPs| `127 <http://www.ros.org/reps/rep-0127.html>`_ and `140 <http://www.ros.org/reps/rep-0140.html>`_, with the possibility of further modifications in future |REPs|.
 
 So anytime some |package| is referred to as an :term:`ament package`, it means that it is a single unit of software (source code, build files, tests, documentation, and other resources) which is described using a :term:`package.xml` manifest file.
 
 .. glossary::
 
-   ament package
-       Any |package| which contains a :term:`package.xml` and follows the packaging guidelines of ``ament``, regardless of the underlying build system.
+  ament package
+      Any |package| which contains a :term:`package.xml` and follows the packaging guidelines of ``ament``, regardless of the underlying build system.
 
 Since the term :term:`ament package` is build system agnostic, there can be different kinds of |ament packages|, e.g. :term:`ament CMake package`, :term:`ament Python package`, etc.
 
@@ -47,17 +47,17 @@ Here is a list of common package types that you might run into in this software 
 
 .. glossary::
 
-    CMake package
-        Any |package| containing a plain CMake project and a :term:`package.xml` manifest file.
+  CMake package
+      Any |package| containing a plain CMake project and a :term:`package.xml` manifest file.
 
-    ament CMake package
-        A :term:`CMake package` that also follows the ``ament`` packaging guidelines.
+  ament CMake package
+      A :term:`CMake package` that also follows the ``ament`` packaging guidelines.
 
-    Python package
-        Any |package| containing a `setuptools <https://pypi.org/project/setuptools/>`_ based Python project and a :term:`package.xml` manifest file.
+  Python package
+      Any |package| containing a `setuptools <https://pypi.org/project/setuptools/>`_ based Python project and a :term:`package.xml` manifest file.
 
-    ament Python package
-        A :term:`Python package` that also follows the ``ament`` packaging guidelines.
+  ament Python package
+      A :term:`Python package` that also follows the ``ament`` packaging guidelines.
 
 The ``ament_cmake`` Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,36 +73,36 @@ Here a list of the |packages| in the repository along with a short description:
 
 -  ``ament_cmake``
 
-   - aggregates all other |packages| in this repository, users need only to depend on this
+  - aggregates all other |packages| in this repository, users need only to depend on this
 
 -  ``ament_cmake_auto``
 
-   - provides convenience CMake functions which automatically handle a lot of the tedious parts of writing a |package|'s ``CMakeLists.txt`` file
+  - provides convenience CMake functions which automatically handle a lot of the tedious parts of writing a |package|'s ``CMakeLists.txt`` file
 
 -  ``ament_cmake_core``
 
-   - provides all built-in core concepts for ``ament``, e.g. environment hooks, resource indexing, symbolic linking install and others
+  - provides all built-in core concepts for ``ament``, e.g. environment hooks, resource indexing, symbolic linking install and others
 
 -  ``ament_cmake_gmock``
 
-   - adds convenience functions for making gmock based unit tests
+  - adds convenience functions for making gmock based unit tests
 
 -  ``ament_cmake_gtest``
 
-   - adds convenience functions for making gtest based automated tests
+  - adds convenience functions for making gtest based automated tests
 
 -  ``ament_cmake_nose``
 
-   - adds convenience functions for making nosetests based python automated tests
+  - adds convenience functions for making nosetests based python automated tests
 
 -  ``ament_cmake_python``
 
-   - provides CMake functions for |packages| that contain Python code
-   - see the :doc:`ament_cmake_python user documentation <../How-To-Guides/Ament-CMake-Python-Documentation>`
+  - provides CMake functions for |packages| that contain Python code
+  - see the :doc:`ament_cmake_python user documentation <../How-To-Guides/Ament-CMake-Python-Documentation>`
 
 -  ``ament_cmake_test``
 
-   - aggregates different kinds of tests, e.g. gtest and nosetests, under a single target using `CTest <https://cmake.org/Wiki/CMake/Testing_With_CTest>`_
+  - aggregates different kinds of tests, e.g. gtest and nosetests, under a single target using `CTest <https://cmake.org/Wiki/CMake/Testing_With_CTest>`_
 
 The ``ament_cmake_core`` |package| contains a lot of the CMake infrastructure that makes it possible to cleanly pass information between |packages| using conventional interfaces.
 This makes the |packages| have more decoupled build interfaces with other |packages|, promoting their reuse and encouraging conventions in the build systems of different |packages|.

--- a/source/Concepts/About-Catment.rst
+++ b/source/Concepts/About-Catment.rst
@@ -110,26 +110,26 @@ Here's an example of how to do that, by doing a minimal installation of ``ament`
 
 .. code-block:: bash
 
-   mkdir -p ~/ament_ws/src
-   cd ~/ament_ws/src
-   git clone https://github.com/osrf/osrf_pycommon.git
-   git clone https://github.com/ament/ament_package.git
-   cd ament_package
-   git checkout catkin
-   cd ..
-   git clone https://github.com/ament/ament_tools.git
-   cd ament_tools
-   git checkout catkin
-   cd ../..
-    ./src/ament_tools/scripts/ament.py build
+  mkdir -p ~/ament_ws/src
+  cd ~/ament_ws/src
+  git clone https://github.com/osrf/osrf_pycommon.git
+  git clone https://github.com/ament/ament_package.git
+  cd ament_package
+  git checkout catkin
+  cd ..
+  git clone https://github.com/ament/ament_tools.git
+  cd ament_tools
+  git checkout catkin
+  cd ../..
+  ./src/ament_tools/scripts/ament.py build
 
 Now build the ROS packages:
 
 .. code-block:: bash
 
-   . $HOME/ament_ws/install/setup.bash
-   cd ~/ros_catkin_ws
-   ament build
+  . $HOME/ament_ws/install/setup.bash
+  cd ~/ros_catkin_ws
+  ament build
 
 Voila: you used the ``ament`` build tool to build your ``catkin`` packages, without having to migrate them.
 
@@ -143,19 +143,19 @@ Here's an example of doing that, installing to ``$HOME/catkin``:
 
 .. code-block:: bash
 
-   # install catkin_pkg
-   git clone https://github.com/ros-infrastructure/catkin_pkg.git
-   cd catkin_pkg
-   git checkout ament
-   python3 setup.py install --prefix $HOME/catkin --single-version-externally-managed --record foo --install-layout deb
-   # install catkin
-   git clone https://github.com/ros/catkin.git
-   cd catkin
-   git checkout ament
-   mkdir build
-   cd build
-   PYTHONPATH=$HOME/catkin/lib/python3/dist-packages/ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/catkin -DPYTHON_EXECUTABLE=/usr/bin/python3
-   make install
+  # install catkin_pkg
+  git clone https://github.com/ros-infrastructure/catkin_pkg.git
+  cd catkin_pkg
+  git checkout ament
+  python3 setup.py install --prefix $HOME/catkin --single-version-externally-managed --record foo --install-layout deb
+  # install catkin
+  git clone https://github.com/ros/catkin.git
+  cd catkin
+  git checkout ament
+  mkdir build
+  cd build
+  PYTHONPATH=$HOME/catkin/lib/python3/dist-packages/ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/catkin -DPYTHON_EXECUTABLE=/usr/bin/python3
+  make install
 
 To use that version of catkin, you just need to source the ``$HOME/catkin/setup.bash`` file.
 
@@ -166,9 +166,9 @@ To build it:
 
 .. code-block:: bash
 
-   cd ~/ros2_ws
-   . $HOME/catkin/setup.bash
-   ./src/ament/ament_tools/scripts/ament.py build
+  cd ~/ros2_ws
+  . $HOME/catkin/setup.bash
+  ./src/ament/ament_tools/scripts/ament.py build
 
 Voila: when adding new packages atop ROS 2, you're free to choose which CMake API you prefer inside your package.
 
@@ -199,46 +199,46 @@ Because we're going to call out to ``ament build``, we will also need a minimal 
 
 .. code-block:: bash
 
-   mkdir -p ~/ament_ws/src
-   cd ~/ament_ws/src
-   git clone https://github.com/osrf/osrf_pycommon.git
-   git clone https://github.com/ament/ament_package.git
-   cd ament_package
-   git checkout catkin
-   cd ..
-   git clone https://github.com/ament/ament_tools.git
-   cd ament_tools
-   git checkout catkin
-   cd ../..
-    ./src/ament_tools/scripts/ament.py build
+  mkdir -p ~/ament_ws/src
+  cd ~/ament_ws/src
+  git clone https://github.com/osrf/osrf_pycommon.git
+  git clone https://github.com/ament/ament_package.git
+  cd ament_package
+  git checkout catkin
+  cd ..
+  git clone https://github.com/ament/ament_tools.git
+  cd ament_tools
+  git checkout catkin
+  cd ../..
+  ./src/ament_tools/scripts/ament.py build
 
 Then we need to install the modified version of catkin somewhere:
 
 .. code-block:: bash
 
-   # install catkin_pkg
-   git clone https://github.com/ros-infrastructure/catkin_pkg.git
-   cd catkin_pkg
-   git checkout ament
-   python3 setup.py install --prefix $HOME/catkin --single-version-externally-managed --record foo --install-layout deb
-   # install catkin
-   git clone https://github.com/ros/catkin.git
-   cd catkin
-   git checkout ament
-   mkdir build
-   cd build
-   PYTHONPATH=$HOME/catkin/lib/python3/dist-packages/ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/catkin -DPYTHON_EXECUTABLE=/usr/bin/python3
-   make install
+  # install catkin_pkg
+  git clone https://github.com/ros-infrastructure/catkin_pkg.git
+  cd catkin_pkg
+  git checkout ament
+  python3 setup.py install --prefix $HOME/catkin --single-version-externally-managed --record foo --install-layout deb
+  # install catkin
+  git clone https://github.com/ros/catkin.git
+  cd catkin
+  git checkout ament
+  mkdir build
+  cd build
+  PYTHONPATH=$HOME/catkin/lib/python3/dist-packages/ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/catkin -DPYTHON_EXECUTABLE=/usr/bin/python3
+  make install
 
 Now build the ROS 2 packages:
 
 .. code-block:: bash
 
-   . $HOME/catkin/setup.bash
-   . $HOME/ament_ws/install/setup.bash
-   cd ~/ros2_ws
-   touch src/eProsima/AMENT_IGNORE
-   PYTHONPATH=$PYTHONPATH:/home/gerkey/ros2_ws_catkin/install_isolated/lib/python3.5/site-packages catkin_make_isolated --install
+  . $HOME/catkin/setup.bash
+  . $HOME/ament_ws/install/setup.bash
+  cd ~/ros2_ws
+  touch src/eProsima/AMENT_IGNORE
+  PYTHONPATH=$PYTHONPATH:/home/gerkey/ros2_ws_catkin/install_isolated/lib/python3.5/site-packages catkin_make_isolated --install
 
 Voila: you've built ROS 2 using the tools that you're familiar with.
 

--- a/source/Concepts/About-Command-Line-Tools.rst
+++ b/source/Concepts/About-Command-Line-Tools.rst
@@ -21,7 +21,7 @@ To see all available sub-commands run:
 
 .. code-block:: bash
 
-   ros2 --help
+  ros2 --help
 
 Examples of sub-commands that are available include:
 
@@ -53,20 +53,20 @@ Publish messages in one terminal with:
 
 .. code-block:: bash
 
-   $ ros2 topic pub /chatter std_msgs/msg/String "data: Hello world"
-   publisher: beginning loop
-   publishing #1: std_msgs.msg.String(data='Hello world')
+  $ ros2 topic pub /chatter std_msgs/msg/String "data: Hello world"
+  publisher: beginning loop
+  publishing #1: std_msgs.msg.String(data='Hello world')
 
-   publishing #2: std_msgs.msg.String(data='Hello world')
+  publishing #2: std_msgs.msg.String(data='Hello world')
 
 Echo messages received in another terminal with:
 
 .. code-block:: bash
 
-   $ ros2 topic echo /chatter
-   data: Hello world
+  $ ros2 topic echo /chatter
+  data: Hello world
 
-   data: Hello world
+  data: Hello world
 
 Behind the scenes
 -----------------

--- a/source/Concepts/About-Composition.rst
+++ b/source/Concepts/About-Composition.rst
@@ -21,7 +21,7 @@ Having different APIs, which was the biggest drawback in ROS 1, is avoided in RO
 
 .. note::
 
-   It is still possible to use the node-like style of "writing your own main" but for the common case it is not recommended.
+  It is still possible to use the node-like style of "writing your own main" but for the common case it is not recommended.
 
 
 By making the process layout a deploy-time decision the user can choose between:
@@ -49,14 +49,14 @@ Additionally, once a component is created, it must be registered with the index 
 
 .. code-block:: cmake
 
-   add_library(talker_component SHARED src/talker_component.cpp)
-   rclcpp_components_register_nodes(talker_component "composition::Talker")
-   # To register multiple components in the same shared library, use multiple calls
-   # rclcpp_components_register_nodes(talker_component "composition::Talker2")
+  add_library(talker_component SHARED src/talker_component.cpp)
+  rclcpp_components_register_nodes(talker_component "composition::Talker")
+  # To register multiple components in the same shared library, use multiple calls
+  # rclcpp_components_register_nodes(talker_component "composition::Talker2")
 
 .. note::
 
-   In order for the component_container to be able to find desired components, it must be executed or launched from a shell that has sourced the corresponding workspace.
+  In order for the component_container to be able to find desired components, it must be executed or launched from a shell that has sourced the corresponding workspace.
 
 .. _composition-using-components:
 

--- a/source/Concepts/About-Domain-ID.rst
+++ b/source/Concepts/About-Domain-ID.rst
@@ -38,26 +38,26 @@ Here are some platform-specific notes about ephemeral ports.
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Linux
 
-     By default, the Linux kernel uses ports 32768-60999 for ephemeral ports.
-     This means that domain IDs 0-101 and 215-232 can be safely used without colliding with ephemeral ports.
-     The ephemeral port range is configurable in Linux by setting custom values in ``/proc/sys/net/ipv4/ip_local_port_range``.
-     If a custom ephemeral port range is used, the above numbers may have to be adjusted accordingly.
+    By default, the Linux kernel uses ports 32768-60999 for ephemeral ports.
+    This means that domain IDs 0-101 and 215-232 can be safely used without colliding with ephemeral ports.
+    The ephemeral port range is configurable in Linux by setting custom values in ``/proc/sys/net/ipv4/ip_local_port_range``.
+    If a custom ephemeral port range is used, the above numbers may have to be adjusted accordingly.
 
-   .. group-tab:: macOS
+  .. group-tab:: macOS
 
-     By default, the ephemeral port range on macOS is 49152-65535.
-     This means that domain IDs 0-166 can be safely used without colliding with ephemeral ports.
-     The ephemeral port range is configurable in macOS by setting custom sysctl values for ``net.inet.ip.portrange.first`` and ``net.inet.ip.portrange.last``.
-     If a custom ephemeral port range is used, the above numbers may have to be adjusted accordingly.
+    By default, the ephemeral port range on macOS is 49152-65535.
+    This means that domain IDs 0-166 can be safely used without colliding with ephemeral ports.
+    The ephemeral port range is configurable in macOS by setting custom sysctl values for ``net.inet.ip.portrange.first`` and ``net.inet.ip.portrange.last``.
+    If a custom ephemeral port range is used, the above numbers may have to be adjusted accordingly.
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-     By default, the ephemeral port range on Windows is 49152-65535.
-     This means that domain IDs 0-166 can be safely used without colliding with ephemeral ports.
-     The ephemeral port range is configurable in Windows by `using netsh <https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-chang>`__.
-     If a custom ephemeral port range is used, the above numbers may have to be adjusted accordingly.
+    By default, the ephemeral port range on Windows is 49152-65535.
+    This means that domain IDs 0-166 can be safely used without colliding with ephemeral ports.
+    The ephemeral port range is configurable in Windows by `using netsh <https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-chang>`__.
+    If a custom ephemeral port range is used, the above numbers may have to be adjusted accordingly.
 
 Participant constraints
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,63 +95,63 @@ Domain ID to UDP Port Calculator
 
 .. raw:: html
 
-    <table>
-      <tr>
-        <td style="text-align: right; vertical-align: middle;"><label>Domain ID:</label></td>
-        <td><input type="number" min="0" max="232" size="3" class="display" value="0" id="domainID" onChange="calculate(this.value)"/></td>
-      </tr>
-      <tr>
-        <td style="text-align: right; vertical-align: middle;"><label>Participant ID:</label></td>
-        <td><input type="number" min="0" size="3" class="display" value="0" id="participantID" onChange="calculate(this.value)"/></td>
-      </tr>
-    </table>
-    <hr/>
-    <table>
-      <tr>
-        <td style="text-align: right; vertical-align: middle;"><label>Discovery Multicast Port:</label></td>
-        <td><input type="text" size="5" class="discoveryMulticastPort" disabled/></td>
-      </tr>
-      <tr>
-        <td style="text-align: right; vertical-align: middle;"><label>User Multicast Port:</label></td>
-        <td><input type="text" size="5" class="userMulticastPort" disabled/></td>
-      </tr>
-      <tr>
-        <td style="text-align: right; vertical-align: middle;"><label>Discovery Unicast Port:</label></td>
-        <td><input type="text" size="5" class="discoveryUnicastPort" disabled/></td>
-      </tr>
-      <tr>
-        <td style="text-align: right; vertical-align: middle;"><label>User Unicast Port:</label></td>
-        <td><input type="text" size="5" class="userUnicastPort" disabled/></td>
-      </tr>
-    </table>
-    <br/>
-    <br/>
+  <table>
+    <tr>
+      <td style="text-align: right; vertical-align: middle;"><label>Domain ID:</label></td>
+      <td><input type="number" min="0" max="232" size="3" class="display" value="0" id="domainID" onChange="calculate(this.value)"/></td>
+    </tr>
+    <tr>
+      <td style="text-align: right; vertical-align: middle;"><label>Participant ID:</label></td>
+      <td><input type="number" min="0" size="3" class="display" value="0" id="participantID" onChange="calculate(this.value)"/></td>
+    </tr>
+  </table>
+  <hr/>
+  <table>
+    <tr>
+      <td style="text-align: right; vertical-align: middle;"><label>Discovery Multicast Port:</label></td>
+      <td><input type="text" size="5" class="discoveryMulticastPort" disabled/></td>
+    </tr>
+    <tr>
+      <td style="text-align: right; vertical-align: middle;"><label>User Multicast Port:</label></td>
+      <td><input type="text" size="5" class="userMulticastPort" disabled/></td>
+    </tr>
+    <tr>
+      <td style="text-align: right; vertical-align: middle;"><label>Discovery Unicast Port:</label></td>
+      <td><input type="text" size="5" class="discoveryUnicastPort" disabled/></td>
+    </tr>
+    <tr>
+      <td style="text-align: right; vertical-align: middle;"><label>User Unicast Port:</label></td>
+      <td><input type="text" size="5" class="userUnicastPort" disabled/></td>
+    </tr>
+  </table>
+  <br/>
+  <br/>
 
-    <script type="text/javascript">
-      window.addEventListener('load', (event) => {
-         calculate(event);
-      });
-      const discoveryMcastPort = document.querySelector('.discoveryMulticastPort');
-      const userMcastPort = document.querySelector('.userMulticastPort');
-      const discoveryUnicastPort = document.querySelector('.discoveryUnicastPort');
-      const userUnicastPort = document.querySelector('.userUnicastPort');
+  <script type="text/javascript">
+    window.addEventListener('load', (event) => {
+        calculate(event);
+    });
+    const discoveryMcastPort = document.querySelector('.discoveryMulticastPort');
+    const userMcastPort = document.querySelector('.userMulticastPort');
+    const discoveryUnicastPort = document.querySelector('.discoveryUnicastPort');
+    const userUnicastPort = document.querySelector('.userUnicastPort');
 
-      const domainID = document.getElementById('domainID');
-      const participantID = document.getElementById('participantID');
+    const domainID = document.getElementById('domainID');
+    const participantID = document.getElementById('participantID');
 
-      // calculate function
-      function calculate(event) {
-        const d0 = 0;
-        const d2 = 1;
-        const d1 = 10;
-        const d3 = 11;
-        const PB = 7400;
-        const DG = 250;
-        const PG = 2;
+    // calculate function
+    function calculate(event) {
+      const d0 = 0;
+      const d2 = 1;
+      const d1 = 10;
+      const d3 = 11;
+      const PB = 7400;
+      const DG = 250;
+      const PG = 2;
 
-        discoveryMcastPort.value = PB + (DG * domainID.value) + d0;
-        userMcastPort.value = PB + (DG * domainID.value) + d2;
-        discoveryUnicastPort.value = PB + (DG * domainID.value) + d1 + (PG * participantID.value);
-        userUnicastPort.value = PB + (DG * domainID.value) + d3 + (PG * participantID.value);
-      }
-    </script>
+      discoveryMcastPort.value = PB + (DG * domainID.value) + d0;
+      userMcastPort.value = PB + (DG * domainID.value) + d2;
+      discoveryUnicastPort.value = PB + (DG * domainID.value) + d1 + (PG * participantID.value);
+      userUnicastPort.value = PB + (DG * domainID.value) + d3 + (PG * participantID.value);
+    }
+  </script>

--- a/source/Concepts/About-Executors.rst
+++ b/source/Concepts/About-Executors.rst
@@ -22,30 +22,30 @@ In the simplest case, the main thread is used for processing the incoming messag
 
 .. code-block:: cpp
 
-   int main(int argc, char* argv[])
-   {
-      // Some initialization.
-      rclcpp::init(argc, argv);
-      ...
+  int main(int argc, char* argv[])
+  {
+    // Some initialization.
+    rclcpp::init(argc, argv);
+    ...
 
-      // Instantiate a node.
-      rclcpp::Node::SharedPtr node = ...
+    // Instantiate a node.
+    rclcpp::Node::SharedPtr node = ...
 
-      // Run the executor.
-      rclcpp::spin(node);
+    // Run the executor.
+    rclcpp::spin(node);
 
-      // Shutdown and exit.
-      ...
-      return 0;
-   }
+    // Shutdown and exit.
+    ...
+    return 0;
+  }
 
 The call to ``spin(node)`` basically expands to an instantiation and invocation of the Single-Threaded Executor, which is the simplest Executor:
 
 .. code-block:: cpp
 
-   rclcpp::executors::SingleThreadedExecutor executor;
-   executor.add_node(node);
-   executor.spin();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
 
 By invoking ``spin()`` of the Executor instance, the current thread starts querying the rcl and middleware layers for incoming messages and other events and calls the corresponding callback functions until the node shuts down.
 In order not to counteract the QoS settings of the middleware, an incoming message is not stored in a queue on the Client Library layer but kept in the middleware until it is taken for processing by a callback function.
@@ -64,17 +64,17 @@ Currently, rclcpp provides three Executor types, derived from a shared parent cl
 
 .. graphviz::
 
-   digraph Flatland {
+  digraph Flatland {
 
-      Executor -> SingleThreadedExecutor [dir = back, arrowtail = empty];
-      Executor -> MultiThreadedExecutor [dir = back, arrowtail = empty];
-      Executor -> StaticSingleThreadedExecutor [dir = back, arrowtail = empty];
-      Executor  [shape=polygon,sides=4];
-      SingleThreadedExecutor  [shape=polygon,sides=4];
-      MultiThreadedExecutor  [shape=polygon,sides=4];
-      StaticSingleThreadedExecutor  [shape=polygon,sides=4];
+    Executor -> SingleThreadedExecutor [dir = back, arrowtail = empty];
+    Executor -> MultiThreadedExecutor [dir = back, arrowtail = empty];
+    Executor -> StaticSingleThreadedExecutor [dir = back, arrowtail = empty];
+    Executor  [shape=polygon,sides=4];
+    SingleThreadedExecutor  [shape=polygon,sides=4];
+    MultiThreadedExecutor  [shape=polygon,sides=4];
+    StaticSingleThreadedExecutor  [shape=polygon,sides=4];
 
-      }
+    }
 
 The *Multi-Threaded Executor* creates a configurable number of threads to allow for processing multiple messages or events in parallel.
 The *Static Single-Threaded Executor* optimizes the runtime costs for scanning the structure of a node in terms of subscriptions, timers, service servers, action servers, etc.
@@ -85,15 +85,15 @@ All three executors can be used with multiple nodes by calling ``add_node(..)`` 
 
 .. code-block:: cpp
 
-   rclcpp::Node::SharedPtr node1 = ...
-   rclcpp::Node::SharedPtr node2 = ...
-   rclcpp::Node::SharedPtr node3 = ...
+  rclcpp::Node::SharedPtr node1 = ...
+  rclcpp::Node::SharedPtr node2 = ...
+  rclcpp::Node::SharedPtr node3 = ...
 
-   rclcpp::executors::StaticSingleThreadedExecutor executor;
-   executor.add_node(node1);
-   executor.add_node(node2);
-   executor.add_node(node2);
-   executor.spin();
+  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  executor.add_node(node1);
+  executor.add_node(node2);
+  executor.add_node(node2);
+  executor.spin();
 
 In the above example, the one thread of a Static Single-Threaded Executor is used to serve three nodes together.
 In case of a Multi-Threaded Executor, the actual parallelism depends on the callback groups.
@@ -109,24 +109,24 @@ Then, this callback group can be specified when creating a subscription, timer, 
 
 .. tabs::
 
-   .. group-tab:: C++
+  .. group-tab:: C++
 
-      .. code-block:: cpp
+    .. code-block:: cpp
 
-        my_callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      my_callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-        rclcpp::SubscriptionOptions options;
-        options.callback_group = my_callback_group;
+      rclcpp::SubscriptionOptions options;
+      options.callback_group = my_callback_group;
 
-        my_subscription = create_subscription<Int32>("/topic", rclcpp::SensorDataQoS(),
-                                                     callback, options);
-   .. group-tab:: Python
+      my_subscription = create_subscription<Int32>("/topic", rclcpp::SensorDataQoS(),
+                                                    callback, options);
+  .. group-tab:: Python
 
-      .. code-block:: python
+    .. code-block:: python
 
-        my_callback_group = MutuallyExclusiveCallbackGroup()
-        my_subscription = self.create_subscription(Int32, "/topic", self.callback, qos_profile=1,
-                                                   callback_group=my_callback_group)
+      my_callback_group = MutuallyExclusiveCallbackGroup()
+      my_subscription = self.create_subscription(Int32, "/topic", self.callback, qos_profile=1,
+                                                  callback_group=my_callback_group)
 
 All subscriptions, timers, etc. that are created without the indication of a callback group are assigned to the *default callback group*.
 The default callback group can be queried via ``NodeBaseInterface::get_default_callback_group()`` in rclcpp

--- a/source/Concepts/About-Internal-Interfaces.rst
+++ b/source/Concepts/About-Internal-Interfaces.rst
@@ -177,7 +177,7 @@ For more information on what exactly is in the ``rosidl`` |API| (static and gene
 
 .. warning::
 
-    TODO: link to definition of ``rosidl`` |APIs|
+  TODO: link to definition of ``rosidl`` |APIs|
 
 The ``rcutils`` Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Concepts/About-Middleware-Implementations.rst
+++ b/source/Concepts/About-Middleware-Implementations.rst
@@ -58,4 +58,4 @@ To learn more about what is required to create a new middleware implementation f
 
 .. warning::
 
-    TODO: Link to more detailed middleware implementation docs and/or tutorial.
+  TODO: Link to more detailed middleware implementation docs and/or tutorial.

--- a/source/Concepts/About-Quality-of-Service-Settings.rst
+++ b/source/Concepts/About-Quality-of-Service-Settings.rst
@@ -137,123 +137,123 @@ The following tables show the compatibility of the different policy settings and
 *Compatibility of reliability QoS policies:*
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Publisher
-     - Subscription
-     - Compatible
-   * - Best effort
-     - Best effort
-     - Yes
-   * - Best effort
-     - Reliable
-     - No
-   * - Reliable
-     - Best effort
-     - Yes
-   * - Reliable
-     - Reliable
-     - Yes
+  * - Publisher
+    - Subscription
+    - Compatible
+  * - Best effort
+    - Best effort
+    - Yes
+  * - Best effort
+    - Reliable
+    - No
+  * - Reliable
+    - Best effort
+    - Yes
+  * - Reliable
+    - Reliable
+    - Yes
 
 *Compatibility of durability QoS policies:*
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Publisher
-     - Subscription
-     - Compatible
-   * - Volatile
-     - Volatile
-     - Yes
-   * - Volatile
-     - Transient local
-     - No
-   * - Transient local
-     - Volatile
-     - Yes
-   * - Transient local
-     - Transient local
-     - Yes
+  * - Publisher
+    - Subscription
+    - Compatible
+  * - Volatile
+    - Volatile
+    - Yes
+  * - Volatile
+    - Transient local
+    - No
+  * - Transient local
+    - Volatile
+    - Yes
+  * - Transient local
+    - Transient local
+    - Yes
 
 *Compatibility of deadline QoS policies:*
 
   Assume *x* and *y* are arbitrary valid duration values.
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Publisher
-     - Subscription
-     - Compatible
-   * - Default
-     - Default
-     - Yes
-   * - Default
-     - *x*
-     - No
-   * - *x*
-     - Default
-     - Yes
-   * - *x*
-     - *x*
-     - Yes
-   * - *x*
-     - *y* (where *y* > *x*)
-     - Yes
-   * - *x*
-     - *y* (where *y* < *x*)
-     - No
+  * - Publisher
+    - Subscription
+    - Compatible
+  * - Default
+    - Default
+    - Yes
+  * - Default
+    - *x*
+    - No
+  * - *x*
+    - Default
+    - Yes
+  * - *x*
+    - *x*
+    - Yes
+  * - *x*
+    - *y* (where *y* > *x*)
+    - Yes
+  * - *x*
+    - *y* (where *y* < *x*)
+    - No
 
 *Compatibility of liveliness QoS policies:*
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Publisher
-     - Subscription
-     - Compatible
-   * - Automatic
-     - Automatic
-     - Yes
-   * - Automatic
-     - Manual by topic
-     - No
-   * - Manual by topic
-     - Automatic
-     - Yes
-   * - Manual by topic
-     - Manual by topic
-     - Yes
+  * - Publisher
+    - Subscription
+    - Compatible
+  * - Automatic
+    - Automatic
+    - Yes
+  * - Automatic
+    - Manual by topic
+    - No
+  * - Manual by topic
+    - Automatic
+    - Yes
+  * - Manual by topic
+    - Manual by topic
+    - Yes
 
 *Compatibility of lease duration QoS policies:*
 
   Assume *x* and *y* are arbitrary valid duration values.
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Publisher
-     - Subscription
-     - Compatible
-   * - Default
-     - Default
-     - Yes
-   * - Default
-     - *x*
-     - No
-   * - *x*
-     - Default
-     - Yes
-   * - *x*
-     - *x*
-     - Yes
-   * - *x*
-     - *y* (where *y* > *x*)
-     - Yes
-   * - *x*
-     - *y* (where *y* < *x*)
-     - No
+  * - Publisher
+    - Subscription
+    - Compatible
+  * - Default
+    - Default
+    - Yes
+  * - Default
+    - *x*
+    - No
+  * - *x*
+    - Default
+    - Yes
+  * - *x*
+    - *x*
+    - Yes
+  * - *x*
+    - *y* (where *y* > *x*)
+    - Yes
+  * - *x*
+    - *y* (where *y* < *x*)
+    - No
 
 In order for a connection to be made, all of the policies that affect compatibility must be compatible.
 For example, even if a requested and offered QoS profile pair has compatible reliability QoS policies, but they have incompatible durability QoS policies, a connection will still not be made.

--- a/source/Concepts/About-ROS-2-Parameters.rst
+++ b/source/Concepts/About-ROS-2-Parameters.rst
@@ -63,10 +63,11 @@ This callback will be called before a parameter is declared or changed on a node
 The main purpose of this callback is to give the user the ability to inspect the upcoming change to the parameter and explicitly reject the change.
 
 .. note::
-   It is important that "set parameter" callbacks have no side-effects.
-   Since multiple "set parameter" callbacks can be chained, there is no way for an individual callback to know if a later callback will reject the update.
-   If the individual callback were to make changes to the class it is in, for instance, it may get out-of-sync with the actual parameter.
-   To get a callback *after* a parameter has been successfully changed, see the next type of callback below.
+
+  It is important that "set parameter" callbacks have no side-effects.
+  Since multiple "set parameter" callbacks can be chained, there is no way for an individual callback to know if a later callback will reject the update.
+  If the individual callback were to make changes to the class it is in, for instance, it may get out-of-sync with the actual parameter.
+  To get a callback *after* a parameter has been successfully changed, see the next type of callback below.
 
 The second type of callback is known as an "on parameter event" callback, and can be set by calling ``on_parameter_event`` from one of the parameter client APIs.
 The callback should accept an ``rcl_interfaces/msg/ParameterEvent`` object, and return nothing.
@@ -127,6 +128,6 @@ ROS 2 ships with one in the ``ros-{DISTRO}-demo-nodes-cpp`` package called ``par
 
 .. code-block:: console
 
-   ros2 run demo_nodes_cpp parameter_blackboard
+  ros2 run demo_nodes_cpp parameter_blackboard
 
 The code for the ``parameter_blackboard`` is `here <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp>`__.

--- a/source/Concepts/About-ROS-Interfaces.rst
+++ b/source/Concepts/About-ROS-Interfaces.rst
@@ -38,16 +38,16 @@ Each field consists of a type and a name, separated by a space, i.e:
 
 .. code-block:: bash
 
-   fieldtype1 fieldname1
-   fieldtype2 fieldname2
-   fieldtype3 fieldname3
+  fieldtype1 fieldname1
+  fieldtype2 fieldname2
+  fieldtype3 fieldname3
 
 For example:
 
 .. code-block:: bash
 
-   int32 my_int
-   string my_string
+  int32 my_int
+  string my_string
 
 2.1.1 Field types
 ~~~~~~~~~~~~~~~~~
@@ -61,99 +61,99 @@ Field types can be:
 *Built-in-types currently supported:*
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Type name
-     - `C++ <https://design.ros2.org/articles/generated_interfaces_cpp.html>`__
-     - `Python <https://design.ros2.org/articles/generated_interfaces_python.html>`__
-     - `DDS type <https://design.ros2.org/articles/mapping_dds_types.html>`__
-   * - bool
-     - bool
-     - builtins.bool
-     - boolean
-   * - byte
-     - uint8_t
-     - builtins.bytes*
-     - octet
-   * - char
-     - char
-     - builtins.str*
-     - char
-   * - float32
-     - float
-     - builtins.float*
-     - float
-   * - float64
-     - double
-     - builtins.float*
-     - double
-   * - int8
-     - int8_t
-     - builtins.int*
-     - octet
-   * - uint8
-     - uint8_t
-     - builtins.int*
-     - octet
-   * - int16
-     - int16_t
-     - builtins.int*
-     - short
-   * - uint16
-     - uint16_t
-     - builtins.int*
-     - unsigned short
-   * - int32
-     - int32_t
-     - builtins.int*
-     - long
-   * - uint32
-     - uint32_t
-     - builtins.int*
-     - unsigned long
-   * - int64
-     - int64_t
-     - builtins.int*
-     - long long
-   * - uint64
-     - uint64_t
-     - builtins.int*
-     - unsigned long long
-   * - string
-     - std::string
-     - builtins.str
-     - string
-   * - wstring
-     - std::u16string
-     - builtins.str
-     - wstring
+  * - Type name
+    - `C++ <https://design.ros2.org/articles/generated_interfaces_cpp.html>`__
+    - `Python <https://design.ros2.org/articles/generated_interfaces_python.html>`__
+    - `DDS type <https://design.ros2.org/articles/mapping_dds_types.html>`__
+  * - bool
+    - bool
+    - builtins.bool
+    - boolean
+  * - byte
+    - uint8_t
+    - builtins.bytes*
+    - octet
+  * - char
+    - char
+    - builtins.str*
+    - char
+  * - float32
+    - float
+    - builtins.float*
+    - float
+  * - float64
+    - double
+    - builtins.float*
+    - double
+  * - int8
+    - int8_t
+    - builtins.int*
+    - octet
+  * - uint8
+    - uint8_t
+    - builtins.int*
+    - octet
+  * - int16
+    - int16_t
+    - builtins.int*
+    - short
+  * - uint16
+    - uint16_t
+    - builtins.int*
+    - unsigned short
+  * - int32
+    - int32_t
+    - builtins.int*
+    - long
+  * - uint32
+    - uint32_t
+    - builtins.int*
+    - unsigned long
+  * - int64
+    - int64_t
+    - builtins.int*
+    - long long
+  * - uint64
+    - uint64_t
+    - builtins.int*
+    - unsigned long long
+  * - string
+    - std::string
+    - builtins.str
+    - string
+  * - wstring
+    - std::u16string
+    - builtins.str
+    - wstring
 
 
 *Every built-in-type can be used to define arrays:*
 
 .. list-table::
-   :header-rows: 1
+  :header-rows: 1
 
-   * - Type name
-     - `C++ <https://design.ros2.org/articles/generated_interfaces_cpp.html>`__
-     - `Python <https://design.ros2.org/articles/generated_interfaces_python.html>`__
-     - `DDS type <https://design.ros2.org/articles/mapping_dds_types.html>`__
-   * - static array
-     - std::array<T, N>
-     - builtins.list*
-     - T[N]
-   * - unbounded dynamic array
-     - std::vector
-     - builtins.list
-     - sequence
-   * - bounded dynamic array
-     - custom_class<T, N>
-     - builtins.list*
-     - sequence<T, N>
-   * - bounded string
-     - std::string
-     - builtins.str*
-     - string
+  * - Type name
+    - `C++ <https://design.ros2.org/articles/generated_interfaces_cpp.html>`__
+    - `Python <https://design.ros2.org/articles/generated_interfaces_python.html>`__
+    - `DDS type <https://design.ros2.org/articles/mapping_dds_types.html>`__
+  * - static array
+    - std::array<T, N>
+    - builtins.list*
+    - T[N]
+  * - unbounded dynamic array
+    - std::vector
+    - builtins.list
+    - sequence
+  * - bounded dynamic array
+    - custom_class<T, N>
+    - builtins.list*
+    - sequence<T, N>
+  * - bounded string
+    - std::string
+    - builtins.str*
+    - string
 
 
 All types that are more permissive than their ROS definition enforce the ROS constraints in range and length by software
@@ -162,16 +162,16 @@ All types that are more permissive than their ROS definition enforce the ROS con
 
 .. code-block:: bash
 
-   int32[] unbounded_integer_array
-   int32[5] five_integers_array
-   int32[<=5] up_to_five_integers_array
+  int32[] unbounded_integer_array
+  int32[5] five_integers_array
+  int32[<=5] up_to_five_integers_array
 
-   string string_of_unbounded_size
-   string<=10 up_to_ten_characters_string
+  string string_of_unbounded_size
+  string<=10 up_to_ten_characters_string
 
-   string[<=5] up_to_five_unbounded_strings
-   string<=10[] unbounded_array_of_strings_up_to_ten_characters_each
-   string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
+  string[<=5] up_to_five_unbounded_strings
+  string<=10[] unbounded_array_of_strings_up_to_ten_characters_each
+  string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
 
 2.1.2 Field names
 ~~~~~~~~~~~~~~~~~
@@ -189,16 +189,16 @@ Defining a default value is done by adding a third element to the field definiti
 
 .. code-block:: bash
 
-   fieldtype fieldname fielddefaultvalue
+  fieldtype fieldname fielddefaultvalue
 
 For example:
 
 .. code-block:: bash
 
-   uint8 x 42
-   int16 y -2000
-   string full_name "John Doe"
-   int32[] samples [-200, -100, 0, 100, 200]
+  uint8 x 42
+  int16 y -2000
+  string full_name "John Doe"
+  int32[] samples [-200, -100, 0, 100, 200]
 
 Note:
 
@@ -213,20 +213,20 @@ Each constant definition is like a field description with a default value, excep
 
 .. code-block:: bash
 
-   constanttype CONSTANTNAME=constantvalue
+  constanttype CONSTANTNAME=constantvalue
 
 For example:
 
 .. code-block:: bash
 
-   int32 X=123
-   int32 Y=-123
-   string FOO="foo"
-   string EXAMPLE='bar'
+  int32 X=123
+  int32 Y=-123
+  string FOO="foo"
+  string EXAMPLE='bar'
 
 .. note::
 
-   Constants names have to be UPPERCASE
+  Constants names have to be UPPERCASE
 
 3. Service description specification
 ------------------------------------
@@ -240,27 +240,27 @@ Here is a very simple example of a service that takes in a string and returns a 
 
 .. code-block:: bash
 
-   string str
-   ---
-   string str
+  string str
+  ---
+  string str
 
 We can of course get much more complicated (if you want to refer to a message from the same package you must not mention the package name):
 
 .. code-block:: bash
 
-   #request constants
-   int8 FOO=1
-   int8 BAR=2
-   #request fields
-   int8 foobar
-   another_pkg/AnotherMessage msg
-   ---
-   #response constants
-   uint32 SECRET=123456
-   #response fields
-   another_pkg/YetAnotherMessage val
-   CustomMessageDefinedInThisPackage value
-   uint32 an_integer
+  #request constants
+  int8 FOO=1
+  int8 BAR=2
+  #request fields
+  int8 foobar
+  another_pkg/AnotherMessage msg
+  ---
+  #response constants
+  uint32 SECRET=123456
+  #response fields
+  another_pkg/YetAnotherMessage val
+  CustomMessageDefinedInThisPackage value
+  uint32 an_integer
 
 You cannot embed another service inside of a service.
 

--- a/source/Concepts/About-RQt.rst
+++ b/source/Concepts/About-RQt.rst
@@ -23,7 +23,7 @@ You can run any RQt tools/plugins easily by:
 
 .. code-block:: bash
 
-   rqt
+  rqt
 
 This GUI allows you to choose any available plugins on your system.
 You can also run plugins in standalone windows.
@@ -31,14 +31,14 @@ For example, RQt Python Console:
 
 .. code-block:: bash
 
-   ros2 run rqt_py_console rqt_py_console
+  ros2 run rqt_py_console rqt_py_console
 
 Users can create their own plugins for RQt with either ``Python`` or ``C++``.
 To see what RQt plugins are available for your system, run:
 
 .. code-block:: bash
 
-   ros2 pkg list
+  ros2 pkg list
 
 And then look for packages that start with ``rqt_``.
 
@@ -50,7 +50,7 @@ Installing From Debian
 
 .. code-block:: bash
 
-   sudo apt install ros-{DISTRO}-rqt*
+  sudo apt install ros-{DISTRO}-rqt*
 
 
 Building From Source
@@ -91,4 +91,4 @@ Further Reading
 
   .. raw:: html
 
-     <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/CyP9wHu2PpY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/CyP9wHu2PpY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -54,25 +54,25 @@ You will need to run this command on every new shell you open to have access to 
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Linux
 
-      .. code-block:: bash
+    .. code-block:: bash
 
-        # Replace ".bash" with your shell if you're not using bash
-        # Possible values are: setup.bash, setup.sh, setup.zsh
-        source /opt/ros/{DISTRO}/setup.bash
+      # Replace ".bash" with your shell if you're not using bash
+      # Possible values are: setup.bash, setup.sh, setup.zsh
+      source /opt/ros/{DISTRO}/setup.bash
 
-   .. group-tab:: macOS
+  .. group-tab:: macOS
 
-      .. code-block:: console
+    .. code-block:: console
 
-        . ~/ros2_install/ros2-osx/setup.bash
+      . ~/ros2_install/ros2-osx/setup.bash
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      .. code-block:: console
+    .. code-block:: console
 
-        call C:\dev\ros2\local_setup.bat
+      call C:\dev\ros2\local_setup.bat
 
 .. note::
     The exact command depends on where you installed ROS 2.
@@ -85,40 +85,40 @@ If you don't want to have to source the setup file every time you open a new she
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Linux
 
-      .. code-block:: console
+    .. code-block:: console
 
-        echo "source /opt/ros/{DISTRO}/setup.bash" >> ~/.bashrc
+      echo "source /opt/ros/{DISTRO}/setup.bash" >> ~/.bashrc
 
-     To undo this, locate your system's shell startup script and remove the appended source command.
+    To undo this, locate your system's shell startup script and remove the appended source command.
 
-   .. group-tab:: macOS
+  .. group-tab:: macOS
 
-      .. code-block:: console
+    .. code-block:: console
 
-        echo "source ~/ros2_install/ros2-osx/setup.bash" >> ~/.bash_profile
+      echo "source ~/ros2_install/ros2-osx/setup.bash" >> ~/.bash_profile
 
-      To undo this, locate your system's shell startup script and remove the appended source command.
+    To undo this, locate your system's shell startup script and remove the appended source command.
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      Only for PowerShell users, create a folder in 'My Documents' called 'WindowsPowerShell'.
-      Within 'WindowsPowerShell', create file 'Microsoft.PowerShell_profile.ps1'.
-      Inside the file, paste:
+    Only for PowerShell users, create a folder in 'My Documents' called 'WindowsPowerShell'.
+    Within 'WindowsPowerShell', create file 'Microsoft.PowerShell_profile.ps1'.
+    Inside the file, paste:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        C:\dev\ros2_{DISTRO}\local_setup.ps1
+      C:\dev\ros2_{DISTRO}\local_setup.ps1
 
-      PowerShell will request permission to run this script everytime a new shell is opened.
-      To avoid that issue you can run:
+    PowerShell will request permission to run this script everytime a new shell is opened.
+    To avoid that issue you can run:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        Unblock-File C:\dev\ros2_{DISTRO}\local_setup.ps1
+      Unblock-File C:\dev\ros2_{DISTRO}\local_setup.ps1
 
-      To undo this, remove the new 'Microsoft.PowerShell_profile.ps1' file.
+    To undo this, remove the new 'Microsoft.PowerShell_profile.ps1' file.
 
 3 Check environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,23 +128,23 @@ If you ever have problems finding or using your ROS 2 packages, make sure that y
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Linux
 
-      .. code-block:: console
+    .. code-block:: console
 
-        printenv | grep -i ROS
+      printenv | grep -i ROS
 
-   .. group-tab:: macOS
+  .. group-tab:: macOS
 
-      .. code-block:: console
+    .. code-block:: console
 
-        printenv | grep -i ROS
+      printenv | grep -i ROS
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      .. code-block:: console
+    .. code-block:: console
 
-        set | findstr -i ROS
+      set | findstr -i ROS
 
 Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set.
 
@@ -166,41 +166,41 @@ Once you have determined a unique integer for your group of ROS 2 nodes, you can
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Linux
 
-      .. code-block:: console
+    .. code-block:: console
 
-        export ROS_DOMAIN_ID=<your_domain_id>
+      export ROS_DOMAIN_ID=<your_domain_id>
 
-      To maintain this setting between shell sessions, you can add the command to your shell startup script:
+    To maintain this setting between shell sessions, you can add the command to your shell startup script:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        echo "export ROS_DOMAIN_ID=<your_domain_id>" >> ~/.bashrc
+      echo "export ROS_DOMAIN_ID=<your_domain_id>" >> ~/.bashrc
 
-   .. group-tab:: macOS
+  .. group-tab:: macOS
 
-      .. code-block:: console
+    .. code-block:: console
 
-        export ROS_DOMAIN_ID=<your_domain_id>
+      export ROS_DOMAIN_ID=<your_domain_id>
 
-      To maintain this setting between shell sessions, you can add the command to your shell startup script:
+    To maintain this setting between shell sessions, you can add the command to your shell startup script:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        echo "export ROS_DOMAIN_ID=<your_domain_id>" >> ~/.bash_profile
+      echo "export ROS_DOMAIN_ID=<your_domain_id>" >> ~/.bash_profile
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      .. code-block:: console
+    .. code-block:: console
 
-        set ROS_DOMAIN_ID=<your_domain_id>
+      set ROS_DOMAIN_ID=<your_domain_id>
 
-      If you want to make this permanent between shell sessions, also run:
+    If you want to make this permanent between shell sessions, also run:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        setx ROS_DOMAIN_ID <your_domain_id>
+      setx ROS_DOMAIN_ID <your_domain_id>
 
 3.2 The ``ROS_LOCALHOST_ONLY`` variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -213,41 +213,41 @@ You can set the environment variable with the following command:
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Linux
 
-      .. code-block:: console
+    .. code-block:: console
 
-        export ROS_LOCALHOST_ONLY=1
+      export ROS_LOCALHOST_ONLY=1
 
-      To maintain this setting between shell sessions, you can add the command to your shell startup script:
+    To maintain this setting between shell sessions, you can add the command to your shell startup script:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        echo "export ROS_LOCALHOST_ONLY=1" >> ~/.bashrc
+      echo "export ROS_LOCALHOST_ONLY=1" >> ~/.bashrc
 
-   .. group-tab:: macOS
+  .. group-tab:: macOS
 
-      .. code-block:: console
+    .. code-block:: console
 
-        export ROS_LOCALHOST_ONLY=1
+      export ROS_LOCALHOST_ONLY=1
 
-      To maintain this setting between shell sessions, you can add the command to your shell startup script:
+    To maintain this setting between shell sessions, you can add the command to your shell startup script:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        echo "export ROS_LOCALHOST_ONLY=1" >> ~/.bash_profile
+      echo "export ROS_LOCALHOST_ONLY=1" >> ~/.bash_profile
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      .. code-block:: console
+    .. code-block:: console
 
-        set ROS_LOCALHOST_ONLY=1
+      set ROS_LOCALHOST_ONLY=1
 
-      If you want to make this permanent between shell sessions, also run:
+    If you want to make this permanent between shell sessions, also run:
 
-      .. code-block:: console
+    .. code-block:: console
 
-        setx ROS_LOCALHOST_ONLY 1
+      setx ROS_LOCALHOST_ONLY 1
 
 
 Summary

--- a/source/Tutorials/Beginner-CLI-Tools/Launching-Multiple-Nodes/Launching-Multiple-Nodes.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Launching-Multiple-Nodes/Launching-Multiple-Nodes.rst
@@ -89,13 +89,13 @@ In the second terminal:
 
 .. code-block:: console
 
-  ros2 topic pub  /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}"
+  ros2 topic pub /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}"
 
 In the third terminal:
 
 .. code-block:: console
 
-  ros2 topic pub  /turtlesim2/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
+  ros2 topic pub /turtlesim2/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
 
 After running these commands, you should see something like the following:
 

--- a/source/Tutorials/Beginner-CLI-Tools/Launching-Multiple-Nodes/Launching-Multiple-Nodes.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Launching-Multiple-Nodes/Launching-Multiple-Nodes.rst
@@ -48,24 +48,24 @@ Open a new terminal and run:
 
 .. code-block:: console
 
-   ros2 launch turtlesim multisim.launch.py
+  ros2 launch turtlesim multisim.launch.py
 
 This command will run the following launch file:
 
 .. code-block:: python
 
-   # turtlesim/launch/multisim.launch.py
+  # turtlesim/launch/multisim.launch.py
 
-   from launch import LaunchDescription
-   import launch_ros.actions
+  from launch import LaunchDescription
+  import launch_ros.actions
 
-   def generate_launch_description():
-       return LaunchDescription([
-           launch_ros.actions.Node(
-               namespace= "turtlesim1", package='turtlesim', executable='turtlesim_node', output='screen'),
-           launch_ros.actions.Node(
-               namespace= "turtlesim2", package='turtlesim', executable='turtlesim_node', output='screen'),
-       ])
+  def generate_launch_description():
+      return LaunchDescription([
+          launch_ros.actions.Node(
+              namespace= "turtlesim1", package='turtlesim', executable='turtlesim_node', output='screen'),
+          launch_ros.actions.Node(
+              namespace= "turtlesim2", package='turtlesim', executable='turtlesim_node', output='screen'),
+      ])
 
 .. note::
 
@@ -89,13 +89,13 @@ In the second terminal:
 
 .. code-block:: console
 
-   ros2 topic pub  /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}"
+  ros2 topic pub  /turtlesim1/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.8}}"
 
 In the third terminal:
 
 .. code-block:: console
 
-   ros2 topic pub  /turtlesim2/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
+  ros2 topic pub  /turtlesim2/turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -1.8}}"
 
 After running these commands, you should see something like the following:
 

--- a/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
@@ -55,13 +55,13 @@ Open a new terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtle_teleop_key
+  ros2 run turtlesim turtle_teleop_key
 
 Let's also make a new directory to store our saved recordings, just as good practice:
 
@@ -115,7 +115,6 @@ Use the arrow keys to move the turtle around, and you will see data being publis
     ---
 
 
-
 3 ros2 bag record
 ^^^^^^^^^^^^^^^^^
 
@@ -139,7 +138,7 @@ To record the data published to a topic use the command syntax:
 
 .. code-block:: console
 
-    ros2 bag record <topic_name>
+  ros2 bag record <topic_name>
 
 Before running this command on your chosen topic, open a new terminal and move into the ``bag_files`` directory you created earlier, because the rosbag file will save in the directory where you run it.
 
@@ -147,16 +146,16 @@ Run the command:
 
 .. code-block:: console
 
-    ros2 bag record /turtle1/cmd_vel
+  ros2 bag record /turtle1/cmd_vel
 
 You will see the following messages in the terminal (the date and time will be different):
 
 .. code-block:: console
 
-    [INFO] [rosbag2_storage]: Opened database 'rosbag2_2019_10_11-05_18_45'.
-    [INFO] [rosbag2_transport]: Listening for topics...
-    [INFO] [rosbag2_transport]: Subscribed to topic '/turtle1/cmd_vel'
-    [INFO] [rosbag2_transport]: All requested topics are subscribed. Stopping discovery...
+  [INFO] [rosbag2_storage]: Opened database 'rosbag2_2019_10_11-05_18_45'.
+  [INFO] [rosbag2_transport]: Listening for topics...
+  [INFO] [rosbag2_transport]: Subscribed to topic '/turtle1/cmd_vel'
+  [INFO] [rosbag2_transport]: All requested topics are subscribed. Stopping discovery...
 
 Now ``ros2 bag`` is recording the data published on the ``/turtle1/cmd_vel`` topic.
 Return to the teleop terminal and move the turtle around again.
@@ -198,7 +197,7 @@ You can move the turtle around and press ``Ctrl+C`` when you're finished.
 
 .. note::
 
-    There is another option you can add to the command, ``-a``, which records all the topics on your system.
+  There is another option you can add to the command, ``-a``, which records all the topics on your system.
 
 4 ros2 bag info
 ^^^^^^^^^^^^^^^
@@ -207,13 +206,13 @@ You can see details about your recording by running:
 
 .. code-block:: console
 
-    ros2 bag info <bag_file_name>
+  ros2 bag info <bag_file_name>
 
 Running this command on the ``subset`` bag file will return a list of information on the file:
 
 .. code-block:: console
 
-    ros2 bag info subset
+  ros2 bag info subset
 
 .. code-block:: console
 
@@ -239,13 +238,13 @@ Enter the command:
 
 .. code-block:: console
 
-    ros2 bag play subset
+  ros2 bag play subset
 
 The terminal will return the message:
 
 .. code-block:: console
 
-    [INFO] [rosbag2_storage]: Opened database 'subset'.
+  [INFO] [rosbag2_storage]: Opened database 'subset'.
 
 Your turtle will follow the same path you entered while recording (though not 100% exactly; turtlesim is sensitive to small changes in the system's timing).
 
@@ -262,7 +261,7 @@ To get an idea of how often position data is published, you can run the command:
 
 .. code-block:: console
 
-    ros2 topic hz /turtle1/pose
+  ros2 topic hz /turtle1/pose
 
 Summary
 -------

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Actions/Understanding-ROS2-Actions.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Actions/Understanding-ROS2-Actions.rst
@@ -53,13 +53,13 @@ Open a new terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtle_teleop_key
+  ros2 run turtlesim turtle_teleop_key
 
 
 2 Use actions
@@ -69,8 +69,8 @@ When you launch the ``/teleop_turtle`` node, you will see the following message 
 
 .. code-block:: console
 
-    Use arrow keys to move the turtle.
-    Use G|B|V|C|D|E|R|T keys to rotate to absolute orientations. 'F' to cancel a rotation.
+  Use arrow keys to move the turtle.
+  Use G|B|V|C|D|E|R|T keys to rotate to absolute orientations. 'F' to cancel a rotation.
 
 Let's focus on the second line, which corresponds to an action.
 (The first instruction corresponds to the "cmd_vel" topic, discussed previously in the :doc:`topics tutorial <../Understanding-ROS2-Topics/Understanding-ROS2-Topics>`.)
@@ -86,7 +86,7 @@ A message relaying the result of the goal should display once the turtle complet
 
 .. code-block:: console
 
-    [INFO] [turtlesim]: Rotation goal completed successfully
+  [INFO] [turtlesim]: Rotation goal completed successfully
 
 The ``F`` key will cancel a goal mid-execution.
 
@@ -118,7 +118,7 @@ To see the list of actions a node provides, ``/turtlesim`` in this case, open a 
 
 .. code-block:: console
 
-    ros2 node info /turtlesim
+  ros2 node info /turtlesim
 
 Which will return a list of ``/turtlesim``'s subscribers, publishers, services, action servers and action clients:
 
@@ -161,7 +161,7 @@ To see that, run:
 
 .. code-block:: console
 
-    ros2 node info /teleop_turtle
+  ros2 node info /teleop_turtle
 
 Which will return:
 
@@ -195,13 +195,13 @@ To identify all the actions in the ROS graph, run the command:
 
 .. code-block:: console
 
-    ros2 action list
+  ros2 action list
 
 Which will return:
 
 .. code-block:: console
 
-    /turtle1/rotate_absolute
+  /turtle1/rotate_absolute
 
 This is the only action in the ROS graph right now.
 It controls the turtle's rotation, as you saw earlier.
@@ -215,13 +215,13 @@ To find ``/turtle1/rotate_absolute``'s type, run the command:
 
 .. code-block:: console
 
-    ros2 action list -t
+  ros2 action list -t
 
 Which will return:
 
 .. code-block:: console
 
-    /turtle1/rotate_absolute [turtlesim/action/RotateAbsolute]
+  /turtle1/rotate_absolute [turtlesim/action/RotateAbsolute]
 
 In brackets to the right of each action name (in this case only ``/turtle1/rotate_absolute``) is the action type, ``turtlesim/action/RotateAbsolute``.
 You will need this when you want to execute an action from the command line or from code.
@@ -233,7 +233,7 @@ You can further introspect the ``/turtle1/rotate_absolute`` action with the comm
 
 .. code-block:: console
 
-    ros2 action info /turtle1/rotate_absolute
+  ros2 action info /turtle1/rotate_absolute
 
 Which will return
 
@@ -285,7 +285,7 @@ Now let's send an action goal from the command line with the following syntax:
 
 .. code-block:: console
 
-    ros2 action send_goal <action_name> <action_type> <values>
+  ros2 action send_goal <action_name> <action_type> <values>
 
 ``<values>`` need to be in YAML format.
 
@@ -293,7 +293,7 @@ Keep an eye on the turtlesim window, and enter the following command into your t
 
 .. code-block:: console
 
-    ros2 action send_goal /turtle1/rotate_absolute turtlesim/action/RotateAbsolute "{theta: 1.57}"
+  ros2 action send_goal /turtle1/rotate_absolute turtlesim/action/RotateAbsolute "{theta: 1.57}"
 
 You should see the turtle rotating, as well as the following message in your terminal:
 
@@ -317,7 +317,7 @@ To see the feedback of this goal, add ``--feedback`` to the ``ros2 action send_g
 
 .. code-block:: console
 
-    ros2 action send_goal /turtle1/rotate_absolute turtlesim/action/RotateAbsolute "{theta: -1.57}" --feedback
+  ros2 action send_goal /turtle1/rotate_absolute turtlesim/action/RotateAbsolute "{theta: -1.57}" --feedback
 
 Your terminal will return the message:
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Nodes/Understanding-ROS2-Nodes.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Nodes/Understanding-ROS2-Nodes.rst
@@ -56,13 +56,13 @@ The command ``ros2 run`` launches an executable from a package.
 
 .. code-block:: console
 
-    ros2 run <package_name> <executable_name>
+  ros2 run <package_name> <executable_name>
 
 To run turtlesim, open a new terminal, and enter the following command:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 The turtlesim window will open, as you saw in the :doc:`previous tutorial <../Introducing-Turtlesim/Introducing-Turtlesim>`.
 
@@ -81,7 +81,7 @@ Open a new terminal while turtlesim is still running in the other one, and enter
 
 .. code-block:: console
 
-    ros2 node list
+  ros2 node list
 
 The terminal will return the node name:
 
@@ -93,7 +93,7 @@ Open another new terminal and start the teleop node with the command:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtle_teleop_key
+  ros2 run turtlesim turtle_teleop_key
 
 Here, we are referring to the ``turtlesim`` package again, but this time we target the executable named ``turtle_teleop_key``.
 
@@ -123,9 +123,9 @@ However, now if you return to the terminal where you ran ``ros2 node list``, and
 
 .. code-block:: console
 
-    /my_turtle
-    /turtlesim
-    /teleop_turtle
+  /my_turtle
+  /turtlesim
+  /teleop_turtle
 
 3 ros2 node info
 ^^^^^^^^^^^^^^^^
@@ -134,13 +134,13 @@ Now that you know the names of your nodes, you can access more information about
 
 .. code-block:: console
 
-    ros2 node info <node_name>
+  ros2 node info <node_name>
 
 To examine your latest node, ``my_turtle``, run the following command:
 
 .. code-block:: console
 
-    ros2 node info /my_turtle
+  ros2 node info /my_turtle
 
 ``ros2 node info`` returns a list of subscribers, publishers, services, and actions. i.e. the ROS graph connections that interact with that node.
 The output should look like this:

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.rst
@@ -45,13 +45,13 @@ Open a new terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtle_teleop_key
+  ros2 run turtlesim turtle_teleop_key
 
 
 2 ros2 param list
@@ -61,7 +61,7 @@ To see the parameters belonging to your nodes, open a new terminal and enter the
 
 .. code-block:: console
 
-    ros2 param list
+  ros2 param list
 
 You will see the node namespaces, ``/teleop_turtle`` and ``/turtlesim``, followed by each node's parameters:
 
@@ -99,19 +99,19 @@ To display the type and current value of a parameter, use the command:
 
 .. code-block:: console
 
-    ros2 param get <node_name> <parameter_name>
+  ros2 param get <node_name> <parameter_name>
 
 Let's find out the current value of ``/turtlesim``'s parameter ``background_g``:
 
 .. code-block:: console
 
-    ros2 param get /turtlesim background_g
+  ros2 param get /turtlesim background_g
 
 Which will return the value:
 
 .. code-block:: console
 
-    Integer value is: 86
+  Integer value is: 86
 
 Now you know ``background_g`` holds an integer value.
 
@@ -124,13 +124,13 @@ To change a parameter's value at runtime, use the command:
 
 .. code-block:: console
 
-    ros2 param set <node_name> <parameter_name> <value>
+  ros2 param set <node_name> <parameter_name> <value>
 
 Let's change ``/turtlesim``'s background color:
 
 .. code-block:: console
 
-    ros2 param set /turtlesim background_r 150
+  ros2 param set /turtlesim background_r 150
 
 Your terminal should return the message:
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -48,13 +48,13 @@ Open a new terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtle_teleop_key
+  ros2 run turtlesim turtle_teleop_key
 
 2 ros2 service list
 ^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
@@ -51,13 +51,13 @@ Open a new terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 Open another terminal and run:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtle_teleop_key
+  ros2 run turtlesim turtle_teleop_key
 
 Recall from the :doc:`previous tutorial <../Understanding-ROS2-Nodes/Understanding-ROS2-Nodes>` that the names of these nodes are ``/turtlesim`` and ``/teleop_turtle`` by default.
 
@@ -73,7 +73,7 @@ To run rqt_graph, open a new terminal and enter the command:
 
 .. code-block:: console
 
-    rqt_graph
+  rqt_graph
 
 You can also open rqt_graph by opening ``rqt`` and selecting **Plugins** > **Introspection** > **Node Graph**.
 
@@ -129,13 +129,13 @@ To see the data being published on a topic, use:
 
 .. code-block:: console
 
-    ros2 topic echo <topic_name>
+  ros2 topic echo <topic_name>
 
 Since we know that ``/teleop_turtle`` publishes data to ``/turtlesim`` over the ``/turtle1/cmd_vel`` topic, let's use ``echo`` to introspect that topic:
 
 .. code-block:: console
 
-    ros2 topic echo /turtle1/cmd_vel
+  ros2 topic echo /turtle1/cmd_vel
 
 At first, this command won't return any data.
 That's because it's waiting for ``/teleop_turtle`` to publish something.
@@ -171,7 +171,7 @@ Another way to look at this is running:
 
 .. code-block:: console
 
-    ros2 topic info /turtle1/cmd_vel
+  ros2 topic info /turtle1/cmd_vel
 
 Which will return:
 
@@ -192,7 +192,7 @@ Recall that the ``cmd_vel`` topic has the type:
 
 .. code-block:: console
 
-    geometry_msgs/msg/Twist
+  geometry_msgs/msg/Twist
 
 This means that in the package ``geometry_msgs`` there is a ``msg`` called ``Twist``.
 
@@ -201,7 +201,7 @@ Specifically, what structure of data the message expects.
 
 .. code-block:: console
 
-    ros2 interface show geometry_msgs/msg/Twist
+  ros2 interface show geometry_msgs/msg/Twist
 
 For the message type from above it yields:
 
@@ -240,7 +240,7 @@ Now that you have the message structure, you can publish data onto a topic direc
 
 .. code-block:: console
 
-    ros2 topic pub <topic_name> <msg_type> '<args>'
+  ros2 topic pub <topic_name> <msg_type> '<args>'
 
 The ``'<args>'`` argument is the actual data you'll pass to the topic, in the structure you just discovered in the previous section.
 
@@ -297,7 +297,7 @@ For one last introspection on this process, you can view the rate at which data 
 
 .. code-block:: console
 
-    ros2 topic hz /turtle1/pose
+  ros2 topic hz /turtle1/pose
 
 It will return data on the rate at which the ``/turtlesim`` node is publishing data to the ``pose`` topic.
 

--- a/source/Tutorials/Beginner-CLI-Tools/Using-Rqt-Console/Using-Rqt-Console.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Using-Rqt-Console/Using-Rqt-Console.rst
@@ -45,7 +45,7 @@ Start ``rqt_console`` in a new terminal with the following command:
 
 .. code-block:: console
 
-    ros2 run rqt_console rqt_console
+  ros2 run rqt_console rqt_console
 
 The ``rqt_console`` window will open:
 
@@ -63,7 +63,7 @@ Now start ``turtlesim`` in a new terminal with the following command:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node
+  ros2 run turtlesim turtlesim_node
 
 2 Messages on rqt_console
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ In a new terminal, enter the ``ros2 topic pub`` command (discussed in detail in 
 
 .. code-block:: console
 
-    ros2 topic pub -r 1 /turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0,y: 0.0,z: 0.0}}"
+  ros2 topic pub -r 1 /turtle1/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 2.0, y: 0.0, z: 0.0}, angular: {x: 0.0,y: 0.0,z: 0.0}}"
 
 Since the above command is publishing the topic at a steady rate, the turtle is continuously running into the wall.
 In ``rqt_console`` you will see the same message with the ``Warn`` severity level displayed over and over, like so:
@@ -89,11 +89,11 @@ ROS 2's logger levels are ordered by severity:
 
 .. code-block:: console
 
-    Fatal
-    Error
-    Warn
-    Info
-    Debug
+  Fatal
+  Error
+  Warn
+  Info
+  Debug
 
 There is no exact standard for what each level indicates, but it's safe to assume that:
 
@@ -117,7 +117,7 @@ Enter the following command in your terminal:
 
 .. code-block:: console
 
-    ros2 run turtlesim turtlesim_node --ros-args --log-level WARN
+  ros2 run turtlesim turtlesim_node --ros-args --log-level WARN
 
 Now you won't see the initial ``Info`` level messages that came up in the console last time you started ``turtlesim``.
 That's because ``Info`` messages are lower priority than the new default severity, ``Warn``.


### PR DESCRIPTION
There is a mixture of 2-, 3-, 4-, (and other) space (non-renderable) indentations.

Here I normalize the indentations to 2-spaces in the categories of pages I already went through and opened PRs.