### PR TITLE
Added pytest dependency required for launch_test ( Windows )

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -128,7 +128,7 @@ Now install some additional python dependencies:
 
 .. code-block:: bash
 
-   python -m pip install -U catkin_pkg cryptography empy importlib-metadata jsonschema lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pillow psutil pycairo pydot pyparsing==2.4.7 pyyaml rosdistro
+   python -m pip install -U catkin_pkg cryptography empy importlib-metadata jsonschema lark==1.1.1 lxml matplotlib netifaces numpy opencv-python PyQt5 pillow psutil pycairo pydot pyparsing==2.4.7 pytest pyyaml rosdistro
 
 Install miscellaneous prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As seen in osrf/ros2_test_cases#1330, windows installation misses pytest depencency required for launch_test [launch testing examples](https://github.com/ros2/launch/blob/jazzy/launch_testing/README.md#examples)