### PR TITLE
Document NaN support in interfaces and NaN usage in CLI

### DIFF
--- a/source/Concepts/Basic/About-Interfaces.rst
+++ b/source/Concepts/Basic/About-Interfaces.rst
@@ -183,6 +183,7 @@ Field default value
 
 Default values can be set to any field in the message type.
 Currently default values are not supported for string arrays and complex types (i.e. types not present in the built-in-types table above; that applies to all nested messages).
+Special floating point values such as ``NaN``, ``+infinity``, and ``-infinity`` are not yet supported as default values.
 
 Defining a default value is done by adding a third element to the field definition line, i.e:
 
@@ -226,6 +227,8 @@ For example:
 .. note::
 
    Constants names have to be UPPERCASE
+
+Special floating point values such as ``NaN``, ``+infinity``, and ``-infinity`` are not yet supported as constant values.
 
 Services
 --------

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
@@ -303,6 +303,13 @@ If the message does not use a full header, but just has a field with type ``buil
 
   ros2 topic pub /reference sensor_msgs/msg/TimeReference '{header: "auto", time_ref: "now", source: "dumy"}'
 
+Certain messages use ``NaN`` as a significant value. This is supported in YAML. For example, with a ``sensor_msgs/msg/BatteryState``,
+the temperature field may not be measured. If so, it should be set to ``NaN``.
+
+.. code-block:: console
+
+  ros2 topic pub /battery sensor_msgs/msg/BatteryState '{voltage: 12.4, temperature: .nan}'
+
 8 ros2 topic hz
 ^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Topics/Understanding-ROS2-Topics.rst
@@ -303,8 +303,9 @@ If the message does not use a full header, but just has a field with type ``buil
 
   ros2 topic pub /reference sensor_msgs/msg/TimeReference '{header: "auto", time_ref: "now", source: "dumy"}'
 
-Certain messages use ``NaN`` as a significant value. This is supported in YAML. For example, with a ``sensor_msgs/msg/BatteryState``,
-the temperature field may not be measured. If so, it should be set to ``NaN``.
+Certain messages use ``NaN`` as a significant value.
+For example, with a ``sensor_msgs/msg/BatteryState``, the temperature field may not be measured.
+If so, it should be set to ``NaN``.
 
 .. code-block:: console
 


### PR DESCRIPTION
# Purpose

Document what is currently supported by ROS when using NaN/infinity values for floating points in messaging.

# Why

`sensor_msgs/msg/BatteryState` tells users to use `NaN`, but there's not info in the docs on working with NaN's. This documents what currently exists. I plan to improve support for NaN's across the ROS ecosystem because they are heavily used in the aerial messages of REP-147 and in MAVLink. 

# Ticket

Closes #4135