### PR TITLE
Improve launch documentation

### DIFF
--- a/source/Concepts/Basic/About-Launch.rst
+++ b/source/Concepts/Basic/About-Launch.rst
@@ -4,15 +4,71 @@ Launch
 .. contents:: Table of Contents
    :local:
 
-A ROS 2 system typically consists of many nodes running across many different processes (and even different machines).
-While it is possible to run each of these nodes separately, it gets cumbersome quite quickly.
+Overview
+--------
 
-The launch system in ROS 2 is meant to automate the running of many nodes with a single command.
-It helps the user describe the configuration of their system and then executes it as described.
-The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS-specific conventions which make it easy to reuse components throughout the system by giving them each a different configuration.
-It is also responsible for monitoring the state of the processes launched, and reporting and/or reacting to changes in the state of those processes.
+A ROS 2 system typically consists of multiple :doc:`nodes <About-Nodes>` running across different processes (and even different machines).
+While it is possible to start each of these nodes manually, it can get cumbersome rather quickly.
+Automation is also non-trivial, even if existing tools for generic process control and configuration management are leveraged, let alone crafting it from first principles (e.g. proper OS process management using shell scripts or general purpose system programming languages can be tricky on its own).
 
-All of the above is specified in a launch file, which can be written in Python, XML, or YAML.
-This launch file can then be run using the ``ros2 launch`` command, and all of the nodes specified will be run.
+``launch`` provides the means to orchestrate the execution of ROS 2 systems, in ROS 2 terms.
+_Launch files_ describe the orchestration procedure, including but not limited to which nodes to run, how to run them, and which arguments to use for them.
+These descriptions are then executed, starting processes, monitoring them, reporting on their state, and even reacting to their behavior.
 
