### PR TITLE
ROS2 Jazzy Installation on Apple Silicon(M1) MacOS X(Sonoma 14.5) 

### DIFF
--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -15,20 +15,6 @@ System requirements
 
 We currently support macOS Sonoma (14.5) with Apple Silicon (e.g. M1) Mac
 
-
-One-liner installtion script
-----------------------------
-
-Open Terminal.app in Applications and type in the following command:
-
-.. code-block:: bash
-
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/IOES-Lab/ROS2_Jazzy_MacOS_Native_AppleSilicon/main/install.sh)"
-
-
-It will guide you through the installation process and install all the dependencies and ROS 2 Jazzy and Gazebo Harmonic for you.
-
-
 System setup
 ------------
 

--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -44,11 +44,7 @@ You need the following things installed to build ROS 2:
    **brew** *(needed to install dependencies; you probably already have this)*:
 
 
-   * Follow installation instructions at http://brew.sh/. Following is the oneliner installation script for brew
-
-     .. code-block:: bash
-
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   * Follow installation instructions at http://brew.sh/.
 
    *
      Check that ``brew`` is set not to use ``Rosseta`` (we don't want emulation of x86_64 binaries):
@@ -59,12 +55,11 @@ You need the following things installed to build ROS 2:
 
         brew config
 
-     If not, remove one that is using Rosseta (it's installed at ``/usr/local``) with following code and reinstall:
+     If not, remove one that is using Rosseta (it's installed at ``/usr/local``)
 
-     .. code-block:: bash
-   
-        curl -fsSLO https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh
-        /bin/bash uninstall.sh --path /usr/local
+     Use the uninstall script by Homebrew (https://github.com/homebrew/install?tab=readme-ov-file#uninstall-homebrew)
+
+     Make sure you add ``--path /usr/local`` at the end of the uninstall command to remove the Rosseta installation.
 
 #.
    Use ``brew`` to install dependencies:
@@ -146,7 +141,7 @@ Build ROS 2
 Get ROS 2 code
 ^^^^^^^^^^^^^^
 
-Create a workspace and clone all repos:
+Create a workspace and clone all repos (cloning the eact release version tag is required for patches):
 
 .. code-block:: bash
 
@@ -158,7 +153,7 @@ Create a workspace and clone all repos:
 Patch Files for macOS Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-First compile upto ``cyclonedds`` to generate compile structure and apply patches,
+First compile up to ``cyclonedds`` to generate compile structure and apply patches,
 
 .. code-block:: bash
 


### PR DESCRIPTION
Tested and designed on macOS Sonoma 14.5 with an Apple M3 chip (36 GB), it took about 15 minutes each to install ROS2 Jazzy and Gazebo Harmonic.

## Notes
- `eclipse-cyclonedds` is excluded from the installation process
  - It is not supported on Apple Silicon Macbooks (compile errors)
  - Ref : https://ros.org/reps/rep-2000.html

## References: (None of below worked for me, so I made this script)
- https://github.com/pfavr2/install_ros2_rolling_on_mac_m1
  - Much of the code design structure is referenced from this
- https://chenbrian.ca/posts/ros2_m1/
- https://github.com/TakanoTaiga/ros2_m1_native
- https://docs.ros.org/en/jazzy/Installation/Alternatives/macOS-Development-Setup.html

## For those in need, one-liner installation script

```bash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/IOES-Lab/ROS2_Jazzy_MacOS_Native_AppleSilicon/main/install.sh)"
```