### PR TITLE
Add instructions for using `webots_ros2` packages with Docker on macOS and Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+venv/
 build/
 plugins/__pycache__
 _build/

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
@@ -34,7 +34,7 @@ Tasks
 On macOS, a solution based on UTM virtual machines or Docker containers provides an improved user experience with ROS 2 compared to native macOS installation, as it runs ROS in a Linux environment.
 However, Webots should be installed natively on macOS and it will be able to communicate with the ROS nodes running in the virtual environment (VM or container).
 This solution allows for native 3D hardware acceleration for Webots.
-The virtual environment runs all the ROS part and connects to the host machine through TCP to start Webots.
+The virtual environment runs all the ROS parts and connects to the host machine through TCP to start Webots.
 A shared folder allows the script to transfer the world and other resource files from the VM or container to macOS where Webots is running.
 
 The following steps explain how to create the VM image or Docker container with the installation of the ``webots_ros2`` released package.
@@ -73,6 +73,10 @@ It is also possible to install it from sources.
 
       Pull a Docker image for ROS.
       This tutorial uses the latest `ROS Base <https://hub.docker.com/layers/library/ros/latest/images/sha256-52e27b46c352d7ee113f60b05590bb089628a17ef648fff6992ca363c5e14945?context=explore>`_ image.
+
+      .. code-block:: console
+
+        docker image pull ros:latest
 
 2 Configure the virtual environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,13 +121,13 @@ It is also possible to install it from sources.
           export WEBOTS_SHARED_FOLDER=/Users/username/shared:/home/ubuntu/shared
 
         You can add this command line to the ``~/.bashrc`` file to automatically set this environment variable when starting a new terminal.
+        This variable must be set on both the VM and the host machine.
 
     .. group-tab:: Docker container
 
         In this section, the ROS 2 image is installed.
-        The following instructions and commands are all run on the host machine.
 
-        * Create a folder to use as a shared folder.
+        * Create a folder on the host to use as a shared folder.
           In this example, the shared folder on macOS is ``/Users/username/shared``, where ``username`` is your actual username.
 
           .. code-block:: console
@@ -137,6 +141,17 @@ It is also possible to install it from sources.
 
             docker run -it --mount type=bind,src=/Users/username/shared,target=/root/shared ros:latest
 
+          .. note::
+            The ROS Docker images are minimal environments.
+            The ``webots_ros2`` packages rely on some programs and utilities that are not pre-installed, so you will have to install them manually.
+            Inside the container, install the ``iproute2`` package, which provides the ``ip`` command:
+
+            .. code-block:: console
+
+              apt update
+              apt install iproute2
+
+
         * The environment variable ``WEBOTS_SHARED_FOLDER`` must always be set in order for the package to work properly in the Docker container.
           This variable specifies the location of the shared folder that is used to exchange data between the host machine and the container to the ``webots_ros2`` package.
           The value to use for this variable should be in the format of ``<host shared folder>:<container shared folder>``, where ``<host shared folder>`` is the path to the shared folder on the host machine and ``<container shared folder>`` is the path to the same shared folder on the Docker container.
@@ -147,11 +162,12 @@ It is also possible to install it from sources.
 
             export WEBOTS_SHARED_FOLDER=/Users/username/shared:/root/shared
 
+          This variable must be set on both the container and the host machine.
 
 3 Install ``webots_ros2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can either install ``webots_ros2`` from the official released package, or install it from the latest up-to-date sources from `Github <https://github.com/cyberbotics/webots_ros2>`_.
+You can either install ``webots_ros2`` from the official released package, or install it from the latest up-to-date sources from `GitHub <https://github.com/cyberbotics/webots_ros2>`_.
 
 .. tabs::
 
@@ -159,9 +175,11 @@ You can either install ``webots_ros2`` from the official released package, or in
 
         Run the following command in the VM or container terminal.
         If you're using the container, you don't need to use ``sudo`` because the container's user is ``root``.
+        You will, however, need to update APT's package index files since Docker images typically remove them when being built.
 
         .. code-block:: console
 
+            apt-get update  # Only needed for Docker containers
             sudo apt-get install ros-{DISTRO}-webots-ros2
 
     .. group-tab:: Install ``webots_ros2`` from sources
@@ -185,7 +203,7 @@ You can either install ``webots_ros2`` from the official released package, or in
 
             source /opt/ros/{DISTRO}/setup.bash
 
-        Retrieve the sources from Github.
+        Retrieve the sources from GitHub.
 
         .. code-block:: console
 
