### PR TITLE
Remove instructions to install TinyXML on Windows.

### DIFF
--- a/source/How-To-Guides/RQt-Port-Plugin-Windows.rst
+++ b/source/How-To-Guides/RQt-Port-Plugin-Windows.rst
@@ -21,15 +21,6 @@ Here is the ROS 2 port of `python_qt_binding <https://github.com/ros-visualizati
 Considerations for Windows 10
 -----------------------------
 
-Troubles with TinyXML version 1
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-I could not successfully use TinyXML.
-I upgraded to TinyXML-2 where needed.
-It’s a pretty straight forward change.
-
-Checkout `this PR <https://github.com/ros-visualization/qt_gui_core/pull/147>`__ for an example of porting to TinyXML-2.
-
 Code that uses ``__cplusplus`` and code that requires pluginlib
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -108,14 +108,13 @@ Please download these packages from `this <https://github.com/ros2/choco-package
 * bullet.3.17.nupkg
 * cunit.2.1.3.nupkg
 * eigen-3.3.4.nupkg
-* tinyxml-usestl.2.6.2.nupkg
 * tinyxml2.6.0.0.nupkg
 
 Once these packages are downloaded, open an administrative shell and execute the following command:
 
 .. code-block:: bash
 
-   choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml-usestl tinyxml2 bullet
+   choco install -y -s <PATH\TO\DOWNLOADS\> asio cunit eigen tinyxml2 bullet
 
 Please replace ``<PATH\TO\DOWNLOADS>`` with the folder you downloaded the packages to.
 


### PR DESCRIPTION
This is no longer required.

Note that this should *only* be applied to Rolling; it is still required for Humble and Iron.