### PR TITLE
Update ROS Resources on Docs Index

### DIFF
--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -3,7 +3,7 @@
 Contact
 =======
 
-.. _Using Robotics Stack Overflow:
+.. _Using Robotics Stack Exchange:
 
 Support
 -------

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -3,7 +3,7 @@
 Contact
 =======
 
-.. _Using ROS Answers:
+.. _Using Robotics Stack Overflow:
 
 Support
 -------

--- a/source/index.rst
+++ b/source/index.rst
@@ -94,18 +94,18 @@ If you're interested in the advancement of the ROS 2 project:
 * :doc:`Marketing <The-ROS2-Project/Marketing>`
 
   - Downloadable marketing materials
+  - `Information about the ROS trademark <https://www.ros.org/blog/media/>`__
 
-Other ROS resources
--------------------
+ROS community resources
+-----------------------
 
-* `Robotics Stack Exchange - Q&A community website <https://robotics.stackexchange.com/>`__ . (ROS 1, ROS 2)
+If you need help, have an idea, or would like to contribute to the project, please visit our ROS community resources.
+
+* `Official ROS Discord Channel for discussion and support <https://discord.com/servers/open-robotics-1077825543698927656>`__ (ROS 1, ROS 2)
+
+* `Robotics Stack Exchange - community Q&A website <https://robotics.stackexchange.com/>`__ (ROS 1, ROS 2)
+
   - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
-
-* `Official ROS Discord Channel for discussion and support <https://discord.com/servers/open-robotics-1077825543698927656>`__ .(ROS 1, ROS 2)
-
-* `ROS Enhancement Proposals (REPs) <https://ros.org/reps/rep-0000.html>`__ (ROS 1, ROS 2)
-
-  - Proposals for new designs and conventions
 
 * `ROS Discourse <https://discourse.ros.org/>`__ (ROS 1, ROS 2)
 
@@ -119,6 +119,17 @@ Other ROS resources
   - Link to a package's repository, API documentation, or website
   - Inspect a package's license, build type, maintainers, status, and dependencies
   - Get more info for a package on `ROS Answers <https://answers.ros.org/questions/>`__
+
+* `ROS resource status page <https://status.openrobotics.org/>`__ (ROS 1, ROS 2)
+
+  - Check the current status of ROS resources like Discourse or the ROS build farm.
+
+Other resources
+^^^^^^^^^^^^^^^
+
+* `ROS Enhancement Proposals (REPs) <https://ros.org/reps/rep-0000.html>`__ (ROS 1, ROS 2)
+
+  - Proposals for new designs and conventions
 
 * `ROS Prerelease <http://prerelease.ros.org/>`__ (ROS 1)
 
@@ -139,13 +150,12 @@ Other ROS resources
 
   - ROS 1 and ROS 2 product landing page, with high-level description of ROS and links to other ROS sites
 
-* `Official Open Source Robotics Foundation Vimeo Channel <https://vimeo.com/osrfoundation>`__ (ROS 1, ROS 2)
+Events
+^^^^^^
+
+* `Official ROS Vimeo Channel <https://vimeo.com/osrfoundation>`__ (ROS 1, ROS 2)
 
   - Videos of ROSCon Talks, community and working group meetings, and project demos.
-
-* `ROS resource status page <https://status.openrobotics.org/>`__ (ROS 1, ROS 2)
-
-  - Check the current status of ROS resources like Discourse or the ROS build farm.
 
 * `ROSCon website <https://roscon.ros.org/>`__ (ROS 1, ROS 2)
 
@@ -164,10 +174,6 @@ Other ROS resources
 
 Miscellaneous
 ^^^^^^^^^^^^^
-* `Information about the ROS trademark <https://www.ros.org/blog/media/>`__
-
-* ROS 2 can be cited in an academic publication using `DOI: 10.1126/scirobotics.abm6074 <https://www.science.org/doi/10.1126/scirobotics.abm6074>`__
-
 * `Purchase official ROS swag <https://spring.ros.org/>`__
 
 * ROS on social media

