### PR TITLE
Switch all references to "fat archives" to "binary archives".

### DIFF
--- a/source/How-To-Guides/Building-ROS-2-with-Tracing.rst
+++ b/source/How-To-Guides/Building-ROS-2-with-Tracing.rst
@@ -40,7 +40,7 @@ Furthermore, the functions can be completely removed through a CMake option, whi
 Building without tracepoints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This step depends on whether you are :doc:`building ROS 2 from source <../Installation/Alternatives/Ubuntu-Development-Setup>` or using ROS 2 binaries (:doc:`Debian packages <../Installation/Ubuntu-Install-Debians>` or :doc:`"fat" archive <../Installation/Alternatives/Ubuntu-Install-Binary>`).
+This step depends on whether you are :doc:`building ROS 2 from source <../Installation/Alternatives/Ubuntu-Development-Setup>` or using ROS 2 binaries (:doc:`Debian packages <../Installation/Ubuntu-Install-Debians>` or :doc:`binary archive <../Installation/Alternatives/Ubuntu-Install-Binary>`).
 To remove the tracepoints, (re)build ``tracetools`` and set the ``TRACETOOLS_TRACEPOINTS_EXCLUDED`` CMake option to ``ON``:
 
 .. tabs::

--- a/source/How-To-Guides/Using-Python-Packages.rst
+++ b/source/How-To-Guides/Using-Python-Packages.rst
@@ -16,7 +16,7 @@ Using Python Packages with ROS 2
 
 .. note::
 
-    A cautionary note, if you intended to use pre-packaged binaries (either ``deb`` files, or the “fat” binary distributions), the Python interpreter must match what was used to build the original binaries.
+    A cautionary note, if you intended to use pre-packaged binaries (either ``deb`` files, or the binary archive distributions), the Python interpreter must match what was used to build the original binaries.
     If you intend to use something like ``virtualenv`` or ``pipenv``\, make sure to use the system interpreter.
     If you use something like ``conda``, it is very likely that the interpreter will not match the system interpreter and will be incompatible with ROS 2 binaries.
 

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -30,15 +30,16 @@ We provide ROS 2 binary packages for the following platforms:
 * Ubuntu Linux - Noble Numbat (24.04)
 
   * :doc:`Debian packages <Installation/Ubuntu-Install-Debians>` (recommended)
-  * :doc:`"fat" archive <Installation/Alternatives/Ubuntu-Install-Binary>`
+  * :doc:`binary archive <Installation/Alternatives/Ubuntu-Install-Binary>`
 
 * RHEL 9
 
   * :doc:`RPM packages <Installation/RHEL-Install-RPMs>` (recommended)
-  * :doc:`"fat" archive <Installation/Alternatives/RHEL-Install-Binary>`
+  * :doc:`binary archive <Installation/Alternatives/RHEL-Install-Binary>`
 
-* :doc:`Windows (VS 2019) <Installation/Windows-Install-Binary>`
+* Windows 10
 
+  * :doc:`Windows Binary (VS 2019) <Installation/Windows-Install-Binary>`
 
 .. _building-from-source:
 
@@ -47,12 +48,10 @@ Building from source
 
 We support building ROS 2 from source on the following platforms:
 
-
 * :doc:`Ubuntu Linux 24.04 <Installation/Alternatives/Ubuntu-Development-Setup>`
 * :doc:`Windows 10 <Installation/Alternatives/Windows-Development-Setup>`
 * :doc:`RHEL-9/Fedora <Installation/Alternatives/RHEL-Development-Setup>`
 * :doc:`macOS <Installation/Alternatives/macOS-Development-Setup>`
-
 
 Which install should you choose?
 --------------------------------
@@ -65,17 +64,14 @@ This is great for people who want to dive in and start using ROS 2 as-is, right 
 
 Linux users have two options for installing binary packages:
 
