### PR TITLE
Changes to the Iron documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SOURCE     = source
 OUT        = build
 LINKCHECKDIR  = $(OUT)/linkcheck
-BUILD      = python3 -m sphinx
+BUILD      = python -m sphinx
 OPTS       =-c .
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SOURCE     = source
 OUT        = build
 LINKCHECKDIR  = $(OUT)/linkcheck
-BUILD      = python -m sphinx
+BUILD      = python3 -m sphinx
 OPTS       =-c .
 
 help:

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -222,7 +222,29 @@ The console will return the following message:
   * ``--symlink-install`` saves you from having to rebuild every time you tweak python scripts
   * ``--event-handlers console_direct+`` shows console output while building (can otherwise be found in the ``log`` directory)
 
-Once the build is finished, enter ``ls`` in the workspace root (``~/ros2_ws``) and you will see that colcon has created new directories:
+Once the build is finished, enter the command in the workspace root (``~/ros2_ws``):
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+        ls
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+        ls
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+        dir
+
+And you will see that colcon has created new directories:
 
 .. code-block:: console
 


### PR DESCRIPTION
I changed the command for checking the files after the building process in doc of [[Creating a workspace]](https://docs.ros.org/en/iron/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#:~:text=enter%20ls%20in%20the%20workspace%20root%20(~/ros2_ws)).

## For [5 Build the workspace with colcon](https://docs.ros.org/en/iron/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#build-the-workspace-with-colcon)
**Original:**
Used the `ls` command to list files.

**Modified:**
Now using `ls` for Linux and `dir` for Windows to list files.