@@ -217,6 +235,12 @@ You can either install ``webots_ros2`` from the official released package, or in
 
 As mentioned in previous sections, the package uses the shared folder to communicate with Webots from the VM or container to the host.
 In order for Webots to be started on the host from the VM's or container's ROS package, a local TCP simulation server must be run.
+
+If you didn't already, make sure to set ``WEBOTS_SHARED_FOLDER`` on the host before launching the local TCP simulation server.
+
+.. code-block:: console
+
+  export WEBOTS_SHARED_FOLDER=/Users/username/shared:/root/shared
 
 The server can be downloaded here: `local_simulation_server.py <https://github.com/cyberbotics/webots-server/blob/main/local_simulation_server.py>`_.
 Specify the Webots installation folder in ``WEBOTS_HOME`` environment variable (e.g. ``/Applications/Webots.app``) and run the server using the following commands in a new terminal on the host (not in the VM or container):

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
@@ -25,81 +25,128 @@ Prerequisites
 It is recommended to understand basic ROS principles covered in the beginner :doc:`../../../../Tutorials`.
 In particular, :doc:`../../../Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace` and :doc:`../../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package` are useful prerequisites.
 
-It is necessary to install Webots natively on the mac in order to use the ``webots_ros2`` package in the virtual machine as explained below.
+It is necessary to install Webots natively on the mac in order to use the ``webots_ros2`` package in the virtual machine or Docker container as explained below.
 You can follow the `installation procedure <https://cyberbotics.com/doc/guide/installation-procedure>`_ or `build it from sources <https://github.com/cyberbotics/webots/wiki/macOS-installation/>`_.
 
 Tasks
 -----
 
-On macOS, a solution based on UTM virtual machines provides an improved user experience with ROS 2 compared to native macOS installation, as it runs ROS in a Linux environment.
-However, Webots should be installed natively on macOS and it will be able to communicate with the ROS nodes running in the Virtual Machine (VM).
+On macOS, a solution based on UTM virtual machines or Docker containers provides an improved user experience with ROS 2 compared to native macOS installation, as it runs ROS in a Linux environment.
+However, Webots should be installed natively on macOS and it will be able to communicate with the ROS nodes running in the virtual environment (VM or container).
 This solution allows for native 3D hardware acceleration for Webots.
-The VM runs all the ROS part (including RViz) and connects to the host machine through TCP to start Webots.
-A shared folder allows the script to transfer the world and other resource files from the VM to macOS where Webots is running.
+The virtual environment runs all the ROS part and connects to the host machine through TCP to start Webots.
+A shared folder allows the script to transfer the world and other resource files from the VM or container to macOS where Webots is running.
 
-The following steps explain how to create the VM image with the installation of the ``webots_ros2`` released package.
+The following steps explain how to create the VM image or Docker container with the installation of the ``webots_ros2`` released package.
 It is also possible to install it from sources.
 
-1 Create the VM image
-^^^^^^^^^^^^^^^^^^^^^^
+1 Create the virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Install UTM on your macOS machine.
-The link can be found on the `official UTM website <https://mac.getutm.app/>`_.
+.. tabs::
 
-Download the .iso image of `Ubuntu 22.04 <https://cdimage.ubuntu.com/jammy/daily-live/current/>`_ for Humble and Rolling or `Ubuntu 20.04 <https://cdimage.ubuntu.com/focal/daily-live/pending/>`_ for Foxy.
-Be sure to download the image corresponding to your CPU architecture.
+    .. group-tab:: Virtual machine
 
-In the UTM software:
+      Install UTM on your macOS machine.
+      The link can be found on the `official UTM website <https://mac.getutm.app/>`_.
 
-* Create a new image and choose ``Virtualize`` option.
-* Select the ISO image you have downloaded in the ``Boot ISO Image`` field.
-* Leave all hardware settings at default (including hardware acceleration disabled).
-* In the ``Shared Directory`` window, select a folder that will be used by ``webots_ros2`` to transfer all the Webots assets to the host.
-  In this example, the selected folder is ``/Users/username/shared``.
-* Leave all the remaining parameters as default.
-* Start the VM.
-  Note that you can select another shared folder each time you start the VM.
-* During the first launch of the VM, install Ubuntu and choose a username for your account. In this example, the username is ``ubuntu``.
-* Once Ubuntu is installed, close the VM, remove the iso image from the CD/DVD field and restart the VM.
+      Download the .iso image of `Ubuntu 22.04 <https://cdimage.ubuntu.com/jammy/daily-live/current/>`_ for Humble and Rolling or `Ubuntu 20.04 <https://cdimage.ubuntu.com/focal/daily-live/pending/>`_ for Foxy.
+      Be sure to download the image corresponding to your CPU architecture.
 
