### PR TITLE
Small cleanups in the TF2 tutorials.

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
@@ -49,8 +49,9 @@ Tasks
 In our turtle example, we'll add a new frame ``carrot1``, which will be the child of the ``turtle1``.
 This frame will serve as the goal for the second turtle.
 
-Let's first create the source files. Go to the ``learning_tf2_py`` package we created in the previous tutorials.
-Download the fixed frame broadcaster code by entering the following command:
+Let's first create the source files.
+Go to the ``learning_tf2_py`` package we created in the previous tutorials.
+Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the fixed frame broadcaster code by entering the following command:
 
 .. tabs::
 
@@ -149,10 +150,9 @@ The ``carrot1`` frame is 2 meters offset in y axis in terms of the ``turtle1`` f
 1.2 Add an entry point
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To allow the ``ros2 run`` command to run your node, you must add the entry point
-to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
+To allow the ``ros2 run`` command to run your node, you must add the entry point to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
 
-Finally, add the following line between the ``'console_scripts':`` brackets:
+Add the following line between the ``'console_scripts':`` brackets:
 
 .. code-block:: python
 
@@ -321,7 +321,8 @@ Now just rebuild the package, restart the ``turtle_tf2_fixed_frame_demo_launch.p
 The extra frame we published in this tutorial is a fixed frame that doesn't change over time in relation to the parent frame.
 However, if you want to publish a moving frame you can code the broadcaster to change the frame over time.
 Let's change our ``carrot1`` frame so that it changes relative to ``turtle1`` frame over time.
-Now download the dynamic frame broadcaster code by entering the following command:
+Go to the ``learning_tf2_py`` package we created in the previous tutorial.
+Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the dynamic frame broadcaster code by entering the following command:
 
 .. tabs::
 
@@ -417,10 +418,9 @@ Instead of a fixed definition of our x and y offsets, we are using the ``sin()``
 2.2 Add an entry point
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To allow the ``ros2 run`` command to run your node, you must add the entry point
-to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
+To allow the ``ros2 run`` command to run your node, you must add the entry point to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
 
-Finally, add the following line between the ``'console_scripts':`` brackets:
+Add the following line between the ``'console_scripts':`` brackets:
 
 .. code-block:: python
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
@@ -36,7 +36,8 @@ Tasks
 1 Write the listener node
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Let's first create the source files. Go to the ``learning_tf2_py`` package we created in the previous tutorial.
+Let's first create the source files.
+Go to the ``learning_tf2_py`` package we created in the previous tutorial.
 Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the example listener code by entering the following command:
 
 .. tabs::
@@ -67,7 +68,7 @@ Inside the ``src/learning_tf2_py/learning_tf2_py`` directory download the exampl
 
             curl https://raw.githubusercontent.com/ros/geometry_tutorials/ros2/turtle_tf2_py/turtle_tf2_py/turtle_tf2_listener.py -o turtle_tf2_listener.py
 
-Open the file using your preferred text editor.
+Now open the file called ``turtle_tf2_listener.py``.
 
 .. code-block:: python
 
@@ -216,8 +217,9 @@ All this is wrapped in a try-except block to handle possible exceptions.
 1.2 Add an entry point
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To allow the ``ros2 run`` command to run your node, you must add the entry point
-to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
+To allow the ``ros2 run`` command to run your node, you must add the entry point to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
+
+Add the following line between the ``'console_scripts':`` brackets:
 
 .. code-block:: python
 
@@ -226,7 +228,8 @@ to ``setup.py`` (located in the ``src/learning_tf2_py`` directory).
 2 Update the launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Open the launch file called ``turtle_tf2_demo_launch.py`` with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports. The resulting file should look like:
+Open the launch file called ``turtle_tf2_demo_launch.py`` with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports.
+The resulting file should look like:
 
 .. code-block:: python
 


### PR DESCRIPTION
In particular, make it more clear which directory files should be downloaded into.  Also clean up language just a bit and make sure we have one-sentence-per-line.

This should fix #3953 