### PR TITLE
Update link to tracetools_analysis docs in ros2_tracing tutorial

### DIFF
--- a/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
+++ b/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
@@ -187,5 +187,5 @@ Conclusion
 This tutorial showed how to install tracing-related tools.
 Then it showed how to trace a `performance_test <https://gitlab.com/ApexAI/performance_test>`_ experiment using `ros2_tracing <https://github.com/ros2/ros2_tracing>`_ and plot the callback durations using `tracetools_analysis <https://github.com/ros-tracing/tracetools_analysis>`_.
 
-For more trace analyses, take a look at the `other sample notebooks <https://github.com/ros-tracing/tracetools_analysis/tree/{DISTRO}/tracetools_analysis/analysis>`_ and the `tracetools_analysis API documentation <https://ros-tracing.gitlab.io/tracetools_analysis-api/master/tracetools_analysis/>`_.
+For more trace analyses, take a look at the `other sample notebooks <https://github.com/ros-tracing/tracetools_analysis/tree/{DISTRO}/tracetools_analysis/analysis>`_ and the `tracetools_analysis API documentation <https://docs.ros.org/en/{DISTRO}/p/tracetools_analysis/>`_.
 The `ros2_tracing design document <https://github.com/ros2/ros2_tracing/blob/{DISTRO}/doc/design_ros_2.md>`_ also contains a lot of information.


### PR DESCRIPTION
Use docs from https://docs.ros.org/en/rolling/p/tracetools_analysis/ instead.

Note: this can be backported to Iron, but not Humble (#4303) since we do not generate docs for Humble packages.