### PR TITLE
Add devcontainer.json to simplify local documentation creation and build task for VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "ROS 2 Documentation Repository Container",
+    "build": {
+        "dockerfile": "../docker/image/Dockerfile",
+        "args": {
+            "user": "rosindex",
+            "uid": "1000"
+        }
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/tmp/doc_repository,type=bind",
+    "workspaceFolder": "/tmp/doc_repository",
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash"
+            },
+            "extensions":[
+                "ms-python.python",
+                "lextudio.restructuredtext",
+                "trond-snekvik.simple-rst",
+                "eamodio.gitlens"
+            ]
+        }
+    },
+    "remoteUser": "rosindex",
+    "containerUser": "rosindex",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "postCreateCommand": "pip install esbonio && pip3 install --no-warn-script-location --user --upgrade -r requirements.txt"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "make html",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This adds a [`devcontainer.json`](https://containers.dev/) which is based on the provided `Dockerfile` and at the moment it is only configured for Visual Studio Code. Thus it also adds a `tasks.json` to provide a default build task.
It helps to verify changes locally before committing :smile: 