### PR TITLE
Fix up some warnings when building the documentation.

### DIFF
--- a/source/Releases/Release-Jazzy-Jalisco.rst
+++ b/source/Releases/Release-Jazzy-Jalisco.rst
@@ -78,8 +78,8 @@ In Humble, the headers: ``tf2_bullet/tf2_bullet.h``, ``tf2_eigen/tf2_eigen.h``, 
 In Jazzy, the ``tf2_bullet/tf2_bullet.h``, ``tf2_eigen/tf2_eigen.h``, ``tf2_geometry_msgs/tf2_geometry_msgs.h``,
 ``tf2_kdl/tf2_kdl.h``, ``tf2_sensor_msgs/tf2_sensor_msgs.h`` headers have been completely removed.
 
-Return types of `wait_for_transform_async` and `wait_for_transform_full_async` changed
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Return types of ``wait_for_transform_async`` and ``wait_for_transform_full_async`` changed
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 Previously ``wait_for_transform_async`` and ``wait_for_transform_full_async`` of the ``Buffer`` class returned a future containing true or false
 In Jazzy, the future will contain the information of the transform being waited on.
 

--- a/source/Tutorials/Intermediate/URDF/Exporting-an-URDF-File.rst
+++ b/source/Tutorials/Intermediate/URDF/Exporting-an-URDF-File.rst
@@ -1,11 +1,5 @@
-.. redirect-from::
-
-    Tutorials/URDF/Exporting-an-URDF-file
-
-.. _URDFXacro:
-
 Generating an URDF File
-=================================
+=======================
 
 **Goal:** Learn how to Export and URDF File
 


### PR DESCRIPTION
* We don't need a redirect for a new page.
* We don't need an anchor for a new page.
* The length of the underline should match the text above.
* italics are done with double `` in rst, not single.