### PR TITLE
Rename debians to debs everywhere.

### DIFF
--- a/source/Concepts/Intermediate/About-RQt.rst
+++ b/source/Concepts/Intermediate/About-RQt.rst
@@ -43,8 +43,8 @@ And then look for packages that start with ``rqt_``.
 System setup
 ------------
 
-Installing From Debian
-^^^^^^^^^^^^^^^^^^^^^^
+Installing From debs
+^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 

--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -40,7 +40,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers
    How-To-Guides/Visualizing-ROS-2-Data-With-Foxglove-Studio
    How-To-Guides/Core-maintainer-guide
-   How-To-Guides/Building-a-Custom-Debian-Package
+   How-To-Guides/Building-a-Custom-Deb-Package
    How-To-Guides/Building-ROS-2-with-Tracing
    How-To-Guides/Topics-Services-Actions
    How-To-Guides/Using-Variants

--- a/source/How-To-Guides/Building-ROS-2-with-Tracing.rst
+++ b/source/How-To-Guides/Building-ROS-2-with-Tracing.rst
@@ -40,7 +40,7 @@ Furthermore, the functions can be completely removed through a CMake option, whi
 Building without tracepoints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This step depends on whether you are :doc:`building ROS 2 from source <../Installation/Alternatives/Ubuntu-Development-Setup>` or using ROS 2 binaries (:doc:`Debian packages <../Installation/Ubuntu-Install-Debians>` or :doc:`binary archive <../Installation/Alternatives/Ubuntu-Install-Binary>`).
+This step depends on whether you are :doc:`building ROS 2 from source <../Installation/Alternatives/Ubuntu-Development-Setup>` or using ROS 2 binaries (:doc:`deb packages <../Installation/Ubuntu-Install-Debs>` or :doc:`binary archive <../Installation/Alternatives/Ubuntu-Install-Binary>`).
 To remove the tracepoints, (re)build ``tracetools`` and set the ``TRACETOOLS_TRACEPOINTS_EXCLUDED`` CMake option to ``ON``:
 
 .. tabs::

--- a/source/How-To-Guides/Building-a-Custom-Deb-Package.rst
+++ b/source/How-To-Guides/Building-a-Custom-Deb-Package.rst
@@ -1,12 +1,13 @@
 .. redirect-from::
 
   Guides/Building-a-Custom-Debian-Package
+  How-To-Guides/Building-a-Custom-Debian-Package
 
-Building a custom Debian package
-================================
+Building a custom deb package
+=============================
 
-Many Ubuntu users install ROS 2 on their system by installing :doc:`debian packages <../Installation/Ubuntu-Install-Debians>`.
-This guide gives a short set of instructions to build local, custom Debian packages.
+Many Ubuntu users install ROS 2 on their system by installing :doc:`deb packages <../Installation/Ubuntu-Install-Debs>`.
+This guide gives a short set of instructions to build local, custom deb packages.
 
 .. contents:: Table of Contents
    :local:
@@ -38,10 +39,10 @@ Initialize the rosdep database by calling:
 
 Note that the ``rosdep init`` command may fail if it has already been initialized in the past; this can safely be ignored.
 
-Build the debian from the package
----------------------------------
+Build the deb from the package
+------------------------------
 
-Run the following commands to build the debian:
+Run the following commands to build the deb:
 
 .. code:: bash
 

--- a/source/How-To-Guides/Releasing/_Install-Dependencies.rst
+++ b/source/How-To-Guides/Releasing/_Install-Dependencies.rst
@@ -2,7 +2,7 @@ Install tools that you will use in the upcoming steps according to your platform
 
 .. tabs::
 
-   .. group-tab:: Debian (eg. Ubuntu)
+   .. group-tab:: deb (eg. Ubuntu)
 
       .. code-block:: bash
 

