### PR TITLE
Add YAML code and YAML explanation to Launch/Using-Substitutions

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -124,6 +124,7 @@ Finally, make sure to install the launch files:
 ^^^^^^^^^^^^^^^^^^^^
 
 Let's create a launch file that will call and pass arguments to another launch file.
+This launch file can either be in Python, or in YAML.
 
 To do this, create following file in the ``launch`` folder of the ``launch_tutorial`` package.
 
@@ -131,7 +132,6 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
 
   .. group-tab:: Python
 
-    Create an ``example_main_launch.py`` file.
 
     Copy and paste the complete code into the ``launch/example_main_launch.py`` file:
 
@@ -168,7 +168,7 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
           ])
 
 
-    In the ``example_main_launch.py`` file, the ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
     The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions_launch.py`` file name.
 
     .. code-block:: python
@@ -192,7 +192,6 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
 
   .. group-tab:: YAML
 
-    Create an ``example_main_launch.yaml`` file.
 
     Copy and paste the complete code into the ``launch/example_main_launch.yaml`` file:
 
@@ -212,8 +211,8 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
               - name: 'new_background_r'
                 value: '$(var background_r)'
 
-    In the ``example_main_launch.yaml`` file, the ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
-    The path substitution is then extended with the ``example_substitutions_launch.yaml`` file name.
+    The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The path substitution is then joined with the ``example_substitutions_launch.yaml`` file name.
 
     .. code-block:: yaml
 
@@ -241,7 +240,7 @@ Now create the substitution launch file in the same folder:
 
   .. group-tab:: Python
 
-    Create the file ``example_substitutions_launch.py`` and insert the following code:
+    Create the file ``launch/example_substitutions_launch.py`` and insert the following code:
 
     .. code-block:: python
 
@@ -327,7 +326,7 @@ Now create the substitution launch file in the same folder:
                 )
             ])
 
-    In the ``example_substitutions_launch.py`` file, ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
     They are used to store values of launch arguments in the above variables and to pass them to required actions.
     These ``LaunchConfiguration`` substitutions allow us to acquire the value of the launch argument in any part of the launch description.
 
@@ -416,7 +415,7 @@ Now create the substitution launch file in the same folder:
 
   .. group-tab:: YAML
 
-    Create the file ``example_substitutions_launch.yaml`` and insert the following code:
+    Create the file ``launch/example_substitutions_launch.yaml`` and insert the following code:
 
     .. code-block:: yaml
 
@@ -447,7 +446,7 @@ Now create the substitution launch file in the same folder:
                   cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
                   if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
 
-    In the ``example_substitutions_launch.yaml`` file, ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
     They are used to store values of launch arguments in the above variables and to pass them to required actions.
     The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
 
@@ -475,7 +474,8 @@ Now create the substitution launch file in the same folder:
           exec: 'turtlesim_node'
           name: 'sim'
 
-    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag. This command makes a call to the spawn service of the turtlesim node.
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
+    This command makes a call to the spawn service of the turtlesim node.
 
     Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
 

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -40,11 +40,25 @@ Using substitutions
 1 Create and setup the package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create a new package of build_type ``ament_python`` called ``launch_tutorial``:
+First, create a new package with the name ``launch_tutorial``:
 
-.. code-block:: console
+.. tabs::
 
-  ros2 pkg create --build-type ament_python --license Apache-2.0 launch_tutorial
+  .. group-tab:: Python package
+
+    Create a new package of build_type ``ament_python``:
+
+    .. code-block:: console
+
+      ros2 pkg create --build-type ament_python --license Apache-2.0 launch_tutorial
+
+  .. group-tab:: C++ package
+
+    Create a new package of build_type ``ament_cmake``:
+
+    .. code-block:: console
+
+      ros2 pkg create --build-type ament_cmake --license Apache-2.0 launch_tutorial
 
 Inside of that package, create a directory called ``launch``:
 
@@ -68,103 +82,259 @@ Inside of that package, create a directory called ``launch``:
 
       md launch_tutorial/launch
 
-Finally, make sure to add in changes to the ``setup.py`` of the package so that the launch files will be installed:
+Finally, make sure to install the launch files:
 
-.. code-block:: python
+.. tabs::
 
-  import os
-  from glob import glob
-  from setuptools import find_packages, setup
+  .. group-tab:: Python package
 
-  package_name = 'launch_tutorial'
+    Add in following changes to the ``setup.py`` of the package:
 
