### PR TITLE
rename `demo_keys` into `demo_keystore` along with setup tutorial.

### DIFF
--- a/source/Tutorials/Advanced/Security/Examine-Traffic.rst
+++ b/source/Tutorials/Advanced/Security/Examine-Traffic.rst
@@ -141,13 +141,13 @@ Enable encryption for both by setting the security environment variables and run
 .. code-block:: bash
 
   # In terminal 1:
-  export ROS_SECURITY_KEYSTORE=~/sros2_demo/demo_keys
+  export ROS_SECURITY_KEYSTORE=~/sros2_demo/demo_keystore
   export ROS_SECURITY_ENABLE=true
   export ROS_SECURITY_STRATEGY=Enforce
   ros2 run demo_nodes_cpp talker --ros-args --enclave /talker_listener/talker
 
   # In terminal 2:
-  export ROS_SECURITY_KEYSTORE=~/sros2_demo/demo_keys
+  export ROS_SECURITY_KEYSTORE=~/sros2_demo/demo_keystore
   export ROS_SECURITY_ENABLE=true
   export ROS_SECURITY_STRATEGY=Enforce
   ros2 run demo_nodes_cpp listener --ros-args --enclave /talker_listener/listener

--- a/source/Tutorials/Advanced/Security/The-Keystore.rst
+++ b/source/Tutorials/Advanced/Security/The-Keystore.rst
@@ -209,7 +209,7 @@ Begin with a new terminal session and enable security with the keystore created 
 
 .. code-block:: bash
 
-  export ROS_SECURITY_KEYSTORE=~/sros2_demo/demo_keys
+  export ROS_SECURITY_KEYSTORE=~/sros2_demo/demo_keystore
   export ROS_SECURITY_ENABLE=true
   export ROS_SECURITY_STRATEGY=Enforce
 


### PR DESCRIPTION
part of https://github.com/osrf/ros2_test_cases/issues/1094