### PR TITLE
Make installation instruction layout more consistent.

### DIFF
--- a/source/Installation/Alternatives/Latest-Development-Setup.rst
+++ b/source/Installation/Alternatives/Latest-Development-Setup.rst
@@ -9,8 +9,8 @@ Testing binaries
 
 See :doc:`Testing <../Testing>`.
 
-Building from source
---------------------
+Build from source
+-----------------
 
 .. note::
 
@@ -20,7 +20,8 @@ Building from source
 Follow the links below for the latest setup instructions for your platform:
 
 * :doc:`Ubuntu Linux <Ubuntu-Development-Setup>`
-* :doc:`macOS <macOS-Development-Setup>`
 * :doc:`Windows <Windows-Development-Setup>`
+* :doc:`RHEL <RHEL-Development-Setup>`
+* :doc:`macOS <macOS-Development-Setup>`
 
 For keeping your source code up-to-date, see :doc:`Maintain a source checkout <../Maintaining-a-Source-Checkout>`.

--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -2,8 +2,6 @@
 
   Installation/RHEL-Development-Setup
 
-.. _rhel-latest:
-
 RHEL (source)
 =============
 
@@ -18,7 +16,7 @@ The current target Red Hat platforms for {DISTRO_TITLE_FULL} are:
 
 - Tier 2: RHEL 9 64-bit
 
-As defined in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`_
+As defined in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`_.
 
 System setup
 ------------
@@ -42,8 +40,8 @@ They can be enabled by running:
 .. note:: This step may be slightly different depending on the distribution you are using. Check the EPEL documentation: https://docs.fedoraproject.org/en-US/epel/#_quickstart
 
 
-Install development tools and ROS tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Install development tools
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
@@ -79,8 +77,11 @@ Install development tools and ROS tools
 
 .. _Rolling_rhel-dev-get-ros2-code:
 
+Build ROS 2
+-----------
+
 Get ROS 2 code
---------------
+^^^^^^^^^^^^^^
 
 Create a workspace and clone all repos:
 
@@ -90,10 +91,8 @@ Create a workspace and clone all repos:
    cd ~/ros2_{DISTRO}
    vcs import --input https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos src
 
-.. _rhel-development-setup-install-dependencies-using-rosdep:
-
 Install dependencies using rosdep
----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: ../_Dnf-Update-Admonition.rst
 
@@ -104,12 +103,13 @@ Install dependencies using rosdep
    rosdep install --from-paths src --ignore-src -y --skip-keys "assimp fastcdr ignition-cmake2 ignition-math6 python3-matplotlib python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
 
 Install additional DDS implementations (optional)
--------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you would like to use another DDS or RTPS vendor besides the default, you can find instructions :doc:`here <../DDS-Implementations>`.
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
+See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Build the code in the workspace
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you have already installed ROS 2 another way (either via RPMs or the binary distribution), make sure that you run the below commands in a fresh environment that does not have those other installations sourced.
 Also ensure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
@@ -127,11 +127,8 @@ Note: if you are having trouble compiling all examples and this is preventing yo
 Take for instance: you would like to avoid installing the large OpenCV library.
 Well then simply run ``touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
 
-Environment setup
+Setup environment
 -----------------
-
-Source the setup script
-^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
@@ -140,8 +137,6 @@ Set up your environment by sourcing the following file.
    # Replace ".bash" with your shell if you're not using bash
    # Possible values are: setup.bash, setup.sh, setup.zsh
    . ~/ros2_{DISTRO}/install/local_setup.bash
-
-.. _rhel_talker-listener:
 
 Try some examples
 -----------------
@@ -164,12 +159,14 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Additional RMW implementations (optional)
 -----------------------------------------
+
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
 See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
@@ -195,8 +192,8 @@ Stay up to date
 
 See :doc:`../Maintaining-a-Source-Checkout` to periodically refresh your source installation.
 
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :ref:`here <linux-troubleshooting>`.
 

--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -102,7 +102,7 @@ Install dependencies using rosdep
    rosdep update
    rosdep install --from-paths src --ignore-src -y --skip-keys "assimp fastcdr ignition-cmake2 ignition-math6 python3-matplotlib python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
 
-Install additional DDS implementations (optional)
+Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
@@ -163,12 +163,6 @@ Next steps
 ----------
 
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
-
-Additional RMW implementations (optional)
------------------------------------------
-
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -92,9 +92,6 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Download ROS 2
-^^^^^^^^^^^^^^
-
 Binary releases of Rolling Ridley are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
 

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -9,21 +9,29 @@ This page explains how to install ROS 2 on RHEL from a pre-built binary package.
 
 .. note::
 
-    The pre-built binary does not include all ROS 2 packages.
-    All packages in the `ROS base variant <https://ros.org/reps/rep-2001.html#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://ros.org/reps/rep-2001.html#desktop-variants>`_ are included.
-    The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
+   The pre-built binary does not include all ROS 2 packages.
+   All packages in the `ROS base variant <https://ros.org/reps/rep-2001.html#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://ros.org/reps/rep-2001.html#desktop-variants>`_ are included.
+   The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
 
 There are also :doc:`RPM packages <../RHEL-Install-RPMs>` available.
 
