### PR TITLE
Update Introducing-Turtlesim.rst

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
@@ -173,7 +173,7 @@ To run rqt:
 
 .. code-block:: console
 
-  rqt
+  rqt_graph
 
 5 Use rqt
 ^^^^^^^^^


### PR DESCRIPTION
replaced `rqt` with `rqt_graph` as the running `rqt` gives a blank windows with nothing shown with following error in the console:

RosPluginProvider._parse_plugin_xml() plugin file "C:\opt\ros\foxy\x64\share\rqt_gui_cpp/plugin.xml" in package "rqt_gui_cpp" not found RosPluginProvider._parse_plugin_xml() plugin file "C:\opt\ros\foxy\x64\share\rqt_gui_cpp/plugin.xml" in package "rqt_gui_cpp" not found   RosPluginProvider._parse_plugin_xml() plugin file "C:\opt\ros\foxy\x64\share\rqt_image_view/plugin.xml" in package "rqt_image_view" not found RosPluginProvider._parse_plugin_xml() plugin file "C:\opt\ros\foxy\x64\share\rqt_image_view/plugin.xml" in package "rqt_image_view" not found


`rqt_graph` works fine.