### PR TITLE
Copy over Metrics from wiki to ros2_documentation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: automatic backport of common pages
     conditions:
       - base=rolling
-      - "files~=Governance|Contact|index|Marketing|ROSCon-Content|Roadmap|Releases|Feature-Ideas"
+      - "files~=Governance|Contact|index|Marketing|ROSCon-Content|Roadmap|Releases|Feature-Ideas|Metrics"
     actions:
       backport:
         branches:

--- a/source/The-ROS2-Project.rst
+++ b/source/The-ROS2-Project.rst
@@ -13,3 +13,4 @@ Check out the resources below to learn more about the advancement of the ROS 2 p
    The-ROS2-Project/ROSCon-Content
    The-ROS2-Project/Governance
    The-ROS2-Project/Marketing
+   The-ROS2-Project/Metrics

--- a/source/The-ROS2-Project/Metrics.rst
+++ b/source/The-ROS2-Project/Metrics.rst
@@ -1,0 +1,44 @@
+.. _Metrics:
+
+Metrics
+=======
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+
+We measure aspects of the ROS community to understand and track the impact of our work and identify areas for improvement.
+We take inspiration from the MeeGo Project's metrics.
+
+Metrics.ros.org
+---------------
+
+At `metrics.ros.org <https://metrics.ros.org>`_ you can find many visualizations of metrics about ROS.
+
+Periodic Metrics Report
+-----------------------
+
+We periodically publish a metrics report that provides a quantitative view of the ROS community.
+We're collectively learning what to measure and how and evoloving as systems change.
+Please provide feedback!
+Add your suggestions on how to improve these reports by posting them to `ROS Discourse Site Feedback Category <http://discourse.ros.org/c/site-feedback>`_.
+
+Historical Metrics Reports
+..........................
+
+* :download:`2023 <http://download.ros.org/downloads/metrics/metrics-report-2024-01.pdf>`
+* :download:`2022 <http://download.ros.org/downloads/metrics/metrics-report-2022-07.pdf>`
+* :download:`2021 <http://download.ros.org/downloads/metrics/metrics-report-2021-07.pdf>`
+* :download:`2020 <http://download.ros.org/downloads/metrics/metrics-report-2020-07.pdf>`
+* :download:`2019 <http://download.ros.org/downloads/metrics/metrics-report-2019-07.pdf>`
+* :download:`2018 <http://download.ros.org/downloads/metrics/metrics-report-2018-07.pdf>`
+* :download:`2017 <http://download.ros.org/downloads/metrics/metrics-report-2017-07.pdf>`
+* :download:`2016 <http://download.ros.org/downloads/metrics/metrics-report-2016-07.pdf>`
+* :download:`2015 <http://download.ros.org/downloads/metrics/metrics-report-2015-07.pdf>`
+* :download:`2014 <http://download.ros.org/downloads/metrics/metrics-report-2014-07.pdf>`
+* :download:`2013 <http://download.ros.org/downloads/metrics/metrics-report-2013-08.pdf>`
+* :download:`2012 <http://download.ros.org/downloads/metrics/metrics-report-2012-07.pdf>`
+* :download:`2011 <http://download.ros.org/downloads/metrics/metrics-report-2011-08.pdf>`
+
+


### PR DESCRIPTION
These reports are important to continue to provide visiblity for ROS 2 as well as maintain the history.

Migrating from: https://wiki.ros.org/Metrics

This will also avoid the need to upload them to download.ros.org separately.