### PR TITLE
Add "license" option to all uses of ros2 pkg create.

### DIFF
--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -30,7 +30,7 @@ All ROS 2 packages begin by running the command
 
 .. code-block:: bash
 
-   ros2 pkg create <pkg-name> --dependencies [deps]
+   ros2 pkg create --license Apache-2.0 <pkg-name> --dependencies [deps]
 
 in your workspace (usually ``~/ros2_ws/src``).
 
@@ -42,13 +42,13 @@ To create a package for a specific client library:
 
     .. code-block:: bash
 
-       ros2 pkg create <pkg-name> --dependencies [deps] --build-type ament_cmake
+       ros2 pkg create  --build-type ament_cmake --license Apache-2.0 <pkg-name> --dependencies [deps]
 
   .. group-tab:: Python
 
     .. code-block:: bash
 
-       ros2 pkg create <pkg-name> --dependencies [deps] --build-type ament_python
+       ros2 pkg create  --build-type ament_python --license Apache-2.0 <pkg-name> --dependencies [deps]
 
 You can then update the ``package.xml`` with your package info such as dependencies, descriptions, and authorship.
 

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -66,7 +66,7 @@ First, create a new package named ``sync_async_node_example_cpp`` on a new works
 
          mkdir -p ~/ros2_ws/src
          cd ~/ros2_ws/src
-         ros2 pkg create --build-type ament_cmake --dependencies rclcpp std_msgs -- sync_async_node_example_cpp
+         ros2 pkg create --build-type ament_cmake --license Apache-2.0 --dependencies rclcpp std_msgs -- sync_async_node_example_cpp
 
     .. group-tab:: macOS
 
@@ -74,7 +74,7 @@ First, create a new package named ``sync_async_node_example_cpp`` on a new works
 
         mkdir -p ~/ros2_ws/src
         cd ~/ros2_ws/src
-        ros2 pkg create --build-type ament_cmake --dependencies rclcpp std_msgs -- sync_async_node_example_cpp
+        ros2 pkg create --build-type ament_cmake --license Apache-2.0 --dependencies rclcpp std_msgs -- sync_async_node_example_cpp
 
     .. group-tab:: Windows
 
@@ -82,7 +82,7 @@ First, create a new package named ``sync_async_node_example_cpp`` on a new works
 
         md \ros2_ws\src
         cd \ros2_ws\src
-        ros2 pkg create --build-type ament_cmake --dependencies rclcpp std_msgs -- sync_async_node_example_cpp
+        ros2 pkg create --build-type ament_cmake --license Apache-2.0 --dependencies rclcpp std_msgs -- sync_async_node_example_cpp
 
 
 Then, add a file named ``src/sync_async_writer.cpp`` to the package, with the following content.

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
@@ -52,7 +52,7 @@ Navigate into the ``ros2_ws/src`` directory and create a new package:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake bag_recorder_nodes --dependencies example_interfaces rclcpp rosbag2_cpp std_msgs
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 bag_recorder_nodes --dependencies example_interfaces rclcpp rosbag2_cpp std_msgs
 
 Your terminal will return a message verifying the creation of your package ``bag_recorder_nodes`` and all its necessary files and folders.
 The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml`` and ``CMakeLists.txt``.

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
@@ -56,7 +56,7 @@ Navigate into the ``ros2_ws/src`` directory and create a new package:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_python bag_recorder_nodes_py --dependencies rclpy rosbag2_py example_interfaces std_msgs
+  ros2 pkg create --build-type ament_python --license Apache-2.0 bag_recorder_nodes_py --dependencies rclpy rosbag2_py example_interfaces std_msgs
 
 Your terminal will return a message verifying the creation of your package ``bag_recorder_nodes_py`` and all its necessary files and folders.
 The ``--dependencies`` argument will automatically add the necessary dependency lines to the ``package.xml``.

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
@@ -161,13 +161,13 @@ The command syntax for creating a new package in ROS 2 is:
 
       .. code-block:: console
 
