### PR TITLE
Update rosdep install link.

### DIFF
--- a/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
@@ -13,7 +13,7 @@ See also: https://projects.eclipse.org/projects/iot.cyclonedds
 Prerequisites
 -------------
 
-Have `rosdep installed  <https://docs.ros.org/en/{DISTRO}/Tutorials/Intermediate/Rosdep.html#rosdep-installation>`__.
+Have :doc:`rosdep installed <../../Tutorials/Intermediate/Rosdep>`.
 
 Install packages
 ----------------

--- a/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.rst
@@ -13,7 +13,7 @@ See also: https://projects.eclipse.org/projects/iot.cyclonedds
 Prerequisites
 -------------
 
-Have `rosdep installed  <https://wiki.ros.org/rosdep#Installing_rosdep>`__
+Have `rosdep installed  <https://docs.ros.org/en/{DISTRO}/Tutorials/Intermediate/Rosdep.html#rosdep-installation>`__.
 
 Install packages
 ----------------

--- a/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
@@ -8,7 +8,7 @@ See also: https://www.eprosima.com/index.php/products-all/eprosima-fast-dds
 Prerequisites
 -------------
 
-Have `rosdep installed  <https://docs.ros.org/en/{DISTRO}/Tutorials/Intermediate/Rosdep.html#rosdep-installation>`__.
+Have :doc:`rosdep installed <../../Tutorials/Intermediate/Rosdep>`.
 
 Install packages
 ----------------

--- a/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-eProsima-Fast-DDS.rst
@@ -8,7 +8,7 @@ See also: https://www.eprosima.com/index.php/products-all/eprosima-fast-dds
 Prerequisites
 -------------
 
-Have `rosdep installed  <https://wiki.ros.org/rosdep#Installing_rosdep>`__
+Have `rosdep installed  <https://docs.ros.org/en/{DISTRO}/Tutorials/Intermediate/Rosdep.html#rosdep-installation>`__.
 
 Install packages
 ----------------


### PR DESCRIPTION
The hyperlink to [rosdep installed](https://wiki.ros.org/rosdep#Installing_rosdep) points to wiki.ros.org, instead, it was suggested to http://docs.ros.org/en/jazzy/Tutorials/Intermediate/Rosdep.html.

Was suggested in https://github.com/osrf/ros2_test_cases/issues/1475,  not sure how much we want this but opening the PR so it can be considered.

If this gets merged I can backport to `jazzy`.