### PR TITLE
[humble] Change link to composition_demo.launch.py

### DIFF
--- a/source/Tutorials/Intermediate/Composition.rst
+++ b/source/Tutorials/Intermediate/Composition.rst
@@ -194,7 +194,7 @@ Composition using launch actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 While the command line tools are useful for debugging and diagnosing component configurations, it is frequently more convenient to start a set of components at the same time.
-To automate this action, we can use a `launch file <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/launch/composition_demo_launch.py>`__:
+To automate this action, we can use a `launch file <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/composition/launch/composition_demo.launch.py>`__:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Use the older name, since that is what is shipped in Humble.

This will fix #3922 