-  setup(
-      # Other parameters ...
-      data_files=[
-          # ... Other data files
-          # Include all launch files.
-          (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*')))
-      ]
-  )
+    .. code-block:: python
+
+      import os
+      from glob import glob
+      from setuptools import find_packages, setup
+
+      package_name = 'launch_tutorial'
+
+      setup(
+          # Other parameters ...
+          data_files=[
+              # ... Other data files
+              # Include all launch files.
+              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*')))
+          ]
+      )
+
+  .. group-tab:: C++ package
+
+    Append following code to the ``CMakeLists.txt`` just before ``ament_package()``:
+
+    .. code-block:: cmake
+
+      install(DIRECTORY
+              launch
+              DESTINATION share/${PROJECT_NAME}/
+      )
+
 
 
 2 Parent launch file
 ^^^^^^^^^^^^^^^^^^^^
 
 Let's create a launch file that will call and pass arguments to another launch file.
-To do this, create an ``example_main_launch.py`` file in the ``launch`` folder of the ``launch_tutorial`` package.
 
-.. code-block:: python
+To do this, create following file in the ``launch`` folder of the ``launch_tutorial`` package.
 
-    from launch_ros.substitutions import FindPackageShare
+.. tabs::
 
-    from launch import LaunchDescription
-    from launch.actions import IncludeLaunchDescription
-    from launch.launch_description_sources import PythonLaunchDescriptionSource
-    from launch.substitutions import PathJoinSubstitution, TextSubstitution
+  .. group-tab:: Python
 
+    Create an ``example_main_launch.py`` file.
 
-    def generate_launch_description():
-        colors = {
-            'background_r': '200'
-        }
+    Copy and paste the complete code into the ``launch/example_main_launch.py`` file:
 
-        return LaunchDescription([
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([
-                    PathJoinSubstitution([
-                        FindPackageShare('launch_tutorial'),
-                        'launch',
-                        'example_substitutions_launch.py'
-                    ])
-                ]),
-                launch_arguments={
-                    'turtlesim_ns': 'turtlesim2',
-                    'use_provided_red': 'True',
-                    'new_background_r': TextSubstitution(text=str(colors['background_r']))
-                }.items()
-            )
-        ])
+    .. code-block:: python
+
+      from launch_ros.substitutions import FindPackageShare
+
+      from launch import LaunchDescription
+      from launch.actions import IncludeLaunchDescription
+      from launch.launch_description_sources import PythonLaunchDescriptionSource
+      from launch.substitutions import PathJoinSubstitution, TextSubstitution
 
 
-In the ``example_main_launch.py`` file, the ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
-The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions_launch.py`` file name.
+      def generate_launch_description():
+          colors = {
+              'background_r': '200'
+          }
 
-.. code-block:: python
+          return LaunchDescription([
+              IncludeLaunchDescription(
+                  PythonLaunchDescriptionSource([
+                      PathJoinSubstitution([
+                          FindPackageShare('launch_tutorial'),
+                          'launch',
+                          'example_substitutions_launch.py'
+                      ])
+                  ]),
+                  launch_arguments={
+                      'turtlesim_ns': 'turtlesim2',
+                      'use_provided_red': 'True',
+                      'new_background_r': TextSubstitution(text=str(colors['background_r']))
+                  }.items()
+              )
+          ])
 
-    PathJoinSubstitution([
-        FindPackageShare('launch_tutorial'),
-        'launch',
-        'example_substitutions_launch.py'
-    ])
 
-The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
-The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.
+    In the ``example_main_launch.py`` file, the ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions_launch.py`` file name.
 
-.. code-block:: python
+    .. code-block:: python
 
-    launch_arguments={
-        'turtlesim_ns': 'turtlesim2',
-        'use_provided_red': 'True',
-        'new_background_r': TextSubstitution(text=str(colors['background_r']))
-    }.items()
+      PathJoinSubstitution([
+          FindPackageShare('launch_tutorial'),
+          'launch',
+          'example_substitutions_launch.py'
+      ])
+
+    The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
+    The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.
+
+    .. code-block:: python
+
+      launch_arguments={
+          'turtlesim_ns': 'turtlesim2',
+          'use_provided_red': 'True',
+          'new_background_r': TextSubstitution(text=str(colors['background_r']))
+      }.items()
+
+  .. group-tab:: YAML
+
+    Create an ``example_main_launch.yaml`` file.
+
+    Copy and paste the complete code into the ``launch/example_main_launch.yaml`` file:
+
+    .. code-block:: yaml
+
+      launch:
+        - let:
+            name: 'background_r'
+            value: '200'
+        - include:
+            file: '$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.yaml'
+            arg:
+              - name: 'turtlesim_ns'
+                value: 'turtlesim2'
+              - name: 'use_provided_red'
+                value: 'True'
+              - name: 'new_background_r'
+                value: '$(var background_r)'
+
+    In the ``example_main_launch.yaml`` file, the ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The path substitution is then extended with the ``example_substitutions_launch.yaml`` file name.
+
+    .. code-block:: yaml
+
+      file: '$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.yaml'
+
+    The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
+    The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
+
+    .. code-block:: yaml
+
+      arg:
+        - name: 'turtlesim_ns'
+          value: 'turtlesim2'
+        - name: 'use_provided_red'
+          value: 'True'
+        - name: 'new_background_r'
+          value: '$(var background_r)'
 
 3 Substitutions example launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Now create an ``example_substitutions_launch.py`` file in the same folder.
