### PR TITLE
Explicitly state msg srv and action folders

### DIFF
--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -448,6 +448,9 @@ Package layout
 * ``config``: contains configuration files, e.g. YAML parameters files and RViz config files
 * ``doc``: contains all the documentation
 * ``launch``: contains all launch files
+* ``msg``: contains all ROS Message definitions
+* ``srv``: contains all ROS Service definitions
+* ``action``: contains all ROS Action definitions
 * ``package.xml``: as defined by `REP-0140 <https://www.ros.org/reps/rep-0140.html>`_ (may be updated for prototyping)
 * ``CMakeLists.txt``: only ROS packages which use CMake
 * ``setup.py``: only ROS packages which use Python code only


### PR DESCRIPTION
This is the only place that the message generators will look for content. 

It's mentioned in passing in the tutorials but not documented explicitly. https://docs.ros.org/en/rolling/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.html