### PR TITLE
Update the language in development setup for skipping packages.

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -131,9 +131,14 @@ More info on working with a ROS workspace can be found in :doc:`this tutorial <.
    cd ~/ros2_{DISTRO}/
    colcon build --symlink-install
 
-Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
-Take for instance: you would like to avoid installing the large OpenCV library.
-Well then simply run ``touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
+.. note::
+
+   If you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use the ``--packages-skip`` colcon flag to ignore the package that is causing problems.
+   For instance, if you don't want to install the large OpenCV library, you could skip building the packages that depend on it using the command:
+
+   .. code-block:: bash
+
+      colcon build --symlink-install --packages-skip image_tools intra_process_demo
 
 Setup environment
 -----------------

--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -103,9 +103,14 @@ More info on working with a ROS workspace can be found in :doc:`this tutorial <.
    cd ~/ros2_{DISTRO}/
    colcon build --symlink-install
 
-Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
-Take for instance: you would like to avoid installing the large OpenCV library.
-Well then simply run ``touch COLCON_IGNORE`` in the ``cam2image`` demo directory to leave it out of the build process.
+.. note::
+
+   If you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use the ``--packages-skip`` colcon flag to ignore the package that is causing problems.
+   For instance, if you don't want to install the large OpenCV library, you could skip building the packages that depend on it using the command:
+
+   .. code-block:: bash
+
+      colcon build --symlink-install --packages-skip image_tools intra_process_demo
 
 Setup environment
 -----------------


### PR DESCRIPTION
That is, to temporarily skip packages it is probably a better idea for people to use --packages-skip, rather than doing a COLCON_IGNORE.