-        ros2 pkg create --build-type ament_cmake <package_name>
+        ros2 pkg create --build-type ament_cmake --license Apache-2.0 <package_name>
 
    .. group-tab:: Python
 
       .. code-block:: console
 
-        ros2 pkg create --build-type ament_python <package_name>
+        ros2 pkg create --build-type ament_python --license Apache-2.0 <package_name>
 
 For this tutorial, you will use the optional arguments ``--node-name`` and ``--license``.
 ``--node-name`` option creates a simple Hello World type executable in the package, and ``--license`` declares the license information for the package.
@@ -180,13 +180,13 @@ Enter the following command in your terminal:
 
       .. code-block:: console
 
-        ros2 pkg create --build-type ament_cmake --node-name my_node my_package --license Apache-2.0
+        ros2 pkg create --build-type ament_cmake --license Apache-2.0 --node-name my_node my_package --license Apache-2.0
 
    .. group-tab:: Python
 
       .. code-block:: console
 
-        ros2 pkg create --build-type ament_python --node-name my_node my_package --license Apache-2.0
+        ros2 pkg create --build-type ament_python --license Apache-2.0 --node-name my_node my_package --license Apache-2.0
 
 You will now have a new folder within your workspace's ``src`` directory called ``my_package``.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -46,7 +46,7 @@ Since we will use the pub/sub and service/client packages created in earlier tut
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake tutorial_interfaces
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 tutorial_interfaces
 
 ``tutorial_interfaces`` is the name of the new package.
 Note that it is, and can only be, a CMake package, but this doesn't restrict in which type of packages you can use your messages and services.

--- a/source/Tutorials/Beginner-Client-Libraries/Pluginlib.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Pluginlib.rst
@@ -43,7 +43,7 @@ Create a new empty package in your ``ros2_ws/src`` folder with the following com
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake --dependencies pluginlib --node-name area_node --license Apache-2.0 polygon_base
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 --dependencies pluginlib --node-name area_node polygon_base
 
 
 Open your favorite editor, edit ``ros2_ws/src/polygon_base/include/polygon_base/regular_polygon.hpp``, and paste the following inside of it:
@@ -101,7 +101,7 @@ Create a second empty package in your ``ros2_ws/src`` folder with the following 
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake --dependencies polygon_base pluginlib --library-name polygon_plugins --license Apache-2.0 polygon_plugins
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 --dependencies polygon_base pluginlib --library-name polygon_plugins polygon_plugins
 
 2.1 Source code for the plugins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
@@ -50,7 +50,7 @@ In your workspace ``src`` directory, create a package ``more_interfaces`` and ma
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake more_interfaces
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 more_interfaces
   mkdir more_interfaces/msg
 
 2 Create a msg file

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -45,7 +45,7 @@ Navigate into ``ros2_ws/src`` and create a new package:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake cpp_parameters --dependencies rclcpp
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 cpp_parameters --dependencies rclcpp
 
 Your terminal will return a message verifying the creation of your package ``cpp_parameters`` and all its necessary files and folders.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -45,7 +45,7 @@ Navigate into ``ros2_ws/src`` and create a new package:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_python python_parameters --dependencies rclpy
+  ros2 pkg create --build-type ament_python --license Apache-2.0 python_parameters --dependencies rclpy
 
 Your terminal will return a message verifying the creation of your package ``python_parameters`` and all its necessary files and folders.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -46,7 +46,7 @@ So, navigate into ``ros2_ws/src``, and run the package creation command:
 
 .. code-block:: console
 
-    ros2 pkg create --build-type ament_cmake cpp_pubsub
+    ros2 pkg create --build-type ament_cmake --license Apache-2.0 cpp_pubsub
 
 Your terminal will return a message verifying the creation of your package ``cpp_pubsub`` and all its necessary files and folders.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -46,7 +46,7 @@ Navigate into ``ros2_ws/src`` and create a new package:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake cpp_srvcli --dependencies rclcpp example_interfaces
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 cpp_srvcli --dependencies rclcpp example_interfaces
 
 Your terminal will return a message verifying the creation of your package ``cpp_srvcli`` and all its necessary files and folders.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -48,7 +48,7 @@ So, navigate into ``ros2_ws/src``, and run the package creation command:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_python py_pubsub
