### PR TITLE
Add information for ROS 2 Rust Working Group

### DIFF
--- a/source/The-ROS2-Project/Governance/Working-Groups.rst
+++ b/source/The-ROS2-Project/Governance/Working-Groups.rst
@@ -169,10 +169,12 @@ Maritime (MaritimeWG)
 Rust (RustWG)
 ^^^^^^^^^^^^^
 
-* Lead(s): Jacob Hassold
+* Lead(s): Esteve Fernandez, Jacob Hassold, Nikolai Morin
 * Resources:
 
   * Discourse tag: `wg-rust <https://discourse.ros.org/tag/wg-rust>`_
+  * Matrix chat: `#Rust WG Room <https://matrix.to/#/!AiYXdTWExqamTdatBl:matrix.org?via=matrix.org&via=heyquark.com&via=c-base.org>`_
+  * Repository: `ros2-rust <https://github.com/ros2-rust/ros2_rust>`_
 
 SMACC (SMACCWG)
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds in the most up-to-date information about the ROS 2 Rust Working Group, including the current leaders (as of September 2023), the Matrix channel we use to communicate, and the ROS 2 Rust repository that we maintain.