### PR TITLE
Update Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -256,6 +256,12 @@ In order to run this demo, we need to create a launch file ``turtle_tf2_sensor_m
             ),
         ])
 
+To access the launchfile later, we make sure it gets copied during building. Add the following line after the other entries between the ``'data_files':`` brackets:
+
+.. code-block:: python
+
+    ('share/' + package_name + '/launch', ['launch/turtle_tf2_sensor_message.launch.py']),
+
 
 1.3 Add an entry point
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -256,11 +256,15 @@ In order to run this demo, we need to create a launch file ``turtle_tf2_sensor_m
             ),
         ])
 
-To access the launchfile later, we make sure it gets copied during building. Add the following line after the other entries between the ``'data_files':`` brackets:
+To access the launchfile later, we make sure it gets copied during building.
+Add the following line after the other entries between the ``'data_files':`` brackets:
 
 .. code-block:: python
 
-    ('share/' + package_name + '/launch', ['launch/turtle_tf2_sensor_message.launch.py']),
+    data_files=[
+        ...
+        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', 'turtle_tf2_sensor_message.launch.py'))),
+    ],
 
 
 1.3 Add an entry point


### PR DESCRIPTION
Add missing step in messagefilter tutorial

This simple step of installing the launchfile was still required, and missing. This short step fixed it for me, and would be good to complete the instructions.