### PR TITLE
Document LD_LIBRARY_PATH and catching exceptions with GDB when testing

### DIFF
--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -35,7 +35,7 @@ To see the exact test cases which fail, use the ``--verbose`` flag:
 Debugging tests with GDB
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If a C++ test is failing, gdb can be used directly on the test executable in the build directory.
+If a C++ test is failing, GDB can be used directly on the test executable in the build directory.
 Ensure to build the code in debug mode.
 Since the previous build type may be cached by CMake, clean the cache and rebuild.
 
@@ -43,7 +43,7 @@ Since the previous build type may be cached by CMake, clean the cache and rebuil
 
   colcon build --cmake-clean-cache --mixin debug
 
-In order for gdb to load debug symbols for any shared libraries called, make sure to source your environment.
+In order for GDB to load debug symbols for any shared libraries called, make sure to source your environment.
 This configures the value of ``LD_LIBRARY_PATH``.
 
 .. code-block:: console
@@ -51,7 +51,7 @@ This configures the value of ``LD_LIBRARY_PATH``.
   source install/setup.bash
 
 
-Finally, run the test directly through gdb.
+Finally, run the test directly through GDB.
 For example:
 
 .. code-block:: console

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -43,9 +43,26 @@ Since the previous build type may be cached by CMake, clean the cache and rebuil
 
   colcon build --cmake-clean-cache --mixin debug
 
-Next, run the test directly through gdb.
+In order for gdb to load debug symbols for any shared libraries called, make sure to source your environment.
+This configures the value of ``LD_LIBRARY_PATH``.
+
+.. code-block:: console
+
+  source install/setup.bash
+
+
+Finally, run the test directly through gdb.
 For example:
 
 .. code-block:: console
 
   gdb -ex run ./build/rcl/test/test_logging
+
+If the code is throwing an unhandled exception, you can catch it in GDB before gtest handles it.
+
+.. code-block:: console
+
+  gdb ./build/rcl/test/test_logging
+  catch throw
+  run
+

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -50,7 +50,6 @@ This configures the value of ``LD_LIBRARY_PATH``.
 
   source install/setup.bash
 
-
 Finally, run the test directly through GDB.
 For example:
 


### PR DESCRIPTION
# Background

I ran into another test failure that I couldn't track down. According to the guide I wrote earlier, debug symbols only get loaded on the test itself. 

Now, users are recommended to source their workspace. With this, gdb is aware of the path to all the libraries and get debug symbols correctly. I presume this is through LD_LIBRARY_PATH, but I could be wrong. 

Additionally, exceptions thrown in ROS libraries are caught by gtest, and if you want to have gdb find them first, the workflow is slightly different. 

There may be better ways to do this, but the workflow works well for me. 

# Real world example

https://github.com/ANYbotics/grid_map/issues/401#issuecomment-1947929594

# Why is this necessary

Well, I have grid_map installed with binaries, and then develop locally in the workspace with debug. The installed binaries are in release mode, so gdb is actually running the wrong library and I'm testing the wrong code under GDB. Forgetting to source the environment means you might be debugging the wrong code! This explains why any modifications I did seemed to have no effect.

# What about VSCode

VSCode is great, but can't run a script before starting a debug session. This means that the GDB configuration cannot run `source install/setup.bash` and have the environment configured correctly.  I have yet to find a way around this other than telling people to learn CLI GDB.
https://stackoverflow.com/questions/43836861/how-to-run-a-command-in-visual-studio-code-with-launch-json

# Related

https://github.com/ros2/ros2_documentation/pull/3899