### PR TITLE
Update Using-URDF-with-Robot-State-Publisher.rst

### DIFF
--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher.rst
@@ -323,7 +323,7 @@ Open a new terminal, the run Rviz using
 
 .. code-block:: console
 
-  rviz2 -d second_ros2_ws/install/urdf_tutorial_r2d2/share/urdf_tutorial_r2d2/r2d2.rviz
+  rviz2 -d second_ros2_ws/src/urdf_tutorial_r2d2/urdf/r2d2.rviz
 
 See the `User Guide <http://wiki.ros.org/rviz/UserGuide>`__ for details on how to use Rviz.
 


### PR DESCRIPTION
Corrected launch path for r2d2.rvis in Ubuntu to that set earlier in tutorial on the same page.  Possibly related to changes made for issue #3996 on Windows.