### PR TITLE
Update Links in Related Projects

### DIFF
--- a/source/Package-Docs.rst
+++ b/source/Package-Docs.rst
@@ -13,10 +13,10 @@ Here is a brief list of where to look for specific ROS package documentation.
 Larger Packages
 ---------------
 
-Larger packages like MoveIt, Nav2, and microROS, are given their own subdomain on docs.ros.org. Here is a short list.
+Larger packages like MoveIt, Nav2, and microROS, are given their own domain or subdomain on ros.org. Here is a short list.
 
-* `MoveIt <https://moveit.ros.org/>`__
-* `Navigation <https://navigation.ros.org/>`__
+* `MoveIt <https://moveit.ai/>`__
+* `Navigation2 <https://nav2.org/>`__
 * `Control <https://control.ros.org/master/index.html>`__
 * `microROS (embedded systems) <https://micro.ros.org/>`__
 

--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -13,8 +13,8 @@ Large Community Projects
 Large community projects involve multiple developers from all over the globe and are typically backed by a dedicated working group (cf. :doc:`The-ROS2-Project/Governance`).
 
 * **ros2_control** `(control.ros.org) <https://control.ros.org/>`_: Flexible framework for real-time control of robots implemented with ROS 2.
-* **Navigation2** `(navigation.ros.org) <https://navigation.ros.org/>`_: Comprehensive and flexible navigation stack for mobile robots using ROS 2.
-* **MoveIt** `(moveit.ros.org) <https://moveit.ros.org/>`_: A rich platform for building manipulation applications featuring advanced kinematics, motion planning, control, collision checking, and much more.
+* **Navigation2** `(nav2.org) <https://nav2.org/>`_: Comprehensive and flexible navigation stack for mobile robots using ROS 2.
+* **MoveIt** `(moveit.ai) <https://moveit.ai/>`_: A rich platform for building manipulation applications featuring advanced kinematics, motion planning, control, collision checking, and much more.
 * **micro-ROS** `(micro.ros.org) <https://micro.ros.org/>`_: A platform for putting ROS 2 onto microcontrollers, starting at less than 100 kB of RAM.
 
 Further Community Projects


### PR DESCRIPTION
I have updated the links for Large Community Projects in `Related-Projects.rst`.
For Navigation2 the link has been changed from `navigation.ros.org` to `nav2.org`, and for MoveIt the link has been changed from `moveit.ros.org` to `moveit.ai`.