### PR TITLE
Get rid of unnecessary .rst prefixes in links.

### DIFF
--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -38,7 +38,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/Using-Python-Packages
    How-To-Guides/RQt-Port-Plugin-Windows
    How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers
-   How-To-Guides/Visualizing-ROS-2-Data-With-Foxglove-Studio.rst
+   How-To-Guides/Visualizing-ROS-2-Data-With-Foxglove-Studio
    How-To-Guides/Package-maintainer-guide
    How-To-Guides/Building-a-Custom-Debian-Package
    How-To-Guides/Building-ROS-2-with-Tracing

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -23,13 +23,13 @@ Rows in the table marked in green are the currently supported distributions.
 .. toctree::
    :hidden:
 
-   Releases/Release-Iron-Irwini.rst
-   Releases/Release-Humble-Hawksbill.rst
-   Releases/Release-Foxy-Fitzroy.rst
-   Releases/Release-Rolling-Ridley.rst
-   Releases/Development.rst
-   Releases/End-of-Life.rst
-   Releases/Release-Process.rst
+   Releases/Release-Iron-Irwini
+   Releases/Release-Humble-Hawksbill
+   Releases/Release-Foxy-Fitzroy
+   Releases/Release-Rolling-Ridley
+   Releases/Development
+   Releases/End-of-Life
+   Releases/Release-Process
 
 .. raw:: html
 

--- a/source/Releases/Development.rst
+++ b/source/Releases/Development.rst
@@ -6,4 +6,4 @@ Below is the ROS 2 distribution that is currently in development.
 .. toctree::
    :maxdepth: 1
 
-   Release-Jazzy-Jalisco.rst
+   Release-Jazzy-Jalisco

--- a/source/Releases/End-of-Life.rst
+++ b/source/Releases/End-of-Life.rst
@@ -6,13 +6,13 @@ Below is a list of historic ROS 2 distributions that are no longer supported.
 .. toctree::
    :maxdepth: 1
 
-   Release-Galactic-Geochelone.rst
-   Release-Eloquent-Elusor.rst
-   Release-Dashing-Diademata.rst
-   Release-Crystal-Clemmys.rst
-   Release-Bouncy-Bolson.rst
-   Release-Ardent-Apalone.rst
-   Beta3-Overview.rst
-   Beta2-Overview.rst
-   Beta1-Overview.rst
-   Alpha-Overview.rst
+   Release-Galactic-Geochelone
+   Release-Eloquent-Elusor
+   Release-Dashing-Diademata
+   Release-Crystal-Clemmys
+   Release-Bouncy-Bolson
+   Release-Ardent-Apalone
+   Beta3-Overview
+   Beta2-Overview
+   Beta1-Overview
+   Alpha-Overview

--- a/source/Releases/Release-Galactic-Geochelone.rst
+++ b/source/Releases/Release-Galactic-Geochelone.rst
@@ -6,7 +6,7 @@ Galactic Geochelone (``galactic``)
 .. toctree::
    :hidden:
 
-   Galactic-Geochelone-Complete-Changelog.rst
+   Galactic-Geochelone-Complete-Changelog
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -6,7 +6,7 @@ Humble Hawksbill (``humble``)
 .. toctree::
    :hidden:
 
-   Humble-Hawksbill-Complete-Changelog.rst
+   Humble-Hawksbill-Complete-Changelog
 
 .. contents:: Table of Contents
    :depth: 2
@@ -742,7 +742,7 @@ ros1_bridge
 ^^^^^^^^^^^
 
 Since there is no official ROS 1 distribution on Ubuntu Jammy and forward, ``ros1_bridge`` is now compatible with the Ubuntu-packaged versions of ROS 1.
-More details about using ``ros1_bridge`` with Jammy packages are available in `the how-to guides <../How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst>`__.
+More details about using ``ros1_bridge`` with Jammy packages are available in :doc:`the how-to guides <../How-To-Guides/Using-ros1_bridge-Jammy-upstream>`.
 
 ros2cli
 ^^^^^^^

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -8,7 +8,7 @@ Iron Irwini (``iron``)
 .. toctree::
    :hidden:
 
-   Iron-Irwini-Complete-Changelog.rst
+   Iron-Irwini-Complete-Changelog
 
 .. contents:: Table of Contents
    :depth: 2

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -1,6 +1,6 @@
 .. redirect-from::
 
-    Tutorials/Custom-ROS2-Interfaces.rst
+    Tutorials/Custom-ROS2-Interfaces
 
 .. _CustomInterfaces:
 


### PR DESCRIPTION
That is, internal links never need the .rst prefix, they can just use the name of the document they are referring to.  This matches what most of the rest of the documentation does.