-2 Configure the VM
-^^^^^^^^^^^^^^^^^^
-In this section, ROS 2 is installed in the VM and the shared folder is configured.
-The following instructions and commands are all run inside the VM.
+      In the UTM software:
 
-* Open a terminal in the started VM and install the ROS 2 distribution you need by following the instructions in :doc:`../../../../Installation/Ubuntu-Install-Debians`:
-* Create a folder in the VM to use as a shared folder.
-  In this example, the shared folder in the VM is ``/home/ubuntu/shared``.
+      * Create a new image and choose ``Virtualize`` option.
+      * Select the ISO image you have downloaded in the ``Boot ISO Image`` field.
+      * Leave all hardware settings at default (including hardware acceleration disabled).
+      * In the ``Shared Directory`` window, select a folder that will be used by ``webots_ros2`` to transfer all the Webots assets to the host.
+        In this example, the selected folder is ``/Users/username/shared``.
+      * Leave all the remaining parameters as default.
+      * Start the VM.
+        Note that you can select another shared folder each time you start the VM.
+      * During the first launch of the VM, install Ubuntu and choose a username for your account. In this example, the username is ``ubuntu``.
+      * Once Ubuntu is installed, close the VM, remove the iso image from the CD/DVD field and restart the VM.
 
-  .. code-block:: console
+    .. group-tab:: Docker container
 
-      mkdir /home/ubuntu/shared
+      Install Docker Desktop for Mac on your macOS machine.
+      The link can be found on the `Docker website <https://docs.docker.com/desktop/install/mac-install/>`_.
 
-* To mount this folder to the host, execute the following command.
-  Don't forget to modify the path to the shared folder, if it is different in your case.
+      Pull a Docker image for ROS.
+      This tutorial uses the latest `ROS Base <https://hub.docker.com/layers/library/ros/latest/images/sha256-52e27b46c352d7ee113f60b05590bb089628a17ef648fff6992ca363c5e14945?context=explore>`_ image.
 
-  .. code-block:: console
+2 Configure the virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      sudo mount -t 9p -o trans=virtio share /home/ubuntu/shared -oversion=9p2000.L
+.. tabs::
 
-* To automatically mount this folder to the host when starting the VM, add the following line to ``/etc/fstab``.
-  Don't forget to modify the path to the shared folder, if it is different in your case.
+    .. group-tab:: Virtual machine
 
-  .. code-block:: console
+      In this section, ROS 2 is installed in the VM and the shared folder is configured.
+      The following instructions and commands are all run inside the VM.
 
-      share	/home/ubuntu/shared	9p	trans=virtio,version=9p2000.L,rw,_netdev,nofail	0	0
+      * Open a terminal in the started VM and install the ROS 2 distribution you need by following the instructions in :doc:`../../../../Installation/Ubuntu-Install-Debians`:
+      * Create a folder in the VM to use as a shared folder.
+        In this example, the shared folder in the VM is ``/home/ubuntu/shared``.
 
-* The environment variable ``WEBOTS_SHARED_FOLDER`` must always be set in order for the package to work properly in the VM.
-  This variable specifies the location of the shared folder that is used to exchange data between the host machine and the virtual machine (VM) to the ``webots_ros2`` package.
-  The value to use for this variable should be in the format of ``<host shared folder>:<VM shared folder>``, where ``<host shared folder>`` is the path to the shared folder on the host machine and ``<VM shared folder>`` is the path to the same shared folder on the VM.
+        .. code-block:: console
 
-  In this example:
+            mkdir /home/ubuntu/shared
 
-  .. code-block:: console
+      * To mount this folder to the host, execute the following command.
+        Don't forget to modify the path to the shared folder, if it is different in your case.
 
-    export WEBOTS_SHARED_FOLDER=/Users/username/shared:/home/ubuntu/shared
+        .. code-block:: console
 
