### PR TITLE
Add dark mode support

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -83,6 +83,7 @@ extensions = [
     'sphinx_tabs.tabs',
     'sphinx_rtd_theme',
     'sphinx_sitemap_ros',
+    'sphinx_rtd_dark_mode',
 ]
 
 # Intersphinx mapping
@@ -120,6 +121,9 @@ html_context = {
 templates_path = [
     "source/_templates",
 ]
+
+# user starts in light mode
+default_dark_mode = False
 
 # smv_tag_whitelist = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx-copybutton==0.4.0
 sphinx-multiversion==0.2.4
 sphinx-rtd-theme==1.0.0
 sphinx-tabs==3.2.0
+sphinx-rtd-dark-mode==1.2.4


### PR DESCRIPTION
This is a very simple change, just add this button in the bottom right corner:
![image](https://github.com/ros2/ros2_documentation/assets/30636259/f859a2ee-25ce-4c39-b3ca-eb66a330aaac)

And the dark mode page would look like this
![image](https://github.com/ros2/ros2_documentation/assets/30636259/b48291dc-0ed6-4816-9360-1bdd7e99fcda)