-- Debian packages
-- "fat" archive
+- Packages (debians or RPMS, depending on the platform)
+- binary archive
 
-Installing from Debian packages is the recommended method.
-It's more convenient because it installs its necessary dependencies automatically.
-It also updates alongside regular system updates.
-
+Installing from packages is the recommended method, as it installs necessary dependencies automatically and also updates alongside regular system updates.
 However, you need root access in order to install Debian packages.
-If you don't have root access, the "fat" archive is the next best choice.
+If you don't have root access, the binary archive is the next best choice.
 
-macOS and Windows users who choose to install from binary packages only have the "fat" archive option
+Windows users who choose to install from binary packages only have the binary archive option
 (Debian packages are exclusive to Ubuntu/Debian).
 
 **Building from source** is meant for developers looking to alter or explicitly omit parts of ROS 2's base.
@@ -84,4 +80,5 @@ Building from source also gives you the option to install the absolute latest ve
 
 Contributing to ROS 2 core?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 If you plan to contribute directly to ROS 2 core packages, you can install the :doc:`latest development from source <Installation/Alternatives/Latest-Development-Setup>` which shares installation instructions with the :ref:`Rolling distribution <rolling_distribution>`.

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -65,8 +65,8 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 .. _Prerelease_binaries:
 
-Fat binaries
-------------
+Binary archives
+---------------
 
 For core packages, we run nightly packaging jobs for Ubuntu Linux, RHEL, and Windows.
 These packaging jobs produce archives with pre-built binaries that can be downloaded and extracted to your filesystem.
@@ -79,7 +79,7 @@ These packaging jobs produce archives with pre-built binaries that can be downlo
 
 4. Download and extract the archive to your file system.
 
-5. To use the fat binary installation, source the ``setup.*`` file that can be found in the root of the archive.
+5. To use the binary archive installation, source the ``setup.*`` file that can be found in the root of the archive.
 
    .. tabs::
 
@@ -98,7 +98,7 @@ These packaging jobs produce archives with pre-built binaries that can be downlo
 Docker
 ------
 
-For Ubuntu Linux, there is also a nightly Docker image based on the nightly fat archive.
+For Ubuntu Linux, there is also a nightly Docker image based on the nightly binary archive.
 
 1. Pull the Docker image:
 

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -267,7 +267,7 @@ When filing an issue please make sure to:
   - **The operating system and version.**
     Reasoning: ROS 2 supports multiple platforms, and some bugs are specific to particular versions of operating systems/compilers.
   - **The installation method.**
-    Reasoning: Some issues only manifest if ROS 2 has been installed from "fat archives" or from Debians.
+    Reasoning: Some issues only manifest if ROS 2 has been installed from binary archives or from Debians.
     This can help us determine if the issue is with the packaging process.
   - **The specific version of ROS 2.**
     Reasoning: Some bugs may be present in a particular ROS 2 release and later fixed.

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -165,8 +165,8 @@ From the root of your workspace (``ros2_ws``), run the following command:
 
       rosdep only runs on Linux, so you can skip ahead to section "5 Build the workspace with colcon".
 
-If you installed ROS 2 on Linux from source or the "fat" archive, you will need to use the rosdep command from their installation instructions.
-Here are the :ref:`from-source rosdep section <linux-development-setup-install-dependencies-using-rosdep>` and the :ref:`"fat" archive rosdep section <linux-install-binary-install-missing-dependencies>`.
+If you installed ROS 2 on Linux from source or the binary archive, you will need to use the rosdep command from their installation instructions.
+Here are the :ref:`from-source rosdep section <linux-development-setup-install-dependencies-using-rosdep>` and the :ref:`binary archive rosdep section <linux-install-binary-install-missing-dependencies>`.
 
 If you already have all your dependencies, the console will return:
 


### PR DESCRIPTION
This matches what we call them elsewhere, like in the tutorial party.

While we are looking at the Installation page, make some small other tweaks just to make the wording more consistent.