### PR TITLE
Change representative of Canonical to Mirko Ferrati

### DIFF
--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -111,7 +111,7 @@ The current members of the ROS 2 TSC are (23 as of 2022-02-01):
         </tr>
         <tr class="tscclass">
           <td class="tscclass" align="center"><p><a class="reference internal" href="https://ubuntu.com"><img alt="Ubuntu logo" src="../_images/ubuntu.svg" style="height: 35px;" /></a></p></td>
-          <td class="tscclass" align="center"><p>Canonical: Jeremie Deray</p></td>
+          <td class="tscclass" align="center"><p>Canonical: Mirko Ferrati</p></td>
         </tr>
         <tr class="tscclass">
           <td class="tscclass" align="center"><p><a class="reference internal" href="https://eprosima.com"><img alt="eProsima logo" src="../_images/eprosima.svg" style="height: 35px;" /></a></p></td>


### PR DESCRIPTION
as announced in the TSC meeting on 17 August 2023