+Now create the substitution launch file in the same folder:
 
-.. code-block:: python
+.. tabs::
 
-    from launch_ros.actions import Node
+  .. group-tab:: Python
 
-    from launch import LaunchDescription
-    from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
-    from launch.conditions import IfCondition
-    from launch.substitutions import LaunchConfiguration, PythonExpression
+    Create the file ``example_substitutions_launch.py`` and insert the following code:
+
+    .. code-block:: python
+
+        from launch_ros.actions import Node
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
+        from launch.conditions import IfCondition
+        from launch.substitutions import LaunchConfiguration, PythonExpression
 
 
-    def generate_launch_description():
+        def generate_launch_description():
+            turtlesim_ns = LaunchConfiguration('turtlesim_ns')
+            use_provided_red = LaunchConfiguration('use_provided_red')
+            new_background_r = LaunchConfiguration('new_background_r')
+
+            turtlesim_ns_launch_arg = DeclareLaunchArgument(
+                'turtlesim_ns',
+                default_value='turtlesim1'
+            )
+            use_provided_red_launch_arg = DeclareLaunchArgument(
+                'use_provided_red',
+                default_value='False'
+            )
+            new_background_r_launch_arg = DeclareLaunchArgument(
+                'new_background_r',
+                default_value='200'
+            )
+
+            turtlesim_node = Node(
+                package='turtlesim',
+                namespace=turtlesim_ns,
+                executable='turtlesim_node',
+                name='sim'
+            )
+            spawn_turtle = ExecuteProcess(
+                cmd=[[
+                    'ros2 service call ',
+                    turtlesim_ns,
+                    '/spawn ',
+                    'turtlesim/srv/Spawn ',
+                    '"{x: 2, y: 2, theta: 0.2}"'
+                ]],
+                shell=True
+            )
+            change_background_r = ExecuteProcess(
+                cmd=[[
+                    'ros2 param set ',
+                    turtlesim_ns,
+                    '/sim background_r ',
+                    '120'
+                ]],
+                shell=True
+            )
+            change_background_r_conditioned = ExecuteProcess(
+                condition=IfCondition(
+                    PythonExpression([
+                        new_background_r,
+                        ' == 200',
+                        ' and ',
+                        use_provided_red
+                    ])
+                ),
+                cmd=[[
+                    'ros2 param set ',
+                    turtlesim_ns,
+                    '/sim background_r ',
+                    new_background_r
+                ]],
+                shell=True
+            )
+
+            return LaunchDescription([
+                turtlesim_ns_launch_arg,
+                use_provided_red_launch_arg,
+                new_background_r_launch_arg,
+                turtlesim_node,
+                spawn_turtle,
+                change_background_r,
+                TimerAction(
+                    period=2.0,
+                    actions=[change_background_r_conditioned],
+                )
+            ])
+
+    In the ``example_substitutions_launch.py`` file, ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    These ``LaunchConfiguration`` substitutions allow us to acquire the value of the launch argument in any part of the launch description.
+
+    ``DeclareLaunchArgument`` is used to define the launch argument that can be passed from the above launch file or from the console.
+
+    .. code-block:: python
+
         turtlesim_ns = LaunchConfiguration('turtlesim_ns')
         use_provided_red = LaunchConfiguration('use_provided_red')
         new_background_r = LaunchConfiguration('new_background_r')
@@ -182,12 +352,24 @@ Now create an ``example_substitutions_launch.py`` file in the same folder.
             default_value='200'
         )
 
