### PR TITLE
Remove unnecessary references to OS version

### DIFF
--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -710,10 +710,10 @@ There are several categories of jobs on the buildfarm:
 
 * manual jobs (triggered manually by developers):
 
-  * ci_linux: build + test the code on Ubuntu Xenial
-  * ci_linux-aarch64: build + test the code on Ubuntu Xenial on an ARM 64-bit machine (aarch64)
+  * ci_linux: build + test the code on Ubuntu
+  * ci_linux-aarch64: build + test the code on Ubuntu on an ARM 64-bit machine (aarch64)
   * ci_linux_coverage: build + test + generation of test coverage
-  * ci_windows: build + test the code on Windows 10
+  * ci_windows: build + test the code on Windows
   * ci_launcher: trigger all the jobs listed above
 
 * nightly (run every night):


### PR DESCRIPTION
Xenial is definitely outdated, and the OS versions are mentioned above (and seem to get properly updated), so just remove references to the OS versions here.