### PR TITLE
Update Installation Troubleshooting Documentation

### DIFF
--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -106,7 +106,9 @@ If you encounter exceptions when trying to source the environment after building
 Anaconda Python Conflict
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-``conda`` does not play nice with ROS2. To fix this make sure your ``PATH`` environment variable does not have any conda paths in it. You may have to check your `.bashrc` for this line and comment it out.
+``conda`` does not work in conjunction with ROS 2.
+Make sure that your ``PATH`` environment variable does not have any conda paths in it.
+You may have to check your `.bashrc` for this line and comment it out.
 
 .. code-block:: bash
    export PATH="/home/foo/miniconda3/bin:$PATH"

--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -110,9 +110,6 @@ Anaconda Python Conflict
 Make sure that your ``PATH`` environment variable does not have any conda paths in it.
 You may have to check your `.bashrc` for this line and comment it out.
 
-.. code-block:: bash
-   export PATH="/home/foo/miniconda3/bin:$PATH"
-
 .. _macOS-troubleshooting:
 
 macOS

--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -108,7 +108,7 @@ Anaconda Python Conflict
 
 ``conda`` does not work in conjunction with ROS 2.
 Make sure that your ``PATH`` environment variable does not have any conda paths in it.
-You may have to check your `.bashrc` for this line and comment it out.
+You may have to check your ``.bashrc`` for this line and comment it out.
 
 .. _macOS-troubleshooting:
 

--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -103,6 +103,14 @@ If you encounter exceptions when trying to source the environment after building
    colcon version-check  # check if newer versions available
    sudo apt install python3-colcon* --only-upgrade  # upgrade installed colcon packages to latest version
 
+Anaconda Python Conflict
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``conda`` does not play nice with ROS2. To fix this make sure your ``PATH`` environment variable does not have any conda paths in it. You may have to check your `.bashrc` for this line and comment it out.
+
+.. code-block:: bash
+   export PATH="/home/foo/miniconda3/bin:$PATH"
+
 .. _macOS-troubleshooting:
 
 macOS


### PR DESCRIPTION
Adds an extra section to the installation troubleshooting docs for anyone who runs into issues with Conda conflicting with ROS2.