### PR TITLE
Simplify the colcon-argcomplete documentation.

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -334,7 +334,8 @@ To undo this in Linux and macOS, locate your system's shell startup script and r
 Setup ``colcon`` tab completion
 -------------------------------
 
-The command ``colcon`` `supports command completion <https://colcon.readthedocs.io/en/released/user/installation.html#enable-completion>`__ for bash and bash-like shells if the ``colcon-argcomplete`` package is installed.
+The ``colcon`` command supports command completion for bash and bash-like shells.
+The ``colcon-argcomplete`` package must be installed, and `some setup may be required <https://colcon.readthedocs.io/en/released/user/installation.html#enable-completion>`__ to make it work.
 
 Tips
 ----

--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -336,27 +336,6 @@ Setup ``colcon`` tab completion
 
 The command ``colcon`` `supports command completion <https://colcon.readthedocs.io/en/released/user/installation.html#enable-completion>`__ for bash and bash-like shells if the ``colcon-argcomplete`` package is installed.
 
-.. tabs::
-
-   .. group-tab:: Linux
-
-      .. code-block:: console
-
-        echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc
-
-   .. group-tab:: macOS
-
-      .. code-block:: console
-
-        echo "source $HOME/.local/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bash_profile
-
-   .. group-tab:: Windows
-
-      Not yet available
-
-Depending on the way you installed ``colcon`` and where your workspace is, the instructions above may vary, please refer to `the documentation <https://colcon.readthedocs.io/en/released/user/installation.html>`__ for more details.
-To undo this in Linux and macOS, locate your system's shell startup script and remove the appended source command.
-
 Tips
 ----
 


### PR DESCRIPTION
The colcon documentation already states that there may be different locations for the argcomplete script depending on how it was installed.  Just use that documentation as a reference point.

This should fix https://github.com/osrf/ros2_test_cases/issues/1549 .  Original idea from @christophebedard .