-System Requirements
+System requirements
 -------------------
 
 We currently support RHEL 9 64-bit.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 Most people will want to use a stable ROS distribution.
 
+System setup
+------------
+
+Set locale
+^^^^^^^^^^
+
+.. include:: ../_RHEL-Set-Locale.rst
+
 Enable required repositories
-----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rosdep database contains packages from the EPEL and PowerTools repositories, which are not enabled by default.
 They can be enabled by running:
@@ -35,8 +43,8 @@ They can be enabled by running:
 
 .. note:: This step may be slightly different depending on the distribution you are using. Check the EPEL documentation: https://docs.fedoraproject.org/en-US/epel/#_quickstart
 
-Installing prerequisites
-------------------------
+Install prerequisites
+^^^^^^^^^^^^^^^^^^^^^
 
 There are a few packages that must be installed in order to get and unpack the binary release.
 
@@ -44,8 +52,48 @@ There are a few packages that must be installed in order to get and unpack the b
 
    sudo dnf install tar bzip2 wget -y
 
-Downloading ROS 2
------------------
+Install development tools (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are going to build ROS packages or otherwise do development, you can also install the development tools:
+
+.. code-block:: bash
+
+   sudo dnf install -y \
+     cmake \
+     gcc-c++ \
+     git \
+     make \
+     patch \
+     python3-colcon-common-extensions \
+     python3-flake8-builtins \
+     python3-flake8-comprehensions \
+     python3-flake8-docstrings \
+     python3-flake8-import-order \
+     python3-flake8-quotes \
+     python3-mypy \
+     python3-pip \
+     python3-pydocstyle \
+     python3-pytest \
+     python3-pytest-repeat \
+     python3-pytest-rerunfailures \
+     python3-rosdep \
+     python3-setuptools \
+     python3-vcstool \
+     wget
+
+   # install some pip packages needed for testing and
+   # not available as RPMs
+   python3 -m pip install -U --user \
+     flake8-blind-except==0.1.1 \
+     flake8-class-newline \
+     flake8-deprecated
+
+Install ROS 2
+-------------
+
+Download ROS 2
+^^^^^^^^^^^^^^
 
 Binary releases of Rolling Ridley are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
@@ -58,42 +106,27 @@ Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_{DISTRO}
-       cd ~/ros2_{DISTRO}
-       tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
+     mkdir -p ~/ros2_{DISTRO}
+     cd ~/ros2_{DISTRO}
+     tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
-Installing and initializing rosdep
-----------------------------------
-
-.. code-block:: bash
-
-       sudo dnf install -y python3-rosdep
-       sudo rosdep init
-       rosdep update
-
-.. _rhel-install-binary-install-missing-dependencies:
-
-Installing the missing dependencies
------------------------------------
+Install dependencies using rosdep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: ../_Dnf-Update-Admonition.rst
 
-Set your rosdistro according to the release you downloaded.
-
 .. code-block:: bash
 
-       rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "assimp cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 python3-matplotlib python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "assimp cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 python3-matplotlib python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
 
-Install additional DDS implementations (optional)
+Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you would like to use another DDS or RTPS vendor besides the default, you can find instructions :doc:`here <../DDS-Implementations>`.
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
+See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
-Environment setup
+Setup environment
 -----------------
-
-Source the setup script
-^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
@@ -101,7 +134,7 @@ Set up your environment by sourcing the following file.
 
    # Replace ".bash" with your shell if you're not using bash
    # Possible values are: setup.bash, setup.sh, setup.zsh
-  . ~/ros2_{DISTRO}/ros2-linux/setup.bash
+   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
 
 Try some examples
 -----------------
@@ -124,17 +157,13 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Additional RMW implementations (optional)
------------------------------------------
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
-
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :doc:`here <../../How-To-Guides/Installation-Troubleshooting>`.
 
@@ -148,4 +177,4 @@ Uninstall
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_{DISTRO}
+      rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -1,5 +1,3 @@
-.. _linux-latest:
-
 .. redirect-from::
 
    Installation/Linux-Development-Setup
@@ -18,15 +16,7 @@ System requirements
 The current Debian-based target platforms for {DISTRO_TITLE_FULL} are:
 
 - Tier 1: Ubuntu Linux - Jammy (22.04) 64-bit
-- Tier 3: Ubuntu Linux - Focal (20.04) 64-bit
 - Tier 3: Debian Linux - Bullseye (11) 64-bit
-
-
-Other Linux platforms with varying support levels include:
-
-- Arch Linux, see `alternate instructions <https://wiki.archlinux.org/index.php/ROS#ROS_2>`__
-- Fedora Linux, see :doc:`alternate instructions <Fedora-Development-Setup>`
-- OpenEmbedded / webOS OSE, see `alternate instructions <https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions>`__
 
 As defined in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`_.
 
@@ -38,15 +28,13 @@ Set locale
 
 .. include:: ../_Ubuntu-Set-Locale.rst
 
-Add the ROS 2 apt repository
+Enable required repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: ../_Apt-Repositories.rst
 
-Install development tools and ROS tools
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Install common packages.
+Install development tools
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
@@ -54,48 +42,22 @@ Install common packages.
      python3-flake8-docstrings \
      python3-pip \
      python3-pytest-cov \
+     python3-flake8-blind-except \
+     python3-flake8-builtins \
+     python3-flake8-class-newline \
+     python3-flake8-comprehensions \
+     python3-flake8-deprecated \
+     python3-flake8-import-order \
+     python3-flake8-quotes \
+     python3-pytest-repeat \
+     python3-pytest-rerunfailures \
      ros-dev-tools
 
-Install packages according to your Ubuntu version.
-
-.. tabs::
-
-   .. group-tab:: Ubuntu 22.04 LTS and later
-
-      .. code-block:: console
-
-         sudo apt install -y \
-            python3-flake8-blind-except \
-            python3-flake8-builtins \
-            python3-flake8-class-newline \
-            python3-flake8-comprehensions \
-            python3-flake8-deprecated \
-            python3-flake8-import-order \
-            python3-flake8-quotes \
-            python3-pytest-repeat \
-            python3-pytest-rerunfailures
-
-   .. group-tab:: Ubuntu 20.04 LTS
-
-      .. code-block:: bash
-
-         python3 -m pip install -U \
-            flake8-blind-except \
-            flake8-builtins \
-            flake8-class-newline \
-            flake8-comprehensions \
-            flake8-deprecated \
-            flake8-import-order \
-            flake8-quotes \
-            "pytest>=5.3" \
-            pytest-repeat \
-            pytest-rerunfailures
-
-
-.. _Rolling_linux-dev-get-ros2-code:
+Build ROS 2
+-----------
 
 Get ROS 2 code
---------------
+^^^^^^^^^^^^^^
 
 Create a workspace and clone all repos:
 
@@ -108,7 +70,7 @@ Create a workspace and clone all repos:
 .. _linux-development-setup-install-dependencies-using-rosdep:
 
 Install dependencies using rosdep
----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: ../_Apt-Upgrade-Admonition.rst
 
@@ -120,13 +82,14 @@ Install dependencies using rosdep
 
 .. include:: ../_rosdep_Linux_Mint.rst
 
-Install additional DDS implementations (optional)
--------------------------------------------------
+Install additional RMW implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you would like to use another DDS or RTPS vendor besides the default, you can find instructions :doc:`here <../DDS-Implementations>`.
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
+See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Build the code in the workspace
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you have already installed ROS 2 another way (either via Debians or the binary distribution), make sure that you run the below commands in a fresh environment that does not have those other installations sourced.
 Also ensure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
@@ -144,11 +107,8 @@ Note: if you are having trouble compiling all examples and this is preventing yo
 Take for instance: you would like to avoid installing the large OpenCV library.
 Well then simply run ``touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
 
-Environment setup
+Setup environment
 -----------------
-
-Source the setup script
-^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
@@ -181,18 +141,15 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Using the ROS 1 bridge
-----------------------
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+Use the ROS 1 bridge (optional)
+-------------------------------
 
-Additional RMW implementations (optional)
------------------------------------------
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Alternate compilers
 -------------------
@@ -216,8 +173,8 @@ Stay up to date
 
 See :doc:`../Maintaining-a-Source-Checkout` to periodically refresh your source installation.
 
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :ref:`here <linux-troubleshooting>`.
 
@@ -231,4 +188,4 @@ Uninstall
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_{DISTRO}
+      rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -149,7 +149,8 @@ Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your
 Use the ROS 1 bridge (optional)
 -------------------------------
 
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
+See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -19,20 +19,49 @@ This page explains how to install ROS 2 on Ubuntu Linux from a pre-built binary 
 
 There are also :doc:`Debian packages <../Ubuntu-Install-Debians>` available.
 
-System Requirements
+System requirements
 -------------------
 
 We currently support Ubuntu Linux Jammy (22.04) 64-bit x86 and 64-bit ARM.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 Most people will want to use a stable ROS distribution.
 
-Add the ROS 2 apt repository
-----------------------------
+System setup
+------------
+
+Set locale
+^^^^^^^^^^
+
+.. include:: ../_Ubuntu-Set-Locale.rst
+
+Enable required repositories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: ../_Apt-Repositories.rst
 
-Downloading ROS 2
------------------
+Install prerequisites
+^^^^^^^^^^^^^^^^^^^^^
+
+There are a few packages that must be installed in order to get and unpack the binary release.
+
+.. code-block:: bash
+
+   sudo apt install tar bzip2 wget -y
+
+Install development tools (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are going to build ROS packages or otherwise do development, you can also install the development tools:
+
+.. code-block:: bash
+
+   sudo apt install ros-dev-tools
+
+Install ROS 2
+-------------
+
+Download ROS 2
+^^^^^^^^^^^^^^
 
 Binary releases of Rolling Ridley are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
@@ -46,54 +75,35 @@ Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>
 
   .. code-block:: bash
 
-       mkdir -p ~/ros2_{DISTRO}
-       cd ~/ros2_{DISTRO}
-       tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
-
-Installing and initializing rosdep
-----------------------------------
-
-.. code-block:: bash
-
-       sudo apt update
-       sudo apt install -y python3-rosdep
-       sudo rosdep init
-       rosdep update
+     mkdir -p ~/ros2_{DISTRO}
+     cd ~/ros2_{DISTRO}
+     tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
 .. _linux-install-binary-install-missing-dependencies:
 
-Installing the missing dependencies
------------------------------------
+Install dependencies using rosdep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: ../_Apt-Upgrade-Admonition.rst
 
-Set your rosdistro according to the release you downloaded.
-
 .. code-block:: bash
 
-       rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps rti-connext-dds-6.0.1 urdfdom_headers"
+   sudo apt update
+   sudo apt install -y python3-rosdep
+   sudo rosdep init
+   rosdep update
+   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps rti-connext-dds-6.0.1 urdfdom_headers"
 
 .. include:: ../_rosdep_Linux_Mint.rst
 
-Install development tools (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are going to build ROS packages or otherwise do development, you can also install the development tools:
-
-.. code-block:: bash
-
-       sudo apt install ros-dev-tools
-
-Install additional DDS implementations (optional)
+Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you would like to use another DDS or RTPS vendor besides the default, you can find instructions :doc:`here <../DDS-Implementations>`.
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
+See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
-Environment setup
+Setup environment
 -----------------
-
-Source the setup script
-^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
@@ -101,7 +111,7 @@ Set up your environment by sourcing the following file.
 
    # Replace ".bash" with your shell if you're not using bash
    # Possible values are: setup.bash, setup.sh, setup.zsh
-  . ~/ros2_{DISTRO}/ros2-linux/setup.bash
+   . ~/ros2_{DISTRO}/ros2-linux/setup.bash
 
 Try some examples
 -----------------
@@ -124,21 +134,18 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Using the ROS 1 bridge
-----------------------
+Use the ROS 1 bridge (optional)
+-------------------------------
+
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
-Additional RMW implementations (optional)
------------------------------------------
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
-
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :doc:`here <../../How-To-Guides/Installation-Troubleshooting>`.
 
@@ -152,4 +159,4 @@ Uninstall
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_{DISTRO}
+      rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -60,9 +60,6 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Download ROS 2
-^^^^^^^^^^^^^^
-
 Binary releases of Rolling Ridley are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
 
@@ -142,7 +139,8 @@ Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your
 Use the ROS 1 bridge (optional)
 -------------------------------
 
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
+See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Troubleshoot
 ------------

--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -2,8 +2,6 @@
 
    Installation/Windows-Development-Setup
 
-.. _windows-latest:
-
 Windows (source)
 ================
 
@@ -45,7 +43,7 @@ In the resulting dialog, click "Environment Variables", the click "Path" on the 
 Install Python prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Installing additional Python dependencies:
+Install additional Python dependencies:
 
 .. code-block:: bash
 
@@ -86,9 +84,8 @@ Get the ``ros2.repos`` file which defines the repositories to clone from:
 Install additional DDS implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Fast DDS is bundled with the ROS 2 source and will always be built unless you put an ``COLCON_IGNORE`` file in the ``src\eProsima`` folder.
-
-If you would like to use another DDS or RTPS vendor besides the default, you can find instructions :doc:`here <../DDS-Implementations>`.
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
+See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Build the ROS 2 code
 --------------------
@@ -113,7 +110,7 @@ To build the ``\{DISTRO}`` folder tree:
    If you are doing a debug build use ``python_d path\to\colcon_executable`` ``colcon``.
    See `Extra stuff for debug mode`_ for more info on running Python code in debug builds on Windows.
 
-Environment setup
+Setup environment
 -----------------
 
 Start a command shell and source the ROS 2 setup file to set up the workspace:
@@ -166,17 +163,18 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-
 .. note::
 
    It is not recommended to build in the same cmd prompt that you've sourced the ``local_setup.bat``.
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Additional RMW implementations (optional)
 -----------------------------------------
+
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
 See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
@@ -186,20 +184,17 @@ Extra stuff for Debug mode
 
 If you want to be able to run all the tests in Debug mode, you'll need to install a few more things:
 
-
 * To be able to extract the Python source tarball, you can use PeaZip:
 
 .. code-block:: bash
 
    choco install -y peazip
 
-
 * You'll also need SVN, since some of the Python source-build dependencies are checked out via SVN:
 
 .. code-block:: bash
 
    choco install -y svn hg
-
 
 * You'll need to quit and restart the command prompt after installing the above.
 * Get and extract the Python 3.8.3 source from the ``tgz``:
@@ -215,7 +210,6 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    get_externals.bat
    build.bat -p x64 -d
 
-
 * Finally, copy the build products into the Python38 installation directories, next to the Release-mode Python executable and DLL's:
 
 .. code-block:: bash
@@ -228,7 +222,6 @@ If you want to be able to run all the tests in Debug mode, you'll need to instal
    copy python3_d.lib C:\Python38\libs /Y
    copy sqlite3_d.dll C:\Python38\DLLs /Y
    for %I in (*_d.pyd) do copy %I C:\Python38\DLLs /Y
-
 
 * Now, from a fresh command prompt, make sure that ``python_d`` works:
 
@@ -269,8 +262,8 @@ Stay up to date
 
 See :doc:`../Maintaining-a-Source-Checkout` to periodically refresh your source installation.
 
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :ref:`here <windows-troubleshooting>`.
 

--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -24,11 +24,6 @@ For example, for a Chinese-language Windows 10 installation, you may need to ins
 
 .. include:: ../_Windows-Install-Prerequisites.rst
 
-Additional prerequisites
-------------------------
-
-When building from source you'll need a few additional prerequisites installed.
-
 Install additional prerequisites from Chocolatey
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -38,7 +33,6 @@ Install additional prerequisites from Chocolatey
 
 You will need to append the Git cmd folder ``C:\Program Files\Git\cmd`` to the PATH (you can do this by clicking the Windows icon, typing "Environment Variables", then clicking on "Edit the system environment variables".
 In the resulting dialog, click "Environment Variables", the click "Path" on the bottom pane, then click "Edit" and add the path).
-
 
 Install Python prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,8 +52,11 @@ Next install xmllint:
 * Unpack all archives into e.g. ``C:\xmllint``
 * Add ``C:\xmllint\bin`` to the ``PATH``.
 
-Get the ROS 2 code
-------------------
+Build ROS 2
+-----------
+
+Get ROS 2 code
+^^^^^^^^^^^^^^
 
 Now that we have the development tools we can get the ROS 2 source code.
 
@@ -81,14 +78,14 @@ Get the ``ros2.repos`` file which defines the repositories to clone from:
 
    vcs import --input https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos src
 
-Install additional DDS implementations (optional)
+Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
 See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
-Build the ROS 2 code
---------------------
+Build the code in the workspace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. _windows-dev-build-ros2:
 
@@ -123,8 +120,8 @@ This will automatically set up the environment for any DDS vendors that support 
 
 It is normal that the previous command, if nothing else went wrong, outputs "The system cannot find the path specified." exactly once.
 
-Test and run
-------------
+Try some examples
+-----------------
 
 Note that the first time you run any executable you will have to allow access to the network through a Windows Firewall popup.
 
@@ -171,13 +168,6 @@ Next steps
 ----------
 
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
-
-Additional RMW implementations (optional)
------------------------------------------
-
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
-
 
 Extra stuff for Debug mode
 --------------------------

--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -3,8 +3,6 @@
   Installation/Rolling/OSX-Development-Setup
   Installation/macOS-Development-Setup
 
-.. _macOS-latest:
-
 macOS (source)
 ==============
 
@@ -60,29 +58,29 @@ You need the following things installed to build ROS 2:
 
    .. code-block:: bash
 
-       brew install asio assimp bison bullet cmake console_bridge cppcheck \
-         cunit eigen freetype graphviz opencv openssl orocos-kdl pcre poco \
-         pyqt5 python qt@5 sip spdlog tinyxml tinyxml2
+      brew install asio assimp bison bullet cmake console_bridge cppcheck \
+        cunit eigen freetype graphviz opencv openssl orocos-kdl pcre poco \
+        pyqt5 python qt@5 sip spdlog tinyxml tinyxml2
 
 #.
    Setup some environment variables:
 
    .. code-block:: bash
 
-       # Add the openssl dir for DDS-Security
-       # if you are using ZSH, then replace '.bashrc' with '.zshrc'
-       echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
+      # Add the openssl dir for DDS-Security
+      # if you are using ZSH, then replace '.bashrc' with '.zshrc'
+      echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc
 
-       # Add the Qt directory to the PATH and CMAKE_PREFIX_PATH
-       export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/usr/local/opt/qt@5
-       export PATH=$PATH:/usr/local/opt/qt@5/bin
+      # Add the Qt directory to the PATH and CMAKE_PREFIX_PATH
+      export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/usr/local/opt/qt@5
+      export PATH=$PATH:/usr/local/opt/qt@5/bin
 
 #.
    Use ``python3 -m pip`` (just ``pip`` may install Python3 or Python2) to install more stuff:
 
    .. code-block:: bash
 
-       python3 -m pip install -U \
+      python3 -m pip install -U \
         argcomplete catkin_pkg colcon-common-extensions coverage \
         cryptography empy flake8 flake8-blind-except==0.1.1 flake8-builtins \
         flake8-class-newline flake8-comprehensions flake8-deprecated \
@@ -103,8 +101,8 @@ You need the following things installed to build ROS 2:
 
      .. code-block:: bash
 
-          rosinstall_generator catkin common_msgs roscpp rosmsg --rosdistro kinetic --deps --wet-only --tar > kinetic-ros2-bridge-deps.rosinstall
-          wstool init -j8 src kinetic-ros2-bridge-deps.rosinstall
+        rosinstall_generator catkin common_msgs roscpp rosmsg --rosdistro kinetic --deps --wet-only --tar > kinetic-ros2-bridge-deps.rosinstall
+        wstool init -j8 src kinetic-ros2-bridge-deps.rosinstall
 
 
      Otherwise, just follow the normal instructions, then source the resulting ``install_isolated/setup.bash`` before proceeding here to build ROS 2.
@@ -126,10 +124,11 @@ Create a workspace and clone all repos:
    cd ~/ros2_{DISTRO}
    vcs import --input https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos src
 
-Install additional DDS vendors (optional)
------------------------------------------
+Install additional DDS implementations (optional)
+-------------------------------------------------
 
-If you would like to use another DDS or RTPS vendor besides the default, you can find instructions :doc:`here <../DDS-Implementations>`.
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
+See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Build the ROS 2 code
 --------------------
@@ -144,7 +143,7 @@ Run the ``colcon`` tool to build everything (more on using ``colcon`` in :doc:`t
 Note: due to an unresolved issue with SIP, Qt@5, and PyQt5, we need to disable ``python_qt_binding`` to have the build succeed.
 This will be removed when the issue is resolved, see: https://github.com/ros-visualization/python_qt_binding/issues/103
 
-Environment setup
+Setup environment
 -----------------
 
 Source the ROS 2 setup file:
@@ -174,16 +173,19 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the `tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
 Using the ROS 1 bridge
 ----------------------
+
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Additional RMW implementations (optional)
 -----------------------------------------
+
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
 See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
@@ -192,8 +194,8 @@ Stay up to date
 
 See :doc:`../Maintaining-a-Source-Checkout` to periodically refresh your source installation.
 
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :ref:`here <macOS-troubleshooting>`.
 
@@ -207,4 +209,4 @@ Uninstall
 
    .. code-block:: bash
 
-    rm -rf ~/ros2_{DISTRO}
+      rm -rf ~/ros2_{DISTRO}

--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -17,8 +17,11 @@ We currently support macOS Mojave (10.14).
 The Rolling Ridley distribution will change target platforms from time to time as new platforms become available.
 Most people will want to use a stable ROS distribution.
 
+System setup
+------------
+
 Install prerequisites
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 You need the following things installed to build ROS 2:
 
@@ -108,13 +111,16 @@ You need the following things installed to build ROS 2:
      Otherwise, just follow the normal instructions, then source the resulting ``install_isolated/setup.bash`` before proceeding here to build ROS 2.
 
 Disable System Integrity Protection (SIP)
------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 macOS/OS X versions >=10.11 have System Integrity Protection enabled by default.
 So that SIP doesn't prevent processes from inheriting dynamic linker environment variables, such as ``DYLD_LIBRARY_PATH``, you'll need to disable it `following these instructions <https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html>`__.
 
-Get the ROS 2 code
-------------------
+Build ROS 2
+-----------
+
+Get ROS 2 code
+^^^^^^^^^^^^^^
 
 Create a workspace and clone all repos:
 
@@ -124,14 +130,14 @@ Create a workspace and clone all repos:
    cd ~/ros2_{DISTRO}
    vcs import --input https://raw.githubusercontent.com/ros2/ros2/{REPOS_FILE_BRANCH}/ros2.repos src
 
-Install additional DDS implementations (optional)
--------------------------------------------------
+Install additional RMW implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at build or runtime.
 See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
-Build the ROS 2 code
---------------------
+Build the code in the workspace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Run the ``colcon`` tool to build everything (more on using ``colcon`` in :doc:`this tutorial <../../Tutorials/Beginner-Client-Libraries/Colcon-Tutorial>`):
 
@@ -178,16 +184,11 @@ Next steps
 
 Continue with the `tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Using the ROS 1 bridge
-----------------------
+Use the ROS 1 bridge (optional)
+-------------------------------
 
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
-
-Additional RMW implementations (optional)
------------------------------------------
-
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
+See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Stay up to date
 ---------------

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -90,8 +90,8 @@ If you are going to build ROS packages or otherwise do development, you can also
      flake8-class-newline \
      flake8-deprecated
 
-Install ROS 2 packages
-----------------------
+Install ROS 2
+-------------
 
 .. include:: _Dnf-Update-Admonition.rst
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -19,16 +19,16 @@ Resources
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
+System setup
+------------
 
 Set locale
-----------
+^^^^^^^^^^
 
 .. include:: _RHEL-Set-Locale.rst
 
-.. _rhel-install-rpms-setup-sources:
-
-Setup Sources
--------------
+Enable required repositories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You will need to enable the EPEL repositories and the PowerTools repository:
 
@@ -53,7 +53,42 @@ DNF may prompt you to verify the GPG key, which should match the location ``http
 
    sudo dnf makecache
 
-.. _rhel-install-rpms-install-ros-2-packages:
+Install development tools (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are going to build ROS packages or otherwise do development, you can also install the development tools:
+
+.. code-block:: bash
+
+   sudo dnf install -y \
+     cmake \
+     gcc-c++ \
+     git \
+     make \
+     patch \
+     python3-colcon-common-extensions \
+     python3-flake8-builtins \
+     python3-flake8-comprehensions \
+     python3-flake8-docstrings \
+     python3-flake8-import-order \
+     python3-flake8-quotes \
+     python3-mypy \
+     python3-pip \
+     python3-pydocstyle \
+     python3-pytest \
+     python3-pytest-repeat \
+     python3-pytest-rerunfailures \
+     python3-rosdep \
+     python3-setuptools \
+     python3-vcstool \
+     wget
+
+   # install some pip packages needed for testing and
+   # not available as RPMs
+   python3 -m pip install -U --user \
+     flake8-blind-except==0.1.1 \
+     flake8-class-newline \
+     flake8-deprecated
 
 Install ROS 2 packages
 ----------------------
@@ -73,11 +108,14 @@ No GUI tools.
 
    sudo dnf install ros-{DISTRO}-ros-base
 
-Environment setup
------------------
+Install additional RMW implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sourcing the setup script
-^^^^^^^^^^^^^^^^^^^^^^^^^
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
+See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
+
+Setup environment
+-----------------
 
 Set up your environment by sourcing the following file.
 
@@ -110,17 +148,13 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Additional RMW implementations (optional)
------------------------------------------
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
-
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :doc:`here <../How-To-Guides/Installation-Troubleshooting>`.
 
@@ -132,4 +166,4 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo dnf remove ros-{DISTRO}-*
+   sudo dnf remove ros-{DISTRO}-*

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -47,8 +47,8 @@ If you are going to build ROS packages or otherwise do development, you can also
 
    sudo apt install ros-dev-tools
 
-Install ROS 2 packages
-----------------------
+Install ROS 2
+-------------
 
 Update your apt repository caches after setting up the repositories.
 
@@ -126,7 +126,8 @@ Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your
 Use the ROS 1 bridge (optional)
 -------------------------------
 
-The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
+See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
 Troubleshoot
 ------------

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -23,20 +23,29 @@ Resources
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 
+System setup
+------------
 
 Set locale
-----------
+^^^^^^^^^^
 
 .. include:: _Ubuntu-Set-Locale.rst
 
-.. _linux-install-debians-setup-sources:
-
-Setup Sources
--------------
+Enable required repositories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: _Apt-Repositories.rst
 
 .. _linux-install-debians-install-ros-2-packages:
+
+Install development tools (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are going to build ROS packages or otherwise do development, you can also install the development tools:
+
+.. code-block:: bash
+
+   sudo apt install ros-dev-tools
 
 Install ROS 2 packages
 ----------------------
@@ -69,17 +78,14 @@ No GUI tools.
 
    sudo apt install ros-{DISTRO}-ros-base
 
-Development tools: Compilers and other tools to build ROS packages
+Install additional RMW implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
+See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
-   sudo apt install ros-dev-tools
-
-Environment setup
+Setup environment
 -----------------
-
-Sourcing the setup script
-^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Set up your environment by sourcing the following file.
 
@@ -91,9 +97,6 @@ Set up your environment by sourcing the following file.
 
 Try some examples
 -----------------
-
-Talker-listener
-^^^^^^^^^^^^^^^
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
@@ -115,21 +118,18 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Using the ROS 1 bridge
-----------------------
+Use the ROS 1 bridge (optional)
+-------------------------------
+
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa. See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
 
-Additional RMW implementations (optional)
------------------------------------------
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
-
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :doc:`here <../How-To-Guides/Installation-Troubleshooting>`.
 
@@ -141,14 +141,14 @@ have already installed from binaries, run the following command:
 
 .. code-block:: bash
 
-  sudo apt remove ~nros-{DISTRO}-* && sudo apt autoremove
+   sudo apt remove ~nros-{DISTRO}-* && sudo apt autoremove
 
 You may also want to remove the repository:
 
 .. code-block:: bash
 
-  sudo rm /etc/apt/sources.list.d/ros2.list
-  sudo apt update
-  sudo apt autoremove
-  # Consider upgrading for packages previously shadowed.
-  sudo apt upgrade
+   sudo rm /etc/apt/sources.list.d/ros2.list
+   sudo apt update
+   sudo apt autoremove
+   # Consider upgrading for packages previously shadowed.
+   sudo apt upgrade

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -22,8 +22,8 @@ Only Windows 10 is supported.
 
 .. include:: _Windows-Install-Prerequisites.rst
 
-Downloading ROS 2
------------------
+Download ROS 2
+--------------
 
 Binary releases of {DISTRO_TITLE_FULL} are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
@@ -32,16 +32,16 @@ Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>
 
 .. note::
 
-    There may be more than one binary download option which might cause the file name to differ.
+   There may be more than one binary download option which might cause the file name to differ.
 
 .. note::
 
-    To install debug libraries for ROS 2, see `Extra Stuff for Debug`_.
-    Then continue on with downloading ``ros2-package-windows-debug-AMD64.zip``.
+   To install debug libraries for ROS 2, see `Extra Stuff for Debug`_.
+   Then continue on with downloading ``ros2-package-windows-debug-AMD64.zip``.
 
 * Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_{DISTRO}``\ ).
 
-Environment setup
+Setup environment
 -----------------
 
 Start a command shell and source the ROS 2 setup file to set up the workspace:
@@ -72,17 +72,19 @@ This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
 
-Next steps after installing
----------------------------
+Next steps
+----------
+
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
 
-Additional RMW implementations (optional)
------------------------------------------
+Install additional RMW implementations (optional)
+-------------------------------------------------
+
 The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
 See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
-Troubleshooting
----------------
+Troubleshoot
+------------
 
 Troubleshooting techniques can be found :ref:`here <windows-troubleshooting>`.
 
@@ -96,7 +98,7 @@ Uninstall
 
    .. code-block:: bash
 
-    rmdir /s /q \ros2_{DISTRO}
+      rmdir /s /q \ros2_{DISTRO}
 
 Extra Stuff for Debug
 ---------------------
@@ -145,8 +147,8 @@ In an administrative command prompt, run the following commands.
    choco source add -n=ros-win -s="https://aka.ms/ros/public" --priority=1
    choco upgrade ros-foxy-desktop -y --execution-timeout=0
 
-Environment setup
-^^^^^^^^^^^^^^^^^^
+Setup environment
+^^^^^^^^^^^^^^^^^
 
 Start an administrative command prompt and source the ROS 2 setup file to set up the workspace:
 

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -22,8 +22,8 @@ Only Windows 10 is supported.
 
 .. include:: _Windows-Install-Prerequisites.rst
 
-Download ROS 2
---------------
+Install ROS 2
+-------------
 
 Binary releases of {DISTRO_TITLE_FULL} are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
@@ -40,6 +40,13 @@ Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>
    Then continue on with downloading ``ros2-package-windows-debug-AMD64.zip``.
 
 * Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_{DISTRO}``\ ).
+
+Install additional RMW implementations (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
+See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
+
 
 Setup environment
 -----------------
@@ -76,12 +83,6 @@ Next steps
 ----------
 
 Continue with the :doc:`tutorials and demos <../../Tutorials>` to configure your environment, create your own workspace and packages, and learn ROS 2 core concepts.
-
-Install additional RMW implementations (optional)
--------------------------------------------------
-
-The default middleware that ROS 2 uses is ``Fast DDS``, but the middleware (RMW) can be replaced at runtime.
-See the :doc:`guide <../How-To-Guides/Working-with-multiple-RMW-implementations>` on how to work with multiple RMWs.
 
 Troubleshoot
 ------------

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -1,5 +1,5 @@
-Installing prerequisites
-------------------------
+Install prerequisites
+---------------------
 
 Install Chocolatey
 ^^^^^^^^^^^^^^^^^^

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -1,5 +1,5 @@
-Install prerequisites
----------------------
+System setup
+------------
 
 Install Chocolatey
 ^^^^^^^^^^^^^^^^^^
@@ -151,8 +151,3 @@ RQt dependencies
 
 To run rqt_graph you need to `download <https://graphviz.gitlab.io/_pages/Download/Download_windows.html>`__ and install `Graphviz <https://graphviz.gitlab.io/>`__.
 The installer will ask if to add graphviz to PATH, choose to either add it to the current user or all users.
-
-Install additional DDS implementations (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you would like to use another DDS or RTPS vendor besides the default, Fast DDS, you can find instructions `here </Installation/DDS-Implementations>`_.

--- a/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
@@ -145,7 +145,7 @@ Open a new terminal to install ``rqt`` and its plugins:
 
 .. tabs::
 
-  .. group-tab:: Linux (apt 2.0/Ubuntu 20.04 and newer)
+  .. group-tab:: Ubuntu
 
     .. code-block:: console
 
@@ -153,13 +153,11 @@ Open a new terminal to install ``rqt`` and its plugins:
 
       sudo apt install ~nros-{DISTRO}-rqt*
 
-  .. group-tab:: Linux (apt 1.x/Ubuntu 18.04 and older)
+  .. group-tab:: RHEL
 
     .. code-block:: console
 
-      sudo apt update
-
-      sudo apt install ros-{DISTRO}-rqt*
+      sudo dnf install ros-{DISTRO}-rqt*
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
In particular:
1.  Use the imperative in all of the titles: "Install" instead of "Installing"
2.  Remove unused in-page anchors
3.  Make the various Linux installation pages, in particular, be a lot more similar to each other
4.  Rearrange the installation page title hierarchy to be more clear "System", "Install", "Setup", "Examples", "Next steps", "Troubleshoot", and "Uninstall" sections.  This isn't strictly followed as there are necessary differences between the pages, but the flow is a lot more similarity between the various pages now.

Note for reviewers: trying to review this by looking at the diff is going to be quite difficult given the nature of the changes.  Instead I'll suggest pulling the branch down, building the site (`make html`), and then looking at the resulting files.  That should give you a much better idea of how I rearranged the headings here.

@cottsay FYI this is a breakout of the formatting changes from #3398 

Finally, I'll note that while we could backport this to stable releases, I foresee that there will be a *lot* of conflicts.  So I'd prefer to not backport this unless we have a strong reason.