### PR TITLE
Add more explanation about PushRosNamespace action

### DIFF
--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -82,7 +82,7 @@ Each launch file performs the following actions:
             # include a Python launch file in the chatter_py_ns namespace
             launch_py_include_with_namespace = GroupAction(
                 actions=[
-                    # push_ros_namespace to set namespace of included nodes
+                    # push_ros_namespace first to set namespace of included nodes for following actions
                     PushRosNamespace('chatter_py_ns'),
                     IncludeLaunchDescription(
                         PythonLaunchDescriptionSource(
@@ -96,7 +96,7 @@ Each launch file performs the following actions:
             # include a xml launch file in the chatter_xml_ns namespace
             launch_xml_include_with_namespace = GroupAction(
                 actions=[
-                    # push_ros_namespace to set namespace of included nodes
+                    # push_ros_namespace first to set namespace of included nodes for following actions
                     PushRosNamespace('chatter_xml_ns'),
                     IncludeLaunchDescription(
                         XMLLaunchDescriptionSource(
@@ -110,7 +110,7 @@ Each launch file performs the following actions:
             # include a yaml launch file in the chatter_yaml_ns namespace
             launch_yaml_include_with_namespace = GroupAction(
                 actions=[
-                    # push_ros_namespace to set namespace of included nodes
+                    # push_ros_namespace first to set namespace of included nodes for following actions
                     PushRosNamespace('chatter_yaml_ns'),
                     IncludeLaunchDescription(
                         YAMLLaunchDescriptionSource(

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -45,7 +45,7 @@ Each launch file performs the following actions:
         from launch.substitutions import LaunchConfiguration
         from launch.substitutions import TextSubstitution
         from launch_ros.actions import Node
-        from launch_ros.actions import PushRosNamespace
+        from launch_ros.actions import PushROSNamespace
         from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
         from launch_yaml.launch_description_sources import YAMLLaunchDescriptionSource
 
@@ -83,7 +83,7 @@ Each launch file performs the following actions:
             launch_py_include_with_namespace = GroupAction(
                 actions=[
                     # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushRosNamespace('chatter_py_ns'),
+                    PushROSNamespace('chatter_py_ns'),
                     IncludeLaunchDescription(
                         PythonLaunchDescriptionSource(
                             os.path.join(
@@ -97,7 +97,7 @@ Each launch file performs the following actions:
             launch_xml_include_with_namespace = GroupAction(
                 actions=[
                     # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushRosNamespace('chatter_xml_ns'),
+                    PushROSNamespace('chatter_xml_ns'),
                     IncludeLaunchDescription(
                         XMLLaunchDescriptionSource(
                             os.path.join(
@@ -111,7 +111,7 @@ Each launch file performs the following actions:
             launch_yaml_include_with_namespace = GroupAction(
                 actions=[
                     # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushRosNamespace('chatter_yaml_ns'),
+                    PushROSNamespace('chatter_yaml_ns'),
                     IncludeLaunchDescription(
                         YAMLLaunchDescriptionSource(
                             os.path.join(

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -281,6 +281,8 @@ However, if the launch file contains a large number of nodes, defining namespace
 To solve that issue, the ``PushROSNamespace`` action can be used to define the global namespace for each launch file description.
 Every nested node will inherit that namespace automatically.
 
+.. attention:: PushROSNamespace has to be the first Action in the list for the following actions to apply the namespace
+
 To do that, firstly, we need to remove the ``namespace='turtlesim2'`` line from the ``turtlesim_world_2_launch.py`` file.
 Afterwards, we need to update the ``launch_turtlesim_launch.py`` to include the following lines:
 


### PR DESCRIPTION
While trying to work with namespaces, I found myself adding the ```PushRosNamespace()``` action at the end of my action list. That made me spend a lot of time trying to understand why my namespace where not applied. Only to see that PushRosNamespace would only work for the actions called after.

Therefore, I thought it would be relevant to add this information to the documentation if any other developer encounter this issue.

Thanks for giving me feedback on this PR, hope you're having a nice day !