### PR TITLE
Mark the "Examine-traffic" tutorial as Linux specific.

### DIFF
--- a/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
+++ b/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
@@ -1,13 +1,13 @@
 How to use ros2_tracing to trace and analyze an application
 ===========================================================
 
-This guide shows how to use `ros2_tracing <https://github.com/ros2/ros2_tracing>`_ to trace and analyze a ROS 2 application.
-For this guide, the application will be `performance_test <https://gitlab.com/ApexAI/performance_test>`_.
+This tutorial shows how to use `ros2_tracing <https://github.com/ros2/ros2_tracing>`_ to trace and analyze a ROS 2 application.
+For this tutorial, the application will be `performance_test <https://gitlab.com/ApexAI/performance_test>`_.
 
 Overview
 --------
 
-This guide covers:
+This tutorial covers:
 
 1. running and tracing a ``performance_test`` run
 2. analyzing the trace data using `tracetools_analysis <https://github.com/ros-tracing/tracetools_analysis>`_ to plot the callback durations
@@ -15,9 +15,9 @@ This guide covers:
 Prerequisites
 -------------
 
-This guide is aimed at real-time Linux systems.
-See the :doc:`real-time system setup guide <../Miscellaneous/Building-Realtime-rt_preempt-kernel-for-ROS-2>`.
-However, the guide will work if you are using a non-real-time Linux system.
+This tutorial is aimed at real-time Linux systems.
+See the :doc:`real-time system setup tutorial <../Miscellaneous/Building-Realtime-rt_preempt-kernel-for-ROS-2>`.
+However, the tutorial will work if you are using a non-real-time Linux system.
 
 Installing and building
 -----------------------
@@ -26,7 +26,7 @@ Install ROS 2 on Linux by following the :doc:`installation instructions <../../I
 
 .. note::
 
-  This guide should generally work with all supported Linux distributions.
+  This tutorial should generally work with all supported Linux distributions.
   However, you might need to adapt some commands.
 
 Install ``babeltrace`` and ``ros2trace``.
@@ -153,7 +153,7 @@ Analysis
 We can use it in a `Jupyter notebook <https://jupyter.org/>`_ with `bokeh <https://docs.bokeh.org/en/latest/index.html>`_ to plot the data.
 The ``tracetools_analysis`` repository contains a `few sample notebooks <https://github.com/ros-tracing/tracetools_analysis/tree/{DISTRO}/tracetools_analysis/analysis>`_, including `one notebook to analyze subscription callback durations <https://github.com/ros-tracing/tracetools_analysis/blob/{DISTRO}/tracetools_analysis/analysis/callback_duration.ipynb>`_.
 
-For this guide, we will plot the durations of the subscription callback in the subscriber node.
+For this tutorial, we will plot the durations of the subscription callback in the subscriber node.
 
 Install Jupyter notebook and bokeh, and then open the sample notebook.
 
@@ -184,7 +184,7 @@ We can see that most of the callbacks take less than 0.01 ms, but there are some
 Conclusion
 ----------
 
-This guide showed how to install tracing-related tools.
+This tutorial showed how to install tracing-related tools.
 Then it showed how to trace a `performance_test <https://gitlab.com/ApexAI/performance_test>`_ experiment using `ros2_tracing <https://github.com/ros2/ros2_tracing>`_ and plot the callback durations using `tracetools_analysis <https://github.com/ros-tracing/tracetools_analysis>`_.
 
 For more trace analyses, take a look at the `other sample notebooks <https://github.com/ros-tracing/tracetools_analysis/tree/{DISTRO}/tracetools_analysis/analysis>`_ and the `tracetools_analysis API documentation <https://ros-tracing.gitlab.io/tracetools_analysis-api/master/tracetools_analysis/>`_.

--- a/source/Tutorials/Advanced/Security/Examine-Traffic.rst
+++ b/source/Tutorials/Advanced/Security/Examine-Traffic.rst
@@ -18,8 +18,8 @@ Examining network traffic
   :local:
 
 
-Background
-----------
+Overview
+--------
 
 ROS 2 communications security is all about protecting communications between nodes.
 Prior tutorials enabled security, but how can you **really** tell if traffic is being encrypted?
@@ -31,6 +31,11 @@ In this tutorial we'll take a look at capturing live network traffic to show the
   Security enclaves are still applied, and data will be encrypted.
   However, you cannot capture live network traffic since the data will not be on the network interface.
   If you are using  ``rmw_fastrtps_cpp``, you need to either go through this tutorial and use a different host system between the publisher and subscriber, or disable shared memory transport with `Enabling UDP Transport <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/udp/udp.html#enabling-udp-transport>`_ and `How to set Fast-DDS XML configuration <https://github.com/ros2/rmw_fastrtps#full-qos-configuration>`_.
+
+Prerequisites
+-------------
+
+This guide only runs on Linux, and assumes you have already :doc:`installed ROS 2 <../../../Installation>`.
 
 Run the demo
 ------------


### PR DESCRIPTION
While we are in here, also notice that we use the word "guide" in ROS2-Tracing-Trace-and-Analyze, and switch that to "tutorial".

Fixes #4095 