### PR TITLE
Rename pyqt5 package as per Homebrwe

### DIFF
--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -55,7 +55,7 @@ You need the following things installed to build ROS 2:
 
        brew install asio assimp bison bullet cmake console_bridge cppcheck \
          cunit eigen freetype graphviz opencv openssl orocos-kdl pcre poco \
-         pyqt5 python qt@5 sip spdlog osrf/simulation/tinyxml1 tinyxml2
+         pyqt@5 python qt@5 sip spdlog osrf/simulation/tinyxml1 tinyxml2
 
 #.
    Setup some environment variables:


### PR DESCRIPTION
Like brew says, `Warning: Formula pyqt5 was renamed to pyqt@5.`
