### PR TITLE
Drop matplotlib from skipped keys during RHEL install

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -103,7 +103,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src -y --skip-keys "assimp fastcdr ignition-cmake2 ignition-math6 python3-matplotlib python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src -y --skip-keys "assimp fastcdr ignition-cmake2 ignition-math6 python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
 
 Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -109,7 +109,7 @@ Install dependencies using rosdep
 
 .. code-block:: bash
 
-   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "assimp cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 python3-matplotlib python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "assimp cyclonedds fastcdr fastrtps ignition-cmake2 ignition-math6 python3-pygraphviz rti-connext-dds-6.0.1 urdfdom_headers"
 
 Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The python3-matplotlib package is now available in EPEL 9, so the existing rosdep rule is now satisfied.

Verified as part of ros2/ci#736