### PR TITLE
Disable bot HTML artifacts comment if PR from fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Find HTML artifacts link comment
         uses: peter-evans/find-comment@v3
         id: find-comment
+        # Skip if PR from fork
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -78,6 +80,8 @@ jobs:
 
       - name: Create or update HTML artifacts link comment
         uses: peter-evans/create-or-update-comment@v4
+        # Skip if PR from fork
+        if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Follow-up to #4564

I realized with #4572 that the steps to create/modify a comment fail if the PR is coming from a fork due to the lack of write permissions (to create the comment): https://github.com/peter-evans/create-or-update-comment#action-inputs.

I tried to give it write permissions, but I don't think this is going to work without changing a setting at the repo level: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#changing-the-permissions-in-a-forked-repository.

In the meantime, disable these steps if the PR is coming from a fork. I validated in #4575 that it still works with PRs from this repo itself.