### PR TITLE
Make EOL distro docs notice more obvious

### DIFF
--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -24,8 +24,13 @@
 <p>
   <strong>
     {% if current_version.name|string() in eol_versions %}
-    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
-    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+    <div class="admonition warning">
+      <p class="admonition-title">Warning</p>
+      <p>
+        You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
+        If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+      </p>
+    </div>
     {% elif current_version.is_released %}
     You're reading the documentation for an older, but still supported, version of ROS 2.
     For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.


### PR DESCRIPTION
One big problem we have is that the first Google result for "ROS 2 documentation" is the Foxy docs. Users sometimes do not realize that they're looking at docs for EOL distros, which can lead to confusion.

We currently have this warning at the top of all pages for EOL distro docs:

![image](https://github.com/ros2/ros2_documentation/assets/3717345/11adaed7-ade7-434a-b0e0-fe2b789301c5)

I think that just making it bold may not be enough. I'm proposing to turn it into a `.. warning::` block:

![image](https://github.com/ros2/ros2_documentation/assets/3717345/4edc9b7f-806e-4aa9-8019-3b9ebee2d138)

Since the file where this notice is injected is an `.html` file and not an `.rst` file, I just copied the HTML generated from a `.. warning::` block.

We _could_ do the same for non-EOL but not latest distros, but that's probably not as necessary.