### PR TITLE
Enhance contribution setup docs with streamlined commands

### DIFF
--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -33,7 +33,14 @@ The root directory contains configuration and files required to locally build th
 Building the site locally
 -------------------------
 
-Start by installing requirements located in the ``requirements.txt`` file:
+Start by cloning the repo locally with 
+
+.. code-block:: console
+
+   git clone https://github.com/ros2/ros2_documentation.git
+
+
+Then install requirements located in the ``requirements.txt`` file:
 
 .. tabs::
 
@@ -43,7 +50,8 @@ Start by installing requirements located in the ``requirements.txt`` file:
 
     .. code-block:: console
 
-       pip3 install --user --upgrade -r requirements.txt
+       export PATH="~/.local/bin:$PATH" && pip3 install --user --upgrade -r requirements.txt
+
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
As an individual contributor to this open-source project, I noticed an opportunity to enhance the contributor experience by simplifying the initial setup instructions within our documentation. This commit aims to lower the entry barrier for new contributors by providing a concise, all-in-one command sequence that facilitates the setup process.

Key Updates:
- Introduced a command for cloning the repository, ensuring newcomers start off on the right foot without having to navigate through multiple setup steps.
- Integrated the PATH environment variable update (`~/.local/bin`) within the setup commands to eliminate the need for manual configuration, making the environment preparation seamless.
- Combined cloning, environment setup, and dependencies installation into a singular command. This change is designed to make the first-time setup as straightforward as possible, aligning with our project's goal of being accessible and welcoming to new contributors.

Rationale:
The motivation behind these changes is to simplify the contribution process, making it more appealing and less daunting for individuals looking to contribute to our project. By streamlining the setup instructions, we hope to encourage a broader range of contributions and foster a more inclusive community.