### PR TITLE
Document console logging format tokens

### DIFF
--- a/source/Concepts/Intermediate/About-Logging.rst
+++ b/source/Concepts/Intermediate/About-Logging.rst
@@ -111,6 +111,23 @@ For each of the environment settings, note that this is a process-wide setting, 
 
   If no format is given, a default of ``[{severity}] [{time}] [{name}]: {message}`` is used.
 
+``RCUTILS_CONSOLE_OUTPUT_FORMAT`` also supports the following escape character syntax.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Escape character syntax
+      - Character represented
+    * - ``\a``
+      - Alert
+    * - ``\b``
+      - Backspace
+    * - ``\n``
+      - New line
+    * - ``\r``
+      - Carriage return
+    * - ``\t``
+      - Horizontal tab
 
 Node creation
 ^^^^^^^^^^^^^

--- a/source/Concepts/Intermediate/About-Logging.rst
+++ b/source/Concepts/Intermediate/About-Logging.rst
@@ -104,6 +104,7 @@ For each of the environment settings, note that this is a process-wide setting, 
   * ``{file_name}`` - The file name this was called from (may be empty).
   * ``{time}`` - The time in seconds since the epoch.
   * ``{time_as_nanoseconds}`` - The time in nanoseconds since the epoch.
+  * ``{date_time_with_ms}`` - The time in ISO format, e.g. ``2024-06-11 09:29:19.304``
   * ``{line_number}`` - The line number this was called from (may be empty).
 
   If no format is given, a default of ``[{severity}] [{time}] [{name}]: {message}`` is used.

--- a/source/Concepts/Intermediate/About-Logging.rst
+++ b/source/Concepts/Intermediate/About-Logging.rst
@@ -84,6 +84,8 @@ Configuration
 
 Since ``rclcpp`` and ``rclpy`` use the same underlying logging infrastructure, the configuration options are the same.
 
+.. _logging-configuration-environment-variables:
+
 Environment variables
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -404,34 +404,7 @@ For example, to additionally get the timestamp and location of the log calls, st
       ros2 run logging_demo logging_demo_main
 
 You should see the timestamp in seconds and the function name, filename and line number additionally printed with each message.
-*The* ``time`` *option is only supported as of the ROS 2 Bouncy release.*
-
-The following tokens are available
-
-.. list-table::
-   :header-rows: 1
-
-   * - Token
-     - Explanation
-   * - ``severity``
-     - ``DEBUG`` / ``INFO`` / ``WARN`` / ``ERROR`` / ``FATAL``
-   * - ``name``
-     - Logger name as configured in the logger function
-   * - ``message``
-     - The actual message
-   * - ``function_name``
-     - The function containing the logging statement
-   * - ``file_name``
-     - The source file containing the logging statement
-   * - ``time``
-     - Timestamp in epoch format e.g. ``1718090959.304747140``
-   * - ``date_time_with_ms``
-     - Timestamp in ISO format e.g. ``2024-06-11 09:29:19.304``
-   * - ``time_as_nanoseconds``
-     - Timestamp as nanoseconds, e.g. ``1718090959304747140``
-   * - ``line_number``
-     - Line number of the source file where the logging statement is
-     
+*The ``time`` option is only supported as of the ROS 2 Bouncy release.*
 
 ``RCUTILS_CONSOLE_OUTPUT_FORMAT`` also supports the following escape character syntax.
 

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -404,7 +404,34 @@ For example, to additionally get the timestamp and location of the log calls, st
       ros2 run logging_demo logging_demo_main
 
 You should see the timestamp in seconds and the function name, filename and line number additionally printed with each message.
-*The ``time`` option is only supported as of the ROS 2 Bouncy release.*
+*The* ``time`` *option is only supported as of the ROS 2 Bouncy release.*
+
+The following tokens are available
+
+.. list-table::
+   :header-rows: 1
+
+   * - Token
+     - Explanation
+   * - ``severity``
+     - ``DEBUG`` / ``INFO`` / ``WARN`` / ``ERROR`` / ``FATAL``
+   * - ``name``
+     - Logger name as configured in the logger function
+   * - ``message``
+     - The actual message
+   * - ``function_name``
+     - The function containing the logging statement
+   * - ``file_name``
+     - The source file containing the logging statement
+   * - ``time``
+     - Timestamp in epoch format e.g. ``1718090959.304747140``
+   * - ``date_time_with_ms``
+     - Timestamp in ISO format e.g. ``2024-06-11 09:29:19.304``
+   * - ``time_as_nanoseconds``
+     - Timestamp as nanoseconds, e.g. ``1718090959304747140``
+   * - ``line_number``
+     - Line number of the source file where the logging statement is
+     
 
 ``RCUTILS_CONSOLE_OUTPUT_FORMAT`` also supports the following escape character syntax.
 

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -406,6 +406,8 @@ For example, to additionally get the timestamp and location of the log calls, st
 You should see the timestamp in seconds and the function name, filename and line number additionally printed with each message.
 *The ``time`` option is only supported as of the ROS 2 Bouncy release.*
 
+For more information on configuring the console logger formatting, see the :ref:`logger console configuration <logging-configuration-environment-variables>`
+
 ``RCUTILS_CONSOLE_OUTPUT_FORMAT`` also supports the following escape character syntax.
 
 .. list-table::

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -404,7 +404,6 @@ For example, to additionally get the timestamp and location of the log calls, st
       ros2 run logging_demo logging_demo_main
 
 You should see the timestamp in seconds and the function name, filename and line number additionally printed with each message.
-*The ``time`` option is only supported as of the ROS 2 Bouncy release.*
 
 For more information on configuring the console logger formatting, see the :ref:`logger console configuration <logging-configuration-environment-variables>`
 

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -408,24 +408,6 @@ You should see the timestamp in seconds and the function name, filename and line
 
 For more information on configuring the console logger formatting, see the :ref:`logger console configuration <logging-configuration-environment-variables>`
 
-``RCUTILS_CONSOLE_OUTPUT_FORMAT`` also supports the following escape character syntax.
-
-.. list-table::
-    :header-rows: 1
-
-    * - Escape character syntax
-      - Character represented
-    * - ``\a``
-      - Alert
-    * - ``\b``
-      - Backspace
-    * - ``\n``
-      - New line
-    * - ``\r``
-      - Carriage return
-    * - ``\t``
-      - Horizontal tab
-
 Console output colorizing
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
While searching whether it is possible to get a human-readable timestamp to the logging output, I stumbled upon the token definitions in the source file, but found that they aren't documented in the ros2_documentation.

Explicitly list all format tokens as listed in https://github.com/ros2/rcutils/blob/b2ad5ed4c5d11f21d514de9ea54c4d3cd0977ab6/src/logging.c#L390 with a short explanation