--- a/source/index.rst
+++ b/source/index.rst
@@ -124,8 +124,8 @@ If you need help, have an idea, or would like to contribute to the project, plea
 
   - Check the current status of ROS resources like Discourse or the ROS build farm.
 
-Other resources
-^^^^^^^^^^^^^^^
+General ROS project resources
+-----------------------------
 
 * `ROS Enhancement Proposals (REPs) <https://ros.org/reps/rep-0000.html>`__ (ROS 1, ROS 2)
 
@@ -151,7 +151,7 @@ Other resources
   - ROS 1 and ROS 2 product landing page, with high-level description of ROS and links to other ROS sites
 
 Events
-^^^^^^
+------
 
 * `Official ROS Vimeo Channel <https://vimeo.com/osrfoundation>`__ (ROS 1, ROS 2)
 
@@ -173,7 +173,7 @@ Events
   - `Submit your events here <https://bit.ly/OSRFCommunityCalendar>`__ .
 
 Miscellaneous
-^^^^^^^^^^^^^
+-------------
 * `Purchase official ROS swag <https://spring.ros.org/>`__
 
 * ROS on social media
@@ -186,7 +186,7 @@ Miscellaneous
   - Tax deductible charitable donations to the Open Source Robotics Foundation can be sent via `DonorBox. <https://donorbox.org/support-open-robotics?utm_medium=qrcode&utm_source=qrcode>`__
 
 Deprecated
-^^^^^^^^^^
+----------
 * `ROS Answers <https://answers.ros.org/questions/>`__ (ROS 1, ROS 2)
 
   - ROS Answers was the ROS community Q&A website, until August, 2023. ROS Answers is currently available as a read-only resource.

--- a/source/index.rst
+++ b/source/index.rst
@@ -98,11 +98,10 @@ If you're interested in the advancement of the ROS 2 project:
 Other ROS resources
 -------------------
 
-* `Robotics Stack Exchange - Q&A community website.<https://robotics.stackexchange.com/>`__ (ROS 1, ROS 2)
+* `Robotics Stack Exchange - Q&A community website <https://robotics.stackexchange.com/>`__ . (ROS 1, ROS 2)
   - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
 
-* `Official ROS Discord Channel - Discussion and Support.<https://discord.com/servers/open-robotics-1077825543698927656>`__ (ROS 1, ROS 2)
-  - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
+* `Official ROS Discord Channel for discussion and support <https://discord.com/servers/open-robotics-1077825543698927656>`__ .(ROS 1, ROS 2)
 
 * `ROS Enhancement Proposals (REPs) <https://ros.org/reps/rep-0000.html>`__ (ROS 1, ROS 2)
 
@@ -146,35 +145,35 @@ Other ROS resources
 
 * `ROS resource status page <https://status.openrobotics.org/>`__ (ROS 1, ROS 2)
 
-- Check the current status of ROS resources like Discourse or the ROS build farm.
+  - Check the current status of ROS resources like Discourse or the ROS build farm.
 
-    * `ROSCon website <https://roscon.ros.org/>`__ (ROS 1, ROS 2)
+* `ROSCon website <https://roscon.ros.org/>`__ (ROS 1, ROS 2)
 
   - ROSCon is our annual ROS developer conference.
   - This page also lists regional ROS events like ROSConJP and ROSConFr.
 
-* `Open Source Robotics Foundation Official Events Calendar <https://calendar.google.com/calendar/u/0/embed?src=agf3kajirket8khktupm9go748@group.calendar.google.com&ctz=America/Los_Angeles>`__ 
+* `Open Source Robotics Foundation official events calendar <https://calendar.google.com/calendar/u/0/embed?src=agf3kajirket8khktupm9go748@group.calendar.google.com&ctz=America/Los_Angeles>`__ 
 
   - This calendar is for official OSRF Events and working group meetings.
-  - `Submit your events here.<https://bit.ly/OSRFCalendarForm>`__
+  - `Submit your events here <https://bit.ly/OSRFCalendarForm>`__.
 
