### PR TITLE
Remove the "Rolling" references in the stable distribution.

### DIFF
--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -22,7 +22,6 @@ Binary packages
 ---------------
 
 Binaries are only created for the Tier 1 operating systems listed in `REP-2000 <https://www.ros.org/reps/rep-2000.html#rolling-ridley-june-2020-ongoing>`__.
-Given the nature of Rolling, this list may be updated at any time.
 If you are not running any of the following operating systems you may need to build from source or use a :doc:`container solution <How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers>` to run ROS 2 on your platform.
 
 We provide ROS 2 binary packages for the following platforms:

--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -14,8 +14,6 @@ System requirements
 -------------------
 
 We currently support macOS Mojave (10.14).
-The Rolling Ridley distribution will change target platforms from time to time as new platforms become available.
-Most people will want to use a stable ROS distribution.
 
 System setup
 ------------

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -6,9 +6,7 @@ RHEL (RPM packages)
    :local:
 
 RPM packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for RHEL 9.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 The target platforms are defined in `REP 2000 <https://ros.org/reps/rep-2000.html>`__.
-Most people will want to use a stable ROS distribution.
 
 Resources
 ---------

--- a/source/Installation/Ubuntu-Install-Debians.rst
+++ b/source/Installation/Ubuntu-Install-Debians.rst
@@ -10,9 +10,7 @@ Ubuntu (Debian packages)
    :local:
 
 Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Noble (24.04).
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 The target platforms are defined in `REP 2000 <https://ros.org/reps/rep-2000.html>`__.
-Most people will want to use a stable ROS distribution.
 
 Resources
 ---------


### PR DESCRIPTION
That is, we shouldn't mention that Rolling is unstable or may change in the stable branches, because that is not the case for those distributions.

Note well that this targets the 'jazzy' branch, and, if approved, I'll also backport to the 'humble' and 'iron' branches.  This will *not* go onto the 'rolling' branch, as there we actually want these warnings in place.