### PR TITLE
Fix typo in call to `get_clock` (#4099)

### DIFF
--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -105,7 +105,7 @@ The interval parameter specifying milliseconds between messages should have an i
             RCLCPP_ERROR_THROTTLE(node->get_logger(), *node->get_clock(), 1000, "My log message %d", 4);
 
             // C++ stream style
-            RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_lock(), 1000, "My log message " << 4);
+            RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), 1000, "My log message " << 4);
 
             // For now, use the nanoseconds() method to use an existing rclcpp::Duration value, see https://github.com/ros2/rclcpp/issues/1929
             RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), msg_interval.nanoseconds()/1000000, "My log message " << 4);


### PR DESCRIPTION
This commit fixes a call to `get_clock` that is incorrectly spelled as `get_lock`.