### PR TITLE
use --cmake-clean-cache instead of --cmake-force-configure (#3562)

### DIFF
--- a/source/How-To-Guides/Working-with-multiple-RMW-implementations.rst
+++ b/source/How-To-Guides/Working-with-multiple-RMW-implementations.rst
@@ -68,10 +68,10 @@ Adding RMW implementations to your workspace
 Suppose that you have built your ROS 2 workspace with only Fast RTPS installed and therefore only the Fast RTPS RMW implementation built.
 The last time your workspace was built, any other RMW implementation packages, ``rmw_connext_cpp`` for example, were probably unable to find installations of the relevant DDS implementations.
 If you then install an additional DDS implementation, Connext for example, you will need to re-trigger the check for a Connext installation that occurs when the Connext RMW implementation is being built.
-You can do this by specifying the ``--cmake-force-configure`` flag on your next workspace build, and you should see that the RMW implementation package then gets built for the newly installed DDS implementation.
+You can do this by specifying the ``--cmake-clean-cache`` flag on your next workspace build, and you should see that the RMW implementation package then gets built for the newly installed DDS implementation.
 
-It is possible to run into a problem when "rebuilding" the workspace with an additional RMW implementation using the ``--cmake-force-configure`` option where the build complains about the default RMW implementation changing.
-To resolve this, you can either set the default implementation to what is was before with the ``RMW_IMPLEMENTATION`` CMake argument or you can delete the build folder for packages that complain and continue the build with ``--start-with <package name>``.
+It is possible to run into a problem when "rebuilding" the workspace with an additional RMW implementation using the ``--cmake-clean-cache`` option where the build complains about the default RMW implementation changing.
+To resolve this, you can either set the default implementation to what is was before with the ``RMW_IMPLEMENTATION`` CMake argument or you can delete the build folder for packages that complain and continue the build with ``--packages-start <package name>``.
 
 Troubleshooting
 ---------------
@@ -110,7 +110,7 @@ it will generate a daemon with a Fast RTPS implementation:
 
 .. code-block:: bash
 
-   21318 22.0  0.6 535896 55044 pts/8    Sl   16:14   0:00 /usr/bin/python3 /opt/ros/{DISTRO}/bin/_ros2_daemon --rmw-implementation rmw_fastrtps_cpp --ros-domain-id 22
+   21318 22.0  0.6 535896 55044 pts/8    Sl   16:14   0:00 /usr/bin/python3 /opt/ros/{DISTRO}/bin/_ros2_daemon --rmw-implementation rmw_fastrtps_cpp --ros-domain-id 0
 
 Even if you run the command line tool again with the correct RMW implementation, the daemon's RMW implementation will not change and the ROS 2 command line tools will fail.
 


### PR DESCRIPTION
* use --cmake-clean-cache only since it implicitly forces CMake configure step

Signed-off-by: Chen Lihui <lihui.chen@sony.com>
(cherry picked from commit 8d3501f85db93bf96f0371ee92df9486b473e72f)