### PR TITLE
Replace setup bag with subset bag in rolling

### DIFF
--- a/source/Tutorials/Advanced/Reading-From-A-Bag-File-CPP.rst
+++ b/source/Tutorials/Advanced/Reading-From-A-Bag-File-CPP.rst
@@ -297,11 +297,11 @@ Next, source the setup files.
       call install/setup.bat
 
 Now, run the script.
-Make sure to replace ``/path/to/setup`` with the path to your ``setup`` bag.
+Make sure to replace ``/path/to/subset`` with the path to your ``subset`` bag.
 
 .. code-block:: console
 
-    ros2 run bag_reading_cpp simple_bag_reader /path/to/setup
+    ros2 run bag_reading_cpp simple_bag_reader /path/to/subset
 
 You should see the (x, y) coordinates of the turtle printed to the console.
 


### PR DESCRIPTION
This pull request addresses a typographical error found in the ROS 2 Iron documentation, specifically in the "Reading from a bag file (C++)" tutorial. The tutorial erroneously references a "`setup` bag" when it should actually be "subset bag". This confusion was discussed and clarified in Issue #4048.

The correction ensures that the documentation accurately reflects the content of the tutorials, particularly where it guides users in generating and using bag files in ROS 2.