### PR TITLE
Remove duplicate argument to `ros2 pkg create` in tutorial page (#4103)

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
@@ -180,13 +180,13 @@ Enter the following command in your terminal:
 
       .. code-block:: console
 
-        ros2 pkg create --build-type ament_cmake --license Apache-2.0 --node-name my_node my_package --license Apache-2.0
+        ros2 pkg create --build-type ament_cmake --license Apache-2.0 --node-name my_node my_package
 
    .. group-tab:: Python
 
       .. code-block:: console
 
-        ros2 pkg create --build-type ament_python --license Apache-2.0 --node-name my_node my_package --license Apache-2.0
+        ros2 pkg create --build-type ament_python --license Apache-2.0 --node-name my_node my_package
 
 You will now have a new folder within your workspace's ``src`` directory called ``my_package``.
 


### PR DESCRIPTION
The tutorial page to create the first ROS2 package instructs users to pass the `--license` argument twice when calling `ros2 pkg create`.

Using `--license` twice has the effect that the first license in the argument list is ignored. There's no point in adding this twice, it just confuses users and makes the line longer.

This commit removes the second `--license Apache-2.0` in the line for both the CMake and Python variants of the command.