+    The ``turtlesim_node`` node with the ``namespace`` set to ``turtlesim_ns`` ``LaunchConfiguration`` substitution is defined.
+
+    .. code-block:: python
+
         turtlesim_node = Node(
             package='turtlesim',
             namespace=turtlesim_ns,
             executable='turtlesim_node',
             name='sim'
         )
+
+    Afterwards, the ``ExecuteProcess`` action called ``spawn_turtle`` is defined with the corresponding ``cmd`` argument.
+    This command makes a call to the spawn service of the turtlesim node.
+
+    Additionally, the ``LaunchConfiguration`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+
+    .. code-block:: python
+
         spawn_turtle = ExecuteProcess(
             cmd=[[
                 'ros2 service call ',
@@ -198,6 +380,13 @@ Now create an ``example_substitutions_launch.py`` file in the same folder.
             ]],
             shell=True
         )
+
+    The same approach is used for the ``change_background_r`` and ``change_background_r_conditioned`` actions that change the turtlesim background's red color parameter.
+    The difference is that the ``change_background_r_conditioned`` action is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation inside the ``IfCondition`` is done using the ``PythonExpression`` substitution.
+
+    .. code-block:: python
+
         change_background_r = ExecuteProcess(
             cmd=[[
                 'ros2 param set ',
@@ -225,105 +414,90 @@ Now create an ``example_substitutions_launch.py`` file in the same folder.
             shell=True
         )
 
-        return LaunchDescription([
-            turtlesim_ns_launch_arg,
-            use_provided_red_launch_arg,
-            new_background_r_launch_arg,
-            turtlesim_node,
-            spawn_turtle,
-            change_background_r,
-            TimerAction(
-                period=2.0,
-                actions=[change_background_r_conditioned],
-            )
-        ])
+  .. group-tab:: YAML
 
-In the ``example_substitutions_launch.py`` file, ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-They are used to store values of launch arguments in the above variables and to pass them to required actions.
-These ``LaunchConfiguration`` substitutions allow us to acquire the value of the launch argument in any part of the launch description.
+    Create the file ``example_substitutions_launch.yaml`` and insert the following code:
 
-``DeclareLaunchArgument`` is used to define the launch argument that can be passed from the above launch file or from the console.
+    .. code-block:: yaml
 
-.. code-block:: python
+      launch:
+        - arg:
+            name: 'turtlesim_ns'
+            default: 'turtlesim1'
+        - arg:
+            name: 'use_provided_red'
+            default: 'False'
+        - arg:
+            name: 'new_background_r'
+            default: '200'
 
-    turtlesim_ns = LaunchConfiguration('turtlesim_ns')
-    use_provided_red = LaunchConfiguration('use_provided_red')
-    new_background_r = LaunchConfiguration('new_background_r')
+        - node:
+            pkg: 'turtlesim'
+            namespace: '$(var turtlesim_ns)'
+            exec: 'turtlesim_node'
+            name: 'sim'
+        - executable:
+            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
+        - executable:
+            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
+        - timer:
+            period: 2.0
+            children:
+              - executable:
+                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
+                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
 
-    turtlesim_ns_launch_arg = DeclareLaunchArgument(
-        'turtlesim_ns',
-        default_value='turtlesim1'
-    )
-    use_provided_red_launch_arg = DeclareLaunchArgument(
-        'use_provided_red',
-        default_value='False'
-    )
-    new_background_r_launch_arg = DeclareLaunchArgument(
-        'new_background_r',
-        default_value='200'
-    )
+    In the ``example_substitutions_launch.yaml`` file, ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
 
-The ``turtlesim_node`` node with the ``namespace`` set to ``turtlesim_ns`` ``LaunchConfiguration`` substitution is defined.
+    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
 
-.. code-block:: python
+    .. code-block:: yaml
 
-    turtlesim_node = Node(
-        package='turtlesim',
-        namespace=turtlesim_ns,
-        executable='turtlesim_node',
-        name='sim'
-    )
+      - arg:
+          name: 'turtlesim_ns'
+          default: 'turtlesim1'
+      - arg:
+          name: 'use_provided_red'
+          default: 'False'
+      - arg:
+          name: 'new_background_r'
+          default: '200'
 
-Afterwards, the ``ExecuteProcess`` action called ``spawn_turtle`` is defined with the corresponding ``cmd`` argument.
-This command makes a call to the spawn service of the turtlesim node.
+    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
 
-Additionally, the ``LaunchConfiguration`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+    .. code-block:: yaml
 
-.. code-block:: python
+      - node:
+          pkg: 'turtlesim'
+          namespace: '$(var turtlesim_ns)'
+          exec: 'turtlesim_node'
+          name: 'sim'
 
