### PR TITLE
Added support for the Windows platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 SOURCE     = source
 OUT        = build
 LINKCHECKDIR  = $(OUT)/linkcheck
-BUILD      = python3 -m sphinx
+PYTHON := python3
+ifeq ($(OS),Windows_NT)
+    PYTHON := python
+endif
+BUILD      = $(PYTHON) -m sphinx
 OPTS       =-c .
 
 help:


### PR DESCRIPTION
This Pull Request introduces changes to the Makefile to enable documentation generation support on Windows.

Changes in Makefile is as followed:
```
PYTHON := python3
ifeq ($(OS),Windows_NT)
    PYTHON := python
endif
BUILD      = $(PYTHON) -m sphinx
```

These changes have been tested on Windows.
This effort aims to make the ROS2 documentation more accessible to developers and users who are on a Windows platform. 

Any feedback or suggestions are welcome. Thank you.