### PR TITLE
Update the link to the ros1_bridge.

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -150,7 +150,7 @@ Use the ROS 1 bridge (optional)
 -------------------------------
 
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
-See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+See the dedicated :doc:`document <../../How-To-Guides/Using-ros1_bridge-Jammy-upstream>` on how to build and use the ROS 1 bridge.
 
 Alternate compilers
 -------------------

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -140,7 +140,7 @@ Use the ROS 1 bridge (optional)
 -------------------------------
 
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
-See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+See the dedicated :doc:`document <../../How-To-Guides/Using-ros1_bridge-Jammy-upstream>` on how to build and use the ROS 1 bridge.
 
 Troubleshoot
 ------------

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -127,7 +127,7 @@ Use the ROS 1 bridge (optional)
 -------------------------------
 
 The ROS 1 bridge can connect topics from ROS 1 to ROS 2 and vice-versa.
-See the dedicated `documentation <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__ on how to build and use the ROS 1 bridge.
+See the dedicated :doc:`document <../../How-To-Guides/Using-ros1_bridge-Jammy-upstream>` on how to build and use the ROS 1 bridge.
 
 Troubleshoot
 ------------


### PR DESCRIPTION
In particular, point to the page on docs.ros.org that shows how to use the bridge on Ubuntu Jammy.