-    spawn_turtle = ExecuteProcess(
-        cmd=[[
-            'ros2 service call ',
-            turtlesim_ns,
-            '/spawn ',
-            'turtlesim/srv/Spawn ',
-            '"{x: 2, y: 2, theta: 0.2}"'
-        ]],
-        shell=True
-    )
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag. This command makes a call to the spawn service of the turtlesim node.
 
-The same approach is used for the ``change_background_r`` and ``change_background_r_conditioned`` actions that change the turtlesim background's red color parameter.
-The difference is that the ``change_background_r_conditioned`` action is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
-The evaluation inside the ``IfCondition`` is done using the ``PythonExpression`` substitution.
+    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
 
-.. code-block:: python
+    .. code-block:: yaml
 
-    change_background_r = ExecuteProcess(
-        cmd=[[
-            'ros2 param set ',
-            turtlesim_ns,
-            '/sim background_r ',
-            '120'
-        ]],
-        shell=True
-    )
-    change_background_r_conditioned = ExecuteProcess(
-        condition=IfCondition(
-            PythonExpression([
-                new_background_r,
-                ' == 200',
-                ' and ',
-                use_provided_red
-            ])
-        ),
-        cmd=[[
-            'ros2 param set ',
-            turtlesim_ns,
-            '/sim background_r ',
-            new_background_r
-        ]],
-        shell=True
-    )
+        - executable:
+            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
+
+    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
+    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
+
+    .. code-block:: yaml
+
+        - executable:
+            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
+        - timer:
+            period: 2.0
+            children:
+              - executable:
+                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
+                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
 
 4 Build the package
 ^^^^^^^^^^^^^^^^^^^
@@ -339,11 +513,21 @@ Also remember to source the workspace after building.
 Launching example
 -----------------
 
-Now you can launch the ``example_main_launch.py`` file using the ``ros2 launch`` command.
+Now you can launch using the ``ros2 launch`` command.
 
-.. code-block:: console
+.. tabs::
 
-    ros2 launch launch_tutorial example_main_launch.py
+  .. group-tab:: Python
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_main_launch.py
+
+  .. group-tab:: YAML
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_main_launch.yaml
 
 This will do the following:
 
@@ -355,12 +539,25 @@ This will do the following:
 Modifying launch arguments
 --------------------------
 
-If you want to change the provided launch arguments, you can either update them in ``launch_arguments`` dictionary in the ``example_main_launch.py`` or launch the ``example_substitutions_launch.py`` with preferred arguments.
-To see arguments that may be given to the launch file, run the following command:
+.. tabs::
 
-.. code-block:: console
+  .. group-tab:: Python
 
-    ros2 launch launch_tutorial example_substitutions_launch.py --show-args
+    If you want to change the provided launch arguments, you can either update them in ``launch_arguments`` dictionary in the ``example_main_launch.py`` or launch the ``example_substitutions_launch.py`` with preferred arguments.
+    To see arguments that may be given to the launch file, run the following command:
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.py --show-args
+
+  .. group-tab:: YAML
+
+    If you want to change the provided launch arguments, you can either update the ``background_r`` variable in the ``example_main_launch.yaml`` or launch the ``example_substitutions_launch.yaml`` with preferred arguments.
+    To see arguments that may be given to the launch file, run the following command:
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.yaml --show-args
 
 This will show the arguments that may be given to the launch file and their default values.
 
@@ -382,10 +579,19 @@ This will show the arguments that may be given to the launch file and their defa
 
 Now you can pass the desired arguments to the launch file as follows:
 
-.. code-block:: console
+.. tabs::
 
-    ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
+  .. group-tab:: Python
 
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
+
+  .. group-tab:: YAML
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.yaml turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
 Documentation
 -------------


### PR DESCRIPTION
There is only little information about ROS2 launch with "advanced" YAML features (e.g. substitutions and timers) in the tutorials section of the documentation.

To make it easier to use YAML launch files I extended the "[Using-Substitutions](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Launch/Using-Substitutions.html)" section accordingly with YAML samples and explanations.

The extended documentation demonstrates use of:
- `executable` tag for ros2 service call
- `arg` tag for use of launch configurations
- `$(var <name>)` substitutions to use the launch configurations
- conditional actions
- `timer` tag for delayed action exectution
- `$(eval <python-expression>)` substitution for the conditional launch
- `$(find-pkg-share <pkg-name>)` substitution to find packages
