### PR TITLE
Gazebo sim tutorial update

### DIFF
--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -28,7 +28,7 @@ First of all you should install ROS 2 and Gazebo. For ROS you should follow the 
 
       .. code-block:: console
 
-        sudo apt-get install ros-{DISTRO}-gz-ros
+        sudo apt-get install ros-{DISTRO}-ros-gz
 
 To check which versions are available from deb packages for which ROS distros please check this `table <https://github.com/gazebosim/ros_ign>`__. 
 

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -20,7 +20,9 @@ Setting up a robot simulation (Gazebo)
 Prerequisites
 -------------
 
-First of all you should install ROS 2 and Gazebo. For ROS you should follow the `ROS 2 install instructions <../../../../Installation>`. If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by typing:
+First of all you should install ROS 2 and Gazebo.
+For ROS you should follow the `ROS 2 install instructions <../../../../Installation>`.
+If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by typing:
 
 .. tabs::
 

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -11,12 +11,11 @@ Setting up a robot simulation (Gazebo)
 
 **Tutorial level:** Advanced
 
-**Time:** 20 minutes
+**Time:** 5 minutes
 
 .. contents:: Contents
    :depth: 2
    :local:
-
 
  .. note::
 

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -20,14 +20,22 @@ Setting up a robot simulation (Gazebo)
 Prerequisites
 -------------
 
-First of all you should install ROS 2 and Gazebo.
-You have two options:
+First of all you should install ROS 2 and Gazebo. For ROS you should follow the `ROS 2 install instructions <../../../../Installation>`. If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by typing:
 
- - Install from deb packages. To check which versions are available from deb packages please check this `table <https://github.com/gazebosim/ros_ign>`__.
- - Compile from sources:
+.. tabs::
 
-   - :doc:`ROS 2 install instructions <../../../../Installation>`
-   - `Gazebo install instructions <https://gazebosim.org/docs>`__
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+        sudo apt-get install ros-{DISTRO}-gz-ros
+
+To check which versions are available from deb packages for which ROS distros please check this `table <https://github.com/gazebosim/ros_ign>`__. 
+
+If you'd rather like to use newer versions of both the ROS or Gazebo distribution, that would be possible but it will require more work and potentially compiling from source. Please look at the `ROS/gazebo installation instructions <https://gazebosim.org/docs/harmonic/ros_installation>`__ for this, however we do advise new users to install the recommended LTS versions.
+
+ .. note::
+    These instructions are about the current `Gazebo <https://gazebosim.org/>`__ (previously known as Ignition), not  `Gazebo Classic <https://classic.gazebosim.org/>`.
 
 Tasks
 -----

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -30,7 +30,7 @@ You'll need to install both ROS 2 and Gazebo.
 ROS 2
 ^^^^^
 
-For ROS 2 you should follow the `ROS 2 install instructions <../../../../Installation>`.
+For ROS 2 you should follow the :doc:`ROS 2 install instructions <../../../../Installation>`.
 
 Gazebo
 ^^^^^^
@@ -41,7 +41,7 @@ All supported combinations can be seen `here <https://gazebosim.org/docs/harmoni
 
 `ROS REP-2000 <https://www.ros.org/reps/rep-2000.html>`__ standardizes what the default version of Gazebo is for each ROS distribution.
 
-If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by following the `installation instructions <https://gazebosim.org/docs/latest/ros_installation>`__.
+If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by following the `installation instructions <https://gazebosim.org/docs/harmonic/ros_installation>`__.
 
 Quick Check
 -----------

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -25,28 +25,23 @@ Setting up a robot simulation (Gazebo)
 Prerequisites
 -------------
 
-First of all you should install ROS 2 and Gazebo.
-For ROS you should follow the `ROS 2 install instructions <../../../../Installation>`.
+You'll need to install both ROS 2 and Gazebo.
+
+ROS 2
+^^^^^
+
+For ROS 2 you should follow the `ROS 2 install instructions <../../../../Installation>`.
+
+Gazebo
+^^^^^^
+
 Gazebo and ROS support different combinations of versions.
 
 All supported combinations can be seen `here <https://gazebosim.org/docs/harmonic/ros_installation#summary-of-compatible-ros-and-gazebo-combinations>`__.
 
 `ROS REP-2000 <https://www.ros.org/reps/rep-2000.html>`__ standardizes what the default version of Gazebo is for each ROS distribution.
 
-If you haven't installed a version of Gazebo on your system yet, you can install the default Gazebo version by typing:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        sudo apt-get install ros-{DISTRO}-ros-gz
-
-
-If you'd rather use different versions of both the ROS or Gazebo distribution, that is possible, but potentially more work.
-Please look at the `ROS/gazebo installation instructions <https://gazebosim.org/docs/harmonic/ros_installation>`__ for this, however we do advise new users to install the recommended LTS versions.
-
+If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by following the `installation instructions <https://gazebosim.org/docs/latest/ros_installation>`__.
 
 Quick Check
 -----------

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -17,12 +17,24 @@ Setting up a robot simulation (Gazebo)
    :depth: 2
    :local:
 
