### PR TITLE
Fix a broken link in Ubuntu-Install-Debs.rst

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -18,7 +18,7 @@ Resources
 
 * Status Page:
 
-  * ROS 2 {DISTRO_TITLE} (Ubuntu Noble 24.04): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_ujv8.html>`__
+  * ROS 2 {DISTRO_TITLE} (Ubuntu Noble 24.04): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_unv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 


### PR DESCRIPTION
There is only a status page for Ubuntu Noble, not Jammy. Fixing the link accordingly.