### PR TITLE
Specify RHEL 8's system default Python 3 interpreter

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -120,7 +120,7 @@ More info on working with a ROS workspace can be found in :doc:`this tutorial <.
 .. code-block:: bash
 
    cd ~/ros2_{DISTRO}/
-   colcon build --symlink-install --cmake-args -DTHIRDPARTY_Asio=ON --no-warn-unused-cli
+   colcon build --symlink-install --cmake-args -DTHIRDPARTY_Asio=ON -DPython3_EXECUTABLE=/usr/bin/python3 --no-warn-unused-cli
 
 Note: if you are having trouble compiling all examples and this is preventing you from completing a successful build, you can use ``COLCON_IGNORE`` in the same manner as `CATKIN_IGNORE <https://github.com/ros-infrastructure/rep/blob/master/rep-0128.rst>`__ to ignore the subtree or remove the folder from the workspace.
 Take for instance: you would like to avoid installing the large OpenCV library.


### PR DESCRIPTION
As RHEL 8's default Python interpreter becomes more and more dated, parts of the system are moving forward with newer interpreters. It is therefore increasingly likely that a typical installation will have one of such packages. At present, ROS 2 will attempt to use the newest Python 3 interpreter available, but all of our dependencies are installed with the system's default interpreter.

Specifying `Python3_EXECUTABLE=/usr/bin/python3` should make ROS 2 use the system's default interpreter even if a newer version is available.

I'd consider this a stopgap measure until we can teach ROS 2 that unless we specify otherwise, we always want to find the environment's default Python interpreter.