### PR TITLE
Inform users to install zlib when following windows binaries guide

### DIFF
--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -43,15 +43,6 @@ Install additional Python dependencies:
 
    pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock mypy==0.931 pep8 pydocstyle pytest pytest-mock vcstool
 
-Install miscellaneous prerequisites
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Next install xmllint:
-
-* Download the `64 bit binary archives <https://www.zlatkovic.com/pub/libxml/64bit/>`__ of ``libxml2`` (and its dependencies ``iconv`` and ``zlib``) from https://www.zlatkovic.com/projects/libxml/
-* Unpack all archives into e.g. ``C:\xmllint``
-* Add ``C:\xmllint\bin`` to the ``PATH``.
-
 Build ROS 2
 -----------
 

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -126,6 +126,15 @@ Now install some additional python dependencies:
 
    python -m pip install -U catkin_pkg cryptography empy importlib-metadata jsonschema lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro
 
+Install miscellaneous prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Next install xmllint:
+
+* Download the `64 bit binary archives <https://www.zlatkovic.com/pub/libxml/64bit/>`__ of ``libxml2`` (and its dependencies ``iconv`` and ``zlib``) from https://www.zlatkovic.com/projects/libxml/
+* Unpack all archives into e.g. ``C:\xmllint``
+* Add ``C:\xmllint\bin`` to the ``PATH``.
+
 Install Qt5
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Without zlib added to PATH, the following error is thrown when running rviz2 on Windows from binaries. https://github.com/osrf/ros2_test_cases/issues/863#issuecomment-1537489882

If users follow the source installation guide, they will be instructed to install zlib (among other deps) [here](https://docs.ros.org/en/iron/Installation/Alternatives/Windows-Development-Setup.html#install-miscellaneous-prerequisites). However the binary installation only links users to the `Windows-Install-Prerequisites` page that does not include these instructions.

Instead of having duplicate text in this doc as I have in the PR so far, let me know if a `ref` to the source installation instructions is preferred.