--- a/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
+++ b/source/How-To-Guides/Using-ros1_bridge-Jammy-upstream.rst
@@ -12,10 +12,10 @@ Alternatively, there are `upstream variants of ROS 1 packages <https://packages.
 This guide outlines the current mechanism for bridging ROS 2 releases with these upstream packages on Ubuntu 22.04 Jammy Jellyfish.
 This provides a migration path for users who still depend on ROS 1, but desire moving to newer ROS 2 and Ubuntu releases.
 
-ROS 2 via Debian packages
--------------------------
+ROS 2 via deb packages
+----------------------
 
-Installing :doc:`ROS 2 from Debian packages <../Installation/Ubuntu-Install-Debians>` currently does not work for ROS 2 on Ubuntu Jammy.
+Installing :doc:`ROS 2 from deb packages <../Installation/Ubuntu-Install-Debs>` currently does not work for ROS 2 on Ubuntu Jammy.
 The version of ``catkin-pkg-modules`` available in the Ubuntu repository conflicts with that in the ROS 2 package repository.
 
 If the ROS 2 apt repository is in the available apt repositories (``/etc/apt/sources.list.d``), no ROS 1 packages will be installable.

--- a/source/Installation.rst
+++ b/source/Installation.rst
@@ -10,7 +10,7 @@ Options for installing ROS 2 {DISTRO_TITLE_FULL}:
    :hidden:
    :glob:
 
-   Installation/Ubuntu-Install-Debians
+   Installation/Ubuntu-Install-Debs
    Installation/Windows-Install-Binary
    Installation/RHEL-Install-RPMs
    Installation/Alternatives
@@ -29,7 +29,7 @@ We provide ROS 2 binary packages for the following platforms:
 
 * Ubuntu Linux - Noble Numbat (24.04)
 
-  * :doc:`Debian packages <Installation/Ubuntu-Install-Debians>` (recommended)
+  * :doc:`deb packages <Installation/Ubuntu-Install-Debs>` (recommended)
   * :doc:`binary archive <Installation/Alternatives/Ubuntu-Install-Binary>`
 
 * RHEL 9
@@ -64,15 +64,15 @@ This is great for people who want to dive in and start using ROS 2 as-is, right 
 
 Linux users have two options for installing binary packages:
 
-- Packages (debians or RPMS, depending on the platform)
+- Packages (debs or RPMS, depending on the platform)
 - binary archive
 
 Installing from packages is the recommended method, as it installs necessary dependencies automatically and also updates alongside regular system updates.
-However, you need root access in order to install Debian packages.
+However, you need root access in order to install deb packages.
 If you don't have root access, the binary archive is the next best choice.
 
 Windows users who choose to install from binary packages only have the binary archive option
-(Debian packages are exclusive to Ubuntu/Debian).
+(deb packages are exclusive to Ubuntu/Debian).
 
 **Building from source** is meant for developers looking to alter or explicitly omit parts of ROS 2's base.
 It is also recommended for platforms that don't support binaries.

--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -92,7 +92,7 @@ See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementatio
 Build the code in the workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have already installed ROS 2 another way (either via Debians or the binary distribution), make sure that you run the below commands in a fresh environment that does not have those other installations sourced.
+If you have already installed ROS 2 another way (either via debs or the binary distribution), make sure that you run the below commands in a fresh environment that does not have those other installations sourced.
 Also ensure that you do not have ``source /opt/ros/${ROS_DISTRO}/setup.bash`` in your ``.bashrc``.
 You can make sure that ROS 2 is not sourced with the command ``printenv | grep -i ROS``.
 The output should be empty.

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -17,7 +17,7 @@ This page explains how to install ROS 2 on Ubuntu Linux from a pre-built binary 
     All packages in the `ROS base variant <https://ros.org/reps/rep-2001.html#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://ros.org/reps/rep-2001.html#desktop-variants>`_ are included.
     The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
 
-There are also :doc:`Debian packages <../Ubuntu-Install-Debians>` available.
+There are also :doc:`deb packages <../Ubuntu-Install-Debs>` available.
 
 System requirements
 -------------------

