### PR TITLE
Update Creating-A-Workspace.rst to reference the correct line number

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -357,7 +357,7 @@ You can modify ``turtlesim`` in your overlay by editing the title bar on the tur
 To do this, locate the ``turtle_frame.cpp`` file in ``~/ros2_ws/src/ros_tutorials/turtlesim/src``.
 Open ``turtle_frame.cpp`` with your preferred text editor.
 
-On line 52 you will see the function ``setWindowTitle("TurtleSim");``.
+On line 62 you will see the function ``setWindowTitle("TurtleSim");``.
 Change the value ``"TurtleSim"`` to ``"MyTurtleSim"``, and save the file.
 
 Return to the first terminal where you ran ``colcon build`` earlier and run it again.

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -357,8 +357,7 @@ You can modify ``turtlesim`` in your overlay by editing the title bar on the tur
 To do this, locate the ``turtle_frame.cpp`` file in ``~/ros2_ws/src/ros_tutorials/turtlesim/src``.
 Open ``turtle_frame.cpp`` with your preferred text editor.
 
-On line 62 you will see the function ``setWindowTitle("TurtleSim");``.
-Change the value ``"TurtleSim"`` to ``"MyTurtleSim"``, and save the file.
+You can find the function ``setWindowTitle("TurtleSim");``, and change the value ``"TurtleSim"`` to ``"MyTurtleSim"``, and save the file.
 
 Return to the first terminal where you ran ``colcon build`` earlier and run it again.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -357,7 +357,7 @@ You can modify ``turtlesim`` in your overlay by editing the title bar on the tur
 To do this, locate the ``turtle_frame.cpp`` file in ``~/ros2_ws/src/ros_tutorials/turtlesim/src``.
 Open ``turtle_frame.cpp`` with your preferred text editor.
 
-You can find the function ``setWindowTitle("TurtleSim");``, and change the value ``"TurtleSim"`` to ``"MyTurtleSim"``, and save the file.
+Find the function ``setWindowTitle("TurtleSim");``, change the value ``"TurtleSim"`` to ``"MyTurtleSim"``, and save the file.
 
 Return to the first terminal where you ran ``colcon build`` earlier and run it again.
 


### PR DESCRIPTION
Instead of 52, `setWindowTitle` is on line 62. 

https://github.com/ros/ros_tutorials/blob/9481d9a4f09d923cc972d017c6acc0e61fa9d7bb/turtlesim/src/turtle_frame.cpp#L62