### PR TITLE
Try non-default user id to create non-root user in devcontainer.

### DIFF
--- a/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
+++ b/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
@@ -205,12 +205,6 @@ This will build your development docker container for your. It will take a while
 Test Container
 ^^^^^^^^^^^^^^
 
-If your application requires the access to X window system, use the following command in the host system to accept the connection from the container.
-
-.. code-block:: console
-
-    (host system shell) xhost +local
-
 To test if everything worked correctly, open a terminal in the container using ``View->Terminal`` or ``Ctrl+Shift+``` and ``New Terminal`` in VS Code.
 Inside the terminal do the following:
 
@@ -220,4 +214,4 @@ Inside the terminal do the following:
     source /opt/ros/$ROS_DISTRO/setup.bash
     rviz2
 
-.. Note:: There might be a problem with displaying RVIZ. If no window pops up, then check the value of ``echo $DISPLAY`` - if the output is 1, you can fix this problem with ``echo "export DISPLAY=unix:1" >> /etc/bash.bashrc`` and then test it again. You can also change the DISPLAY value in the devcontainer.json and rebuild it.
+.. Note:: There might be a problem with displaying RVIZ. Please make sure to allow the user to access X window system with ``xhost +local:<USERNAME>``. If no window still pops up, then check the value of ``echo $DISPLAY`` - if the output is 1, you can fix this problem with ``echo "export DISPLAY=unix:1" >> /etc/bash.bashrc`` and then test it again. You can also change the DISPLAY value in the devcontainer.json and rebuild it.

--- a/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
+++ b/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
@@ -201,6 +201,12 @@ This will build your development docker container for your. It will take a while
 Test Container
 ^^^^^^^^^^^^^^
 
+If your application requires the access to X window system, use the following command in the host system to accept the connection from the container.
+
+.. code-block:: console
+
+    (host system shell) xhost +local
+
 To test if everything worked correctly, open a terminal in the container using ``View->Terminal`` or ``Ctrl+Shift+``` and ``New Terminal`` in VS Code.
 Inside the terminal do the following:
 

--- a/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
+++ b/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
@@ -110,15 +110,15 @@ Therefore add the following to ``.devcontainer/devcontainer.json``:
     {
         "name": "ROS 2 Development Container",
         "privileged": true,
-        "remoteUser": "ros2dev",
+        "remoteUser": "YOUR_USERNAME",
         "build": {
             "dockerfile": "Dockerfile",
             "args": {
-                "USERNAME": "ros2dev"
+                "USERNAME": "YOUR_USERNAME"
             }
         },
         "workspaceFolder": "/home/ws",
-        "workspaceMount": "source=${localWorkspaceFolder},target=/home/ws/src,type=bind",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/home/ws,type=bind",
         "customizations": {
             "vscode": {
                 "extensions":[
@@ -150,7 +150,8 @@ Therefore add the following to ``.devcontainer/devcontainer.json``:
 
 
 Use ``Ctrl+F`` to open the search and replace menu.
-Search for ``ros2dev`` and replace it with your ``Linux username``.
+Search for ``YOUR_USERNAME`` and replace it with your ``Linux username``.
+If you do not know your username, you can find it by running ``echo $USERNAME`` in the terminal.
 
 
 Edit ``Dockerfile``
@@ -163,8 +164,11 @@ Open the Dockerfile and add the following contents:
 
     FROM ros:ROS_DISTRO
     ARG USERNAME=USERNAME
-    ARG USER_UID=1234
+    ARG USER_UID=1000
     ARG USER_GID=$USER_UID
+
+    # Delete user if it exists in container (e.g Ubuntu Noble: ubuntu)
+    RUN if id -u $USER_UID ; then userdel `id -un $USER_UID` ; fi
 
     # Create the user
     RUN groupadd --gid $USER_GID $USERNAME \
@@ -188,7 +192,7 @@ Open the Dockerfile and add the following contents:
     CMD ["/bin/bash"]
 
 Replace ``ROS_DISTRO`` with the ROS 2 distribution you wish to use as base image above, for example ``rolling``.
-Search for ``USER_UID=1234`` and replace it if that is already used in the host system.
+
 
 Open and Build Development Container
 ------------------------------------

--- a/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
+++ b/source/How-To-Guides/Setup-ROS-2-with-VSCode-and-Docker-Container.rst
@@ -110,11 +110,11 @@ Therefore add the following to ``.devcontainer/devcontainer.json``:
     {
         "name": "ROS 2 Development Container",
         "privileged": true,
-        "remoteUser": "YOUR_USERNAME",
+        "remoteUser": "ros2dev",
         "build": {
             "dockerfile": "Dockerfile",
             "args": {
-                "USERNAME": "YOUR_USERNAME"
+                "USERNAME": "ros2dev"
             }
         },
         "workspaceFolder": "/home/ws",
@@ -142,7 +142,7 @@ Therefore add the following to ``.devcontainer/devcontainer.json``:
         ],
         "mounts": [
            "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
-            "source=/dev/dri,target=/dev/dri,type=bind,consistency=cached"
+           "source=/dev/dri,target=/dev/dri,type=bind,consistency=cached"
         ],
         "postCreateCommand": "sudo rosdep update && sudo rosdep install --from-paths src --ignore-src -y && sudo chown -R $(whoami) /home/ws/"
     }
@@ -150,8 +150,7 @@ Therefore add the following to ``.devcontainer/devcontainer.json``:
 
 
 Use ``Ctrl+F`` to open the search and replace menu.
-Search for ``YOUR_USERNAME`` and replace it with your ``Linux username``.
-If you do not know your username, you can find it by running ``echo $USERNAME`` in the terminal.
+Search for ``ros2dev`` and replace it with your ``Linux username``.
 
 
 Edit ``Dockerfile``
@@ -164,7 +163,7 @@ Open the Dockerfile and add the following contents:
 
     FROM ros:ROS_DISTRO
     ARG USERNAME=USERNAME
-    ARG USER_UID=1000
+    ARG USER_UID=1234
     ARG USER_GID=$USER_UID
 
     # Create the user
@@ -189,7 +188,7 @@ Open the Dockerfile and add the following contents:
     CMD ["/bin/bash"]
 
 Replace ``ROS_DISTRO`` with the ROS 2 distribution you wish to use as base image above, for example ``rolling``.
-
+Search for ``USER_UID=1234`` and replace it if that is already used in the host system.
 
 Open and Build Development Container
 ------------------------------------


### PR DESCRIPTION
closes https://github.com/ros2/ros2_documentation/issues/4590

![image](https://github.com/user-attachments/assets/cab74890-f9cf-473f-a6aa-b6fad7e9b025)
