### PR TITLE
Update Ada client library status for jazzy

### DIFF
--- a/source/Concepts/Basic/About-Client-Libraries.rst
+++ b/source/Concepts/Basic/About-Client-Libraries.rst
@@ -73,7 +73,7 @@ Community-maintained
 
 While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community maintain additional client libraries:
 
-* `Ada <https://github.com/ada-ros/ada4ros2>`__  This is a set of packages (binding to ``rcl``, message generator, binding to ``tf2``, examples and tutorials) that allows the writing of Ada applications for ROS 2 Jazzy.
+* `Ada <https://github.com/ada-ros/ada4ros2>`__  This is a set of packages (binding to ``rcl``, message generator, binding to ``tf2``, examples and tutorials) that allows the writing of Ada applications for ROS 2.
 * `C <https://github.com/ros2/rclc>`__  ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in C. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials.
 * `JVM and Android <https://github.com/ros2-java>`__ Java and Android bindings for ROS 2.
 * `.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__ This is a collection of projects (bindings, code generator, examples and more) for writing ROS 2 applications for .NET Core and .NET Standard.

--- a/source/Concepts/Basic/About-Client-Libraries.rst
+++ b/source/Concepts/Basic/About-Client-Libraries.rst
@@ -73,6 +73,7 @@ Community-maintained
 
 While the C++ and Python client libraries are maintained by the core ROS 2 team, members of the ROS 2 community maintain additional client libraries:
 
+* `Ada <https://github.com/ada-ros/ada4ros2>`__  This is a set of packages (binding to ``rcl``, message generator, binding to ``tf2``, examples and tutorials) that allows the writing of Ada applications for ROS 2 Jazzy.
 * `C <https://github.com/ros2/rclc>`__  ``rclc`` does not put a layer on top of rcl but complements rcl to make rcl+rclc a feature-complete client library in C. See `micro.ros.org <https://micro.ros.org/>`__ for tutorials.
 * `JVM and Android <https://github.com/ros2-java>`__ Java and Android bindings for ROS 2.
 * `.NET Core, UWP and C# <https://github.com/esteve/ros2_dotnet>`__ This is a collection of projects (bindings, code generator, examples and more) for writing ROS 2 applications for .NET Core and .NET Standard.
@@ -81,7 +82,6 @@ While the C++ and Python client libraries are maintained by the core ROS 2 team,
 
 Older, unmaintained client libraries are:
 
-* `Ada <https://github.com/ada-ros/ada4ros2>`__
 * `C# <https://github.com/firesurfer/rclcs>`__
 * `Objective C and iOS <https://github.com/esteve/ros2_objc>`__
 * `Zig <https://github.com/jacobperron/rclzig>`__


### PR DESCRIPTION
My apologies if this is not the proper venue, or there are specific requirements for a client library to be considered maintained.

I've just updated the Ada library to work on `jazzy`, and I'm generally available to attend issues about this library (which I authored). 

A related question is: should this PR be (also/instead) opened against the `jazzy` branch?