### PR TITLE
Update documentation to correct default publishing mode

### DIFF
--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -43,15 +43,15 @@ Mixing synchronous and asynchronous publications in the same node
 
 In this first example, a node with two publishers, one of them with synchronous publication mode and the other one with asynchronous publication mode, will be created.
 
-When the publisher invokes the write operation, the data is copied into a queue,
-a background thread (asynchronous thread) is notified about the addition to the queue, and control of the thread is returned to the user before the data is actually sent.
-The background thread is in charge of consuming the queue and sending the data to every matched reader.
+``rmw_fastrtps`` uses synchronous publication mode by default.
 
-On the other hand, with synchronous publication mode the data is sent directly within the context of the user thread.
+With synchronous publication mode the data is sent directly within the context of the user thread.
 This entails that any blocking call occurring during the write operation would block the user thread, thus preventing the application from continuing its operation.
 However, this mode typically yields higher throughput rates at lower latencies, since there is no notification nor context switching between threads.
 
-``rmw_fastrtps`` uses synchronous publication mode by default.
+On the other hand, with asynchronous publication mode, each time the publisher invokes the write operation, the data is copied into a queue,
+a background thread (asynchronous thread) is notified about the addition to the queue, and control of the thread is returned to the user before the data is actually sent.
+The background thread is in charge of consuming the queue and sending the data to every matched reader.
 
 Create the node with the publishers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -43,7 +43,6 @@ Mixing synchronous and asynchronous publications in the same node
 
 In this first example, a node with two publishers, one of them with synchronous publication mode and the other one with asynchronous publication mode, will be created.
 
-``rmw_fastrtps`` uses asynchronous publication mode by default.
 When the publisher invokes the write operation, the data is copied into a queue,
 a background thread (asynchronous thread) is notified about the addition to the queue, and control of the thread is returned to the user before the data is actually sent.
 The background thread is in charge of consuming the queue and sending the data to every matched reader.
@@ -52,6 +51,7 @@ On the other hand, with synchronous publication mode the data is sent directly w
 This entails that any blocking call occurring during the write operation would block the user thread, thus preventing the application from continuing its operation.
 However, this mode typically yields higher throughput rates at lower latencies, since there is no notification nor context switching between threads.
 
+``rmw_fastrtps`` uses synchronous publication mode by default.
 
 Create the node with the publishers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I checked both the [documentation](https://github.com/ros2/rmw_fastrtps/blob/humble/README.md?plain=1#L58) and the [source code](https://github.com/ros2/rmw_fastrtps/blob/humble/rmw_fastrtps_shared_cpp/src/participant.cpp#L191-L223). The documentation shall be updated to reference the default publishing mode. 