### PR TITLE
Mention not needing to source workspace before running tests

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -231,6 +231,8 @@ To run tests for the packages we just built, run the following:
 
     You also need to specify ``--merge-install`` here since we used it for building above.
 
+.. _colcon-tutorial-source-the-environment:
+
 Source the environment
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -14,6 +14,9 @@ To compile and run the tests, simply run the `test <https://colcon.readthedocs.i
 
 (where ``package_selection_args`` are optional package selection arguments for ``colcon`` to limit which packages are built and run)
 
+:ref:`Sourcing the workspace <colcon-tutorial-source-the-environment>` before testing should not be necessary.
+``colcon test`` makes sure that the tests run with the right environment, have access to their dependencies, etc.
+
 Examine Test Results
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
While it is known that it should not be necessary to source a workspace before running tests, it is not explicitly mentioned anywhere. Mention it here.

I wrote "should not" instead of "is not" since needing to source a workspace before running tests generally indicates that something is not configured properly. Also, the second sentence is somewhat vague and could be improved, However, in both cases, I don't think there is a need to go into too much detail.