### PR TITLE
macOS: use tinyxml1 formula

### DIFF
--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -61,7 +61,7 @@ You need the following things installed to build ROS 2:
 
       brew install asio assimp bison bullet cmake console_bridge cppcheck \
         cunit eigen freetype graphviz opencv openssl orocos-kdl pcre poco \
-        pyqt5 python qt@5 sip spdlog tinyxml tinyxml2
+        pyqt5 python qt@5 sip spdlog osrf/simulation/tinyxml1 tinyxml2
 
 #.
    Setup some environment variables:


### PR DESCRIPTION
The tinyxml formula is about to be deprecated (https://github.com/Homebrew/homebrew-core/pull/119829), so switch to an alternate tinyxml1 formula hosted in the osrf/simulation tap.

The `tinyxml1` formula was added in https://github.com/osrf/homebrew-simulation/pull/2522 and will be used by `sdformat9` and `gazebo11` in https://github.com/osrf/homebrew-simulation/pull/2526.