-* `Open Source Robotics Foundation Community Calendar <https://calendar.google.com/calendar/embed?src=c_3fc5c4d6ece9d80d49f136c1dcd54d7f44e1acefdbe87228c92ff268e85e2ea0%40group.calendar.google.com&ctz=America%2FLos_Angeles>
+* `Open Source Robotics Foundation community calendar <https://calendar.google.com/calendar/embed?src=c_3fc5c4d6ece9d80d49f136c1dcd54d7f44e1acefdbe87228c92ff268e85e2ea0%40group.calendar.google.com&ctz=America%2FLos_Angeles>`__
 
   - This calendar is for unofficial ROS community events.
-  - `Submit your events here.<https://bit.ly/OSRFCommunityCalendar>`__
+  - `Submit your events here <https://bit.ly/OSRFCommunityCalendar>`__ .
 
 Miscellaneous
-^^^^^^^^^^
+^^^^^^^^^^^^^
 * `Information about the ROS trademark <https://www.ros.org/blog/media/>`__
 
-* ROS 2 can be cited in an academic publication using `DOI: 10.1126/scirobotics.abm6074<https://www.science.org/doi/10.1126/scirobotics.abm6074>`__
+* ROS 2 can be cited in an academic publication using `DOI: 10.1126/scirobotics.abm6074 <https://www.science.org/doi/10.1126/scirobotics.abm6074>`__
 
 * `Purchase official ROS swag <https://spring.ros.org/>`__
 
 * ROS on social media
 
-  - `@OpenRoboticsOrg<https://twitter.com/OpenRoboticsOrg>`__ and `@rosorg<https://twitter.com/ROSOrg>`__ on Twitter
-  - `Open Robotics on LinkedIn<https://www.linkedin.com/company/open-source-robotics-foundation>`__
+  - `@OpenRoboticsOrg <https://twitter.com/OpenRoboticsOrg>`__ and `@ROSOrg <https://twitter.com/ROSOrg>`__ on Twitter
+  - `Open Robotics on LinkedIn <https://www.linkedin.com/company/open-source-robotics-foundation>`__
 
 * Visit the `Open Source Robotics Foundation website <https://www.openrobotics.org/>`__
 
@@ -184,7 +183,7 @@ Deprecated
 ^^^^^^^^^^
 * `ROS Answers <https://answers.ros.org/questions/>`__ (ROS 1, ROS 2)
 
-  - ROS Answers was the ROS community Q&A website, until August,2023. The website is currently available as a read-only resource
+  - ROS Answers was the ROS community Q&A website, until August, 2023. ROS Answers is currently available as a read-only resource.
 
 * `ROS 2 Docs <https://docs.ros2.org>`_
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -152,7 +152,7 @@ Other ROS resources
   - ROSCon is our annual ROS developer conference.
   - This page also lists regional ROS events like ROSConJP and ROSConFr.
 
-* `Open Source Robotics Foundation official events calendar <https://calendar.google.com/calendar/u/0/embed?src=agf3kajirket8khktupm9go748@group.calendar.google.com&ctz=America/Los_Angeles>`__ 
+* `Open Source Robotics Foundation official events calendar <https://calendar.google.com/calendar/u/0/embed?src=agf3kajirket8khktupm9go748@group.calendar.google.com&ctz=America/Los_Angeles>`__
 
   - This calendar is for official OSRF Events and working group meetings.
   - `Submit your events here <https://bit.ly/OSRFCalendarForm>`__.

--- a/source/index.rst
+++ b/source/index.rst
@@ -131,11 +131,6 @@ General ROS project resources
 
   - Proposals for new designs and conventions
 
-* `ROS Prerelease <http://prerelease.ros.org/>`__ (ROS 1)
-
-  - Generates commands to emulate the `ROS Buildfarm <https://build.ros.org/>`_ on your local machine
-  - Currently only shows ROS 1 distributions
-
 * `ROS Robots <https://robots.ros.org/>`__ (ROS 1, ROS 2)
 
   - Showcases robots projects from the community

--- a/source/index.rst
+++ b/source/index.rst
@@ -98,10 +98,11 @@ If you're interested in the advancement of the ROS 2 project:
 Other ROS resources
 -------------------
 