-  You can add this command line to the ``~/.bashrc`` file to automatically set this environment variable when starting a new terminal.
+            sudo mount -t 9p -o trans=virtio share /home/ubuntu/shared -oversion=9p2000.L
+
+      * To automatically mount this folder to the host when starting the VM, add the following line to ``/etc/fstab``.
+        Don't forget to modify the path to the shared folder, if it is different in your case.
+
+        .. code-block:: console
+
+            share	/home/ubuntu/shared	9p	trans=virtio,version=9p2000.L,rw,_netdev,nofail	0	0
+
+      * The environment variable ``WEBOTS_SHARED_FOLDER`` must always be set in order for the package to work properly in the VM.
+        This variable specifies the location of the shared folder that is used to exchange data between the host machine and the virtual machine (VM) to the ``webots_ros2`` package.
+        The value to use for this variable should be in the format of ``<host shared folder>:<VM shared folder>``, where ``<host shared folder>`` is the path to the shared folder on the host machine and ``<VM shared folder>`` is the path to the same shared folder on the VM.
+
+        In this example:
+
+        .. code-block:: console
+
+          export WEBOTS_SHARED_FOLDER=/Users/username/shared:/home/ubuntu/shared
+
+        You can add this command line to the ``~/.bashrc`` file to automatically set this environment variable when starting a new terminal.
+
+    .. group-tab:: Docker container
+
+        In this section, the ROS 2 image is installed.
+        The following instructions and commands are all run on the host machine.
+
+        * Create a folder to use as a shared folder.
+          In this example, the shared folder on macOS is ``/Users/username/shared``, where ``username`` is your actual username.
+
+          .. code-block:: console
+
+            mkdir /Users/username/shared
+
+        * Start a new ROS 2 container with a bind mount for the shared directory you created in the previous step.
+          The shared directory will be located at ``/root/shared`` inside the container.
+
+          .. code-block:: console
+
+            docker run -it --mount type=bind,src=/Users/username/shared,target=/root/shared ros:latest
+
+        * The environment variable ``WEBOTS_SHARED_FOLDER`` must always be set in order for the package to work properly in the Docker container.
+          This variable specifies the location of the shared folder that is used to exchange data between the host machine and the container to the ``webots_ros2`` package.
+          The value to use for this variable should be in the format of ``<host shared folder>:<container shared folder>``, where ``<host shared folder>`` is the path to the shared folder on the host machine and ``<container shared folder>`` is the path to the same shared folder on the Docker container.
+
+          In this example:
+
+          .. code-block:: console
+
+            export WEBOTS_SHARED_FOLDER=/Users/username/shared:/root/shared
+
 
 3 Install ``webots_ros2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,7 +157,8 @@ You can either install ``webots_ros2`` from the official released package, or in
 
     .. group-tab:: Install ``webots_ros2`` distributed package
 
-        Run the following command in the VM terminal.
+        Run the following command in the VM or container terminal.
+        If you're using the container, you don't need to use ``sudo`` because the container's user is ``root``.
 
         .. code-block:: console
 
@@ -119,6 +167,7 @@ You can either install ``webots_ros2`` from the official released package, or in
     .. group-tab:: Install ``webots_ros2`` from sources
 
         Install git.
+        If you're using the container, you don't need to use ``sudo`` because the container's user is ``root``.
 
         .. code-block:: console
 
@@ -166,18 +215,20 @@ You can either install ``webots_ros2`` from the official released package, or in
 4 Launch the ``webots_ros2_universal_robot`` example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As mentioned in previous sections, the package uses the shared folder to communicate with Webots from the VM to the host.
-In order for Webots to be started on the host from the VM's ROS package, a local TCP simulation server must be run.
+As mentioned in previous sections, the package uses the shared folder to communicate with Webots from the VM or container to the host.
+In order for Webots to be started on the host from the VM's or container's ROS package, a local TCP simulation server must be run.
 
 The server can be downloaded here: `local_simulation_server.py <https://github.com/cyberbotics/webots-server/blob/main/local_simulation_server.py>`_.
-Specify the Webots installation folder in ``WEBOTS_HOME`` environment variable (e.g. ``/Applications/Webots.app``) and run the server using the following commands in a new terminal on the host (not in the VM):
+Specify the Webots installation folder in ``WEBOTS_HOME`` environment variable (e.g. ``/Applications/Webots.app``) and run the server using the following commands in a new terminal on the host (not in the VM or container):
 
 .. code-block:: console
 
         export WEBOTS_HOME=/Applications/Webots.app
         python3 local_simulation_server.py
 
-In the VM, open a terminal and execute the following commands to start a package:
+
+Execute the following commands in the virtual environment to start a package.
+If you're using a VM, you may need to open a terminal first.
 
 First source the ROS 2 environment, if not done already.
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
@@ -50,14 +50,14 @@ Tasks
 
 If you're using Ubuntu, you most likely will want to install Webots and its associated ROS packages natively.
 However, you can set up an alternative configuration where the ROS packages run in a Docker container and Webots runs on the host.
