### PR TITLE
Fix the toctree for the Core maintainer guide rename.

### DIFF
--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -39,7 +39,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/RQt-Port-Plugin-Windows
    How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers
    How-To-Guides/Visualizing-ROS-2-Data-With-Foxglove-Studio
-   How-To-Guides/Package-maintainer-guide
+   How-To-Guides/Core-maintainer-guide
    How-To-Guides/Building-a-Custom-Debian-Package
    How-To-Guides/Building-ROS-2-with-Tracing
    How-To-Guides/Topics-Services-Actions


### PR DESCRIPTION
This is a follow-up to https://github.com/ros2/ros2_documentation/pull/4619