-* `ROS Answers <https://answers.ros.org/questions/>`__ (ROS 1, ROS 2)
+* `Robotics Stack Exchange - Q&A community website.<https://robotics.stackexchange.com/>`__ (ROS 1, ROS 2)
+  - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
 
-  - Q&A community website, similar to `Stack Exchange <https://stackexchange.com/>`_
-  - See :ref:`Contact Page <Using ROS Answers>` for more information
+* `Official ROS Discord Channel - Discussion and Support.<https://discord.com/servers/open-robotics-1077825543698927656>`__ (ROS 1, ROS 2)
+  - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
 
 * `ROS Enhancement Proposals (REPs) <https://ros.org/reps/rep-0000.html>`__ (ROS 1, ROS 2)
 
@@ -139,8 +140,51 @@ Other ROS resources
 
   - ROS 1 and ROS 2 product landing page, with high-level description of ROS and links to other ROS sites
 
+* `Official Open Source Robotics Foundation Vimeo Channel <https://vimeo.com/osrfoundation>`__ (ROS 1, ROS 2)
+
+  - Videos of ROSCon Talks, community and working group meetings, and project demos.
+
+* `ROS resource status page <https://status.openrobotics.org/>`__ (ROS 1, ROS 2)
+
+- Check the current status of ROS resources like Discourse or the ROS build farm.
+
+    * `ROSCon website <https://roscon.ros.org/>`__ (ROS 1, ROS 2)
+
+  - ROSCon is our annual ROS developer conference.
+  - This page also lists regional ROS events like ROSConJP and ROSConFr.
+
+* `Open Source Robotics Foundation Official Events Calendar <https://calendar.google.com/calendar/u/0/embed?src=agf3kajirket8khktupm9go748@group.calendar.google.com&ctz=America/Los_Angeles>`__ 
+
+  - This calendar is for official OSRF Events and working group meetings.
+  - `Submit your events here.<https://bit.ly/OSRFCalendarForm>`__
+
+* `Open Source Robotics Foundation Community Calendar <https://calendar.google.com/calendar/embed?src=c_3fc5c4d6ece9d80d49f136c1dcd54d7f44e1acefdbe87228c92ff268e85e2ea0%40group.calendar.google.com&ctz=America%2FLos_Angeles>
+
+  - This calendar is for unofficial ROS community events.
+  - `Submit your events here.<https://bit.ly/OSRFCommunityCalendar>`__
+
+Miscellaneous
+^^^^^^^^^^
+* `Information about the ROS trademark <https://www.ros.org/blog/media/>`__
+
+* ROS 2 can be cited in an academic publication using `DOI: 10.1126/scirobotics.abm6074<https://www.science.org/doi/10.1126/scirobotics.abm6074>`__
+
+* `Purchase official ROS swag <https://spring.ros.org/>`__
+
+* ROS on social media
+
+  - `@OpenRoboticsOrg<https://twitter.com/OpenRoboticsOrg>`__ and `@rosorg<https://twitter.com/ROSOrg>`__ on Twitter
+  - `Open Robotics on LinkedIn<https://www.linkedin.com/company/open-source-robotics-foundation>`__
+
+* Visit the `Open Source Robotics Foundation website <https://www.openrobotics.org/>`__
+
+  - Tax deductible charitable donations to the Open Source Robotics Foundation can be sent via `DonorBox. <https://donorbox.org/support-open-robotics?utm_medium=qrcode&utm_source=qrcode>`__
+
 Deprecated
 ^^^^^^^^^^
+* `ROS Answers <https://answers.ros.org/questions/>`__ (ROS 1, ROS 2)
+
+  - ROS Answers was the ROS community Q&A website, until August,2023. The website is currently available as a read-only resource
 
 * `ROS 2 Docs <https://docs.ros2.org>`_
 


### PR DESCRIPTION
This pull requests 

* Adds ROS Discord, the ROS community calendars, ROS Vimeo channel and a few other resources to the wiki index page. 
* Adds a miscellaneous section to the index that includes trademark and citation information. 
* Lists ROS Answers as deprecated
* Updates a reference to refer to Stack Exchange, not ROS Answers. 