### PR TITLE
Fix numerous inconsistencies in ament-cmake-docs w.r.t installation of linkage, and target installation

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -80,7 +80,8 @@ The following best practice is proposed:
 
     target_include_directories(my_library
       PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 This adds all files in the folder ``${CMAKE_CURRENT_SOURCE_DIR}/include`` to the public interface during build time and all files in the include folder (relative to ``${CMAKE_INSTALL_DIR}``) when being installed.
 
@@ -147,12 +148,13 @@ Add all the nodes and libraries for your project to the ``TARGETS`` argument.
 
 .. code-block:: cmake
 
-    include(GNUInstallDirs)
     install(
       TARGETS my_library my_node
       EXPORT my_libraryTargets
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
       RUNTIME DESTINATION lib/${PROJECT_NAME}
-      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+      INCLUDES DESTINATION include/${PROJECT_NAME}
     )
 
     ament_export_targets(my_libraryTargets HAS_LIBRARY_TARGET)


### PR DESCRIPTION
* Nodes need a special RUNTIME directory to be recognized by ROS 2 CLI
* The order of creating the export set and using it was not intuitive
* target_link_libraries was missing linkage type which is not recommended
* It did not show to install nodes and libraries at the same time
* Header install location did not match colcon's recommendations for supporting overlays
* HAS_LIBRARY_TARGET wasn't explained that it's only needed if you are installing libraries

Relates to https://github.com/ros2/ros2cli/issues/845

It would be a good idea to make these changes to an autogenerated package and check the includes are still working as expected. I understand the other tutorials and `ros2 pkg create` could also use an update to match, and can do that work once we're happy with it. 

This work was contributed on behalf of AeroVironment, Inc. 