-This setup is similar to macOS and Windows hosts.
+This type of setup is similar to macOS and Windows hosts.
 
 * Install Docker Engine on your Ubuntu machine.
   The instructions can be found on the `Docker website <https://docs.docker.com/engine/install/ubuntu/>`_.
 
 * Pull a Docker image for ROS. This tutorial uses the latest `ROS Base <https://hub.docker.com/layers/library/ros/latest/images/sha256-52e27b46c352d7ee113f60b05590bb089628a17ef648fff6992ca363c5e14945?context=explore>`_ image.
 
-The following instructions and commands are all run on the host machine.
+The following instructions and commands all are run on the host machine.
 
 * Create a folder to use as a shared folder.
   In this example, the shared folder on Ubuntu is ``/home/username/shared``, where ``username`` is your actual username.
@@ -69,13 +69,15 @@ The following instructions and commands are all run on the host machine.
 * Start a new ROS 2 container with a bind mount for the shared directory you created in the previous step.
   The shared directory will be located at ``/root/shared`` inside the container.
 
-  Unlike Docker Desktop for Mac and Docker Desktop for Windows, you will need to specify your machine as an extra host.
-  This allows the container to resolve Docker's special ``host.docker.internal`` DNS name, allowing the container to communicate with the host.
-  (See `this <https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach>`_ StackOverflow post for more information about why this is needed).
-
   .. code-block:: console
 
     docker run -it --mount type=bind,src=/home/username/shared,target=/root/shared --add-host host.docker.internal:host-gateway ros:latest
+
+  .. note::
+    Unlike Docker Desktop for Mac and Docker Desktop for Windows, you will need to specify your machine as an extra host.
+    This allows the container to resolve Docker's special ``host.docker.internal`` DNS name, allowing the container to communicate with the host.
+    See `this <https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach>`_ StackOverflow post for more information about why this is needed.
+
 
 * The environment variable ``WEBOTS_SHARED_FOLDER`` must always be set in order for the package to work properly in the Docker container.
   This variable specifies the location of the shared folder that is used to exchange data between the host machine and the container to the ``webots_ros2`` package.
@@ -148,18 +150,19 @@ You can either install the official released package, or install it from the lat
 2 Launch the ``webots_ros2_universal_robot`` example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are using a Docker container, you will need to run a local TCP simulation server on the host so the ``webots_ros2`` packages can communicate with the Webots simulator.
-The server can be downloaded here: `local_simulation_server.py <https://github.com/cyberbotics/webots-server/blob/main/local_simulation_server.py>`_.
-Specify (on the host) the Webots installation folder in ``WEBOTS_HOME`` environment variable and run the server using the following commands in a new terminal on the host (not in the container):
+.. note::
+  If you are using a Docker container, you will need to run a local TCP simulation server on the host so the ``webots_ros2`` packages can communicate with the Webots simulator.
+  The server can be downloaded here: `local_simulation_server.py <https://github.com/cyberbotics/webots-server/blob/main/local_simulation_server.py>`_.
+  Specify (on the host) the Webots installation folder in ``WEBOTS_HOME`` environment variable and run the server using the following commands in a new terminal on the host (not in the container):
 
-.. code-block:: console
+  .. code-block:: console
 
     export WEBOTS_HOME=<path to webots binary>
     python3 local_simulation_server.py
 
-Be sure to also set ``WEBOTS_SHARED_FOLDER`` on the host.
+  Be sure to also set ``WEBOTS_SHARED_FOLDER`` on the host.
 
-.. code-block:: console
+  .. code-block:: console
 
     export WEBOTS_SHARED_FOLDER=/home/username/shared:/root/shared
 
@@ -185,6 +188,8 @@ If installed from sources, source your ROS 2 workspace, if not done already.
 
         cd ~/ros2_ws
         source install/local_setup.bash
+
+If you are using a Docker container, be sure to set the ``WEBOTS_SHARED_FOLDER`` environment variable on the container to the same value you set it to on the host.
 
 Use the ROS 2 launch command to start demo packages (e.g. ``webots_ros2_universal_robot``).
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Ubuntu.rst
@@ -45,6 +45,51 @@ If you have installed different versions of Webots on your computer, ``webots_ro
 Tasks
 -----
 