+
+ .. note::
+
+    These instructions are about the current `Gazebo <https://gazebosim.org/>`__ (previously known as Ignition), not  `Gazebo Classic <https://classic.gazebosim.org/>`.
+
 Prerequisites
 -------------
 
 First of all you should install ROS 2 and Gazebo.
 For ROS you should follow the `ROS 2 install instructions <../../../../Installation>`.
-If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by typing:
+Gazebo and ROS support different combinations of versions.
+
+All supported combinations can be seen `here <https://gazebosim.org/docs/harmonic/ros_installation#summary-of-compatible-ros-and-gazebo-combinations>`__.
+
+`ROS REP-2000 <https://www.ros.org/reps/rep-2000.html>`__ standardizes what the default
+version of Gazebo is for each ROS distribution.
+
+If you haven't installed a version of Gazebo on your system yet, you can install the default Gazebo version by typing:
 
 .. tabs::
 
@@ -32,219 +44,28 @@ If you haven't installed a version of Gazebo on your system yet, you can install
 
         sudo apt-get install ros-{DISTRO}-ros-gz
 
-To check which versions are available from deb packages for which ROS distros please check this `table <https://github.com/gazebosim/ros_ign>`__. 
 
-If you'd rather like to use newer versions of both the ROS or Gazebo distribution, that would be possible but it will require more work and potentially compiling from source. Please look at the `ROS/gazebo installation instructions <https://gazebosim.org/docs/harmonic/ros_installation>`__ for this, however we do advise new users to install the recommended LTS versions.
+If you'd rather use different versions of both the ROS or Gazebo distribution, that is possible, but potentially more work.
+Please look at the `ROS/gazebo installation instructions <https://gazebosim.org/docs/harmonic/ros_installation>`__ for this, however we do advise new users to install the recommended LTS versions.
 
- .. note::
-    These instructions are about the current `Gazebo <https://gazebosim.org/>`__ (previously known as Ignition), not  `Gazebo Classic <https://classic.gazebosim.org/>`.
 
-Tasks
------
+Quick Check
+-----------
 
-1 Launch the simulation
-^^^^^^^^^^^^^^^^^^^^^^^
+To verify your Gazebo installation is correct, check you can run it:
 
-In this demo you are going to simulate a simple diff drive robot in Gazebo.
-You are going to use one of the worlds defined in the Gazebo examples called
-`visualize_lidar.sdf <https://github.com/gazebosim/gz-sim/blob/main/examples/worlds/visualize_lidar.sdf>`__.
-To run this example you should execute the following command in a terminal:
+.. code-block:: console
 
+   gz sim
 
-.. tabs::
+Further Resources
+-----------------
 
-   .. group-tab:: Linux
+Once Gazebo is installed and is all clear on the last quick test, you can move to the `Gazebo tutorials <https://gazebosim.org/docs/harmonic/tutorials>`__ to try out building your own robot!
 
