### PR TITLE
Update the Binary install instructions for Ubuntu and RHEL.

### DIFF
--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -19,8 +19,6 @@ System requirements
 -------------------
 
 We currently support RHEL 9 64-bit.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-Most people will want to use a stable ROS distribution.
 
 System setup
 ------------
@@ -87,9 +85,7 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for RHEL; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -23,8 +23,6 @@ System requirements
 -------------------
 
 We currently support Ubuntu Noble (24.04) 64-bit x86 and 64-bit ARM.
-The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
-Most people will want to use a stable ROS distribution.
 
 System setup
 ------------
@@ -60,9 +58,7 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for Ubuntu; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.


### PR DESCRIPTION
In particular, make sure to point at the releases page, not the nightly tarball download.

Note that this *only* goes on the `jazzy` branch.