### PR TITLE
Fix colcon python warnings

### DIFF
--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
@@ -155,6 +155,7 @@ You can either install ``webots_ros2`` from the official released package, or in
         Fix some `python warnings <https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349>`_ (if not already done)
 
         .. code-block:: console
+
             echo 'export PYTHONWARNINGS="ignore:setup.py install is deprecated::setuptools.command.install"' >> ~/.bashrc
             source ~/.bashrc
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
@@ -152,6 +152,12 @@ You can either install ``webots_ros2`` from the official released package, or in
             sudo rosdep init && rosdep update
             rosdep install --from-paths src --ignore-src --rosdistro {DISTRO}
 
+        Fix some `python warnings <https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349>`_ (if not already done)
+
+        .. code-block:: console
+            echo 'export PYTHONWARNINGS="ignore:setup.py install is deprecated::setuptools.command.install"' >> ~/.bashrc
+            source ~/.bashrc
+
         Build the package using ``colcon``.
 
         .. code-block:: console

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
@@ -88,6 +88,12 @@ You can either install the official released package, or install it from the lat
             sudo rosdep init && rosdep update
             rosdep install --from-paths src --ignore-src --rosdistro {DISTRO}
 
+        Fix some `python warnings <https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349>`_ (if not already done)
+
+        .. code-block:: console
+            echo 'export PYTHONWARNINGS="ignore:setup.py install is deprecated::setuptools.command.install"' >> ~/.bashrc
+            source ~/.bashrc
+
         Build the package using ``colcon``.
 
         .. code-block:: console

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
@@ -91,6 +91,7 @@ You can either install the official released package, or install it from the lat
         Fix some `python warnings <https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349>`_ (if not already done)
 
         .. code-block:: console
+
             echo 'export PYTHONWARNINGS="ignore:setup.py install is deprecated::setuptools.command.install"' >> ~/.bashrc
             source ~/.bashrc
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Windows.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Windows.rst
@@ -100,6 +100,12 @@ The following commands must be run inside the WSL environment.
             sudo rosdep init && rosdep update
             rosdep install --from-paths src --ignore-src --rosdistro {DISTRO}
 
+        Fix some `python warnings <https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349>`_ (if not already done)
+
+        .. code-block:: console
+            echo 'export PYTHONWARNINGS="ignore:setup.py install is deprecated::setuptools.command.install"' >> ~/.bashrc
+            source ~/.bashrc
+
         Build the package using ``colcon``.
 
         .. code-block:: console

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Windows.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Windows.rst
@@ -103,6 +103,7 @@ The following commands must be run inside the WSL environment.
         Fix some `python warnings <https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349>`_ (if not already done)
 
         .. code-block:: console
+
             echo 'export PYTHONWARNINGS="ignore:setup.py install is deprecated::setuptools.command.install"' >> ~/.bashrc
             source ~/.bashrc
 


### PR DESCRIPTION
This PR adds instructions to disable the print of colcon python warnings on stderr that are confusing users.
It implements the recommended solution explained [here](https://robotics.stackexchange.com/questions/24230/setuptoolsdeprecationwarning-in-ros2-humble/24349#24349).

We are aiming at merging this PR to rolling, humble and iron.