### PR TITLE
use pathlib path in sitemap plugin for sphinx compatibility

### DIFF
--- a/plugins/sphinx_sitemap_ros.py
+++ b/plugins/sphinx_sitemap_ros.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree
 from pathlib import Path
 
+import sphinx
 from sphinx.application import Sphinx
 from sphinx.util.logging import getLogger
 
@@ -226,7 +227,11 @@ def create_sitemap(app: Sphinx, exception):
                 href=site_url + scheme.format(lang=lang, version=version, link=link),
             )
 
-    filename = Path.joinpath(app.outdir, app.config.sitemap_filename)
+    if sphinx.version_info[0] >= 7:
+        filename = Path.joinpath(app.outdir, app.config.sitemap_filename)
+    else:
+        filename = app.outdir + "/" + app.config.sitemap_filename
+
     ElementTree.ElementTree(root).write(
         filename, xml_declaration=True, encoding="utf-8", method="xml"
     )

--- a/plugins/sphinx_sitemap_ros.py
+++ b/plugins/sphinx_sitemap_ros.py
@@ -25,6 +25,7 @@ import queue
 from multiprocessing import Manager
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree
+from pathlib import Path
 
 from sphinx.application import Sphinx
 from sphinx.util.logging import getLogger
@@ -225,7 +226,7 @@ def create_sitemap(app: Sphinx, exception):
                 href=site_url + scheme.format(lang=lang, version=version, link=link),
             )
 
-    filename = app.outdir + "/" + app.config.sitemap_filename
+    filename = Path.joinpath(app.outdir, app.config.sitemap_filename)
     ElementTree.ElementTree(root).write(
         filename, xml_declaration=True, encoding="utf-8", method="xml"
     )


### PR DESCRIPTION
fixes this sphinx warning:
```
/home/jonas/workspace/ros2_documentation/plugins/sphinx_sitemap_ros.py:228: RemovedInSphinx80Warning: Sphinx 8 will drop support for representing paths as strings. Use "pathlib.Path" or "os.fspath" instead.
  filename = app.outdir + "/" + app.config.sitemap_filename
```