### PR TITLE
Small fix for Foxy.

### DIFF
--- a/source/Releases/Release-Humble-Hawksbill.rst
+++ b/source/Releases/Release-Humble-Hawksbill.rst
@@ -741,10 +741,6 @@ ros1_bridge
 ^^^^^^^^^^^
 
 Since there is no official ROS 1 distribution on Ubuntu Jammy and forward, ``ros1_bridge`` is now compatible with the Ubuntu-packaged versions of ROS 1.
-<<<<<<< HEAD
-=======
-More details about using ``ros1_bridge`` with Jammy packages are available in :doc:`the how-to guides <../How-To-Guides/Using-ros1_bridge-Jammy-upstream>`.
->>>>>>> 5bb98f78 (Get rid of unnecessary .rst prefixes in links. (#3723))
 
 ros2cli
 ^^^^^^^


### PR DESCRIPTION
GitHub did not end up merging the correct thing in https://github.com/ros2/ros2_documentation/pull/3726, which is concerning but a different problem.  Fix up the build here.