### PR TITLE
Add missing period in RHEL installation page

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -7,7 +7,7 @@ RHEL (RPM packages)
 
 RPM packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for RHEL 9.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__
+The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__.
 Most people will want to use a stable ROS distribution.
 
 Resources


### PR DESCRIPTION
This can only be backported to Iron, because Humble doesn't contain this part: https://docs.ros.org/en/humble/Installation/RHEL-Install-RPMs.html