### PR TITLE
Prepare for ROS Answers migration to Robotics Stack Exchange.

### DIFF
--- a/source/Concepts/Intermediate/About-RQt.rst
+++ b/source/Concepts/Intermediate/About-RQt.rst
@@ -72,7 +72,7 @@ Compared to building your own GUIs from scratch:
 * Standardized common procedures for GUI (start-shutdown hook, restore previous states).
 * Multiple widgets can be docked in a single window.
 * Easily turn your existing Qt widgets into RQt plugins.
-* Expect support at `ROS Answers <https://answers.ros.org>`__ (ROS community website for the questions).
+* Expect support at `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ (ROS community website for the questions).
 
 From system architecture's perspective:
 

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -3,7 +3,7 @@
 Contact
 =======
 
-.. _Using ROS Answers:
+.. _Using Robotics Stack Exchange:
 
 Support
 -------
@@ -12,9 +12,9 @@ Different types of questions or discussions correspond to different avenues of c
 check the descriptions below to ensure you choose the right method.
 
 Need help troubleshooting your system?
-First, search `ROS Answers <https://answers.ros.org>`__ to see if others have had similar issues, and if their solution works for you.
+First, search `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ to see if others have had similar issues, and if their solution works for you.
 
-If not, ask a new question on `ROS Answers <https://answers.ros.org>`__.
+If not, ask a new question on `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__.
 Make sure to add tags, at the very least the ``ros2`` tag and the distro version you are running, e.g. ``{DISTRO}``.
 If your question is related to the documentation here, add a tag like ``docs``, or more specifically, ``tutorials``.
 
@@ -24,7 +24,7 @@ Contributing support
 ROS 2 users come from a wide range of technical backgrounds, use a variety of different operating systems, and don’t necessarily have any prior experience with ROS (1 or 2).
 So, it's important for users with any amount of experience to contribute support.
 
-If you see an issue on `ROS Answers <https://answers.ros.org/questions/tags:ros2/>`__ that is similar to something you’ve run into yourself, please consider providing some pointers to what helped in your situation.
+If you see an issue on `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ that is similar to something you’ve run into yourself, please consider providing some pointers to what helped in your situation.
 Don’t worry if you aren't sure if your response is correct.
 Simply say so, and other community members will jump in if necessary.
 
@@ -40,7 +40,7 @@ You can search for individual ROS 2 repositories on `ROS 2's GitHub <https://git
 
 Before opening an issue, check if other users have reported similar issues by searching across the ros2 and ament GitHub organizations: `example search query <https://github.com/search?q=user%3Aros2+user%3Aament+turtlesim&type=Issues>`__.
 
-Next, check `ROS Answers <https://answers.ros.org/>`__ to see if someone else has asked your question or reported your issue.
+Next, check `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ to see if someone else has asked your question or reported your issue.
 
 If it has not been reported, feel free to open an issue in the appropriate repository tracker.
 If it's not clear which tracker to use for a particular issue, file it in the `ros2/ros2 repository <https://github.com/ros2/ros2/issues>`__ and we'll have a look at it.
@@ -106,7 +106,7 @@ This also applies to crossposting.
 Try to pick the forum which you think matches best and ask there.
 If you are referred to a new forum, provide a link to the old discussion.
 
-On https://answers.ros.org you can edit your question to provide more details.
+On `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ you can edit your question to provide more details.
 The more details that you include in your question the easier it is for others to help you find your solution which makes it more likely for you to get a response.
 
 It's considered bad form to list your personal deadlines; community members answering questions also have them.
@@ -122,7 +122,7 @@ Content, links, and images unrelated to the topic are considered spam.
 For commercial posts, see also `this discussion <https://discourse.ros.org/t/sponsorship-notation-in-posts-on-ros-org/2078>`_.
 
 Minimize references to content behind pay walls.
