### PR TITLE
Change how we install OpenSSL.

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -36,11 +36,11 @@ Open a Command Prompt and type the following to install them via Chocolatey:
 Install OpenSSL
 ^^^^^^^^^^^^^^^
 
-Download the *Win64 OpenSSL v1.1.1n* OpenSSL installer from `this page <https://slproweb.com/products/Win32OpenSSL.html>`__.
-Scroll to the bottom of the page and download *Win64 OpenSSL v1.1.1t*.
-Don't download the Win32 or Light versions, or the v3.X.Y installers.
+Open a Command Prompt and type the following to install OpenSSL via Chocolatey:
 
-Run the installer with default parameters, as the following commands assume you used the default installation directory.
+.. code-block:: bash
+
+  choco install -y openssl --version 1.1.1.2100
 
 This command sets an environment variable that persists over sessions:
 


### PR DESCRIPTION
That's because v1.1.1, which we relied on for years, is no longer available from SLproweb.  While we are here, we notice that it is actually possible to install OpenSSL 3.3.0 via chocolatey, which is significantly simpler for users.

We also need to update our CI to handle this; see https://github.com/ros2/ci/pull/778 for that.