### PR TITLE
typo fix for the tutorial how to write the service node.

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -90,7 +90,7 @@ Inside the ``ros2_ws/src/cpp_srvcli/src`` directory, create a new file called ``
   #include "rclcpp/rclcpp.hpp"
 
   using AddTwoInts = example_interfaces::srv::AddTwoInts;
-  rclcpp::node::SharedPtr g_node = nullptr;
+  rclcpp::Node::SharedPtr g_node = nullptr;
 
   void handle_service(
     const std::shared_ptr<rmw_request_id_t> request_header,


### PR DESCRIPTION
just a typo fix, introduced by https://github.com/ros2/ros2_documentation/pull/4586

@clalancette @ahcorde can you do me a favor?

No backport required, related code is only available on rolling.