### PR TITLE
macOS rolling: don't need tinyxml

### DIFF
--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -63,7 +63,7 @@ You need the following things installed to build ROS 2:
 
       brew install asio assimp bison bullet cmake console_bridge cppcheck \
         cunit eigen freetype graphviz opencv openssl orocos-kdl pcre poco \
-        pyqt5 python qt@5 sip spdlog tinyxml tinyxml2
+        pyqt5 python qt@5 sip spdlog tinyxml2
 
 #.
    Setup some environment variables:


### PR DESCRIPTION
This removes tinyxml from the list of brew dependencies to install on rolling.