### PR TITLE
Replace links to REP 2000 on GitHub with links to ros.org/reps

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -7,7 +7,7 @@ RHEL (RPM packages)
 
 RPM packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for RHEL 9.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__.
+The target platforms are defined in `REP 2000 <https://ros.org/reps/rep-2000.html>`__.
 Most people will want to use a stable ROS distribution.
 
 Resources

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -11,7 +11,7 @@ Ubuntu (Debian packages)
 
 Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Jammy.
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-The target platforms are defined in `REP 2000 <https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst>`__.
+The target platforms are defined in `REP 2000 <https://ros.org/reps/rep-2000.html>`__.
 Most people will want to use a stable ROS distribution.
 
 Resources


### PR DESCRIPTION
The rendering by GitHub isn't very good. It makes more sense to link to the rendered page on ros.org/reps