+  ros2 pkg create --build-type ament_python --license Apache-2.0 py_pubsub
 
 Your terminal will return a message verifying the creation of your package ``py_pubsub`` and all its necessary files and folders.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
@@ -45,7 +45,7 @@ Navigate into ``ros2_ws/src`` and create a new package:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_python py_srvcli --dependencies rclpy example_interfaces
+  ros2 pkg create --build-type ament_python --license Apache-2.0 py_srvcli --dependencies rclpy example_interfaces
 
 Your terminal will return a message verifying the creation of your package ``py_srvcli`` and all its necessary files and folders.
 

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -67,13 +67,13 @@ Create a workspace for the package to live in:
 
     .. code-block:: console
 
-      ros2 pkg create py_launch_example --build-type ament_python
+      ros2 pkg create --build-type ament_python --license Apache-2.0 py_launch_example
 
   .. group-tab:: C++ package
 
     .. code-block:: console
 
-      ros2 pkg create cpp_launch_example --build-type ament_cmake
+      ros2 pkg create --build-type ament_cmake --license Apache-2.0 cpp_launch_example
 
 2 Creating the structure to hold launch files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -44,7 +44,7 @@ Create a new package of build_type ``ament_python`` called ``launch_tutorial``:
 
 .. code-block:: console
 
-  ros2 pkg create launch_tutorial --build-type ament_python
+  ros2 pkg create --build-type ament_python --license Apache-2.0 launch_tutorial
 
 Inside of that package, create a directory called ``launch``:
 

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -48,7 +48,7 @@ So, navigate into ``ros2_ws/src`` and then create a new package there:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_cmake cpp_parameter_event_handler --dependencies rclcpp
+  ros2 pkg create --build-type ament_cmake --license Apache-2.0 cpp_parameter_event_handler --dependencies rclcpp
 
 Your terminal will return a message verifying the creation of your package ``cpp_parameter_event_handler`` and all its necessary files and folders.
 

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -44,7 +44,7 @@ So, navigate into ``ros2_ws/src`` and then create a new package there:
 
 .. code-block:: console
 
-  ros2 pkg create --build-type ament_python python_parameter_event_handler --dependencies rclpy --license Apache-2.0
+  ros2 pkg create --build-type ament_python --license Apache-2.0 python_parameter_event_handler --dependencies rclpy
 
 Your terminal will return a message verifying the creation of your package ``python_parameter_event_handler`` and all its necessary files and folders.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -48,7 +48,7 @@ Navigate to workspace's ``src`` folder and create a new package:
 
 .. code-block:: console
 
-   ros2 pkg create --build-type ament_cmake --dependencies geometry_msgs rclcpp tf2 tf2_ros turtlesim --license Apache-2.0 -- learning_tf2_cpp
+   ros2 pkg create --build-type ament_cmake --license Apache-2.0 --dependencies geometry_msgs rclcpp tf2 tf2_ros turtlesim -- learning_tf2_cpp
 
 Your terminal will return a message verifying the creation of your package ``learning_tf2_cpp`` and all its necessary files and folders.
 

--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher.rst
@@ -66,7 +66,7 @@ Then create the package:
 .. code-block:: console
 
     cd second_ros2_ws/src
-    ros2 pkg create urdf_tutorial_r2d2 --build-type ament_python --dependencies rclpy --license Apache-2.0
+    ros2 pkg create --build-type ament_python --license Apache-2.0 urdf_tutorial_r2d2 --dependencies rclpy
     cd urdf_tutorial_r2d2
 
 You should now see a ``urdf_tutorial_r2d2`` folder.


### PR DESCRIPTION
This is our best practice for a while and avoides a warning when running "ros2 pkg create".