### PR TITLE
Remove references to docs.ros2.org from the documentation.

### DIFF
--- a/source/Concepts/Intermediate/About-Logging.rst
+++ b/source/Concepts/Intermediate/About-Logging.rst
@@ -185,7 +185,6 @@ Logging usage
 
     * See the `rclcpp logging demo <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/logging_demo>`_ for some simple examples.
     * See the :doc:`logging demo <../../Tutorials/Demos/Logging-and-logger-configuration>` for example usage.
-    * See the `rclcpp documentation <https://docs.ros2.org/latest/api/rclcpp/logging_8hpp.html>`__ for an extensive list of functionality.
 
   .. group-tab:: Python
 

--- a/source/How-To-Guides/Node-arguments.rst
+++ b/source/How-To-Guides/Node-arguments.rst
@@ -125,7 +125,7 @@ As an example, save the following as ``demo_params.yaml``:
               some_integers: [1, 2, 3, 4]
               some_doubles : [3.14, 2.718]
 
-Then either declare the parameters within your node with ``declare_parameter``  or ``declare_parameters`` (see `documentation <https://docs.ros2.org/foxy/api/rclcpp/classrclcpp_1_1Node.html#a095ea977b26e7464d9371efea5f36c42>`__ for function signatures), or `set the node to automatically declare parameters <https://docs.ros2.org/foxy/api/rclcpp/classrclcpp_1_1NodeOptions.html#a094ceb7af7c9b358ec007a4b8e14d40d>`__ if they were passed in via a command line override.
+Then either declare the parameters within your node with `declare_parameter <http://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/classrclcpp_1_1Node.html#_CPPv4N6rclcpp4Node17declare_parameterERKNSt6stringERKN6rclcpp14ParameterValueERKN14rcl_interfaces3msg19ParameterDescriptorEb>`__  or `declare_parameters <http://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/classrclcpp_1_1Node.html#_CPPv4I0EN6rclcpp4Node18declare_parametersENSt6vectorI10ParameterTEERKNSt6stringERKNSt3mapINSt6stringENSt4pairI10ParameterTN14rcl_interfaces3msg19ParameterDescriptorEEEEEb>`__, or `set the node to automatically declare parameters <http://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/classrclcpp_1_1NodeOptions.html#_CPPv4NK6rclcpp11NodeOptions47automatically_declare_parameters_from_overridesEv>`__ if they were passed in via a command line override.
 
 Then run the following:
 

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -460,7 +460,7 @@ Therefore, in the example, a valid value for this policy has been explicitly set
 Prioritization of rmw_qos_profile_t
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ROS 2 QoS contained in `rmw_qos_profile_t <http://docs.ros2.org/latest/api/rmw/structrmw__qos__profile__t.html>`_ are always honored, unless set to ``*_SYSTEM_DEFAULT``.
+ROS 2 QoS contained in `rmw_qos_profile_t <http://docs.ros.org/en/{DISTRO}/p/rmw/generated/structrmw__qos__profile__s.html>`_ are always honored, unless set to ``*_SYSTEM_DEFAULT``.
 In that case, XML values (or *Fast DDS* default values in the absence of XML ones) are applied.
 This means that if any QoS in ``rmw_qos_profile_t`` is set to something other than ``*_SYSTEM_DEFAULT``, the corresponding value in the XML is ignored.
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
@@ -110,7 +110,7 @@ In another terminal, we can use the command line interface to send a goal:
 In the terminal that is running the action server, you should see a logged message "Executing goal..." followed by a warning that the goal state was not set.
 By default, if the goal handle state is not set in the execute callback it assumes the *aborted* state.
 
-We can use the method `succeed() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.server.ServerGoalHandle.succeed>`_ on the goal handle to indicate that the goal was successful:
+We can call ``succeed()`` on the goal handle to indicate that the goal was successful:
 
 .. literalinclude:: scripts/server_1.py
     :language: python
@@ -135,7 +135,7 @@ You should see the goal finish with the proper result sequence.
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 One of the nice things about actions is the ability to provide feedback to an action client during goal execution.
-We can make our action server publish feedback for action clients by calling the goal handle's `publish_feedback() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.server.ServerGoalHandle.publish_feedback>`_ method.
+We can make our action server publish feedback for action clients by calling the goal handle's ``publish_feedback()`` method.
 
 We'll replace the ``sequence`` variable, and use a feedback message to store the sequence instead.
 After every update of the feedback message in the for-loop, we publish the feedback message and sleep for dramatic effect:
@@ -266,7 +266,7 @@ Here's the complete code for this example:
 .. literalinclude:: scripts/client_1.py
     :language: python
 
-The `ActionClient.send_goal_async() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.client.ActionClient.send_goal_async>`_ method returns a future to a goal handle.
+The ``ActionClient.send_goal_async()`` method returns a future to a goal handle.
 First we register a callback for when the future is complete:
 
 .. literalinclude:: scripts/client_1.py
@@ -281,7 +281,7 @@ We can check to see if the goal was rejected and return early since we know ther
     :language: python
     :lines: 24-30
 
-Now that we've got a goal handle, we can use it to request the result with the method `get_result_async() <http://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.client.ClientGoalHandle.get_result_async>`_.
+Now that we've got a goal handle, we can use it to request the result with the method ``get_result_async()``.
 Similar to sending the goal, we will get a future that will complete when the result is ready.
 Let's register a callback just like we did for the goal response:
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -185,14 +185,6 @@ Miscellaneous
 
 Deprecated
 ----------
-* `ROS Answers <https://answers.ros.org/questions/>`__ (ROS 1, ROS 2)
-
-  - ROS Answers was the ROS community Q&A website, until August, 2023. ROS Answers is currently available as a read-only resource.
-
-* `ROS 2 Docs <https://docs.ros2.org>`_
-
-  - API documentation up to and including Galactic
-
 * `ROS 2 Design <http://design.ros2.org/>`__
 
   - Early design decisions behind ROS 2 development


### PR DESCRIPTION
There aren't too many left, but the ones that are there should be either removed or pointed to modern places. This commit does exactly that, and outside of release notes there are no more references to docs.ros2.org after this.

This will close #2866 (though only for Iron, Jazzy, and Rolling).