-The `design document <https://design.ros2.org/articles/roslaunch.html>`__ details the goal of the design of ROS 2's launch system (not all functionality is currently available).
+Moving parts
+------------
+
+``launch`` works with [_actions_](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.Action), abstract representations of computational procedures with side effects on its execution environment.
+Logging to standard output, executing a program, forcing a ``launch`` shutdown, are examples of actions.
+An action may also encompass another action or a collection thereof to describe more complex functionality.
+A collection of actions makes up the [_description_](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.LaunchDescription) of a procedure that ``launch`` can take and execute.
+These descriptions are typically read from [sources](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.LaunchDescriptionSource), so called _launch files_, which may be written in Python, or using specific XML or YAML syntax.
+
+While the extent of the execution environment of an action depends on its nature e.g. logging to standard output is circumscribed to the ``launch`` process whereas executing a program reaches out to the host operating system, ``launch`` maintains an execution [_context_](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.LaunchContext) in which these actions take place and through which these can interact between them and with the user.
+The ``launch`` context holds _configuration variables_ and propagates _events_, both of which are available to actions and to ``launch`` itself:
+
+* Configuration variables populate the ``launch`` context as shared state.
+  It is as configuration variables, for example, that arguments to ``launch`` descriptions are made available.
+  Configuration variables are organized in scopes with visibility and persistence implications.
+  These scopes are, however, not implicitly managed by the ``launch`` context but explicitly defined through [pushing](https://docs.ros.org/en/rolling/p/launch/launch.actions.html#launch.actions.PushLaunchConfigurations) and [popping](https://docs.ros.org/en/rolling/p/launch/launch.actions.html#launch.actions.PopLaunchConfigurations) actions.
+  In general and by default, all configuration variables live in the same scope.
+
+* [Events](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.Event) are signals emitted and reacted on by actions or ``launch`` itself.
+  An action completing, a process exiting, ``launch`` shutting down, are examples of events.
+  These signals have no inherent side effects, only those that result from actions handling them (if any).
+  Events only exist within the ``launch`` context, but are not bound to any scopes.
+
+Actions and events are the main moving parts in ``launch``, even if events are used indirectly more often than not (i.e. it is through events that the ``launch`` internal event loop is driven).
+In addition to these, and to better leverage configuration variables, ``launch`` defines _conditions_, _substitutions_, and _event handlers_:
+
+* [Conditions](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.Condition) encapsulate boolean predicates evaluated in ``launch`` context, and therefore in runtime.
+  These are mainly used to define actions that execute _if_ or _unless_ a given boolean predicate turns out to be true.
+* [Substitutions](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.Substitution) are string interpolation expressions evaluated in ``launch`` context, though these may also tap into the larger execution environment.
+  Evaluating a configuration variable value, fetching an environment variable value, retrieving the absolute path in the filesystem of an executable file, are examples of substitutions.
+  Substitutions are the closest to general purpose expressions in ``launch``, enabling dynamic ``launch`` descriptions.
+* [Event handlers](https://docs.ros.org/en/rolling/p/launch/launch.html#launch.EventHandler) are similar to actions, but their execution is bound to the occurrence of an specific set of events.
+  These are typically defined in terms of a collection of actions to execute when and if a matching event occurs.
+
+In a way, ``launch`` descriptions are analogous to programs in a domain specific language tailored for process orchestration, and, in particular, ROS 2 system orchestration. When composed using the building blocks available in its native Python implementation, these descriptions resemble `ASTs <https://en.wikipedia.org/wiki/Abstract_syntax_tree>`_ in procedural programming languages. The analogy has its limits, however: context is not implicitly restricted to syntactical boundaries like it would for typical variable scopes, and action execution is naturally concurrent as opposed to sequential, to name a few. However, it does bring about an important distinction that is easy to miss when writing launch files in Python: no action nor condition nor substitution carries out a computation upon instantiation but simply specifies a computation to be carried out in runtime.
+
+.. note::
+
+    A simple mental model to reason about Python launch files is one of two phases: a configuration phase, during which the description is fully constructed, and an execution phase, during which ``launch`` executes based on the provided description until shutdown.
+
+Practical aspects
+-----------------
+
+* Launch files can be written in Python, XML, or YAML.
+  XML and YAML launch files keep it simple and avoid the confusion that a domain specific language embedded in a general purpose programming language may bring, but the flexibility and complexity that Python launch files afford may sometimes be useful if not necessary.
+  Refer to the examples in the :doc:`../../How-To-Guides/Launch-file-different-formats` guide on how to write launch files.
+* Launch files can include other launch files, written in any of the supported languages, for modular system description and component reuse.
+* Launch files, written in any of the supported languages, can be run using the ``ros2 launch`` command, which also can take their arguments.
+  Note the difference with the ``ros2 run`` command, which works with executables installed by ROS 2 packages, not launch files.
+* Most of ``launch`` infrastructure lives in the ``launch`` Python package, but ROS 2 specifics live in the ``launch_ros`` Python package.
+
+References
+----------
+
+The most thorough reference on the design of ``launch`` is, unsurprisingly, its seminal `design document <https://design.ros2.org/articles/roslaunch.html>`__ (which even includes functionality not yet available).
+[``launch`` documentation](https://docs.ros.org/en/rolling/p/launch) complements it, detailing the architecture of the core Python library.
+For everything else, both ``launch`` and ``launch_ros`` APIs are documented.

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -10,12 +10,809 @@ Using Python, XML, and YAML for ROS 2 Launch Files
    :local:
 
 ROS 2 launch files can be written in Python, XML, and YAML.
-This guide shows how to use these different formats to accomplish the same task, as well as has some discussion on when to use each format.
+This guide shows how to use these different formats to accomplish the same task.
+It also discusses when to use each format.
 
-Launch file examples
+Primer on running launch files
+------------------------------
+
+Launching
+^^^^^^^^^
+
+Any of the example launch files can be run with ``ros2 launch``.
+To try them locally, you can either create a new package and use
+
+.. code-block:: console
+
+  ros2 launch <package_name> <launch_file_name>
+
+or run the file directly by specifying the path to the launch file
+
+.. code-block:: console
+
+  ros2 launch <path_to_launch_file>
+
+Setting arguments
+^^^^^^^^^^^^^^^^^
+
+To set the arguments that are passed to the launch file, you should use ``key:=value`` syntax.
+For example, you can set the value of argument ``arg`` in the following way:
+
+.. code-block:: console
+
+  ros2 launch <package_name> <launch_file_name> arg:=value
+
+or
+
+.. code-block:: console
+
+  ros2 launch <path_to_launch_file> arg:=value
+
+Example launch files
 --------------------
 
-Below is a launch file implemented in Python, XML, and YAML.
+Taking arguments
+^^^^^^^^^^^^^^^^
+
+Each launch file performs the following actions:
+
+* Declares arguments with and without defaults.
+* Logs a message that uses those arguments.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_taking_arguments_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import LogInfo
+        from launch.substitutions import LaunchConfiguration
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('who'),
+                DeclareLaunchArgument('where', default_value='home'),
+
+                LogInfo(msg=[LaunchConfiguration('who'), ' is at ', LaunchConfiguration('where')])
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- example_taking_arguments_launch.xml -->
+
+        <launch>
+            <arg name="who"/>
+            <arg name="where" default="home"/>
+
+            <log message="$(var who) is at $(var where)"/>
+        </launch>
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # example_taking_arguments_launch.yaml
+
+        launch:
+        - arg:
+            name: "who"
+        - arg:
+            name: "where"
+            default: "home"
+        - log:
+            message: "$(var who) is at $(var where)"
+
+On execution, availability of the ``who`` argument is enforced, while for the ``where`` argument its default applies if not provided.
+Then, a message is logged after both arguments are substituted against the current context (holding their values).
+
+This can be reproduced with a local copy of any of these launch files e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_taking_arguments_launch.xml
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [ERROR] [launch]: Caught exception in launch (see debug for traceback): Included launch description missing required argument 'who' (description: 'no description given'), given: []
+
+.. code-block:: shell
+
+    $ ros2 launch example_taking_arguments_launch.xml who:=someone
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [launch.user]: someone is at home
+
+.. code-block:: shell
+
+    $ ros2 launch example_taking_arguments_launch.xml who:=someone where:="the movies"
+
+    [INFO] [launch]: All log files can be found below ...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [launch.user]: someone is at the movies
+
+Requiring processes
+^^^^^^^^^^^^^^^^^^^
+
+Each launch file performs the following actions:
+
+* Declares an argument with defaults.
+* Sleeps for some time, then shuts down launch.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_requiring_processes_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import ExecuteProcess
+        from launch.actions import LogInfo
+        from launch.actions import Shutdown
+        from launch.substitutions import LaunchConfiguration
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('sleep_duration', default_value='10', description='Time to sleep, in seconds'),
+                ExecuteProcess(
+                    cmd=['sleep', LaunchConfiguration('sleep_duration')],
+                    on_exit=[
+                        LogInfo(msg='Done sleeping!'),
+                        Shutdown(reason='main process terminated')
+                    ]
+                ),
+                LogInfo(msg=['Sleeping for ', LaunchConfiguration('sleep_duration'), ' seconds']),
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- Currently unsupported -->
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # Currently unsupported
+
+On execution, availability of the ``sleep_duration`` argument is enforced, applying its default value if necessary.
+Then, a ``sleep`` command is started to wait for as long as ``sleep_duration`` specifies.
+Additionally, when this command exits, a shutdown is initiated.
+Until then (or user interrupt), ``launch`` remain idle.
+
+This can be reproduced with a local copy of the Python launch file (XML and YAML launch files cannot describe this example yet) e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_requiring_processes_launch.py
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [launch.user]: Sleeping for 10 seconds
+    [INFO] [sleep-1]: process started with pid [NNNNNN]
+    [INFO] [sleep-1]: process has finished cleanly [pid NNNNNN]
+    [INFO] [launch.user]: Done sleeping!
+    [INFO] [launch]: process[sleep-1] was required: shutting down launched system
+
+Replicating hierarchies
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Each launch file performs the following actions:
+
+* Declares an argument without defaults.
+* Generates multiple namespaced groups of nodes based on that argument.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_replicating_hierarchies_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import GroupAction
+        from launch.actions import OpaqueFunction
+        from launch.substitutions import LaunchConfiguration
+        from launch_ros.actions import Node
+        from launch_ros.actions import PushRosNamespace
+
+        def generate_turtles_description(context, turtles):
+            return [
+                GroupAction(
+                    actions=[
+                        PushRosNamespace(turtle_name),
+                        Node(
+                            package='turtlesim',
+                            executable='turtlesim_node',
+                            output='screen')
+                    ]
+                )
+                for turtle_name in turtles.perform(context).split()
+            ]
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('turtles', description='A space-separated list of turtle names'),
+                OpaqueFunction(
+                    function=generate_turtles_description,
+                    args=[LaunchConfiguration('turtles')])
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- Currently unsupported -->
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # Currently unsupported
+
+On execution, availability of the ``turtles`` argument is first enforced.
+Then, the ``generate_turtles_description`` Python function is invoked with both the current context and the ``turtles`` configuration variable as arguments.
+This function has no side effect -- it is used as a escape hatch to dynamically extend the ``launch`` description.
+To do so, it evaluates the ``turtles`` configuration variable in context and, assuming it is a spaced-separated list of turtle names, it produces a group per turtle.
+Each group sets the corresponding turtle name as namespace for all ROS 2 nodes within and starts a ``turtlesim`` node.
+
+This can be reproduced with a local copy of the Python launch file (XML and YAML launch files cannot describe this example yet) e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_replicating_hierarchies_launch.py turtles:="alice bob"
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [turtlesim_node-1]: process started with pid [NNNNNN]
+    [INFO] [turtlesim_node-2]: process started with pid [NNNNNN]
+    [turtlesim_node-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [alice.turtlesim]: Starting turtlesim with node name /alice/turtlesim
+    [turtlesim_node-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [bob.turtlesim]: Starting turtlesim with node name /bob/turtlesim
+    [turtlesim_node-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [bob.turtlesim]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
+    [turtlesim_node-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [alice.turtlesim]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
+
+A pair of ``turtlesim`` windows will pop up: one for ``alice``, one for ``bob``.
+
+Cleaning after
+^^^^^^^^^^^^^^
+
+Each launch file performs the following actions:
+
+* Declares an argument without defaults.
+* Registers an action to execute on shutdown.
+* Forces shutdown after a time specified by the argument.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_cleaning_after_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import ExecuteProcess
+        from launch.actions import RegisterEventHandler
+        from launch.actions import Shutdown
+        from launch.actions import TimerAction
+        from launch.event_handlers import OnShutdown
+        from launch.substitutions import LaunchConfiguration
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('timeout', description='Timeout before shutdown, in seconds'),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    ExecuteProcess(cmd=['rm', '-f', '/tmp/resource']),
+                ])),
+                ExecuteProcess(cmd=['touch', '/tmp/resource']),
+                TimerAction(period=LaunchConfiguration('timeout'), actions=[
+                    Shutdown(reason='launch timed out!')
+                ])
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- Currently unsupported -->
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # Currently unsupported
+
+On execution, availability of the ``timeout`` argument is enforced first.
+Then, an ``rm -f`` command to drop a temporary ``/tmp/resource`` file is registered for execution upon shutdown.
+That temporary file is created by a ``touch`` command initiated right after.
+A ``launch`` shutdown is finally scheduled to occur after ``timeout`` seconds.
+
+This can be reproduced with a local copy of the Python launch file (XML and YAML launch files cannot describe this example yet) e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_cleaning_after_launch.py timeout:=5
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [touch-1]: process started with pid [NNNNNN]
+    [INFO] [touch-1]: process has finished cleanly [pid NNNNNN]
+    # ...and after 5 seconds
+    [INFO] [rm-2]: process started with pid [NNNNNN]
+    [INFO] [rm-2]: process has finished cleanly [pid NNNNNN]
+
+Configuring nodes
+^^^^^^^^^^^^^^^^^
+
+Each talker launch file performs the following actions:
+
+* Declares an argument without defaults.
+* Starts a talker node, passing command line arguments to it.
+
+Each example launch file performs the following actions:
+
+* Declares an argument with defaults.
+* Forces a name remapping on all nodes.
+* Includes the talker launch file with a given argument.
+* Starts a listener node.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # talker_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import Shutdown
+        from launch.substitutions import LaunchConfiguration
+        from launch_ros.actions import Node
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('cycles', description='number of times to talk'),
+                Node(
+                    package='demo_nodes_py', executable='talker_qos', output='screen',
+                    arguments=['--reliable', '-n', LaunchConfiguration('cycles')]),
+            ])
+
+    .. code-block:: python
+
+        # example_configuring_nodes_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import IncludeLaunchDescription
+        from launch.substitutions import LaunchConfiguration
+        from launch_ros.actions import Node
+        from launch_ros.actions import SetRemap
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('shared_topic' default_value='chat'),
+                SetRemap('chatter', dst=LaunchConfiguration('shared_topic')),
+                IncludeLaunchDescription('talker_launch.py', launch_arguments=[('cycles', '10')]),
+                Node(package='demo_nodes_py', executable='listener', output='screen')
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- talker_launch.xml -->
+
+        <launch>
+            <arg name="cycles" description="number of times to talk"/>
+            <node pkg="demo_nodes_py" exec="talker_qos" args="--reliable -n $(var cycles)" output="screen"/>
+        </launch>
+
+      .. code-block:: xml
+
+        <!-- example_configuring_nodes_launch.py -->
+
+        <launch>
+            <arg name="shared_topic" default="chat"/>
+            <set_remap from="chatter" to="$(var shared_topic)"/>
+            <include file="talker_launch.xml">
+                <arg name="cycles" value="10"/>
+            </include>
+            <node pkg="demo_nodes_py" exec="listener" output="screen"/>
+        </launch>
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # talker_launch.yaml
+
+        launch:
+        - arg:
+            name: "cycles"
+            description: "number of times to talk"
+        - node:
+            pkg: "demo_nodes_py"
+            exec: "talker_qos"
+            args: "--reliable -n $(var cycles)"
+            output: "screen"
+
+      .. code-block:: yaml
+
+        # example_configuring_nodes_launch.yaml
+
+        launch:
+        - arg:
+            name: "shared_topic"
+            default: "chat"
+        - set_remap:
+            from: "chatter"
+            to: "$(var shared_topic)"
+        - include:
+            file: "talker_launch.yaml"
+            arg:
+            - name: "cycles"
+              value: "10"
+        - node:
+            pkg: "demo_nodes_py"
+            exec: "listener"
+            output: "screen"
+
+On execution, availability of the ``shared_topic`` argument is enforced, applying defaults if necessary.
+Then, a remapping rule for the ``chatter`` topic is applied globally, to all nodes in the launch file.
+The talker launch file is included, providing a value for the ``cycles`` argument.
+This ``cycles`` argument is passed as the number of talking cycles for the talker node on start.
+Finally, a listener node is started.
+
+This can be reproduced with a local copy of any of the launch file sets e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_configuring_nodes_launch.yaml
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [talker_qos-1]: process started with pid [NNNNNN]
+    [INFO] [listener-2]: process started with pid [NNNNNN]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Reliable talker
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 0"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 0]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 1"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 1]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 2"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 2]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 3"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 3]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 4"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 4]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 5"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 5]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 6"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 6]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 7"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 7]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 8"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 8]
+    [talker_qos-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker_qos]: Publishing: "Hello World: 9"
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 9]
+    [INFO] [talker_qos-1]: process has finished cleanly [pid NNNNNN]
+
+Switching modes
+^^^^^^^^^^^^^^^
+
+Each launch file performs the following actions:
+
+* Declares a boolean argument, false by default.
+* Starts talker and a listener composable nodes if the argument is true.
+* Starts talker and a listener nodes if the argument is false.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_switching modes_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import GroupAction
+        from launch.actions import IncludeLaunchDescription
+        from launch.actions import LogInfo
+        from launch.conditions import IfCondition
+        from launch.conditions import UnlessCondition
+        from launch.substitutions import LaunchConfiguration
+        from launch_ros.actions import Node
+        from launch_ros.actions import ComposableNodeContainer
+        from launch_ros.descriptions import ComposableNode
+        from launch_ros.substitutions import FindPackagePrefix
+
+        def generate_launch_description():
+            return LaunchDescription([
+                DeclareLaunchArgument('use_composition', default_value='false'),
+                GroupAction(
+                    condition=IfCondition(LaunchConfiguration('use_composition')),
+                    actions=[
+                        LogInfo(msg='Running talker and listener composable nodes in the same process'),
+                        LogInfo(msg=["Components taken from the 'composition' package (in ", FindPackagePrefix('composition'), ")"]),
+                        ComposableNodeContainer(
+                            package='rclcpp_components',
+                            executable='component_container',
+                            name='container',
+                            namespace='/',
+                            output='screen',
+                            composable_node_descriptions=[
+                                ComposableNode(package='composition', plugin='composition::Talker', name='talker'),
+                                ComposableNode(package='composition', plugin='composition::Listener', name='listener')
+                            ]
+                        ),
+                    ]
+                ),
+                GroupAction(
+                    condition=UnlessCondition(LaunchConfiguration('use_composition')),
+                    actions=[
+                        LogInfo(msg='Running talker and listener nodes in separate processes'),
+                        LogInfo(msg=["Nodes taken from the 'demo_nodes_cpp' package (in ", FindPackagePrefix('demo_nodes_cpp'), ")"]),
+                        Node(package='demo_nodes_cpp', executable='talker', name='talker', output='screen'),
+                        Node(package='demo_nodes_cpp', executable='listener', name='listener', output='screen')
+                    ]
+                )
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- example_switching modes_launch.xml -->
+
+        <launch>
+            <arg name="use_composition" default="false"/>
+            <group if="$(var use_composition)">
+                <log message="Running talker and listener composable nodes in the same process"/>
+                <log message="Components taken from the 'composition' package in $(find-pkg-prefix composition)"/>
+                <node_container pkg="rclcpp_components" exec="component_container" name="container" namespace="/" output="screen">
+                    <composable_node pkg="composition" plugin="composition::Talker" name="talker"/>
+                    <composable_node pkg="composition" plugin="composition::Listener" name="listener"/>
+                </node_container>
+            </group>
+            <group unless="$(var use_composition)">
+                <log message="Running talker and listener nodes in separate processes"/>
+                <log message="Nodes taken from the 'demo_nodes_cpp' package in $(find-pkg-prefix demo_nodes_cpp)"/>
+                <node pkg="demo_nodes_cpp" exec="talker" name="talker" output="screen"/>
+                <node pkg="demo_nodes_cpp" exec="listener" name="listener" output="screen"/>
+            </group>
+        </launch>
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # example_switching_modes_launch.yaml
+
+        launch:
+        - arg:
+            name: "use_composition"
+            default: "false"
+        - group:
+            if: "$(var use_composition)"
+            children:
+              - log:
+                  message: "Running talker and listener composable nodes in the same process"
+              - log:
+                  message: "Components taken from the 'composition' package in $(find-pkg-prefix composition)"
+              - node_container:
+                  pkg: "rclcpp_components"
+                  exec: "component_container"
+                  name: "container"
+                  namespace: "/"
+                  output: "screen"
+                  composable_node:
+                    - pkg: "composition"
+                      plugin: "composition::Talker"
+                      name: "talker"
+                    - pkg: "composition"
+                      plugin: "composition::Listener"
+                      name: "listener"
+        - group:
+            unless: "$(var use_composition)"
+            children:
+              - log:
+                  message: "Running talker and listener nodes in separate processes"
+              - log:
+                  message: "Nodes taken from the 'demo_nodes_cpp' package in $(find-pkg-prefix demo_nodes_cpp)"
+              - node:
+                  pkg: "demo_nodes_py"
+                  exec: "talker"
+                  name: "talker"
+                  output: "screen"
+              - node:
+                  pkg: "demo_nodes_py"
+                  exec: "listener"
+                  name: "listener"
+                  output: "screen"
+
+On execution, availability of the ``use_composition`` argument is enforced, applying defaults if necessary.
+If ``use_composition`` is true, talker and listener composable nodes are started in a component container.
+If ``use_composition`` is false, talker and listener nodes are started in their own processes.
+In both cases, informational logs are produced.
+
+This can be reproduced with a local copy of any of the launch file sets e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_switching_modes_launch.xml
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [launch.user]: Running talker and listener nodes in separate processes
+    [INFO] [launch.user]: Nodes taken from the 'demo_nodes_cpp' package in /opt/ros/...
+    [INFO] [talker-1]: process started with pid [NNNNNN]
+    [INFO] [listener-2]: process started with pid [NNNNNN]
+    [talker-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker]: Publishing: 'Hello World: 1'
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 1]
+    # ... and on and on
+
+.. code-block:: console
+
+    $ ros2 launch example_switching_modes_launch.xml use_composition:=true
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [launch.user]: Running talker and listener composable nodes in the same process
+    [INFO] [launch.user]: Components taken from the 'composition' package in /opt/ros/...
+    [INFO] [component_container-1]: process started with pid [NNNNNN]
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [container]: Load Library: /opt/ros/humble/lib/libtalker_component.so
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [container]: Found class: rclcpp_components::NodeFactoryTemplate<composition::Talker>
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<composition::Talker>
+    [INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/talker' in container '/container'
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [container]: Load Library: /opt/ros/humble/lib/liblistener_component.so
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [container]: Found class: rclcpp_components::NodeFactoryTemplate<composition::Listener>
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<composition::Listener>
+    [INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/listener' in container '/container'
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker]: Publishing: 'Hello World: 1'
+    [component_container-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 1]
+    # ... and on and on
+
+Managing lifecycles
+^^^^^^^^^^^^^^^^^^^
+
+Each launch file performs the following actions:
+
+* Registers a custom event handler to manage lifecycles synchronously.
+* Starts talker and listener managed nodes.
+
+Note this is a significantly more complex example, effectively extending ``launch`` to achieve its goal.
+For further reference on managed nodes, see :doc:`../Tutorials/Demos/Managed-Nodes`.
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_managing_lifecycles_launch.py
+
+        from launch import LaunchDescription
+        from launch.actions import RegisterEventHandler
+        from launch.actions import EmitEvent
+        from launch.event_handler import BaseEventHandler
+        from launch.events import Shutdown
+        from launch.events import matches_action
+        from launch.events.process import ProcessStarted
+        from launch_ros.actions import LifecycleNode
+        from launch_ros.events.lifecycle import ChangeState
+        from launch_ros.events.lifecycle import StateTransition
+
+        import lifecycle_msgs.msg
+
+        class LifecycleManager(BaseEventHandler):
+
+            BRINGUP_SEQUENCE = {
+                lifecycle_msgs.msg.State.PRIMARY_STATE_UNCONFIGURED: lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                lifecycle_msgs.msg.State.PRIMARY_STATE_INACTIVE: lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE
+            }
+
+            def __init__(self, nodes):
+                # Track the state of all managed nodes in a dictionary.
+                self.managees = {node: lifecycle_msgs.msg.State.PRIMARY_STATE_UNKNOWN for node in nodes}
+                # Configure event matcher to handle both process start and state transition events from all managed nodes.
+                matcher = (lambda event: (
+                    isinstance(event, (ProcessStarted, StateTransition)) and event.action in self.managees))
+                super().__init__(matcher=matcher)
+
+            def handle(self, event, context):
+                if isinstance(event, ProcessStarted):  # node just started, unconfigured
+                    self.managees[event.action] = lifecycle_msgs.msg.State.PRIMARY_STATE_UNCONFIGURED
+                if isinstance(event, StateTransition):  # node changed state, track it
+                    self.managees[event.action] = event.msg.goal_state.id
+                states = list(set(self.managees.values()))
+                common_state = states[0] if len(states) == 1 else None
+                if common_state in self.BRINGUP_SEQUENCE:
+                    # all managed nodes have reached the same state and the bringup sequence is not complete
+                    matcher = lambda action: action in self.managees
+                    # trigger state transitions for all managed nodes to next state in the bringup sequence
+                    return [
+                        EmitEvent(event=ChangeState(
+                            lifecycle_node_matcher=matcher,
+                            transition_id=self.BRINGUP_SEQUENCE[common_state]))]
+                return None  # do nothing
+
+        def generate_launch_description():
+            first_talker_node = LifecycleNode(
+                package='lifecycle', executable='lifecycle_talker',
+                name='first_talker', namespace='', output='screen')
+            second_talker_node = LifecycleNode(
+                package='lifecycle', executable='lifecycle_talker',
+                name='second_talker', namespace='', output='screen')
+            listener_node = LifecycleNode(
+                package='lifecycle', executable='lifecycle_listener',
+                name='listener', namespace='', output='screen',
+                remappings=[('/lc_talker/transition_event',
+                             '/first_talker/transition_event')])
+            manager = LifecycleManager([first_talker_node, second_talker_node])
+            return LaunchDescription([
+                RegisterEventHandler(manager),
+                first_talker_node, second_talker_node, listener_node
+            ])
+
+   .. group-tab:: XML
+
+      .. code-block:: xml
+
+        <!-- Currently unsupported -->
+
+   .. group-tab:: YAML
+
+      .. code-block:: yaml
+
+        # Currently unsupported
+
+During configuration, a ``LifecycleManager`` event handler is instantiated, taking references to both talker nodes.
+On execution, the ``LifecycleManager`` event handler is registered and all nodes are started.
+The ``LifecycleManager`` event handler then takes care of managing both talker nodes from the unconfigured state
+through the configured state and to the active state.
+
+This can be reproduced with a local copy of the Python launch file (``launch`` cannot be extended like this in XML and YAML launch files) e.g.:
+
+.. code-block:: console
+
+    $ ros2 launch example_managing_lifecycles_launch.py
+
+    [INFO] [launch]: All log files can be found below /...
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [lifecycle_talker-1]: process started with pid [NNNNNN]
+    [INFO] [lifecycle_talker-2]: process started with pid [NNNNNN]
+    [INFO] [lifecycle_listener-3]: process started with pid [NNNNNN]
+    [lifecycle_listener-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: notify callback: Transition from state unconfigured to configuring
+    [lifecycle_listener-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: notify callback: Transition from state configuring to inactive
+    [lifecycle_talker-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [first_talker]: on_configure() is called.
+    [lifecycle_talker-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [second_talker]: on_configure() is called.
+    [lifecycle_talker-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [second_talker]: on_activate() is called.
+    [lifecycle_talker-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [first_talker]: on_activate() is called.
+    [lifecycle_listener-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: notify callback: Transition from state inactive to activating
+    [lifecycle_talker-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [second_talker]: Lifecycle publisher is active. Publishing: [Lifecycle HelloWorld #1]
+    [lifecycle_listener-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: data_callback: Lifecycle HelloWorld #1
+    [lifecycle_talker-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [first_talker]: Lifecycle publisher is active. Publishing: [Lifecycle HelloWorld #1]
+    [lifecycle_listener-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: notify callback: Transition from state activating to active
+    [lifecycle_listener-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: data_callback: Lifecycle HelloWorld #1
+    # ... and on and on until user interruption
+
+Launching many nodes
+^^^^^^^^^^^^^^^^^^^^
+
 Each launch file performs the following actions:
 
 * Setup command line arguments with defaults
@@ -31,7 +828,7 @@ Each launch file performs the following actions:
 
       .. code-block:: python
 
-        # example_launch.py
+        # example_many_nodes_launch.py
 
         import os
 
@@ -175,7 +972,7 @@ Each launch file performs the following actions:
 
       .. code-block:: xml
 
-        <!-- example_launch.xml -->
+        <!-- example_many_nodes_launch.xml -->
 
         <launch>
 
@@ -228,7 +1025,7 @@ Each launch file performs the following actions:
 
       .. code-block:: yaml
 
-        # example_launch.yaml
+        # example_many_nodes_launch.yaml
 
         launch:
 
@@ -315,50 +1112,47 @@ Each launch file performs the following actions:
                 from: "/output/cmd_vel"
                 to: "/turtlesim2/turtle1/cmd_vel"
 
-Using the Launch files from the command line
---------------------------------------------
+On execution, availability of background color and chatter namespace arguments is enforced, applying defaults if necessary.
+Then, talker-listener pairs, as described in a demo launch file, are launched with different namespaces.
+Finally, multiple ``turtlesim`` nodes are started, using default parameters, setting custom background colors, and remapping topics.
 
-Launching
-^^^^^^^^^
-
-Any of the launch files above can be run with ``ros2 launch``.
-To try them locally, you can either create a new package and use
+This can be reproduced with a local copy of any of the launch files e.g.:
 
 .. code-block:: console
 
-  ros2 launch <package_name> <launch_file_name>
+    $ ros2 launch example_many_nodes_launch.py
 
-or run the file directly by specifying the path to the launch file
-
-.. code-block:: console
-
-  ros2 launch <path_to_launch_file>
-
-Setting arguments
-^^^^^^^^^^^^^^^^^
-
-To set the arguments that are passed to the launch file, you should use ``key:=value`` syntax.
-For example, you can set the value of ``background_r`` in the following way:
-
-.. code-block:: console
-
-  ros2 launch <package_name> <launch_file_name> background_r:=255
-
-or
-
-.. code-block:: console
-
-  ros2 launch <path_to_launch_file> background_r:=255
-
-Controlling the turtles
-^^^^^^^^^^^^^^^^^^^^^^^
+    [INFO] [launch]: All log files can be found below /home/hidmic/.ros/log/2023-09-19-20-16-48-522323-mhidalgo-spot-197115
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [talker-1]: process started with pid [NNNNNN]
+    [INFO] [listener-2]: process started with pid [NNNNNN]
+    [INFO] [talker-3]: process started with pid [NNNNNN]
+    [INFO] [listener-4]: process started with pid [NNNNNN]
+    [INFO] [talker-5]: process started with pid [NNNNNN]
+    [INFO] [listener-6]: process started with pid [NNNNNN]
+    [INFO] [talker-7]: process started with pid [NNNNNN]
+    [INFO] [listener-8]: process started with pid [NNNNNN]
+    [INFO] [turtlesim_node-9]: process started with pid [NNNNNN]
+    [INFO] [turtlesim_node-10]: process started with pid [NNNNNN]
+    [INFO] [mimic-11]: process started with pid [NNNNNN]
+    [turtlesim_node-10] [INFO] [TTTTTTTTTT.TTTTTTTTT] [turtlesim2.sim]: Starting turtlesim with node name /turtlesim2/sim
+    [turtlesim_node-9] [INFO] [TTTTTTTTTT.TTTTTTTTT] [turtlesim1.sim]: Starting turtlesim with node name /turtlesim1/sim
+    [turtlesim_node-10] [INFO] [TTTTTTTTTT.TTTTTTTTT] [turtlesim2.sim]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
+    [turtlesim_node-9] [INFO] [TTTTTTTTTT.TTTTTTTTT] [turtlesim1.sim]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
+    [talker-1] [INFO] [TTTTTTTTTT.TTTTTTTTT] [talker]: Publishing: 'Hello World: 1'
+    [listener-2] [INFO] [TTTTTTTTTT.TTTTTTTTT] [listener]: I heard: [Hello World: 1]
+    [talker-3] [INFO] [TTTTTTTTTT.TTTTTTTTT] [chatter.py.ns.talker]: Publishing: 'Hello World: 1'
+    [listener-4] [INFO] [TTTTTTTTTT.TTTTTTTTT] [chatter.py.ns.listener]: I heard: [Hello World: 1]
+    [talker-5] [INFO] [TTTTTTTTTT.TTTTTTTTT] [chatter.xml.ns.talker]: Publishing: 'Hello World: 1'
+    [listener-6] [INFO] [TTTTTTTTTT.TTTTTTTTT] [chatter.xml.ns.listener]: I heard: [Hello World: 1]
+    [talker-7] [INFO] [TTTTTTTTTT.TTTTTTTTT] [chatter.yaml.ns.talker]: Publishing: 'Hello World: 1'
+    [listener-8] [INFO] [TTTTTTTTTT.TTTTTTTTT] [chatter.yaml.ns.listener]: I heard: [Hello World: 1]
 
 To test that the remapping is working, you can control the turtles by running the following command in another terminal:
 
 .. code-block:: console
 
-  ros2 run turtlesim turtle_teleop_key --ros-args --remap __ns:=/turtlesim1
-
+    ros2 run turtlesim turtle_teleop_key --ros-args --remap __ns:=/turtlesim1
 
 Python, XML, or YAML: Which should I use?
 -----------------------------------------
@@ -370,9 +1164,9 @@ Python, XML, or YAML: Which should I use?
 
 For most applications the choice of which ROS 2 launch format comes down to developer preference.
 However, if your launch file requires flexibility that you cannot achieve with XML or YAML, you can use Python to write your launch file.
-Using Python for ROS 2 launch is more flexible because of following two reasons:
+Using Python for ROS 2 launch is more flexible because:
 
 * Python is a scripting language, and thus you can leverage the language and its libraries in your launch files.
-* `ros2/launch <https://github.com/ros2/launch>`_ (general launch features) and `ros2/launch_ros <https://github.com/ros2/launch_ros>`_ (ROS 2 specific launch features) are written in Python and thus you have lower level access to launch features that may not be exposed by XML and YAML.
+* `ros2/launch <https://github.com/ros2/launch>`_ (general launch features) and `ros2/launch_ros <https://github.com/ros2/launch_ros>`_ (ROS 2 specific launch features) are written in Python and thus you have lower level access to launch features that may not be yet exposed via XML and YAML.
 
 That being said, a launch file written in Python may be more complex and verbose than one in XML or YAML.


### PR DESCRIPTION
This patch improves upon existing documentation on `launch` to make it easier on newcomers to use it. In particular, it:

* reworks the `About Launch` page under `Concepts` to be a bit more thorough, and
* extends the guide on `Using Python, XML, and YAML for ROS 2 Launch files` with more examples.

Contributed by [The AI Institute](https://theaiinstitute.com/).