### PR TITLE
Add instructions for debugging C++ tests in GDB when using colcon

### DIFF
--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -31,3 +31,19 @@ To see the exact test cases which fail, use the ``--verbose`` flag:
 .. code-block:: console
 
   colcon test-result --all --verbose
+
+Debugging tests with GDB
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a C++ test is failing, gdb can be used directly on the test executable in the build directory.
+Ensure to build the code in debug mode. Since the previous build type may be cached by CMake, clean the cache and rebuild.
+
+.. code-block:: console
+
+  colcon build --cmake-clean-cache --mixin debug
+
+Next, run the test directly through gdb. For example, with nav2's geometry utility:
+
+.. code-block:: console
+
+  gdb -ex run ./build/nav2_util/test/test_geometry_utils

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -48,4 +48,4 @@ For example, with nav2's geometry utility:
 
 .. code-block:: console
 
-  gdb -ex run ./build/nav2_util/test/test_geometry_utils
+  gdb -ex run ./build/rcl/test/test_logging

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -36,7 +36,8 @@ Debugging tests with GDB
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 If a C++ test is failing, gdb can be used directly on the test executable in the build directory.
-Ensure to build the code in debug mode. Since the previous build type may be cached by CMake, clean the cache and rebuild.
+Ensure to build the code in debug mode.
+Since the previous build type may be cached by CMake, clean the cache and rebuild.
 
 .. code-block:: console
 

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -43,7 +43,8 @@ Since the previous build type may be cached by CMake, clean the cache and rebuil
 
   colcon build --cmake-clean-cache --mixin debug
 
-Next, run the test directly through gdb. For example, with nav2's geometry utility:
+Next, run the test directly through gdb.
+For example, with nav2's geometry utility:
 
 .. code-block:: console
 

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -44,7 +44,7 @@ Since the previous build type may be cached by CMake, clean the cache and rebuil
   colcon build --cmake-clean-cache --mixin debug
 
 Next, run the test directly through gdb.
-For example, with nav2's geometry utility:
+For example:
 
 .. code-block:: console
 


### PR DESCRIPTION
This stack overflow wasn't answered, and I ran into the same issue. Here is my approach to debugging failed C++ tests with gdb. 
https://stackoverflow.com/questions/76589443/run-colcon-test-with-gdb-backtrack

Since `colcon` is lacking any [references on using gdb](https://github.com/search?q=org%3Acolcon%20gdb&type=code), we can add information to the ROS 2 tutorials.

