### PR TITLE
Switch the name of the custom action interface package.

### DIFF
--- a/source/Tutorials/Intermediate/Creating-an-Action.rst
+++ b/source/Tutorials/Intermediate/Creating-an-Action.rst
@@ -47,24 +47,24 @@ Tasks
 
     .. code-block:: bash
 
-      mkdir -p ros2_ws/src # you can reuse an existing workspace with this naming convention
-      cd ros2_ws/src
+      mkdir -p ~/ros2_ws/src # you can reuse an existing workspace with this naming convention
+      cd ~/ros2_ws/src
       ros2 pkg create --license Apache-2.0 custom_action_interfaces
 
   .. group-tab:: macOS
 
     .. code-block:: bash
 
-      mkdir -p ros2_ws/src
-      cd ros2_ws/src
+      mkdir -p ~/ros2_ws/src
+      cd ~/ros2_ws/src
       ros2 pkg create --license Apache-2.0 custom_action_interfaces
 
   .. group-tab:: Windows
 
     .. code-block:: bash
 
-      md ros2_ws\src
-      cd ros2_ws\src
+      md \ros2_ws\src
+      cd \ros2_ws\src
       ros2 pkg create --license Apache-2.0 custom_action_interfaces
 
 
@@ -156,7 +156,7 @@ We should now be able to build the package containing the ``Fibonacci`` action d
 .. code-block:: bash
 
     # Change to the root of the workspace
-    cd ../..
+    cd ~/ros2_ws
     # Build
     colcon build
 

--- a/source/Tutorials/Intermediate/Creating-an-Action.rst
+++ b/source/Tutorials/Intermediate/Creating-an-Action.rst
@@ -31,9 +31,15 @@ Prerequisites
 
 You should have :doc:`ROS 2 <../../Installation>` and `colcon <https://colcon.readthedocs.org>`__ installed.
 
-Set up a :doc:`workspace <../Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace>` and create a package named ``action_tutorials_interfaces``:
+You should know how to set up a :doc:`workspace <../Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace>` and create packages.
 
-(Remember to :doc:`source your ROS 2 installation <../Beginner-CLI-Tools/Configuring-ROS2-Environment>` first.)
+Remember to :doc:`source your ROS 2 installation <../Beginner-CLI-Tools/Configuring-ROS2-Environment>` first.
+
+Tasks
+-----
+
+1 Creating an interface package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
 
@@ -41,9 +47,9 @@ Set up a :doc:`workspace <../Beginner-Client-Libraries/Creating-A-Workspace/Crea
 
     .. code-block:: bash
 
-      mkdir -p ros2_ws/src #you can reuse existing workspace with this naming convention
+      mkdir -p ros2_ws/src # you can reuse an existing workspace with this naming convention
       cd ros2_ws/src
-      ros2 pkg create action_tutorials_interfaces
+      ros2 pkg create --license Apache-2.0 custom_action_interfaces
 
   .. group-tab:: macOS
 
@@ -51,7 +57,7 @@ Set up a :doc:`workspace <../Beginner-Client-Libraries/Creating-A-Workspace/Crea
 
       mkdir -p ros2_ws/src
       cd ros2_ws/src
-      ros2 pkg create action_tutorials_interfaces
+      ros2 pkg create --license Apache-2.0 custom_action_interfaces
 
   .. group-tab:: Windows
 
@@ -59,12 +65,10 @@ Set up a :doc:`workspace <../Beginner-Client-Libraries/Creating-A-Workspace/Crea
 
       md ros2_ws\src
       cd ros2_ws\src
-      ros2 pkg create action_tutorials_interfaces
+      ros2 pkg create --license Apache-2.0 custom_action_interfaces
 
-Tasks
------
 
-1 Defining an action
+2 Defining an action
 ^^^^^^^^^^^^^^^^^^^^
 
 Actions are defined in ``.action`` files of the form:
@@ -87,7 +91,7 @@ An instance of an action is typically referred to as a *goal*.
 
 Say we want to define a new action "Fibonacci" for computing the `Fibonacci sequence <https://en.wikipedia.org/wiki/Fibonacci_number>`__.
 
