### PR TITLE
Remove an unnecessary note about Iron Irwini.

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -352,10 +352,6 @@ Now we are able to see the service communication between ``introspection_client`
    response: [{sum: 5}]
    ---
 
-.. note::
-
-   This feature is available on ``Iron Irwini`` or later.
-
 Summary
 -------
 

--- a/source/Tutorials/Demos/Service-Introspection.rst
+++ b/source/Tutorials/Demos/Service-Introspection.rst
@@ -23,10 +23,6 @@ It is possible to introspect service data communication with service introspecti
 
 In this demo, we'll be highlighting how to configure service introspection state for a service client and a server and monitor service communication with ``ros2 service echo``.
 
-.. note::
-
-   This feature is available on ``Iron Irwini`` or later.
-
 Installing the demo
 -------------------
 


### PR DESCRIPTION
We only backport the tutorials to the branches where they are valid, so we never need to say what release they are available for.  If they are in that branch, they are available for that release.