### PR TITLE
Release Jazzy Jalisco

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 
 multiversion: Makefile
 	sphinx-multiversion $(OPTS) "$(SOURCE)" build/html
-	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=iron/index.html\" /></head></html>" > build/html/index.html
+	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=jazzy/index.html\" /></head></html>" > build/html/index.html
 	$(PYTHON) make_sitemapindex.py
 
 %: Makefile

--- a/conf.py
+++ b/conf.py
@@ -127,9 +127,9 @@ templates_path = [
 smv_branch_whitelist = r'^(rolling|jazzy|iron|humble|galactic|foxy|eloquent|dashing|crystal)$'
 
 
-smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(iron|humble|galactic|foxy|eloquent|dashing|crystal).*$'
+smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(jazzy|iron|humble|galactic|foxy|eloquent|dashing|crystal).*$'
 smv_remote_whitelist = r'^(origin)$'
-smv_latest_version = 'iron'
+smv_latest_version = 'jazzy'
 smv_eol_versions = ['crystal', 'dashing', 'eloquent', 'foxy', 'galactic']
 
 distro_full_names = {

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -23,6 +23,7 @@ Rows in the table marked in green are the currently supported distributions.
 .. toctree::
    :hidden:
 
+   Releases/Release-Jazzy-Jalisco
    Releases/Release-Iron-Irwini
    Releases/Release-Humble-Hawksbill
    Releases/Release-Rolling-Ridley
@@ -47,11 +48,16 @@ Rows in the table marked in green are the currently supported distributions.
    -->
    <style>
      .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
+     .rst-content table.docutils:not(.field-list) tr:nth-child(3) td {background-color: #33cc66;}
      .rst-content tr:nth-child(2) {background-color: #33cc66;}
+     .rst-content tr:nth-child(3) {background-color: #33cc66;}
    </style>
 
 .. |rolling| image:: Releases/rolling-small.png
    :alt: Rolling logo
+
+.. |jazzy| image:: Releases/jazzy-small.png
+   :alt: Jazzy logo
 
 .. |iron| image:: Releases/iron-small.png
    :alt: Iron logo
@@ -89,6 +95,10 @@ Rows in the table marked in green are the currently supported distributions.
      - Release date
      - Logo
      - EOL date
+   * - :doc:`Jazzy Jalisco <Releases/Release-Jazzy-Jalisco>`
+     - May 23rd, 2024
+     - |jazzy|
+     - May 2029
    * - :doc:`Iron Irwini <Releases/Release-Iron-Irwini>`
      - May 23rd, 2023
      - |iron|
@@ -158,10 +168,10 @@ There is a new ROS 2 distribution released yearly on May 23rd (`World Turtle Day
      - Release date
      - Logo
      - EOL date
-   * - :doc:`Jazzy Jalisco <Releases/Release-Jazzy-Jalisco>`
-     - May 2024
+   * - :doc:`K-turtle <Releases/Release-K-turtle>`
+     - May 2025
      - TBD
-     - May 2029
+     - Nov 2026
 
 
 .. _rolling_distribution:

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -168,7 +168,7 @@ There is a new ROS 2 distribution released yearly on May 23rd (`World Turtle Day
      - Release date
      - Logo
      - EOL date
-   * - :doc:`K-turtle <Releases/Release-K-turtle>`
+   * - :doc:`Kilted Kaiju <Releases/Release-Kilted-Kaiju>`
      - May 2025
      - TBD
      - Nov 2026

--- a/source/Releases/Development.rst
+++ b/source/Releases/Development.rst
@@ -6,4 +6,4 @@ Below is the ROS 2 distribution that is currently in development.
 .. toctree::
    :maxdepth: 1
 
-   Release-K-turtle
+   Release-Kilted-Kaiju

--- a/source/Releases/Development.rst
+++ b/source/Releases/Development.rst
@@ -6,4 +6,4 @@ Below is the ROS 2 distribution that is currently in development.
 .. toctree::
    :maxdepth: 1
 
-   Release-Jazzy-Jalisco
+   Release-K-turtle

--- a/source/Releases/Release-Iron-Irwini.rst
+++ b/source/Releases/Release-Iron-Irwini.rst
@@ -1,5 +1,3 @@
-.. _latest_release:
-
 .. _iron-release:
 
 Iron Irwini (``iron``)

--- a/source/Releases/Release-Jazzy-Jalisco.rst
+++ b/source/Releases/Release-Jazzy-Jalisco.rst
@@ -1,4 +1,4 @@
-.. _upcoming-release:
+.. _latest-release:
 
 .. _jazzy-release:
 

--- a/source/Releases/Release-K-turtle.rst
+++ b/source/Releases/Release-K-turtle.rst
@@ -1,0 +1,47 @@
+.. _upcoming-release:
+
+.. _k-turtle-release:
+
+K-turtle (codename 'k'; May, 2024)
+===========================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+*K-turtle* is the eleventh release of ROS 2.
+What follows is highlights of the important changes and features in K-turtle since the last release.
+
+Supported Platforms
+-------------------
+
+K-turtle is primarily supported on the following platforms:
+
+Tier 1 platforms:
+
+* TODO
+
+Tier 2 platforms:
+
+* TODO
+
+Tier 3 platforms:
+
+* TODO
+
+For more information about RMW implementations, compiler / interpreter versions, and system dependency versions see `REP 2000 <https://www.ros.org/reps/rep-2000.html>`__.
+
+Installation
+------------
+
+TODO
+
+New features in this ROS 2 release
+----------------------------------
+
+Development progress
+--------------------
+
+For progress on the development of K-turtle, see `this project board <https://github.com/orgs/ros2/projects/52>`__.
+
+For the broad process followed by K-turtle, see the :doc:`process description page <Release-Process>`.

--- a/source/Releases/Release-Kilted-Kaiju.rst
+++ b/source/Releases/Release-Kilted-Kaiju.rst
@@ -1,21 +1,21 @@
 .. _upcoming-release:
 
-.. _k-turtle-release:
+.. _kilted-release:
 
-K-turtle (codename 'k'; May, 2024)
+Kilted Kaiju (codename 'kilted'; May, 2024)
 ===========================================
 
 .. contents:: Table of Contents
    :depth: 2
    :local:
 
-*K-turtle* is the eleventh release of ROS 2.
-What follows is highlights of the important changes and features in K-turtle since the last release.
+*Kilted Kaiju* is the eleventh release of ROS 2.
+What follows is highlights of the important changes and features in Kilted Kaiju since the last release.
 
 Supported Platforms
 -------------------
 
-K-turtle is primarily supported on the following platforms:
+Kilted Kaiju is primarily supported on the following platforms:
 
 Tier 1 platforms:
 
@@ -42,6 +42,6 @@ New features in this ROS 2 release
 Development progress
 --------------------
 
-For progress on the development of K-turtle, see `this project board <https://github.com/orgs/ros2/projects/52>`__.
+For progress on the development of Kiltled Kaiju, see `this project board <https://github.com/orgs/ros2/projects/63>`__.
 
-For the broad process followed by K-turtle, see the :doc:`process description page <Release-Process>`.
+For the broad process followed by Kilted Kaiju, see the :doc:`process description page <Release-Process>`.

--- a/source/Releases/Release-Kilted-Kaiju.rst
+++ b/source/Releases/Release-Kilted-Kaiju.rst
@@ -2,7 +2,7 @@
 
 .. _kilted-release:
 
-Kilted Kaiju (codename 'kilted'; May, 2024)
+Kilted Kaiju (codename 'kilted'; May, 2025)
 ===========================================
 
 .. contents:: Table of Contents


### PR DESCRIPTION
This PR:

Marks Jazzy as released and sets the same to default. Also moves the latest_release label from Iron to Jazzy. 
It also adds K-Turtle to development. Once K-turtle has a name we can update this branch.

Will keep this as draft until release. 