### PR TITLE
fixed missed installation of the .yaml parameters file

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -221,6 +221,7 @@ Let's now create a configuration file, ``turtlesim.yaml``, in the ``/config`` fo
 If we now start the ``turtlesim_world_2.launch.py`` launch file, we will start the ``turtlesim_node`` with preconfigured background colors.
 
 Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++ package, write in the package ``CMakeLists.txt``: 
+
 .. code-block:: console
     install(DIRECTORY
       config

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -227,6 +227,7 @@ Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++
       config
       DESTINATION share/${PROJECT_NAME}
     )
+
 Instead, if you have a Python package, add in package ``setup.py`` file:
 
 .. code-block:: console

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -287,7 +287,6 @@ We will now update the ``turtlesim.yaml``, in the ``/config`` folder in the foll
 Now include the ``turtlesim_world_3.launch.py`` launch description in our main launch file.
 Using that configuration file in our launch descriptions will assign ``background_b``, ``background_g``, and ``background_r`` parameters to specified values in ``turtlesim3/sim`` and ``turtlesim2/sim`` nodes.
 
-
 3 Namespaces
 ^^^^^^^^^^^^
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -220,6 +220,22 @@ Let's now create a configuration file, ``turtlesim.yaml``, in the ``/config`` fo
 
 If we now start the ``turtlesim_world_2.launch.py`` launch file, we will start the ``turtlesim_node`` with preconfigured background colors.
 
+Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++ package, write in the package ``CMakeLists.txt``: 
+.. code-block:: console
+    install(DIRECTORY
+      config
+      DESTINATION share/${PROJECT_NAME}
+    )
+Instead, if you have a Python package, add in package ``setup.py`` file:
+.. code-block:: console
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml'))
+    ],
+
 To learn more about using parameters and using YAML files, take a look at the :doc:`Understand parameters <../../Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters>` tutorial.
 
 2.3 Using wildcards in YAML files
@@ -268,6 +284,7 @@ We will now update the ``turtlesim.yaml``, in the ``/config`` folder in the foll
 
 Now include the ``turtlesim_world_3.launch.py`` launch description in our main launch file.
 Using that configuration file in our launch descriptions will assign ``background_b``, ``background_g``, and ``background_r`` parameters to specified values in ``turtlesim3/sim`` and ``turtlesim2/sim`` nodes.
+
 
 3 Namespaces
 ^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -219,17 +219,26 @@ Let's now create a configuration file, ``turtlesim.yaml``, in the ``/config`` fo
          background_r: 150
 
 Make sure that you have installed the ``turtlesim.yaml`` file. 
+
 .. tabs::
+
     .. group-tab:: C++
-    If you have a C++ package, write in the package ``CMakeLists.txt``: 
+
+        If you have a C++ package, write in the package ``CMakeLists.txt``: 
+
         .. code-block:: cmake
+
             install(DIRECTORY
               config
               DESTINATION share/${PROJECT_NAME}
             )
+
     .. group-tab:: Python
-    Instead, if you have a Python package, add in package ``setup.py`` file:
+
+        Instead, if you have a Python package, add in package ``setup.py`` file:
+
         .. code-block:: python
+
             data_files=[
                 ('share/ament_index/resource_index/packages',
                     ['resource/' + package_name]),

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -230,7 +230,7 @@ Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++
 
 Instead, if you have a Python package, add in package ``setup.py`` file:
 
-.. code-block:: console
+.. code-block:: Python
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -218,28 +218,30 @@ Let's now create a configuration file, ``turtlesim.yaml``, in the ``/config`` fo
          background_g: 86
          background_r: 150
 
-If we now start the ``turtlesim_world_2.launch.py`` launch file, we will start the ``turtlesim_node`` with preconfigured background colors.
-
-Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++ package, write in the package ``CMakeLists.txt``: 
-
-.. code-block:: cmake
-    install(DIRECTORY
-      config
-      DESTINATION share/${PROJECT_NAME}
-    )
-
-Instead, if you have a Python package, add in package ``setup.py`` file:
-
-.. code-block:: Python
-    data_files=[
-        ('share/ament_index/resource_index/packages',
-            ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
-        (os.path.join('share', package_name, 'config'), glob('config/*.yaml'))
-    ],
+Make sure that you have installed the ``turtlesim.yaml`` file. 
+.. tabs::
+    .. group-tab:: C++
+    If you have a C++ package, write in the package ``CMakeLists.txt``: 
+        .. code-block:: cmake
+            install(DIRECTORY
+              config
+              DESTINATION share/${PROJECT_NAME}
+            )
+    .. group-tab:: Python
+    Instead, if you have a Python package, add in package ``setup.py`` file:
+        .. code-block:: python
+            data_files=[
+                ('share/ament_index/resource_index/packages',
+                    ['resource/' + package_name]),
+                ('share/' + package_name, ['package.xml']),
+                (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
+                (os.path.join('share', package_name, 'config'), glob('config/*.yaml'))
+            ],
 
 To learn more about using parameters and using YAML files, take a look at the :doc:`Understand parameters <../../Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters>` tutorial.
+
+
+If we now start the ``turtlesim_world_2.launch.py`` launch file, we will start the ``turtlesim_node`` with preconfigured background colors.
 
 2.3 Using wildcards in YAML files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -222,7 +222,7 @@ If we now start the ``turtlesim_world_2.launch.py`` launch file, we will start t
 
 Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++ package, write in the package ``CMakeLists.txt``: 
 
-.. code-block:: console
+.. code-block:: cmake
     install(DIRECTORY
       config
       DESTINATION share/${PROJECT_NAME}

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -227,6 +227,7 @@ Make sure that you have installed the ``turtlesim.yaml`` file. If you have a C++
       DESTINATION share/${PROJECT_NAME}
     )
 Instead, if you have a Python package, add in package ``setup.py`` file:
+
 .. code-block:: console
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
In the section "2.2 Loading parameters from YAML file", it was missing the necessity of installing the .yaml file. Missing that step, I was not generating the .yaml file in the /install folder, and therefore getting a runtime error. 
I tested what is written in C++.

I was able to understand the solution to my problem thanks to this guide https://roboticsbackend.com/ros2-yaml-params/