### PR TITLE
Remove mergify from action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: 
+      - '!mergify/bp/*'
+  pull_request:
+    branches: 
+      - '!mergify/bp/*'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,6 @@
 name: Test
 
-on: 
-  push:
-    branches: 
-      - '!mergify/bp/*'
-  pull_request:
-    branches: 
-      - '*'
+on: pull_request
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - '!mergify/bp/*'
   pull_request:
     branches: 
-      - '!mergify/bp/*'
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
I have made several contributions and have noticed that `Mergify` generates a new pull request for each backport branch. This leads to the GitHub action being triggered 8 times for every accepted pull request.

![image](https://github.com/ros2/ros2_documentation/assets/30636259/9c5c8949-b163-4d87-a887-d0294151a302)

Due to this issue, I suggest excluding the check from the triggers for branches that begin with `mergify/bp/`. By doing so, we can prevent 4 unnecessary executions (2 from Iron and 2 from Humble).

It would be beneficial to also implement a feature that disables triggering upon each branch merge.