### PR TITLE
Update Gazebo.rst

### DIFF
--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -138,7 +138,7 @@ There are two options:
 
        .. code-block:: console
 
-        ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/Twist "linear: { x: 0.1 }"
+        ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.1, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}"
 
 * ``teleop_twist_keyboard`` package. This node takes keypresses from the keyboard and publishes them as Twist messages. You can install it typing:
 


### PR DESCRIPTION
The topic pub command on line 141 does not work as written.

Updated the line to call the proper message and pass the correct arguments in YAML format.

old: ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/Twist "linear: { x: 0.1 }"

new: ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.1, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}"