### PR TITLE
Split build processes to save execution time in gh-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -14,8 +15,26 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies with pip
-        run: |
-          pip install --no-warn-script-location --user --upgrade -r requirements.txt
+        run: pip install --no-warn-script-location --user --upgrade -r requirements.txt
 
-      - run: make html
-      - run: make test
+      - name: Test doc8
+        run: make test
+    
+  build:
+    needs: test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies with pip
+        run: pip install --no-warn-script-location --user --upgrade -r requirements.txt
+
+      - name: Build the docs
+        run: make html
+


### PR DESCRIPTION
**Sorry, I deleted the fork to make some tests and the PR #3652 was closed, so I open it again.**

The action to test is divided in two in order to avoid compilation time in GitHub Actions. For example in run [#8442](https://github.com/ros2/ros2_documentation/actions/runs/5004193173) it took 2m 30s to run, of which 1m 56s was to build the html and then failed the test.

![image](https://github.com/ros2/ros2_documentation/assets/30636259/576b5862-57a3-48f0-9b60-c562b54846d0)
![image](https://github.com/ros2/ros2_documentation/assets/30636259/39988757-aae6-4d4d-b83b-66a9d0340c1d)

With this new action, if the test fails, the build is not executed:
![image](https://github.com/ros2/ros2_documentation/assets/30636259/4cb785bb-5954-4072-b5b3-c8554c5c946f)

> __Note__: It can be seen that only 35 seconds are consumed in the test and if it fails, no ghactions time is spent in build 