### PR TITLE
MinimumSocketReceiveBufferSize is moved

### DIFF
--- a/source/How-To-Guides/DDS-tuning.rst
+++ b/source/How-To-Guides/DDS-tuning.rst
@@ -129,7 +129,7 @@ Next, to set the minimum socket receive buffer size that Cyclone requests, write
   https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
       <Domain id="any">
           <Internal>
-              <MinimumSocketReceiveBufferSize>10MB</MinimumSocketReceiveBufferSize>
+              <SocketReceiveBufferSize min="10MB"/>
           </Internal>
       </Domain>
   </CycloneDDS>


### PR DESCRIPTION
In Humble (Cyclone DDS=0.9.x) and later, MinimumSocketReceiveBufferSize is moved. The following warning is displayed.

```
1691062843.863621 [0]       ros2: config: //CycloneDDS/Domain/Internal/MinimumSocketReceiveBufferSize: setting moved to //CycloneDDS/Domain/Internal/SocketReceiveBufferSize[@min] (file:///xxx/cyclonedds.xml line 6)
```

See https://github.com/eclipse-cyclonedds/cyclonedds/commit/8da20663feef072e0d6f0092467f30fb62d8124b