### PR TITLE
Update Colcon-Tutorial.rst

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -42,6 +42,9 @@ Install colcon
     .. code-block:: bash
 
         sudo apt install python3-colcon-common-extensions
+        # If you are using the core version of ROS instead of the desktop version, 
+        # you can still run these tutorials by installing the example-interfaces package
+        sudo apt install ros-${ROS_DISTRO}-example-interfaces
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
Added instructions for how to run the tutorials if you are on the core version of ROS2.  Updated because there will be people who install a minimal version of ROS2 who want to follow the tutorials. This could include users following the [ROS2 Docker instructions](https://docs.ros.org/en/rolling/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.html).