### PR TITLE
Remove extra section in beginner tutorial.

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
@@ -131,37 +131,6 @@ Also make sure you export the message runtime dependency:
 Now you're ready to generate source files from your msg definition.
 We'll skip the compile step for now as we'll do it all together below in step 4.
 
-2.2 (Extra) Set multiple interfaces
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-
-  You can use ``set`` in ``CMakeLists.txt`` to neatly list all of your interfaces:
-
-  .. code-block:: cmake
-
-     set(msg_files
-       "msg/Message1.msg"
-       "msg/Message2.msg"
-       # etc
-       )
-
-     set(srv_files
-       "srv/Service1.srv"
-       "srv/Service2.srv"
-        # etc
-       )
-
-  And generate all lists at once like so:
-
-  .. code-block:: cmake
-
-     rosidl_generate_interfaces(${PROJECT_NAME}
-       ${msg_files}
-       ${srv_files}
-     )
-
-
 3 Use an interface from the same package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Since this is a beginner tutorial, we don't need to show all ways to do things, just one.  Further, this particular section doesn't fit into the flow of the article.  Just remove it here.

This is a replacement for #4584 , where the contributor has gone quiet.