### PR TITLE
Switch from 'docker-compose' to 'docker compose'.

### DIFF
--- a/source/How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers.rst
+++ b/source/How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers.rst
@@ -86,4 +86,4 @@ As an alternative to the command line invocation, you can create a ``docker-comp
        depends_on:
          - talker
 
-To run the containers call ``docker-compose up`` in the same directory. You can close the containers with ``Ctrl+C``.
+To run the containers call ``docker compose up`` in the same directory. You can close the containers with ``Ctrl+C``.


### PR DESCRIPTION
As far as I understand, docker-compose is the V1 version of the tool (which will stop being supported in June 2023). 'docker compose' is the V2 version of the tool, which is still supported.