### PR TITLE
Jazzy prerelease instructions

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -44,7 +44,7 @@ Next, download the ROS 2 .repo file:
 .. code-block:: bash
 
    sudo dnf install curl
-   sudo curl --output /etc/yum.repos.d/ros2.repo http://packages.ros.org/ros2/rhel/ros2.repo
+   sudo curl --output /etc/yum.repos.d/ros2.repo http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo
 
 Then, update your metadata cache.
 DNF may prompt you to verify the GPG key, which should match the location ``https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc``.

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -25,10 +25,8 @@ Only Windows 10 is supported.
 Install ROS 2
 -------------
 
-Binary releases of {DISTRO_TITLE_FULL} are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
-* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
+* Go to the releases page: https://github.com/ros2/ros2/releases
+* Download the latest package for Windows, e.g., ``ros2-{DISTRO}-*-windows-release-amd64.zip``.
 
 .. note::
 
@@ -37,7 +35,7 @@ Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>
 .. note::
 
    To install debug libraries for ROS 2, see `Extra Stuff for Debug`_.
-   Then continue on with downloading ``ros2-package-windows-debug-AMD64.zip``.
+   Then continue on with downloading ``ros2-{DISTRO}-*-windows-debug-amd64.zip``.
 
 * Unpack the zip file somewhere (we'll assume ``C:\dev\ros2_{DISTRO}``\ ).
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -18,4 +18,4 @@ Then add the repository to your sources list.
 
 .. code-block:: bash
 
-   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null


### PR DESCRIPTION
There are 2 commits here:

The first one updates to point to the prerelease repositories.  This one is necessary for now, but will need to be reverted once we officially release Jazzy.

The second one does a small update to the Windows installation instructions.

@marcoag FYI