-Create an ``action`` directory in our ROS 2 package ``action_tutorials_interfaces``:
+Create an ``action`` directory in our ROS 2 package ``custom_action_interfaces``:
 
 .. tabs::
 
@@ -95,21 +99,21 @@ Create an ``action`` directory in our ROS 2 package ``action_tutorials_interface
 
     .. code-block:: bash
 
-      cd action_tutorials_interfaces
+      cd custom_action_interfaces
       mkdir action
 
   .. group-tab:: macOS
 
     .. code-block:: bash
 
-      cd action_tutorials_interfaces
+      cd custom_action_interfaces
       mkdir action
 
   .. group-tab:: Windows
 
     .. code-block:: bash
 
-      cd action_tutorials_interfaces
+      cd custom_action_interfaces
       md action
 
 Within the ``action`` directory, create a file called ``Fibonacci.action`` with the following contents:
@@ -124,12 +128,12 @@ Within the ``action`` directory, create a file called ``Fibonacci.action`` with 
 
 The goal request is the ``order`` of the Fibonacci sequence we want to compute, the result is the final ``sequence``, and the feedback is the ``partial_sequence`` computed so far.
 
-2 Building an action
+3 Building an action
 ^^^^^^^^^^^^^^^^^^^^
 
 Before we can use the new Fibonacci action type in our code, we must pass the definition to the rosidl code generation pipeline.
 
-This is accomplished by adding the following lines to our ``CMakeLists.txt`` before the ``ament_package()`` line, in the ``action_tutorials_interfaces``:
+This is accomplished by adding the following lines to our ``CMakeLists.txt`` before the ``ament_package()`` line, in the ``custom_action_interfaces``:
 
 .. code-block:: cmake
 
@@ -152,26 +156,43 @@ We should now be able to build the package containing the ``Fibonacci`` action d
 .. code-block:: bash
 
     # Change to the root of the workspace
-    cd ~/ros2_ws
+    cd ../..
     # Build
     colcon build
 
 We're done!
 
 By convention, action types will be prefixed by their package name and the word ``action``.
-So when we want to refer to our new action, it will have the full name ``action_tutorials_interfaces/action/Fibonacci``.
+So when we want to refer to our new action, it will have the full name ``custom_action_interfaces/action/Fibonacci``.
 
-We can check that our action built successfully with the command line tool:
+We can check that our action built successfully with the command line tool.
+First source our workspace:
 
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: bash
+
+      source install/local_setup.bash
+
+  .. group-tab:: macOS
+
+    .. code-block:: bash
+
+      source install/local_setup.bash
+
+  .. group-tab:: Windows
+
+    .. code-block:: bash
+
+      call install\local_setup.bat
+
+Now check that our action definition exists:
 
 .. code-block:: bash
 
-   # Source our workspace
-   # On Windows: call install/setup.bat
-   . install/setup.bash
-   # Check that our action definition exists
-   ros2 interface show action_tutorials_interfaces/action/Fibonacci
-
+   ros2 interface show custom_action_interfaces/action/Fibonacci
 
 You should see the Fibonacci action definition printed to the screen.
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -64,7 +64,7 @@ Go into the action workspace you created in the :doc:`previous tutorial <../Crea
 
     .. code-block:: bash
 
-      cd \dev\ros2_ws\src
+      cd \ros2_ws\src
       ros2 pkg create --dependencies custom_action_interfaces rclcpp rclcpp_action rclcpp_components --license Apache-2.0 -- custom_action_cpp
 
 1.2 Adding in visibility control

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -27,19 +27,19 @@ Actions are a form of asynchronous communication in ROS.
 Prerequisites
 -------------
 
-You will need the ``action_tutorials_interfaces`` package and the ``Fibonacci.action``
+You will need the ``custom_action_interfaces`` package and the ``Fibonacci.action``
 interface defined in the previous tutorial, :doc:`../Creating-an-Action`.
 
 Tasks
 -----
 
-1 Creating the action_tutorials_cpp package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1 Creating the custom_action_cpp package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As we saw in the :doc:`../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package` tutorial, we need to create a new package to hold our C++ and supporting code.
 
-1.1 Creating the action_tutorials_cpp package
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1.1 Creating the custom_action_cpp package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Go into the action workspace you created in the :doc:`previous tutorial <../Creating-an-Action>` (remember to source the workspace), and create a new package for the C++ action server:
 
@@ -51,21 +51,21 @@ Go into the action workspace you created in the :doc:`previous tutorial <../Crea
     .. code-block:: bash
 
       cd ~/ros2_ws/src
