### PR TITLE
Add recommendation on example source PR

### DIFF
--- a/source/How-To-Guides/Releasing/Release-Team-Repository.rst
+++ b/source/How-To-Guides/Releasing/Release-Team-Repository.rst
@@ -42,7 +42,7 @@ Start a new release team
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Fill the `New Release Team issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_team.md&title=Add+release+team>`_ issue template
-if no release team exists for your project yet, request for a new release team to be created.
+if no release team exists for your project yet by requesting for a new release team to be created.
 
 .. _what-is-a-release-repository:
 
@@ -62,6 +62,7 @@ Create a new release repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your repository is new to the ROS community, you should first open a pull request on `ros/rosdistro <https://github.com/ros/rosdistro>`_ adding a ``source`` entry for your repository.
+An example can be seen `here <https://github.com/ros/rosdistro/pull/39513>`_.
 The review process for the rosdistro database will ensure your repository and packages conform to the `REP 144 package naming conventions <https://www.ros.org/reps/rep-0144.html>`_ and other requirements before release.
 Once your package name has been approved and merged, fill in the `Add New Release Repositories issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_repository.md&title=Add+new+release+repositories>`_ issue template
 if you don't have a release repo for your project yet.

--- a/source/How-To-Guides/Releasing/Release-Team-Repository.rst
+++ b/source/How-To-Guides/Releasing/Release-Team-Repository.rst
@@ -61,8 +61,7 @@ Having a release repository separate from your source code repository is a requi
 Create a new release repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If your repository is new to the ROS community, you should first open a pull request on `ros/rosdistro <https://github.com/ros/rosdistro>`_ adding a ``source`` entry for your repository.
-An example can be seen `here <https://github.com/ros/rosdistro/pull/39513>`_.
+If your repository is new to the ROS community, you should first open a pull request on `ros/rosdistro <https://github.com/ros/rosdistro>`_ adding a ``source`` entry for your repository (e.g. https://github.com/ros/rosdistro/pull/39513).
 The review process for the rosdistro database will ensure your repository and packages conform to the `REP 144 package naming conventions <https://www.ros.org/reps/rep-0144.html>`_ and other requirements before release.
 Once your package name has been approved and merged, fill in the `Add New Release Repositories issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_repository.md&title=Add+new+release+repositories>`_ issue template
 if you don't have a release repo for your project yet.

--- a/source/How-To-Guides/Releasing/Release-Team-Repository.rst
+++ b/source/How-To-Guides/Releasing/Release-Team-Repository.rst
@@ -41,8 +41,7 @@ if a release team already exists for your project but you are not part of it.
 Start a new release team
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Fill the `New Release Team issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_team.md&title=Add+release+team>`_ issue template
-if no release team exists for your project yet by requesting for a new release team to be created.
+If no release team exists for your project yet, fill out the `New Release Team issue <https://github.com/ros2-gbp/ros2-gbp-github-org/issues/new?assignees=&labels=&template=new_release_team.md&title=Add+release+team>`_ issue template to request one be created.
 
 .. _what-is-a-release-repository:
 


### PR DESCRIPTION
# Purpose

It is not clear what a `source` PR to rosdistro is. I was told to do this, but not how. Now, we directly link an example.
I also fixed some grammar. 

# Reference

Others had the same question here: 
https://github.com/ros2-gbp/ros2-gbp-github-org/issues/393#issuecomment-1889202386

