### PR TITLE
Switch to ros2-testing for Iron pre-release testing

### DIFF
--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -19,8 +19,6 @@ System requirements
 -------------------
 
 We currently support RHEL 9 64-bit.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-Most people will want to use a stable ROS distribution.
 
 System setup
 ------------
@@ -92,9 +90,7 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for RHEL; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
@@ -103,9 +99,9 @@ Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>
 
   .. code-block:: bash
 
-     mkdir -p ~/ros2_{DISTRO}
-     cd ~/ros2_{DISTRO}
-     tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
+       mkdir -p ~/ros2_{DISTRO}
+       cd ~/ros2_{DISTRO}
+       tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
 Install dependencies using rosdep
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -23,8 +23,6 @@ System requirements
 -------------------
 
 We currently support Ubuntu Linux Jammy (22.04) 64-bit x86 and 64-bit ARM.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-Most people will want to use a stable ROS distribution.
 
 System setup
 ------------
@@ -60,21 +58,18 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for Ubuntu; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
 
-*
-  Unpack it:
+* Unpack it:
 
   .. code-block:: bash
 
-     mkdir -p ~/ros2_{DISTRO}
-     cd ~/ros2_{DISTRO}
-     tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
+       mkdir -p ~/ros2_{DISTRO}
+       cd ~/ros2_{DISTRO}
+       tar xf ~/Downloads/ros2-package-linux-x86_64.tar.bz2
 
 .. _linux-install-binary-install-missing-dependencies:
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -44,7 +44,7 @@ Next, download the ROS 2 .repo file:
 .. code-block:: bash
 
    sudo dnf install curl
-   sudo curl --output /etc/yum.repos.d/ros2.repo http://packages.ros.org/ros2/rhel/ros2.repo
+   sudo curl --output /etc/yum.repos.d/ros2.repo http://packages.ros.org/ros2-testing/rhel/ros2.repo
 
 Then, update your metadata cache.
 DNF may prompt you to verify the GPG key, which should match the location ``https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc``.

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -25,19 +25,17 @@ Only Windows 10 is supported.
 Install ROS 2
 -------------
 
-Binary releases of {DISTRO_TITLE_FULL} are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
-* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
+* Go to the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for Windows, e.g., ``ros2-{DISTRO}-*-windows-release-amd64.zip``.
 
 .. note::
 
-   There may be more than one binary download option which might cause the file name to differ.
+    There may be more than one binary download option which might cause the file name to differ.
 
 .. note::
 
-   To install debug libraries for ROS 2, see `Extra Stuff for Debug`_.
-   Then continue on with downloading ``ros2-package-windows-debug-AMD64.zip``.
+    To install debug libraries for ROS 2, see `Extra Stuff for Debug`_.
+    Then continue on with downloading ``ros2-package-windows-debug-AMD64.zip``.
 
 * Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_{DISTRO}``\ ).
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -18,4 +18,4 @@ Then add the repository to your sources list.
 
 .. code-block:: bash
 
-   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null


### PR DESCRIPTION
This PR aims to temporarily switch the source of packages to `ros2-testing` such that pre-release `iron` debians may be installed by users.

This PR should be reverted following the release of `iron`.