-The content posted on `ROS Discourse <https://discourse.ros.org/>`__ and `ROS Answers <https://answers.ros.org/>`__ should "generally" be free and open to all users.
+The content posted on `ROS Discourse <https://discourse.ros.org/>`__ and `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ should "generally" be free and open to all users.
 Links to content behind pay walls such as private journal articles, text books, and paid news websites, while helpful and relevant, may not be accessible to all users.
 Where possible primary sources should be free and open with paid content playing a supporting role.
 

--- a/source/How-To-Guides/Package-maintainer-guide.rst
+++ b/source/How-To-Guides/Package-maintainer-guide.rst
@@ -162,7 +162,7 @@ Responding to issues
 
 Package maintainers should also look at incoming issues on the repository and triage the problems that users are having.
 
-For issues that look like questions, the issue should be closed and the user redirected to https://answers.ros.org.
+For issues that look like questions, the issue should be closed and the user redirected to `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ .
 
 If an issue looks like a problem, but is not relevant to this particular repository, it should be moved to the appropriate repository with the GitHub "Transfer issue" button.
 

--- a/source/The-ROS2-Project/Roadmap.rst
+++ b/source/The-ROS2-Project/Roadmap.rst
@@ -63,4 +63,4 @@ Looking for something to work on, or just want to help out? Here are a few resou
 3. For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
 4. The core code for ROS 2 is in the `ros2 GitHub organization <https://github.com/ros2>`__.
 5. The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
-6. Questions should be asked on `ROS answers <https://answers.ros.org>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``{DISTRO}``.
+6. Questions should be asked on `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``{DISTRO}``.

--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -155,7 +155,7 @@ Check that variables like ``ROS_DISTRO`` and ``ROS_VERSION`` are set.
   ROS_DISTRO={DISTRO}
 
 If the environment variables are not set correctly, return to the ROS 2 package installation section of the installation guide you followed.
-If you need more specific help (because environment setup files can come from different places), you can `get answers <https://answers.ros.org>`__ from the community.
+If you need more specific help (because environment setup files can come from different places), you can `get answers <https://robotics.stackexchange.com/>`__ from the community.
 
 3.1 The ``ROS_DOMAIN_ID`` variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -11,7 +11,7 @@
             |
             <a href="http://status.ros.org/">Service Status</a>
             |
-            <a href="http://answers.ros.org/">Q&A answers.ros.org</a>
+            <a href="https://robotics.stackexchange.com/">Q&A Robotics Stack Exchange</a>
 
         </td>
       </tr>

--- a/source/index.rst
+++ b/source/index.rst
@@ -98,10 +98,10 @@ If you're interested in the advancement of the ROS 2 project:
 Other ROS resources
 -------------------
 
-* `ROS Answers <https://answers.ros.org/questions/>`__ (ROS 1, ROS 2)
+* `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ (ROS 1, ROS 2)
 
-  - Q&A community website, similar to `Stack Exchange <https://stackexchange.com/>`_
-  - See :ref:`Contact Page <Using ROS Answers>` for more information
+  - Community Q&A website.
+  - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
 
 * `ROS Enhancement Proposals (REPs) <https://ros.org/reps/rep-0000.html>`__ (ROS 1, ROS 2)
 
@@ -118,7 +118,7 @@ Other ROS resources
   - See which ROS distributions a package supports
   - Link to a package's repository, API documentation, or website
   - Inspect a package's license, build type, maintainers, status, and dependencies
-  - Get more info for a package on `ROS Answers <https://answers.ros.org/questions/>`__
+  - Get more info for a package on `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__
 
 * `ROS Prerelease <http://prerelease.ros.org/>`__ (ROS 1)
 


### PR DESCRIPTION
* The ROS Answers to Robotics Stack Exchange migration is imminent. 
* This pull request updates every instance where we refer to answers.ros.org. 
* The transition is scheduled for August 11th, 2023 and we should merge the PR on that day if possible. 