### PR TITLE
Add release note about tracepoints for intra-process communication

### DIFF
--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -611,10 +611,10 @@ Note that this only applies to Linux.
 See https://github.com/ros2/ros2_tracing/pull/31 and https://github.com/ros2/ros2/issues/1177 for more information.
 See :doc:`this how-to guide to remove the instrumentation (or add the instrumentation with Humble and older) <../How-To-Guides/Building-ROS-2-with-Tracing>`.
 
-New tracepoints for intra-process are added
+New tracepoints for ``rclcpp`` intra-process are added
 """""""""""""""""""""""""""""""""""""""""""
 
-New tracepoints have been added to support intra-process communication.
+New tracepoints have been added to support ``rclcpp`` intra-process communication.
 This allows the evaluation of the time between the message publishing and the callback start in intra-process communication.
 
 See https://github.com/ros2/ros2_tracing/pull/30 and https://github.com/ros2/rclcpp/pull/2091 for more information.

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -611,6 +611,16 @@ Note that this only applies to Linux.
 See https://github.com/ros2/ros2_tracing/pull/31 and https://github.com/ros2/ros2/issues/1177 for more information.
 See :doc:`this how-to guide to remove the instrumentation (or add the instrumentation with Humble and older) <../How-To-Guides/Building-ROS-2-with-Tracing>`.
 
+
+New tracepoints for intra-process are added
+"""""""""""""""""""""""""""""""""""""""""""
+
+The current tracetools do not support intra-process communication.
+This allows the evaluation of the time between the message publishing and the callback start in intra-process communication.
+
+See https://github.com/ros2/ros2_tracing/pull/30 and https://github.com/ros2/rclcpp/pull/2091 for more information.
+
+
 Known Issues
 ------------
 

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -614,7 +614,7 @@ See :doc:`this how-to guide to remove the instrumentation (or add the instrument
 New tracepoints for intra-process are added
 """""""""""""""""""""""""""""""""""""""""""
 
-The current tracetools do not support intra-process communication.
+New tracepoints have been added to support intra-process communication.
 This allows the evaluation of the time between the message publishing and the callback start in intra-process communication.
 
 See https://github.com/ros2/ros2_tracing/pull/30 and https://github.com/ros2/rclcpp/pull/2091 for more information.

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -611,7 +611,6 @@ Note that this only applies to Linux.
 See https://github.com/ros2/ros2_tracing/pull/31 and https://github.com/ros2/ros2/issues/1177 for more information.
 See :doc:`this how-to guide to remove the instrumentation (or add the instrumentation with Humble and older) <../How-To-Guides/Building-ROS-2-with-Tracing>`.
 
-
 New tracepoints for intra-process are added
 """""""""""""""""""""""""""""""""""""""""""
 
@@ -619,7 +618,6 @@ The current tracetools do not support intra-process communication.
 This allows the evaluation of the time between the message publishing and the callback start in intra-process communication.
 
 See https://github.com/ros2/ros2_tracing/pull/30 and https://github.com/ros2/rclcpp/pull/2091 for more information.
-
 
 Known Issues
 ------------

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -612,7 +612,7 @@ See https://github.com/ros2/ros2_tracing/pull/31 and https://github.com/ros2/ros
 See :doc:`this how-to guide to remove the instrumentation (or add the instrumentation with Humble and older) <../How-To-Guides/Building-ROS-2-with-Tracing>`.
 
 New tracepoints for ``rclcpp`` intra-process are added
-"""""""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 New tracepoints have been added to support ``rclcpp`` intra-process communication.
 This allows the evaluation of the time between the message publishing and the callback start in intra-process communication.


### PR DESCRIPTION
The current `tracetools` did not support intra-process communication.
The following PRs add tracepoints for evaluating intra-process communication.

Related PRs
- https://github.com/ros2/rclcpp/pull/2091
- https://github.com/ros2/ros2_tracing/pull/30