### PR TITLE
Update Developer Guide on Documentation 

### DIFF
--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -207,7 +207,7 @@ Examples:
 API Documetation for ROS Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-API documentation for all released ROS packages, including `rclcpp <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html#>`_, and `rclpy <https://docs.ros.org/en/{DISTRO}/p/rclpy/>`_ can be `found here <https://docs.ros.org/en/{DISTRO/p/>`_.
+API documentation for all released ROS packages, including `rclcpp <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html#>`_, and `rclpy <https://docs.ros.org/en/{DISTRO}/p/rclpy/>`_ can be `found here <https://docs.ros.org/en/{DISTRO}/p/>`_.
 We recommend using `index.ros.org <https://index.ros.org/>`_ to search through available ROS packages to find their documentation.
 
 If you are a ROS package developer looking for guidance on documenting your package please see :doc:`our "how to" guide on package level documentation <../../How-To-Guides/Documenting-a-ROS-2-Package>`. The documentation for all released ROS 2 packages is automatically hosted on docs.ros.org

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -204,7 +204,13 @@ Examples:
 
   * This is an example of describing an extension point for a package
 
-*(API docs are not yet being automatically generated)*
+API Documetation for ROS Packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+API documentation for all released ROS packages, including `rclcpp <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html#>`_, and `rclpy <https://docs.ros.org/en/{DISTRO}/p/rclpy/>`_ can be `found here <https://docs.ros.org/en/{DISTRO/p/>`_.
+We recommend using `index.ros.org <https://index.ros.org/>`_ to search through available ROS packages to find their documentation.
+
+If you are a ROS package developer looking for guidance on documenting your package please see :doc:`our "how to" guide on package level documentation <../../How-To-Guides/Documenting-a-ROS-2-Package>`. The documentation for all released ROS 2 packages is automatically hosted on docs.ros.org
 
 Testing
 ^^^^^^^

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -207,7 +207,7 @@ Examples:
 API Documetation for ROS Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-API documentation for all released ROS packages, including `rclcpp <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html#>`_, and `rclpy <https://docs.ros.org/en/{DISTRO}/p/rclpy/>`_ can be `found here <https://docs.ros.org/en/{DISTRO}/p/>`_.
+API documentation for all released ROS packages can be `found here <https://docs.ros.org/en/{DISTRO}/p/>`__.
 We recommend using `index.ros.org <https://index.ros.org/>`_ to search through available ROS packages to find their documentation.
 
 If you are a ROS package developer looking for guidance on documenting your package please see :doc:`our "how to" guide on package level documentation <../../How-To-Guides/Documenting-a-ROS-2-Package>`.

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -210,7 +210,8 @@ API Documetation for ROS Packages
 API documentation for all released ROS packages, including `rclcpp <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html#>`_, and `rclpy <https://docs.ros.org/en/{DISTRO}/p/rclpy/>`_ can be `found here <https://docs.ros.org/en/{DISTRO}/p/>`_.
 We recommend using `index.ros.org <https://index.ros.org/>`_ to search through available ROS packages to find their documentation.
 
-If you are a ROS package developer looking for guidance on documenting your package please see :doc:`our "how to" guide on package level documentation <../../How-To-Guides/Documenting-a-ROS-2-Package>`. The documentation for all released ROS 2 packages is automatically hosted on docs.ros.org
+If you are a ROS package developer looking for guidance on documenting your package please see :doc:`our "how to" guide on package level documentation <../../How-To-Guides/Documenting-a-ROS-2-Package>`.
+The documentation for all released ROS 2 packages is automatically hosted on `docs.ros.org <https://docs.ros.org/en/{DISTRO/p/>`_.
 
 Testing
 ^^^^^^^

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -211,7 +211,7 @@ API documentation for all released ROS packages can be `found here <https://docs
 We recommend using `index.ros.org <https://index.ros.org/>`_ to search through available ROS packages to find their documentation.
 
 If you are a ROS package developer looking for guidance on documenting your package please see :doc:`our "how to" guide on package level documentation <../../How-To-Guides/Documenting-a-ROS-2-Package>`.
-The documentation for all released ROS 2 packages is automatically hosted on `docs.ros.org <https://docs.ros.org/en/{DISTRO/p/>`_.
+The documentation for all released ROS 2 packages is automatically hosted on `docs.ros.org <https://docs.ros.org/en/{DISTRO}/p/>`_.
 
 Testing
 ^^^^^^^


### PR DESCRIPTION
There is still some frustration about finding guidance on package-level documentation practices. I updated our developer guide to point to the package-level documentation "How-To" as well as the locations for the API docs for `rclpy` and `rclcpp` so documentation writers have examples to model our documentation style. 

[Please see this discussion for more context.](https://discourse.ros.org/t/plans-for-ros-2-documentation-particularly-api-docs/28638/17?u=katherine_scott)

@severin-lemaignan your feedback is welcome here. 