### PR TITLE
Update _Windows-Install-Prerequisites.rst

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -107,7 +107,7 @@ Please download these packages from `this <https://github.com/ros2/choco-package
 * asio.1.12.1.nupkg
 * bullet.3.17.nupkg
 * cunit.2.1.3.nupkg
-* eigen-3.3.4.nupkg
+* eigen.3.3.4.nupkg
 * tinyxml-usestl.2.6.2.nupkg
 * tinyxml2.6.0.0.nupkg
 


### PR DESCRIPTION
The package list that users will need to download features "eigen-3.3.4.nupkg" when the file on that github page is called "eigen.3.3.4.nupkg"