### PR TITLE
Change cite to literal text

### DIFF
--- a/source/Citations.rst
+++ b/source/Citations.rst
@@ -5,7 +5,7 @@ Citations
 
 If you use ROS 2 in your work please cite the 2022 Science Robotics paper `Robot Operating System 2: Design, architecture, and uses in the wild <https://www.science.org/doi/10.1126/scirobotics.abm6074>`_.
 
-S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, “Robot Operating System 2: Design, architecture, and uses in the wild,” Science Robotics vol. 7, May 2022.
+:samp:`S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, “Robot Operating System 2: Design, architecture, and uses in the wild,” Science Robotics vol. 7, May 2022.`
 
 .. code-block::
 
@@ -24,7 +24,7 @@ S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, “Robot Operating 
 
 If you use ROS 2 Composition in your work, please cite the 2023 IEEE RA-L paper `Impact of ROS 2 Node Composition in Robotic Systems <https://arxiv.org/abs/2305.09933>`_.
 
-S. Macenski, A. Soragna, M. Carroll, Z. Ge, “Impact of ROS 2 Node Composition in Robotic Systems”, IEEE Robotics and Autonomous Letters (RA-L), 2023.
+:samp:`S. Macenski, A. Soragna, M. Carroll, Z. Ge, “Impact of ROS 2 Node Composition in Robotic Systems”, IEEE Robotics and Autonomous Letters (RA-L), 2023.`
 
 .. code-block::
 

--- a/source/Citations.rst
+++ b/source/Citations.rst
@@ -5,7 +5,7 @@ Citations
 
 If you use ROS 2 in your work please cite the 2022 Science Robotics paper `Robot Operating System 2: Design, architecture, and uses in the wild <https://www.science.org/doi/10.1126/scirobotics.abm6074>`_.
 
-    | S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, “Robot Operating System 2: Design, architecture, and uses in the wild,” Science Robotics vol. 7, May 2022.
+    | S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, "Robot Operating System 2: Design, architecture, and uses in the wild," Science Robotics vol. 7, May 2022.
 
 .. code-block:: bibtex
 
@@ -24,7 +24,7 @@ If you use ROS 2 in your work please cite the 2022 Science Robotics paper `Robot
 
 If you use ROS 2 Composition in your work, please cite the 2023 IEEE RA-L paper `Impact of ROS 2 Node Composition in Robotic Systems <https://arxiv.org/abs/2305.09933>`_.
 
-    | S. Macenski, A. Soragna, M. Carroll, Z. Ge, “Impact of ROS 2 Node Composition in Robotic Systems”, IEEE Robotics and Autonomous Letters (RA-L), 2023.
+    | S. Macenski, A. Soragna, M. Carroll, Z. Ge, "Impact of ROS 2 Node Composition in Robotic Systems", IEEE Robotics and Autonomous Letters (RA-L), 2023.
 
 .. code-block:: bibtex
 

--- a/source/Citations.rst
+++ b/source/Citations.rst
@@ -5,13 +5,12 @@ Citations
 
 If you use ROS 2 in your work please cite the 2022 Science Robotics paper `Robot Operating System 2: Design, architecture, and uses in the wild <https://www.science.org/doi/10.1126/scirobotics.abm6074>`_.
 
-:samp:`S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, “Robot Operating System 2: Design, architecture, and uses in the wild,” Science Robotics vol. 7, May 2022.`
+    | S. Macenski, T. Foote, B. Gerkey, C. Lalancette, W. Woodall, “Robot Operating System 2: Design, architecture, and uses in the wild,” Science Robotics vol. 7, May 2022.
 
-.. code-block::
+.. code-block:: bibtex
 
-    @article{
-        doi:10.1126/scirobotics.abm6074,
-        author = {Steven Macenski  and Tully Foote  and Brian Gerkey  and Chris Lalancette  and William Woodall },
+    @article{doi:10.1126/scirobotics.abm6074,
+        author = {Steven Macenski and Tully Foote and Brian Gerkey and Chris Lalancette and William Woodall},
         title = {Robot Operating System 2: Design, architecture, and uses in the wild},
         journal = {Science Robotics},
         volume = {7},
@@ -22,15 +21,18 @@ If you use ROS 2 in your work please cite the 2022 Science Robotics paper `Robot
         URL = {https://www.science.org/doi/abs/10.1126/scirobotics.abm6074}
     }
 
+
 If you use ROS 2 Composition in your work, please cite the 2023 IEEE RA-L paper `Impact of ROS 2 Node Composition in Robotic Systems <https://arxiv.org/abs/2305.09933>`_.
 
-:samp:`S. Macenski, A. Soragna, M. Carroll, Z. Ge, “Impact of ROS 2 Node Composition in Robotic Systems”, IEEE Robotics and Autonomous Letters (RA-L), 2023.`
+    | S. Macenski, A. Soragna, M. Carroll, Z. Ge, “Impact of ROS 2 Node Composition in Robotic Systems”, IEEE Robotics and Autonomous Letters (RA-L), 2023.
 
-.. code-block::
+.. code-block:: bibtex
 
-    @article{
-        author = {Steven Macenski  and Alberto Soragna and Michael Carroll  and Zhenpeng Ge },
+    @article{doi:10.48550/arXiv.2305.09933,
+        author = {Steven Macenski and Alberto Soragna and Michael Carroll and Zhenpeng Ge},
         title = {Impact of ROS 2 Node Composition in Robotic Systems},
         journal = {IEEE Robotics and Autonomous Letters (RA-L)},
         year = {2023},
+        doi = {10.48550/arXiv.2305.09933},
+        URL = {https://arxiv.org/abs/2305.09933}
     }


### PR DESCRIPTION
Add `:samp` role to improve copy-paste (Before, Sphinx detected the `S.` for Steven Macenski as a numbered list)

Before:
![image](https://github.com/ros2/ros2_documentation/assets/30636259/78755ede-75d6-4528-bf0c-263d0ecf14e8)

Now:
![image](https://github.com/ros2/ros2_documentation/assets/30636259/245c9157-8fdf-49de-b66e-e5b479e0e0ee)