### PR TITLE
FIx license snippets on package.xml and setup.py

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -317,7 +317,7 @@ Here is the content of those three files:
      <version>0.0.0</version>
      <description>talker</description>
      <maintainer email="gerkey@osrfoundation.org">Brian Gerkey</maintainer>
-     <license>Apache 2.0</license>
+     <license>Apache-2.0</license>
      <buildtool_depend>catkin</buildtool_depend>
      <build_depend>roscpp</build_depend>
      <build_depend>std_msgs</build_depend>
@@ -617,7 +617,7 @@ Putting it all together, our ``package.xml`` now looks like this:
      <version>0.0.0</version>
      <description>talker</description>
      <maintainer email="gerkey@osrfoundation.org">Brian Gerkey</maintainer>
-     <license>Apache License 2.0</license>
+     <license>Apache-2.0</license>
    <!--  <buildtool_depend>catkin</buildtool_depend> -->
      <buildtool_depend>ament_cmake</buildtool_depend>
    <!--  <build_depend>roscpp</build_depend> -->

--- a/source/How-To-Guides/Using-Variants.rst
+++ b/source/How-To-Guides/Using-Variants.rst
@@ -34,7 +34,7 @@ To do so you need only create two files:
       <version>1.0.0</version>
       <description>A package to aggregate all packages in my_project.</description>
       <maintainer email="maintainer-email">Maintainer Name</maintainer>
-      <license>Apache License 2.0</license>
+      <license>Apache-2.0</license>
       <!-- packages in my_project -->
       <exec_depend>my_project_msgs</exec_depend>
       <exec_depend>my_project_services</exec_depend>

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
@@ -69,7 +69,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>C++ bag writing tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 2 Write the C++ node
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
@@ -73,7 +73,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>Python bag writing tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 Also be sure to add this information to the ``setup.py`` file as well.
 
@@ -82,7 +82,7 @@ Also be sure to add this information to the ``setup.py`` file as well.
    maintainer='Your Name',
    maintainer_email='you@email.com',
    description='Python bag writing tutorial',
-   license='Apache License 2.0',
+   license='Apache-2.0',
 
 2 Write the Python node
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
@@ -461,11 +461,11 @@ Then, edit the ``description`` line to summarize the package:
 Then, update the ``license`` line.
 You can read more about open source licenses `here <https://opensource.org/licenses/alphabetical>`__.
 Since this package is only for practice, it's safe to use any license.
-We'll use ``Apache License 2.0``:
+We'll use ``Apache-2.0``:
 
 .. code-block:: xml
 
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 Don't forget to save once you're done editing.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -62,7 +62,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>C++ parameter tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 2 Write the C++ node
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -62,7 +62,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>Python parameter tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 2 Write the Python node
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +194,7 @@ Again, match the ``maintainer``, ``maintainer_email``, ``description`` and ``lic
   maintainer='YourName',
   maintainer_email='you@email.com',
   description='Python parameter tutorial',
-  license='Apache License 2.0',
+  license='Apache-2.0',
 
 Add the following line within the ``console_scripts`` brackets of the ``entry_points`` field:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -224,7 +224,7 @@ As mentioned in the :doc:`previous tutorial <./Creating-Your-First-ROS2-Package>
 
       <description>Examples of minimal publisher/subscriber using rclcpp</description>
       <maintainer email="you@email.com">Your Name</maintainer>
-      <license>Apache License 2.0</license>
+      <license>Apache-2.0</license>
 
 Add a new line after the ``ament_cmake`` buildtool dependency and paste the following dependencies corresponding to your node's include statements:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -73,7 +73,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>C++ client server tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 
 2 Write the service node

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Publisher-And-Subscriber.rst
@@ -221,7 +221,7 @@ As mentioned in the :doc:`previous tutorial <./Creating-Your-First-ROS2-Package>
 
   <description>Examples of minimal publisher/subscriber using rclpy</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 After the lines above, add the following dependencies corresponding to your node's import statements:
 
@@ -245,7 +245,7 @@ Again, match the ``maintainer``, ``maintainer_email``, ``description`` and ``lic
   maintainer='YourName',
   maintainer_email='you@email.com',
   description='Examples of minimal publisher/subscriber using rclpy',
-  license='Apache License 2.0',
+  license='Apache-2.0',
 
 Add the following line within the ``console_scripts`` brackets of the ``entry_points`` field:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Py-Service-And-Client.rst
@@ -72,7 +72,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>Python client server tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 1.2 Update ``setup.py``
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -84,7 +84,7 @@ Add the same information to the ``setup.py`` file for the ``maintainer``, ``main
     maintainer='Your Name',
     maintainer_email='you@email.com',
     description='Python client server tutorial',
-    license='Apache License 2.0',
+    license='Apache-2.0',
 
 2 Write the service node
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -64,7 +64,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>C++ parameter events client tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 2 Write the C++ node
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -60,7 +60,7 @@ As always, though, make sure to add the description, maintainer email and name, 
 
   <description>Python parameter events client tutorial</description>
   <maintainer email="you@email.com">Your Name</maintainer>
-  <license>Apache License 2.0</license>
+  <license>Apache-2.0</license>
 
 2 Write the Python node
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ Again, match the ``maintainer``, ``maintainer_email``, ``description`` and ``lic
     maintainer='YourName',
     maintainer_email='you@email.com',
     description='Python parameter tutorial',
-    license='Apache License 2.0',
+    license='Apache-2.0',
 
 Add the following line within the ``console_scripts`` brackets of the ``entry_points`` field:
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -251,7 +251,7 @@ As mentioned in the :doc:`Create a package <../../Beginner-Client-Libraries/Crea
 
     <description>Learning tf2 with rclcpp</description>
     <maintainer email="you@email.com">Your Name</maintainer>
-    <license>Apache License 2.0</license>
+    <license>Apache-2.0</license>
 
 Make sure to save the file.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -271,7 +271,7 @@ As mentioned in the :doc:`Create a package <../../Beginner-Client-Libraries/Crea
 
     <description>Learning tf2 with rclpy</description>
     <maintainer email="you@email.com">Your Name</maintainer>
-    <license>Apache License 2.0</license>
+    <license>Apache-2.0</license>
 
 After the lines above, add the following dependencies corresponding to your node’s import statements:
 


### PR DESCRIPTION
From testing https://github.com/osrf/ros2_test_cases/issues/1179

License mismatch between the snippets 
```
<license>Apache License 2.0</license>
```

And actual package.xml generated by:
```
ros2 pkg create --build-type XX --license Apache-2.0
```
```
<license>Apache-2.0</license>
```