### PR TITLE
Update Windows-Install-Binary.rst to include link to releases page

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -25,7 +25,7 @@ Only Windows 10 is supported.
 Install ROS 2
 -------------
 
-* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
+* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip`` from https://github.com/ros2/ros2/releases.
 
 .. note::
 

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -25,7 +25,8 @@ Only Windows 10 is supported.
 Install ROS 2
 -------------
 
-* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip`` from https://github.com/ros2/ros2/releases.
+* Go to the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``
 
 .. note::
 


### PR DESCRIPTION
Previous Ros2 distros include this link in the install section of their documentation. This allows users to easily find the download page for the windows package.