-      .. code-block:: console
-
-        ign gazebo -v 4 -r visualize_lidar.sdf
-
-.. image:: Image/gazebo_diff_drive.png
-
-When the simulation is running you can check the topics provided by Gazebo with the ``ign`` command line tool:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        ign topic -l
-
-      Which should show:
-
-      .. code-block:: console
-
-        /clock
-        /gazebo/resource_paths
-        /gui/camera/pose
-        /gui/record_video/stats
-        /model/vehicle_blue/odometry
-        /model/vehicle_blue/tf
-        /stats
-        /world/visualize_lidar_world/clock
-        /world/visualize_lidar_world/dynamic_pose/info
-        /world/visualize_lidar_world/pose/info
-        /world/visualize_lidar_world/scene/deletion
-        /world/visualize_lidar_world/scene/info
-        /world/visualize_lidar_world/state
-        /world/visualize_lidar_world/stats
-
-Since you have not launched an ROS 2 nodes yet, the output from ``ros2 topic list``
-should be free of any robot topics:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        ros2 topic list
-
-      Which should show:
-
-      .. code-block:: console
-
-        /parameter_events
-        /rosout
-
-2 Configuring ROS 2
-^^^^^^^^^^^^^^^^^^^
-
-To be able to communicate our simulation with ROS 2 you need to use a package called ``ros_gz_bridge``.
-This package provides a network bridge which enables the exchange of messages between ROS 2 and Gazebo Transport.
-You can install this package by typing:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        sudo apt-get install ros-{DISTRO}-ros-ign-bridge
-
-At this point you are ready to launch a bridge from ROS to Gazebo.
-In particular you are going to create a bridge for the topic ``/model/vehicle_blue/cmd_vel``:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        source /opt/ros/{DISTRO}/setup.bash
-        ros2 run ros_gz_bridge parameter_bridge /model/vehicle_blue/cmd_vel@geometry_msgs/msg/Twist]ignition.msgs.Twist
-
-For more details about the ``ros_gz_bridge`` please check this `README <https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge>`__ .
-
-Once the bridge is running the robot is able to follow your motor commands.
-There are two options:
-
-* Send a command to the topic using ``ros2 topic pub``
-
- .. tabs::
-
-    .. group-tab:: Linux
-
-       .. code-block:: console
-
-        ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/Twist "linear: { x: 0.1 }"
-
-* ``teleop_twist_keyboard`` package. This node takes keypresses from the keyboard and publishes them as Twist messages. You can install it typing:
-
- .. tabs::
-
-    .. group-tab:: Linux
-
-       .. code-block:: console
-
-         sudo apt-get install ros-{DISTRO}-teleop-twist-keyboard
-
- The default topic where ``teleop_twist_keyboard`` is publishing Twist messages is ``/cmd_vel`` but you can remap this
- topic to make use of the topic used in the bridge:
-
- .. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        source /opt/ros/{DISTRO}/setup.bash
-        ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r /cmd_vel:=/model/vehicle_blue/cmd_vel
-
-      Which will show:
-
-      .. code-block:: console
-
-        This node takes keypresses from the keyboard and publishes them
-        as Twist messages. It works best with a US keyboard layout.
-        ---------------------------
-        Moving around:
-           u    i    o
-           j    k    l
-           m    ,    .
-
-        For Holonomic mode (strafing), hold down the shift key:
-        ---------------------------
-           U    I    O
-           J    K    L
-           M    <    >
-
-        t : up (+z)
-        b : down (-z)
-
-        anything else : stop
-
-        q/z : increase/decrease max speeds by 10%
-        w/x : increase/decrease only linear speed by 10%
-        e/c : increase/decrease only angular speed by 10%
-
-        CTRL-C to quit
-
-        currently:      speed 0.5       turn 1.0
-
-3 Visualizing lidar data in ROS 2
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The diff drive robot has a lidar.
-To send the data generated by Gazebo to ROS 2, you need to launch another bridge.
-In the case the data from the lidar is provided in the Gazebo Transport topic ``/lidar2``, which you are going to remap in the bridge.
-This topic will be available under the topic ``/lidar_scan``:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        source /opt/ros/{DISTRO}/setup.bash
-        ros2 run ros_gz_bridge parameter_bridge /lidar2@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan --ros-args -r /lidar2:=/laser_scan
-
-To visualize the data from the lidar in ROS 2 you can use Rviz2:
-
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        source /opt/ros/{DISTRO}/setup.bash
-        rviz2
-
-Then you need to configure the ``fixed frame``:
-
-.. image:: Image/fixed_frame.png
-
-And then click in the button "Add" to include a display to visualize the lidar:
-
-.. image:: Image/add_lidar.png
-
-Now you should see the data from the lidar in Rviz2:
-
-.. image:: Image/rviz2.png
+If you use a different version of Gazebo than the recommended version, make sure to use the dropdown to select the correct version of documentation.
 
 Summary
 -------
 
-In this tutorial, you launched a robot simulation with Gazebo, launched
-bridges with actuators and sensors, visualized data from a sensor, and moved a diff drive robot.
+In this tutorial, you have installed Gazebo and set-up your workspace to start with the `Gazebo tutorials <https://gazebosim.org/docs/harmonic/tutorials>`__.

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -31,8 +31,7 @@ Gazebo and ROS support different combinations of versions.
 
 All supported combinations can be seen `here <https://gazebosim.org/docs/harmonic/ros_installation#summary-of-compatible-ros-and-gazebo-combinations>`__.
 
-`ROS REP-2000 <https://www.ros.org/reps/rep-2000.html>`__ standardizes what the default
-version of Gazebo is for each ROS distribution.
+`ROS REP-2000 <https://www.ros.org/reps/rep-2000.html>`__ standardizes what the default version of Gazebo is for each ROS distribution.
 
 If you haven't installed a version of Gazebo on your system yet, you can install the default Gazebo version by typing:
 

--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -17,9 +17,10 @@ Setting up a robot simulation (Gazebo)
    :depth: 2
    :local:
 
- .. note::
 
-    These instructions are about the current `Gazebo <https://gazebosim.org/>`__ (previously known as Ignition), not  `Gazebo Classic <https://classic.gazebosim.org/>`.
+.. note::
+
+   These instructions are about the current `Gazebo <https://gazebosim.org/>`__ (previously known as Ignition), not  `Gazebo Classic <https://classic.gazebosim.org/>`__.
 
 Prerequisites
 -------------


### PR DESCRIPTION
Add more clear instructions for the prerequisites of gazebo sim installation. Also, the instructions are more tailored now towards people who are just newly setting their system up and beginners (eventhough the tutorial is for advanced, the tutorial itself is still quite beginner to be honest).

addresses  #3340 (not sure if it is enough to actually close it)