### PR TITLE
Remove 'Using Turtlebot 2' link on Demos page

### DIFF
--- a/source/Tutorials/Demos.rst
+++ b/source/Tutorials/Demos.rst
@@ -18,7 +18,6 @@ External resources
 
 * `Bridging communication between ROS 1 and ROS 2 <https://github.com/ros2/ros1_bridge/blob/master/README.md>`__
 * `Motion planning for a MoveIt 2 arm <http://moveit2_tutorials.picknik.ai/>`__
-* `Using Turtlebot 2 <https://github.com/ros2/turtlebot2_demo>`__
 * Using Turtlebot 3 (community-contributed)
 
     - `Getting started <https://emanual.robotis.com/docs/en/platform/turtlebot3/quick-start/>`__


### PR DESCRIPTION
See https://github.com/osrf/ros2_test_cases/issues/959

The repo that "Using Turtlebot 2" links to is old and has been archived, so remove it, at least from the Iron and Rolling docs. I very much doubt that it works with Iron/Rolling.