### PR TITLE
Update the current state of  `char` in `rclpy`

### DIFF
--- a/source/Concepts/Basic/About-Interfaces.rst
+++ b/source/Concepts/Basic/About-Interfaces.rst
@@ -78,7 +78,7 @@ Field types can be:
      - octet
    * - char
      - char
-     - builtins.str*
+     - builtins.int*
      - char
    * - float32
      - float


### PR DESCRIPTION
`char` currently translates to `int` not `str` in `rclpy`. 

See: https://github.com/ros2/rosidl/issues/775

After attempting to change this in my spare time I think any change will caused more confusion and suffering for end users.