### PR TITLE
Tell users to 'apt update' before installing ros-dev-tools.

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -55,7 +55,7 @@ If you are going to build ROS packages or otherwise do development, you can also
 
 .. code-block:: bash
 
-   sudo apt install ros-dev-tools
+   sudo apt update && sudo apt install ros-dev-tools
 
 Install ROS 2
 -------------

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -45,7 +45,7 @@ If you are going to build ROS packages or otherwise do development, you can also
 
 .. code-block:: bash
 
-   sudo apt install ros-dev-tools
+   sudo apt update && sudo apt install ros-dev-tools
 
 Install ROS 2
 -------------


### PR DESCRIPTION
If the users follow the instructions as-is right now, they will fail to apt update before trying to install ros-dev-tools, which will lead to failure.  Update the instructions here for that.