### PR TITLE
Launch large project tutorial fix

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -218,8 +218,6 @@ Let's now create a configuration file, ``turtlesim.yaml``, in the ``/config`` fo
          background_g: 86
          background_r: 150
 
-If we now start the ``turtlesim_world_2_launch.py`` launch file, we will start the ``turtlesim_node`` with preconfigured background colors.
-
 To learn more about using parameters and using YAML files, take a look at the :doc:`Understand parameters <../../Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters>` tutorial.
 
 2.3 Using wildcards in YAML files

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -473,7 +473,7 @@ Let's now create the last launch file called ``fixed_broadcaster_launch.py`` in 
 This launch file shows the way environment variables can be called inside the launch files.
 Environment variables can be used to define or push namespaces for distinguishing nodes on different computers or robots.
 
-.. note:: If you running the launch file from an environment where `USER` is not defined like in the ROS docker (check with echo $USER), then you can substitute `EnvironmentVariable('USER')` with any other word of your liking.
+.. note:: If you are running the launch file where the `USER` environment variable is not defined (like in the ROS docker file), then you can replace the `EnvironmentVariable('USER')` above with any other word of your liking.
 
 Running launch files
 --------------------

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -473,6 +473,8 @@ Let's now create the last launch file called ``fixed_broadcaster_launch.py`` in 
 This launch file shows the way environment variables can be called inside the launch files.
 Environment variables can be used to define or push namespaces for distinguishing nodes on different computers or robots.
 
+.. note:: If you running the launch file from an environment where `USER` is not defined like in the ROS docker (check with echo $USER), then you can substitute `EnvironmentVariable('USER')` with any other word of your liking.
+
 Running launch files
 --------------------
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -495,6 +495,8 @@ The ``data_files`` field should now look like this:
             glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
          (os.path.join('share', package_name, 'config'),
             glob(os.path.join('config', '*.yaml'))),
+         (os.path.join('share', package_name, 'rviz'),
+            glob(os.path.join('config', '*.rviz'))),
       ],
 
 2 Build and run


### PR DESCRIPTION
Fixes partly this issue from the jazzy tutorial testing: https://github.com/osrf/ros2_test_cases/issues/1151

I can't really figure out why the carrot1 frame is not showing up other than that it is forgotten in the launch file? I still get this error:
```
[turtle_tf2_listener-6] [INFO] [1715366094.127739162] [listener]: Could not transform turtle2 to carrot1: "carrot1" passed to lookupTransform argument source_frame does not exist.
```
I could  consider fixing this by adding the carrot1 somewhere... or removing all notion of carrot1 all together? I've started a proposal in this ticket to reshape the launch tutorials anyway... https://github.com/ros2/ros2_documentation/issues/4453.

Anyway, this should at least target Rolling and Jazzy documents.