### PR TITLE
Update About-Nodes.rst

### DIFF
--- a/source/Concepts/Basic/About-Nodes.rst
+++ b/source/Concepts/Basic/About-Nodes.rst
@@ -10,7 +10,7 @@ Nodes are typically the unit of computation in a ROS graph; each node should do 
 
 Nodes can :doc:`publish <About-Topics>` to named topics to deliver data to other nodes, or :doc:`subscribe <About-Topics>` to named topics to get data from other nodes.
 They can also act as a :doc:`service client <About-Services>` to have another node perform a computation on their behalf, or as a :doc:`service server <About-Services>` to provide functionality to other nodes.
-For long-running computations, a node can act as an :doc:`action server <About-Actions>` to perform it, or as an :doc:`action client <About-Actions>` to have another node perform it.
+For long-running computations, a node can act as an :doc:`action client <About-Actions>` to have another node perform it on their behalf, or as an :doc:`action server <About-Actions>` to provide functionality to other nodes.
 Nodes can provide configurable :doc:`parameters <About-Parameters>` to change behavior during run-time.
 
 Nodes are often a complex combination of publishers, subscribers, service servers, service clients, action servers, and action clients, all at the same time.

--- a/source/Concepts/Basic/About-Nodes.rst
+++ b/source/Concepts/Basic/About-Nodes.rst
@@ -10,7 +10,7 @@ Nodes are typically the unit of computation in a ROS graph; each node should do 
 
 Nodes can :doc:`publish <About-Topics>` to named topics to deliver data to other nodes, or :doc:`subscribe <About-Topics>` to named topics to get data from other nodes.
 They can also act as a :doc:`service client <About-Services>` to have another node perform a computation on their behalf, or as a :doc:`service server <About-Services>` to provide functionality to other nodes.
-For long-running computations, a node can act as an :doc:`action client <About-Actions>` to perform it, or as an :doc:`action server <About-Actions>` to have another node perform it.
+For long-running computations, a node can act as an :doc:`action server <About-Actions>` to perform it, or as an :doc:`action client <About-Actions>` to have another node perform it.
 Nodes can provide configurable :doc:`parameters <About-Parameters>` to change behavior during run-time.
 
 Connections between nodes are established through a distributed :doc:`discovery <About-Discovery>` process.

--- a/source/Concepts/Basic/About-Nodes.rst
+++ b/source/Concepts/Basic/About-Nodes.rst
@@ -13,4 +13,6 @@ They can also act as a :doc:`service client <About-Services>` to have another no
 For long-running computations, a node can act as an :doc:`action server <About-Actions>` to perform it, or as an :doc:`action client <About-Actions>` to have another node perform it.
 Nodes can provide configurable :doc:`parameters <About-Parameters>` to change behavior during run-time.
 
+Oftentimes, nodes are a complex combination of a bunch of things. A node can contain a combination of publishers, subscribers, service servers, service clients, action servers, and action clients, all at the same time and based on the required functionality, they can use the required feature.
+
 Connections between nodes are established through a distributed :doc:`discovery <About-Discovery>` process.

--- a/source/Concepts/Basic/About-Nodes.rst
+++ b/source/Concepts/Basic/About-Nodes.rst
@@ -13,6 +13,6 @@ They can also act as a :doc:`service client <About-Services>` to have another no
 For long-running computations, a node can act as an :doc:`action server <About-Actions>` to perform it, or as an :doc:`action client <About-Actions>` to have another node perform it.
 Nodes can provide configurable :doc:`parameters <About-Parameters>` to change behavior during run-time.
 
-Oftentimes, nodes are a complex combination of a bunch of things. A node can contain a combination of publishers, subscribers, service servers, service clients, action servers, and action clients, all at the same time and based on the required functionality, they can use the required feature.
+Nodes are often a complex combination of publishers, subscribers, service servers, service clients, action servers, and action clients, all at the same time.
 
 Connections between nodes are established through a distributed :doc:`discovery <About-Discovery>` process.


### PR DESCRIPTION
There is a discrepancy between the client-server definitions from here and their actual hyperlinks. We may need the same fix in Iron and other versions. 