### PR TITLE
improve docker section of RaspberryPi install guide

### DIFF
--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -27,9 +27,18 @@ Raspberry Pi OS is based on Debian which receives Tier 3 support, but it can run
 
 After flashing the OS, `install Docker <https://docs.docker.com/engine/install/debian/#install-using-the-convenience-script>`__.
 
-The official OSRF ROS 2 Docker container definitions can be found `here <https://github.com/osrf/docker_images/>`__.
+The official ROS 2 Docker images can be found `here <https://hub.docker.com/_/ros/tags`__.
 
-You may choose from ros-core, ros-base, or ros-desktop. See `here <https://www.ros.org/reps/rep-2001.html>`__ for more information on these variants.
+You may choose from ros-core, ros-base, or perception. See `here <https://www.ros.org/reps/rep-2001.html>`__ for more information on these variants.
+
+Fetch and run the images:
+
+.. code-block:: bash
+
+    docker pull ros:rolling
+    docker run -it --rm ros:rolling
+
+You can also build images yourself:
 
 Clone the `docker_images git repo <https://github.com/osrf/docker_images>`__ onto the Raspberry Pi, change in to the directory linked above, then to the directory with your preferred variant.
 

--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -35,8 +35,8 @@ Fetch and run an image:
 
 .. code-block:: bash
 
-    docker pull ros:rolling-ros-core
-    docker run -it --rm ros:rolling-ros-core
+    docker pull ros:{DISTRO}-ros-core
+    docker run -it --rm ros:{DISTRO}-ros-core
 
 You can also build images yourself:
 

--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -31,12 +31,12 @@ The official ROS 2 Docker images can be found `here <https://hub.docker.com/_/ro
 
 You may choose from ros-core, ros-base, or perception. See `here <https://www.ros.org/reps/rep-2001.html>`__ for more information on these variants.
 
-Fetch and run the images:
+Fetch and run an image:
 
 .. code-block:: bash
 
-    docker pull ros:rolling
-    docker run -it --rm ros:rolling
+    docker pull ros:rolling-ros-core
+    docker run -it --rm ros:rolling-ros-core
 
 You can also build images yourself:
 
@@ -49,10 +49,3 @@ Inside of the directory, build the container with:
     docker build -t ros_docker .
 
 On a supported system it will only take a minute or two to build the docker containers, as the source code is already built in to binaries.
-
-Pre-built Docker container
---------------------------
-
-A pre-built container for the desktop variant is available as well, which only requires a docker pull command.
-
-See :doc:`this page <Run-2-nodes-in-single-or-separate-docker-containers>` for more information.

--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -27,7 +27,7 @@ Raspberry Pi OS is based on Debian which receives Tier 3 support, but it can run
 
 After flashing the OS, `install Docker <https://docs.docker.com/engine/install/debian/#install-using-the-convenience-script>`__.
 
-The official ROS 2 Docker images can be found `here <https://hub.docker.com/_/ros/tags`__.
+The official ROS 2 Docker images can be found `here <https://hub.docker.com/_/ros/tags>`__.
 
 You may choose from ros-core, ros-base, or perception. See `here <https://www.ros.org/reps/rep-2001.html>`__ for more information on these variants.
 


### PR DESCRIPTION
Following reports from https://github.com/osrf/docker_images/issues/703

Here is a fixup PR to clarify where to get images from.

I didnt touch the part about building images on device but there may be some update to do there ine the future based on https://github.com/osrf/docker_images/issues/703

Finally I mention rolling on this file for the example but hapy to change it to be more easily backported.

Cheers!

---

FYI @knmcguire @kscottz 