### PR TITLE
Simplify and update a bit of the ros2 bag documentation.

### DIFF
--- a/source/Tutorials/Advanced/Reading-From-A-Bag-File-CPP.rst
+++ b/source/Tutorials/Advanced/Reading-From-A-Bag-File-CPP.rst
@@ -23,14 +23,8 @@ Prerequisites
 
 You should have the ``rosbag2`` packages installed as part of your regular ROS 2 setup.
 
-If you've installed from Debian packages on Linux, it may be installed by default.
-If it is not, you can install it using this command.
+If you need to install ROS 2, see the :doc:`Installation instructions <../../Installation>`.
 
-.. code-block:: console
-
-  sudo apt install ros-{DISTRO}-rosbag2
-
-This tutorial discusses using ROS 2 bags.
 You should have already completed the :doc:`basic ROS 2 bag tutorial <../Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data>`, and we will be using the ``subset`` bag you created there.
 
 Tasks

--- a/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
@@ -31,12 +31,7 @@ Prerequisites
 
 You should have ``ros2 bag`` installed as a part of your regular ROS 2 setup.
 
-If you installed ROS from Debian packages on Linux and your system doesn't recognize the command, install it like so:
-
-.. code-block:: console
-
-  sudo apt-get install ros-{DISTRO}-ros2bag \
-                       ros-{DISTRO}-rosbag2-storage-default-plugins
+If you need to install ROS 2, see the :doc:`Installation instructions <../../../Installation>`.
 
 This tutorial talks about concepts covered in previous tutorials, like :doc:`nodes <../Understanding-ROS2-Nodes/Understanding-ROS2-Nodes>` and :doc:`topics <../Understanding-ROS2-Topics/Understanding-ROS2-Topics>`.
 It also uses the :doc:`turtlesim package <../Introducing-Turtlesim/Introducing-Turtlesim>`.
@@ -65,10 +60,29 @@ Open another terminal and run:
 
 Let's also make a new directory to store our saved recordings, just as good practice:
 
-.. code-block:: console
+.. tabs::
 
-  mkdir bag_files
-  cd bag_files
+    .. group-tab:: Linux
+
+        .. code-block:: console
+
+            mkdir bag_files
+            cd bag_files
+
+    .. group-tab:: macOS
+
+        .. code-block:: console
+
+            mkdir bag_files
+            cd bag_files
+
+    .. group-tab:: Windows
+
+        .. code-block:: console
+
+            md bag_files
+            cd bag_files
+
 
 2 Choose a topic
 ^^^^^^^^^^^^^^^^
@@ -115,24 +129,10 @@ Use the arrow keys to move the turtle around, and you will see data being publis
     ---
 
 
-
 3 ros2 bag record
 ^^^^^^^^^^^^^^^^^
 
-3.1 Recording formats
-~~~~~~~~~~~~~~~~~~~~~
-
-By default, ``ros2 bag record`` will record data files using the `MCAP file format <https://mcap.dev>`_ (``.mcap``).
-
-To record files using the `SQLite3 file format <https://www.sqlite.org/index.html>`_ (``.db3``), add the ``--storage sqlite3`` flag (or ``-s sqlite3``) to your ``ros2 bag record`` commands.
-
-For more information on `ROS 2 storage plugin options <https://github.com/ros2/rosbag2/tree/{DISTRO}/#storage-format-plugin-architecture>`_, check out the following resources:
-
-* `MCAP <https://github.com/ros2/rosbag2/blob/{DISTRO}/rosbag2_storage_mcap/README.md#writer-configuration>`_
-* `SQLite3 <https://github.com/ros2/rosbag2/blob/{DISTRO}/rosbag2_storage_sqlite3/README.md#storage-configuration-file>`_
-
-
-3.2 Record a single topic
+3.1 Record a single topic
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To record the data published to a topic use the command syntax:
@@ -169,7 +169,7 @@ Press ``Ctrl+C`` to stop recording.
 The data will be accumulated in a new bag directory with a name in the pattern of ``rosbag2_year_month_day-hour_minute_second``.
 This directory will contain a ``metadata.yaml`` along with the bag file in the recorded format.
 
-3.3 Record multiple topics
+3.2 Record multiple topics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also record multiple topics, as well as change the name of the file ``ros2 bag`` saves to.
@@ -227,8 +227,6 @@ Running this command on the ``subset`` bag file will return a list of informatio
   Messages:          3013
   Topic information: Topic: /turtle1/cmd_vel | Type: geometry_msgs/msg/Twist | Count: 9 | Serialization Format: cdr
                    Topic: /turtle1/pose | Type: turtlesim/msg/Pose | Count: 3004 | Serialization Format: cdr
-
-To view the individual messages, you would have to open up the database, in this case sqlite3, to examine it, which is beyond the scope of ROS 2.
 
 5 ros2 bag play
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
In particular, do 2 things:

1.  Make the installation instructions less Linux-centric.
2.  Remove unnecessary options and explanations in the beginner tutorial.  Since it is for beginners, they don't need to know every specific.