-      ros2 pkg create --dependencies action_tutorials_interfaces rclcpp rclcpp_action rclcpp_components -- action_tutorials_cpp
+      ros2 pkg create --dependencies custom_action_interfaces rclcpp rclcpp_action rclcpp_components --license Apache-2.0 -- custom_action_cpp
 
   .. group-tab:: macOS
 
     .. code-block:: bash
 
       cd ~/ros2_ws/src
-      ros2 pkg create --dependencies action_tutorials_interfaces rclcpp rclcpp_action rclcpp_components -- action_tutorials_cpp
+      ros2 pkg create --dependencies custom_action_interfaces rclcpp rclcpp_action rclcpp_components --license Apache-2.0 -- custom_action_cpp
 
   .. group-tab:: Windows
 
     .. code-block:: bash
 
       cd \dev\ros2_ws\src
-      ros2 pkg create --dependencies action_tutorials_interfaces rclcpp rclcpp_action rclcpp_components -- action_tutorials_cpp
+      ros2 pkg create --dependencies custom_action_interfaces rclcpp rclcpp_action rclcpp_components --license Apache-2.0 -- custom_action_cpp
 
 1.2 Adding in visibility control
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,12 +73,12 @@ Go into the action workspace you created in the :doc:`previous tutorial <../Crea
 In order to make the package compile and work on Windows, we need to add in some "visibility control".
 For more details, see :ref:`Windows Symbol Visibility in the Windows Tips and Tricks document <Windows_Symbol_Visibility>`.
 
-Open up ``action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h``, and put the following code in:
+Open up ``custom_action_cpp/include/custom_action_cpp/visibility_control.h``, and put the following code in:
 
 .. code-block:: c++
 
-  #ifndef ACTION_TUTORIALS_CPP__VISIBILITY_CONTROL_H_
-  #define ACTION_TUTORIALS_CPP__VISIBILITY_CONTROL_H_
+  #ifndef CUSTOM_ACTION_CPP__VISIBILITY_CONTROL_H_
+  #define CUSTOM_ACTION_CPP__VISIBILITY_CONTROL_H_
 
   #ifdef __cplusplus
   extern "C"
@@ -90,37 +90,37 @@ Open up ``action_tutorials_cpp/include/action_tutorials_cpp/visibility_control.h
 
   #if defined _WIN32 || defined __CYGWIN__
     #ifdef __GNUC__
-      #define ACTION_TUTORIALS_CPP_EXPORT __attribute__ ((dllexport))
-      #define ACTION_TUTORIALS_CPP_IMPORT __attribute__ ((dllimport))
+      #define CUSTOM_ACTION_CPP_EXPORT __attribute__ ((dllexport))
+      #define CUSTOM_ACTION_CPP_IMPORT __attribute__ ((dllimport))
     #else
-      #define ACTION_TUTORIALS_CPP_EXPORT __declspec(dllexport)
-      #define ACTION_TUTORIALS_CPP_IMPORT __declspec(dllimport)
+      #define CUSTOM_ACTION_CPP_EXPORT __declspec(dllexport)
+      #define CUSTOM_ACTION_CPP_IMPORT __declspec(dllimport)
     #endif
-    #ifdef ACTION_TUTORIALS_CPP_BUILDING_DLL
-      #define ACTION_TUTORIALS_CPP_PUBLIC ACTION_TUTORIALS_CPP_EXPORT
+    #ifdef CUSTOM_ACTION_CPP_BUILDING_DLL
+      #define CUSTOM_ACTION_CPP_PUBLIC CUSTOM_ACTION_CPP_EXPORT
     #else
-      #define ACTION_TUTORIALS_CPP_PUBLIC ACTION_TUTORIALS_CPP_IMPORT
+      #define CUSTOM_ACTION_CPP_PUBLIC CUSTOM_ACTION_CPP_IMPORT
     #endif
-    #define ACTION_TUTORIALS_CPP_PUBLIC_TYPE ACTION_TUTORIALS_CPP_PUBLIC
-    #define ACTION_TUTORIALS_CPP_LOCAL
+    #define CUSTOM_ACTION_CPP_PUBLIC_TYPE CUSTOM_ACTION_CPP_PUBLIC
+    #define CUSTOM_ACTION_CPP_LOCAL
   #else
-    #define ACTION_TUTORIALS_CPP_EXPORT __attribute__ ((visibility("default")))
-    #define ACTION_TUTORIALS_CPP_IMPORT
+    #define CUSTOM_ACTION_CPP_EXPORT __attribute__ ((visibility("default")))
+    #define CUSTOM_ACTION_CPP_IMPORT
     #if __GNUC__ >= 4
-      #define ACTION_TUTORIALS_CPP_PUBLIC __attribute__ ((visibility("default")))
-      #define ACTION_TUTORIALS_CPP_LOCAL  __attribute__ ((visibility("hidden")))
+      #define CUSTOM_ACTION_CPP_PUBLIC __attribute__ ((visibility("default")))
+      #define CUSTOM_ACTION_CPP_LOCAL  __attribute__ ((visibility("hidden")))
     #else
-      #define ACTION_TUTORIALS_CPP_PUBLIC
-      #define ACTION_TUTORIALS_CPP_LOCAL
+      #define CUSTOM_ACTION_CPP_PUBLIC
+      #define CUSTOM_ACTION_CPP_LOCAL
     #endif
-    #define ACTION_TUTORIALS_CPP_PUBLIC_TYPE
+    #define CUSTOM_ACTION_CPP_PUBLIC_TYPE
   #endif
 
   #ifdef __cplusplus
   }
   #endif
 
-  #endif  // ACTION_TUTORIALS_CPP__VISIBILITY_CONTROL_H_
+  #endif  // CUSTOM_ACTION_CPP__VISIBILITY_CONTROL_H_
 
 2 Writing an action server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -130,7 +130,7 @@ Let's focus on writing an action server that computes the Fibonacci sequence usi
 2.1 Writing the action server code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open up ``action_tutorials_cpp/src/fibonacci_action_server.cpp``, and put the following code in:
+Open up ``custom_action_cpp/src/fibonacci_action_server.cpp``, and put the following code in:
 
 .. literalinclude:: scripts/server.cpp
     :language: c++
@@ -209,7 +209,7 @@ In the previous section we put the action server code into place.
 To get it to compile and run, we need to do a couple of additional things.
 
 First we need to setup the CMakeLists.txt so that the action server is compiled.
-Open up ``action_tutorials_cpp/CMakeLists.txt``, and add the following right after the ``find_package`` calls:
+Open up ``custom_action_cpp/CMakeLists.txt``, and add the following right after the ``find_package`` calls:
 
 .. code-block:: cmake
 
@@ -219,13 +219,13 @@ Open up ``action_tutorials_cpp/CMakeLists.txt``, and add the following right aft
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
   target_compile_definitions(action_server
-    PRIVATE "ACTION_TUTORIALS_CPP_BUILDING_DLL")
+    PRIVATE "CUSTOM_ACTION_CPP_BUILDING_DLL")
   ament_target_dependencies(action_server
-    "action_tutorials_interfaces"
+    "custom_action_interfaces"
     "rclcpp"
     "rclcpp_action"
     "rclcpp_components")
-  rclcpp_components_register_node(action_server PLUGIN "action_tutorials_cpp::FibonacciActionServer" EXECUTABLE fibonacci_action_server)
+  rclcpp_components_register_node(action_server PLUGIN "custom_action_cpp::FibonacciActionServer" EXECUTABLE fibonacci_action_server)
   install(TARGETS
     action_server
     ARCHIVE DESTINATION lib
@@ -238,7 +238,7 @@ And now we can compile the package.  Go to the top-level of the ``ros2_ws``, and
 
   colcon build
 
-This should compile the entire workspace, including the ``fibonacci_action_server`` in the ``action_tutorials_cpp`` package.
+This should compile the entire workspace, including the ``fibonacci_action_server`` in the ``custom_action_cpp`` package.
 
 2.3 Running the action server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -248,7 +248,7 @@ Source the workspace we just built (``ros2_ws``), and try to run the action serv
 
 .. code-block:: bash
 
-  ros2 run action_tutorials_cpp fibonacci_action_server
+  ros2 run custom_action_cpp fibonacci_action_server
 
 3 Writing an action client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -256,7 +256,7 @@ Source the workspace we just built (``ros2_ws``), and try to run the action serv
 3.1 Writing the action client code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Open up ``action_tutorials_cpp/src/fibonacci_action_client.cpp``, and put the following code in:
+Open up ``custom_action_cpp/src/fibonacci_action_client.cpp``, and put the following code in:
 
 .. literalinclude:: scripts/client.cpp
     :language: c++
@@ -337,7 +337,7 @@ In the previous section we put the action client code into place.
 To get it to compile and run, we need to do a couple of additional things.
 
 First we need to setup the CMakeLists.txt so that the action client is compiled.
-Open up ``action_tutorials_cpp/CMakeLists.txt``, and add the following right after the ``find_package`` calls:
+Open up ``custom_action_cpp/CMakeLists.txt``, and add the following right after the ``find_package`` calls:
 
 .. code-block:: cmake
 
@@ -347,13 +347,13 @@ Open up ``action_tutorials_cpp/CMakeLists.txt``, and add the following right aft
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
   target_compile_definitions(action_client
-    PRIVATE "ACTION_TUTORIALS_CPP_BUILDING_DLL")
+    PRIVATE "CUSTOM_ACTION_CPP_BUILDING_DLL")
   ament_target_dependencies(action_client
-    "action_tutorials_interfaces"
+    "custom_action_interfaces"
     "rclcpp"
     "rclcpp_action"
     "rclcpp_components")
-  rclcpp_components_register_node(action_client PLUGIN "action_tutorials_cpp::FibonacciActionClient" EXECUTABLE fibonacci_action_client)
+  rclcpp_components_register_node(action_client PLUGIN "custom_action_cpp::FibonacciActionClient" EXECUTABLE fibonacci_action_client)
   install(TARGETS
     action_client
     ARCHIVE DESTINATION lib
@@ -366,7 +366,7 @@ And now we can compile the package.  Go to the top-level of the ``ros2_ws``, and
 
   colcon build
 
-This should compile the entire workspace, including the ``fibonacci_action_client`` in the ``action_tutorials_cpp`` package.
+This should compile the entire workspace, including the ``fibonacci_action_client`` in the ``custom_action_cpp`` package.
 
 3.3 Running the action client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -377,7 +377,7 @@ Now source the workspace we just built (``ros2_ws``), and try to run the action 
 
 .. code-block:: bash
 
-  ros2 run action_tutorials_cpp fibonacci_action_client
+  ros2 run custom_action_cpp fibonacci_action_client
 
 You should see logged messages for the goal being accepted, feedback being printed, and the final result.
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
@@ -27,7 +27,7 @@ Actions are a form of asynchronous communication in ROS 2.
 Prerequisites
 -------------
 
-You will need the ``action_tutorials_interfaces`` package and the ``Fibonacci.action``
+You will need the ``custom_action_interfaces`` package and the ``Fibonacci.action``
 interface defined in the previous tutorial, :doc:`../Creating-an-Action`.
 
 Tasks
@@ -105,7 +105,7 @@ In another terminal, we can use the command line interface to send a goal:
 
 .. code-block:: bash
 
-    ros2 action send_goal fibonacci action_tutorials_interfaces/action/Fibonacci "{order: 5}"
+    ros2 action send_goal fibonacci custom_action_interfaces/action/Fibonacci "{order: 5}"
 
 In the terminal that is running the action server, you should see a logged message "Executing goal..." followed by a warning that the goal state was not set.
 By default, if the goal handle state is not set in the execute callback it assumes the *aborted* state.
@@ -148,7 +148,7 @@ After restarting the action server, we can confirm that feedback is now publishe
 
 .. code-block:: bash
 
-    ros2 action send_goal --feedback fibonacci action_tutorials_interfaces/action/Fibonacci "{order: 5}"
+    ros2 action send_goal --feedback fibonacci custom_action_interfaces/action/Fibonacci "{order: 5}"
 
 2 Writing an action client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client.cpp
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client.cpp
@@ -4,18 +4,18 @@
 #include <string>
 #include <sstream>
 
-#include "action_tutorials_interfaces/action/fibonacci.hpp"
+#include "custom_action_interfaces/action/fibonacci.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-namespace action_tutorials_cpp
+namespace custom_action_cpp
 {
 class FibonacciActionClient : public rclcpp::Node
 {
 public:
-  using Fibonacci = action_tutorials_interfaces::action::Fibonacci;
+  using Fibonacci = custom_action_interfaces::action::Fibonacci;
   using GoalHandleFibonacci = rclcpp_action::ClientGoalHandle<Fibonacci>;
 
   explicit FibonacciActionClient(const rclcpp::NodeOptions & options)
@@ -106,6 +106,6 @@ private:
   }
 };  // class FibonacciActionClient
 
-}  // namespace action_tutorials_cpp
+}  // namespace custom_action_cpp
 
-RCLCPP_COMPONENTS_REGISTER_NODE(action_tutorials_cpp::FibonacciActionClient)
+RCLCPP_COMPONENTS_REGISTER_NODE(custom_action_cpp::FibonacciActionClient)

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_0.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_0.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionClient(Node):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_1.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_1.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionClient(Node):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_2.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_2.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionClient(Node):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server.cpp
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server.cpp
@@ -2,22 +2,22 @@
 #include <memory>
 #include <thread>
 
-#include "action_tutorials_interfaces/action/fibonacci.hpp"
+#include "custom_action_interfaces/action/fibonacci.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "action_tutorials_cpp/visibility_control.h"
+#include "custom_action_cpp/visibility_control.h"
 
-namespace action_tutorials_cpp
+namespace custom_action_cpp
 {
 class FibonacciActionServer : public rclcpp::Node
 {
 public:
-  using Fibonacci = action_tutorials_interfaces::action::Fibonacci;
+  using Fibonacci = custom_action_interfaces::action::Fibonacci;
   using GoalHandleFibonacci = rclcpp_action::ServerGoalHandle<Fibonacci>;
 
-  ACTION_TUTORIALS_CPP_PUBLIC
+  CUSTOM_ACTION_CPP_PUBLIC
   explicit FibonacciActionServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
   : Node("fibonacci_action_server", options)
   {
@@ -95,6 +95,6 @@ private:
   }
 };  // class FibonacciActionServer
 
-}  // namespace action_tutorials_cpp
+}  // namespace custom_action_cpp
 
-RCLCPP_COMPONENTS_REGISTER_NODE(action_tutorials_cpp::FibonacciActionServer)
+RCLCPP_COMPONENTS_REGISTER_NODE(custom_action_cpp::FibonacciActionServer)

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_0.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_0.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.action import ActionServer
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionServer(Node):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_1.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_1.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.action import ActionServer
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionServer(Node):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_2.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_2.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.action import ActionServer
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionServer(Node):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_3.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_3.py
@@ -4,7 +4,7 @@ import rclpy
 from rclpy.action import ActionServer
 from rclpy.node import Node
 
-from action_tutorials_interfaces.action import Fibonacci
+from custom_action_interfaces.action import Fibonacci
 
 
 class FibonacciActionServer(Node):


### PR DESCRIPTION
This is so we don't collide with an existing package name in the examples.

This should fix #3531 