+0 Set up a virtual environment (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you're using Ubuntu, you most likely will want to install Webots and its associated ROS packages natively.
+However, you can set up an alternative configuration where the ROS packages run in a Docker container and Webots runs on the host.
+This setup is similar to macOS and Windows hosts.
+
+* Install Docker Engine on your Ubuntu machine.
+  The instructions can be found on the `Docker website <https://docs.docker.com/engine/install/ubuntu/>`_.
+
+* Pull a Docker image for ROS. This tutorial uses the latest `ROS Base <https://hub.docker.com/layers/library/ros/latest/images/sha256-52e27b46c352d7ee113f60b05590bb089628a17ef648fff6992ca363c5e14945?context=explore>`_ image.
+
+The following instructions and commands are all run on the host machine.
+
+* Create a folder to use as a shared folder.
+  In this example, the shared folder on Ubuntu is ``/home/username/shared``, where ``username`` is your actual username.
+
+  .. code-block:: console
+
+    mkdir /home/username/shared
+
+* Start a new ROS 2 container with a bind mount for the shared directory you created in the previous step.
+  The shared directory will be located at ``/root/shared`` inside the container.
+
+  Unlike Docker Desktop for Mac and Docker Desktop for Windows, you will need to specify your machine as an extra host.
+  This allows the container to resolve Docker's special ``host.docker.internal`` DNS name, allowing the container to communicate with the host.
+  (See `this <https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach>`_ StackOverflow post for more information about why this is needed).
+
+  .. code-block:: console
+
+    docker run -it --mount type=bind,src=/home/username/shared,target=/root/shared --add-host host.docker.internal:host-gateway ros:latest
+
+* The environment variable ``WEBOTS_SHARED_FOLDER`` must always be set in order for the package to work properly in the Docker container.
+  This variable specifies the location of the shared folder that is used to exchange data between the host machine and the container to the ``webots_ros2`` package.
+  The value to use for this variable should be in the format of ``<host shared folder>:<container shared folder>``, where ``<host shared folder>`` is the path to the shared folder on the host machine and ``<container shared folder>`` is the path to the same shared folder on the Docker container.
+
+  In this example:
+
+  .. code-block:: console
+
+    export WEBOTS_SHARED_FOLDER=/home/username/shared:/root/shared
+
+If you decide to use a Docker container, you will run steps 1 and 2 in the container unless otherwise specified.
+You won't need to use ``sudo`` when you're running the commands because the container's user is ``root``.
+
 1 Install ``webots_ros2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 You can either install the official released package, or install it from the latest up-to-date sources from `Github <https://github.com/cyberbotics/webots_ros2>`_.
@@ -103,7 +148,23 @@ You can either install the official released package, or install it from the lat
 2 Launch the ``webots_ros2_universal_robot`` example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+If you are using a Docker container, you will need to run a local TCP simulation server on the host so the ``webots_ros2`` packages can communicate with the Webots simulator.
+The server can be downloaded here: `local_simulation_server.py <https://github.com/cyberbotics/webots-server/blob/main/local_simulation_server.py>`_.
+Specify (on the host) the Webots installation folder in ``WEBOTS_HOME`` environment variable and run the server using the following commands in a new terminal on the host (not in the container):
+
+.. code-block:: console
+
+    export WEBOTS_HOME=<path to webots binary>
+    python3 local_simulation_server.py
+
+Be sure to also set ``WEBOTS_SHARED_FOLDER`` on the host.
+
+.. code-block:: console
+
+    export WEBOTS_SHARED_FOLDER=/home/username/shared:/root/shared
+
 The following instructions explain how to start a provided example.
+If you're using a Docker container, run these commands in the container.
 
 First source the ROS 2 environment, if not done already.
 
@@ -112,6 +173,7 @@ First source the ROS 2 environment, if not done already.
         source /opt/ros/{DISTRO}/setup.bash
 
 Setting the ``WEBOTS_HOME`` environment variable allows you to start a specific Webots installation.
+Skip this step if you're using Docker container.
 
 .. code-block:: console
 


### PR DESCRIPTION
# Overview

This PR adds instructions for using the `webots_ros2` packages when Webots is installed natively on macOS or Ubuntu and the associated ROS packages are installed in a Docker container. There is a PR that adds Docker support for working with ROS and Webots on macOS and Ubuntu, and the relevant documentation needs to be updated.

# Related issues

Related to cyberbotics/webots_ros2#889
Depends on cyberbotics/webots_ros2#889