### PR TITLE
Make CI create comment with link to HTML artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,25 @@ jobs:
           retention-days: 30 # default 90
           compression-level: 9 # maximum compression, default 6
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
+
+      - name: Find HTML artifacts link comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "HTML artifacts:"
+
+      - name: Create or update HTML artifacts link comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            HTML artifacts: ${{ steps.artifact-upload-step.outputs.artifact-url }}.
+
+            To view the resulting site:
+            1. Click on the above link to download the artifacts archive
+            2. Extract it
+            3. Open `html-artifacts/index.html` in your favorite browser
+          edit-mode: replace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v4
         id: artifact-upload-step
         with:
-          name: html-artifacts
+          name: html-artifacts-${{ github.event.pull_request.number }}
           path: build/html
           retention-days: 30 # default 90
           compression-level: 9 # maximum compression, default 6
@@ -87,5 +87,5 @@ jobs:
             To view the resulting site:
             1. Click on the above link to download the artifacts archive
             2. Extract it
-            3. Open `html-artifacts/index.html` in your favorite browser
+            3. Open `html-artifacts-${{ github.event.pull_request.number }}/index.html` in your favorite browser
           edit-mode: replace


### PR DESCRIPTION
To make it easier to find the link.

Basically, this:

1. Gets the URL to the artifact from [`actions/upload-artifact`'s output](https://github.com/actions/upload-artifact#outputs)
2. Uses the [`peter-evans/find-comment` action](https://github.com/peter-evans/find-comment) to try to find an existing comment from the bot, if possible
3. Uses the [`peter-evans/create-or-update-comment` action](https://github.com/peter-evans/create-or-update-comment#where-to-find-the-id-of-a-comment) to create a comment and include the artifact URL, or edit the existing comment if it was found

For example, see the comment from the bot below.

Follow-up to #4544

Relates #4548

This should make documenting this "feature" in the ROS 2 docs easier.