--- a/source/Installation/DDS-Implementations.rst
+++ b/source/Installation/DDS-Implementations.rst
@@ -35,10 +35,10 @@ Ubuntu Linux source install
 RTI Connext (version 6.0.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Debian packages provided in the ROS 2 apt repositories
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Deb packages provided in the ROS 2 apt repositories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can install a Debian package of RTI Connext available on the ROS 2 apt repositories.
+You can install a deb package of RTI Connext available on the ROS 2 apt repositories.
 You will need to accept a license from RTI.
 
 .. code-block:: bash
@@ -88,10 +88,10 @@ RTI Connext (version 6.0.1, amd64 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To use RTI Connext DDS there are full-suite install options available for :doc:`university, purchase or evaluation <DDS-Implementations/Install-Connext-University-Eval>`
-or you can install a libraries-only Debian package of RTI Connext 6.0.1, available from the OSRF Apt repository
+or you can install a libraries-only deb package of RTI Connext 6.0.1, available from the OSRF Apt repository
 under a `non-commercial license <https://www.rti.com/ncl>`__.
 
-To install the libs-only Debian package:
+To install the libs-only deb package:
 
 .. code-block:: bash
 

--- a/source/Installation/DDS-Implementations/Working-with-GurumNetworks-GurumDDS.rst
+++ b/source/Installation/DDS-Implementations/Working-with-GurumNetworks-GurumDDS.rst
@@ -13,11 +13,11 @@ Prerequisites
 -------------
 
 The following description assumes that you have completed the 'Environment setup' process
-from the :doc:`Installing ROS 2 via Debian Packages <../Ubuntu-Install-Debians>` or
+from the :doc:`Installing ROS 2 via deb Packages <../Ubuntu-Install-Debs>` or
 from the :doc:`Building ROS 2 on Ubuntu Linux <../Alternatives/Ubuntu-Development-Setup>`.
 
 rmw_gurumdds requires version of GurumDDS-2.8.x.
-Debian packages of GurumDDS are provided in the ROS 2 apt repositories on ubuntu.
+Deb packages of GurumDDS are provided in the ROS 2 apt repositories on Ubuntu.
 Windows binary installer of GurumDDS will be supported soon.
 
 GurumDDS requires a license. See the next page: https://gurum.cc/free_trial_eng.html

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -10,10 +10,10 @@ Usually, you will get the released version of binaries when following :doc:`../I
 There are also pre-released versions of binaries that are useful for testing before making an official release.
 This article describes several options if you would like to try out pre-released versions of ROS binaries.
 
-Debian testing repository
--------------------------
+deb testing repository
+----------------------
 
-When packages are released into a ROS distribution (using bloom), the buildfarm builds them into debian packages which are stored temporarily in the **building** apt repository.
+When packages are released into a ROS distribution (using bloom), the buildfarm builds them into deb packages which are stored temporarily in the **building** apt repository.
 As dependent packages are rebuilt, an automatic process periodically synchronizes the packages in **building** to a secondary repository called **ros-testing**.
 **ros-testing** is intended as a soaking area where developers and bleeding-edge users may give the packages extra testing, before they are manually synced into the public ros repository from which users typically install packages.
 
@@ -21,7 +21,7 @@ Approximately every two weeks, the rosdistro's release manager manually synchron
 
 For Debian-based operating systems, you can install binary packages from the **ros-testing** repository.
 
-1. Make sure you have a working ROS 2 installation from Debian packages (see :doc:`../Installation`).
+1. Make sure you have a working ROS 2 installation from deb packages (see :doc:`../Installation`).
 
 2. Edit (with sudo) the file ``/etc/apt/sources.list.d/ros2.list`` and change ``ros2`` with ``ros2-testing``.
    For example, on Ubuntu Noble the contents should look like the following:

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -1,15 +1,16 @@
 .. redirect-from::
 
    Installation/Linux-Install-Debians
+   Installation/Ubuntu-Install-Debians
 
-Ubuntu (Debian packages)
-========================
+Ubuntu (deb packages)
+=====================
 
 .. contents:: Table of Contents
    :depth: 2
    :local:
 
-Debian packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Noble (24.04).
+Deb packages for ROS 2 {DISTRO_TITLE_FULL} are currently available for Ubuntu Noble (24.04).
 The Rolling Ridley distribution will change target platforms from time to time as new platforms are selected for development.
 The target platforms are defined in `REP 2000 <https://ros.org/reps/rep-2000.html>`__.
 Most people will want to use a stable ROS distribution.
@@ -36,7 +37,7 @@ Enable required repositories
 
 .. include:: _Apt-Repositories.rst
 
-.. _linux-install-debians-install-ros-2-packages:
+.. _linux-install-debs-install-ros-2-packages:
 
 Install development tools (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/The-ROS2-Project/Contributing/Build-Farms.rst
+++ b/source/The-ROS2-Project/Contributing/Build-Farms.rst
@@ -31,7 +31,7 @@ Jobs and Deployment
 The ROS build farms perform several different jobs.
 For each job type you will find a detailed description of what they do and how they work:
 
-* `release jobs`_ generate binary packages, e.g., debian packages
+* `release jobs`_ generate binary packages, e.g., deb packages
 * `devel jobs`_ build and test ROS packages within a single repository on a polling basis
 * `pull_request jobs`_ build and test ROS packages within a single repository triggered by webhooks
 * `CI jobs`_ build and test ROS packages across repositories with the option of using artifacts
@@ -98,7 +98,7 @@ Frequency Asked Questions (FAQ) and Troubleshooting
 
    a) Inspect the release job that raised the issue (see 1.) and localize the cmake dependency
       issue. To do so, browse to the cmake section, e.g., navigate to the *build binarydeb*
-      section through the menu on the left in case of a ubuntu/debian build job. The *CMake Error*
+      section through the menu on the left in case of a Ubuntu/Debian build job. The *CMake Error*
       will typically hint at a dependency required by the cmake configuration but missing in the
       `package manifest`_. Once you have fixed the dependency in the manifest, do a new release
       of your package and wait for feedback from the build farms or...

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -274,7 +274,7 @@ When filing an issue please make sure to:
   - **The operating system and version.**
     Reasoning: ROS 2 supports multiple platforms, and some bugs are specific to particular versions of operating systems/compilers.
   - **The installation method.**
-    Reasoning: Some issues only manifest if ROS 2 has been installed from binary archives or from Debians.
+    Reasoning: Some issues only manifest if ROS 2 has been installed from binary archives or from debs.
     This can help us determine if the issue is with the packaging process.
   - **The specific version of ROS 2.**
     Reasoning: Some bugs may be present in a particular ROS 2 release and later fixed.

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
@@ -29,7 +29,7 @@ Prerequisites
 
 You should have the ``rosbag2`` packages installed as part of your regular ROS 2 setup.
 
-If you've installed from Debian packages on Linux, it may be installed by default.
+If you've installed from deb packages on Linux, it may be installed by default.
 If it is not, you can install it using this command.
 
 .. code-block:: console

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
@@ -32,7 +32,7 @@ Prerequisites
 
 You should have the ``rosbag2`` packages installed as part of your regular ROS 2 setup.
 
-If you've installed from Debian packages on Linux, it may be installed by default.
+If you've installed from deb packages on Linux, it may be installed by default.
 If it is not, you can install it using this command.
 
 .. code-block:: console

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
@@ -67,7 +67,7 @@ In the UTM software:
 In this section, ROS 2 is installed in the VM and the shared folder is configured.
 The following instructions and commands are all run inside the VM.
 
-* Open a terminal in the started VM and install the ROS 2 distribution you need by following the instructions in :doc:`../../../../Installation/Ubuntu-Install-Debians`:
+* Open a terminal in the started VM and install the ROS 2 distribution you need by following the instructions in :doc:`../../../../Installation/Ubuntu-Install-Debs`:
 * Create a folder in the VM to use as a shared folder.
   In this example, the shared folder in the VM is ``/home/ubuntu/shared``.
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-Windows.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-Windows.rst
@@ -53,7 +53,7 @@ Install WSL with an Ubuntu version which is compatible with your ROS distributio
 2 Install ROS 2 in WSL
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Install ROS 2 inside Ubuntu WSL, following :doc:`../../../../Installation/Ubuntu-Install-Debians`.
+Install ROS 2 inside Ubuntu WSL, following :doc:`../../../../Installation/Ubuntu-Install-Debs`.
 
 3 Install ``webots_ros2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -38,7 +38,7 @@ Prerequisites
 
 Before starting these tutorials, install ROS 2 by following the instructions on the ROS 2 :doc:`../../Installation` page.
 
-The commands used in this tutorial assume you followed the binary packages installation guide for your operating system (Debian packages for Linux).
+The commands used in this tutorial assume you followed the binary packages installation guide for your operating system (deb packages for Linux).
 You can still follow along if you built from source, but the path to your setup files will likely be different.
 You also won't be able to use the ``sudo apt install ros-<distro>-<package>`` command (used frequently in the beginner level tutorials) if you install from source.
 

--- a/source/Tutorials/Beginner-CLI-Tools/Launching-Multiple-Nodes/Launching-Multiple-Nodes.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Launching-Multiple-Nodes/Launching-Multiple-Nodes.rst
@@ -32,7 +32,7 @@ Prerequisites
 
 Before starting these tutorials, install ROS 2 by following the instructions on the ROS 2 :doc:`../../../Installation/` page.
 
-The commands used in this tutorial assume you followed the binary packages installation guide for your operating system (Debian packages for Linux).
+The commands used in this tutorial assume you followed the binary packages installation guide for your operating system (deb packages for Linux).
 You can still follow along if you built from source, but the path to your setup files will likely be different.
 You also won't be able to use the ``sudo apt install ros-<distro>-<package>`` command (used frequently in the beginner level tutorials) if you install from source.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -63,7 +63,7 @@ To build the samples, you will need to install ROS 2.
 
 Follow the :doc:`installation instructions <../../Installation>`.
 
-.. attention:: If installing from Debian packages, this tutorial requires the :ref:`desktop installation <linux-install-debians-install-ros-2-packages>`.
+.. attention:: If installing from deb packages, this tutorial requires the :ref:`desktop installation <linux-install-debs-install-ros-2-packages>`.
 
 Basics
 ------

--- a/source/Tutorials/Demos/dummy-robot-demo.rst
+++ b/source/Tutorials/Demos/dummy-robot-demo.rst
@@ -26,7 +26,7 @@ To start the demo, we execute the demo bringup launch file, which we are going t
     source ~/ros2_ws/install/setup.bash
     ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
 
-  .. group-tab:: Debian Package
+  .. group-tab:: deb Package
 
     sudo apt install ros-${ROS_DISTRO}-dummy-robot-bringup
     ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py

--- a/source/Tutorials/Miscellaneous/Building-Realtime-rt_preempt-kernel-for-ROS-2.rst
+++ b/source/Tutorials/Miscellaneous/Building-Realtime-rt_preempt-kernel-for-ROS-2.rst
@@ -127,7 +127,7 @@ Save and exit menuconfig. Now we're going to build the kernel which will take qu
 
    make -j `nproc` deb-pkg
 
-After the build is finished check the debian packages
+After the build is finished check the deb packages
 
 .. code-block:: bash
 
@@ -135,7 +135,7 @@ After the build is finished check the debian packages
    ../linux-headers-5.4.78-rt41_5.4.78-rt44-1_amd64.deb  ../linux-image-5.4.78-rt44-dbg_5.4.78-rt44-1_amd64.deb
    ../linux-image-5.4.78-rt41_5.4.78-rt44-1_amd64.deb    ../linux-libc-dev_5.4.78-rt44-1_amd64.deb
 
-Then we install all kernel debian packages
+Then we install all kernel deb packages
 
 .. code-block:: bash
 


### PR DESCRIPTION
That's because "debians" specifically refers to packages for Debian, while "debs" more generally refers to packages in the .deb format (which describes at least Debian and Ubuntu).

This should fix #4639 .