### PR TITLE
Remove instructions for apt-1.x installation.

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
@@ -145,21 +145,13 @@ Open a new terminal to install ``rqt`` and its plugins:
 
 .. tabs::
 
-  .. group-tab:: Linux (apt 2.0/Ubuntu 20.04 and newer)
+  .. group-tab:: Ubuntu Linux
 
     .. code-block:: console
 
       sudo apt update
 
       sudo apt install '~nros-{DISTRO}-rqt*'
-
-  .. group-tab:: Linux (apt 1.x/Ubuntu 18.04 and older)
-
-    .. code-block:: console
-
-      sudo apt update
-
-      sudo apt install 'ros-{DISTRO}-rqt*'
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
That doesn't apply to Ubuntu 22.04 on Humble at all, so just remove it.