### PR TITLE
Use classic PAT generation

### DIFF
--- a/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
+++ b/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
@@ -10,6 +10,7 @@ Create a Personal Access Token by:
 
 #. Log in to GitHub and go to `Personal access tokens <https://github.com/settings/tokens>`_.
 #. Click the **Generate new token** button.
+#. In the dropdown, select **Generate new token (classic)**
 #. Set **Note** to something like ``Bloom token``.
 #. Set **Expiration** to **No expiration**.
 #. Tick the ``public_repo`` and ``workflow`` checkboxes.


### PR DESCRIPTION
The bloom release instructions were built for the original way to create personal access tokens. Now that Github has two methods to create a PAT, we should instruct users to use the classic UI. 

I tried using the new beta UI, but the token did not work, and the instructions did not line up well. A future PR could add the necessary instructions on how to use the new beta token generation., perhaps once it's out of beta.

Here is what the dropdown looks like:
![image](https://github.com/ros2/ros2_documentation/assets/25047695/384f1d4b-fc9a-41f6-9a85-8ddf5e48ca54)
