### PR TITLE
Update 'Motion planning for a MoveIt 2 arm' link on Demos page

### DIFF
--- a/source/Tutorials/Demos.rst
+++ b/source/Tutorials/Demos.rst
@@ -17,7 +17,7 @@ External resources
 ------------------
 
 * `Bridging communication between ROS 1 and ROS 2 <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__
-* `Motion planning for a MoveIt 2 arm <http://moveit2_tutorials.picknik.ai/>`__
+* `Motion planning for a MoveIt 2 arm <https://moveit.picknik.ai/main/index.html>`__
 * Using Turtlebot 3 (community-contributed)
 
     - `Getting started <https://emanual.robotis.com/docs/en/platform/turtlebot3/quick-start/>`__


### PR DESCRIPTION
See https://github.com/osrf/ros2_test_cases/issues/959

The "Motion planning for a MoveIt 2 arm" link is being redirected from http://moveit2_tutorials.picknik.ai/ to https://moveit.picknik.ai/humble/index.html, so update the link.

There _is_ https://moveit.picknik.ai/main/index.html (for Rolling), but there are no versions for other ROS 2 distros, so I just used the Humble version. Perhaps `rolling` could point to https://moveit.picknik.ai/main/index.html and Iron and older can point to https://moveit.picknik.ai/humble/index.html?