### PR TITLE
Polish the ROS 1 -> 2 CMake instructions

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -124,13 +124,13 @@ Imagine your ``CMakeLists.txt`` has a call to ``catkin_package`` like this:
 
 
 Replacing ``catkin_package(INCLUDE_DIRS ...)``
-++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you've used modern CMake targets and ``target_include_directories()``, you don't need to do anything further.
 Users of your package won't see a ``your_package_INCLUDE_DIRS`` variable, but your users will get the include directories by depending on your modern CMake targets.
 
 Replacing ``catkin_package(LIBRARIES ...)``
-+++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use ``ament_export_targets()`` and ``install(TARGETS ... EXPORT ...)`` to replace the ``LIBRARIES`` argument.
 
@@ -165,7 +165,7 @@ Add a call to ``ament_export_targets()`` with the same name you gave to the ``EX
 
 
 Replacing ``catkin_package(CATKIN_DEPENDS .. DEPENDS ..)``
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use `ament_export_dependencies <https://github.com/ament/ament_cmake/blob/{REPOS_FILE_BRANCH}/ament_cmake_export_dependencies/cmake/ament_export_dependencies.cmake>`__ with all package names that were previously given to ``CATKIN_DEPENDS`` or ``DEPENDS``.
 

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -24,6 +24,17 @@ ROS 2 C++ packages use `CMake <https://cmake.org/>`__ with convenience functions
 Apply the following changes to use ``ament_cmake`` instead of ``catkin``.
 
 
+Require a newer version of CMake
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROS 2 relies on newer versions of CMake than used by ROS 1.
+Find the minimum version of CMake used by the ROS distribution you want to support in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`__, and use that version at the top of your ``CMakeLists.txt``.
+For example, `3.14.4 is the minimum recommended support for ROS Humble <https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027>`__.
+
+.. code-block::
+
+   cmake_minimum_required(VERSION 3.14.4)
+
 Set the build type to ament_cmake
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -462,13 +473,13 @@ Replace:
 Example: Converting an existing ROS 1 package to ROS 2
 ------------------------------------------------------
 
-Let's say that we have simple ROS 1 package called ``talker`` that uses ``roscpp`` in one node, called ``talker``.
+Say you have a ROS 1 package called ``talker`` that uses ``roscpp`` in one node, called ``talker``.
 This package is in a catkin workspace, located at ``~/ros1_talker``.
 
 The ROS 1 code
 ^^^^^^^^^^^^^^
 
-Here's the directory layout of our catkin workspace:
+Your ROS 1 workspace has the following directory layout:
 
 .. code-block:: bash
 
@@ -481,7 +492,7 @@ Here's the directory layout of our catkin workspace:
    ./src/talker/CMakeLists.txt
    ./src/talker/talker.cpp
 
-Here is the content of those three files:
+The files have the following content:
 
 ``src/talker/package.xml``:
 
@@ -542,43 +553,10 @@ Here is the content of those three files:
      return 0;
    }
 
-Building the ROS 1 code
-~~~~~~~~~~~~~~~~~~~~~~~
-
-We source an environment setup file (in this case for Noetic using bash), then we
-build our package using ``catkin_make install``:
-
-.. code-block:: bash
-
-   . /opt/ros/noetic/setup.bash
-   cd ~/ros1_talker
-   catkin_make install
-
-Running the ROS 1 node
-~~~~~~~~~~~~~~~~~~~~~~
-
-If there's not already one running, we start a ``roscore``, first sourcing the
-setup file from our ``catkin`` install tree (the system setup file at
-``/opt/ros/noetic/setup.bash`` would also work here):
-
-.. code-block:: bash
-
-   . ~/ros1_talker/install/setup.bash
-   roscore
-
-In another shell, we run the node from the ``catkin`` install space using
-``rosrun``, again sourcing the setup file first (in this case it must be the one
-from our workspace):
-
-.. code-block:: bash
-
-   . ~/ros1_talker/install/setup.bash
-   rosrun talker talker
-
 Migrating to ROS 2
 ^^^^^^^^^^^^^^^^^^
 
-Let's start by creating a new workspace in which to work:
+Creating a new ROS 2 workspace:
 
 .. code-block:: bash
 
@@ -811,10 +789,9 @@ Changing the CMake code
 
 ROS 2 relies on a higher version of CMake:
 
-.. code-block:: bash
+.. code-block::
 
-   #cmake_minimum_required(VERSION 2.8.3)
-   cmake_minimum_required(VERSION 3.5)
+   cmake_minimum_required(VERSION 3.14.4)
 
 ROS 2 relies on the C++17 standard.
 Depending on what compiler you're using, support for C++17 might not be enabled by default.

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -609,42 +609,24 @@ provided by ``roscpp``.
 The concepts are very similar between the two libraries, which makes the changes
 reasonably straightforward to make.
 
-Change the C++ code
-~~~~~~~~~~~~~~~~~~~
+Included headers
+~~~~~~~~~~~~~~~~
 
-Modify the C++ code after you have finished modifying the ``package.xml`` and ``CMakeLists.txt``.
-The biggest change to make is to move from ``roscpp`` APIs to ``rclcpp`` APIs, but the concepts are similar between the two packages.
-
-Change the included headers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The package needs to include headers from ``rclcpp`` instead of ``roscpp``.
-
-Remove the include for ``roscpp``:
-
-.. code-block::
-
-   // remove this
-   #include "ros/ros.h"
-
-Add the include for ``rclcpp``:
+In place of ``ros/ros.h``, which gave us access to the ``roscpp`` library API, we
+need to include ``rclcpp/rclcpp.hpp``, which gives us access to the ``rclcpp``
+library API:
 
 .. code-block:: cpp
 
+   //#include "ros/ros.h"
    #include "rclcpp/rclcpp.hpp"
 
-ROS 2 messages, services, and actions use lower case header names, and include the type of interface in the name.
-
-Change the include for the ``String`` message from this:
-
-.. code-block::
-
-   #include "std_msgs/String.h"
-
-to this:
+To get the ``std_msgs/String`` message definition, in place of
+``std_msgs/String.h``, we need to include ``std_msgs/msg/string.hpp``:
 
 .. code-block:: cpp
 
+   //#include "std_msgs/String.h"
    #include "std_msgs/msg/string.hpp"
 
 Changing C++ library calls

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -673,7 +673,7 @@ Add a call to ``ament_package()`` at the bottom of the ``CMakeLists.txt``.
    ament_package()
 
 Delete the call to ``include_directories()``.
-Replace it with a call to ``target_include_directories()`` for your package's `include` directory.
+Replace it with a call to ``target_include_directories()`` for your package's ``include`` directory.
 Don't add other package's ``*_INCLUDE_DIRS`` variables, those will be handled by depending on modern CMake targets.
 
 .. code-block:: cmake
@@ -724,33 +724,42 @@ The new ``CMakeLists.txt`` looks like this:
    ament_package()
 
 
-Changing C++ code
-~~~~~~~~~~~~~~~~~
+Change the C++ code
+~~~~~~~~~~~~~~~~~~~
 
-Now we'll modify the C++ code in the node.
-The ROS 2 C++ library, called ``rclcpp``, provides a different API from that
-provided by ``roscpp``.
-The concepts are very similar between the two libraries, which makes the changes
-reasonably straightforward to make.
+Modify the C++ code after you have finished modifying the ``package.xml`` and ``CMakeLists.txt``.
+The biggest change to make is to move from ``roscpp`` APIs to ``rclcpp`` APIs, but the concepts are similar between the two packages.
 
-Included headers
-~~~~~~~~~~~~~~~~
+Change the included headers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In place of ``ros/ros.h``, which gave us access to the ``roscpp`` library API, we
-need to include ``rclcpp/rclcpp.hpp``, which gives us access to the ``rclcpp``
-library API:
+The package needs to include headers from ``rclcpp`` instead of ``roscpp``.
+
+Remove the include for ``roscpp``:
+
+.. code-block::
+
+   // remove this
+   #include "ros/ros.h"
+
+Add the include for ``rclcpp``:
 
 .. code-block:: cpp
 
-   //#include "ros/ros.h"
    #include "rclcpp/rclcpp.hpp"
 
-To get the ``std_msgs/String`` message definition, in place of
-``std_msgs/String.h``, we need to include ``std_msgs/msg/string.hpp``:
+ROS 2 messages, services, and actions use lower case header names, and include the type of interface in the name.
+
+Change the include for the ``String`` message from this:
+
+.. code-block::
+
+   #include "std_msgs/String.h"
+
+to this:
 
 .. code-block:: cpp
 
-   //#include "std_msgs/String.h"
    #include "std_msgs/msg/string.hpp"
 
 Changing C++ library calls

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -248,6 +248,9 @@ Add the following dependencies to the ``package.xml`` of the package that contai
 
 3. Add a ``<member_of_group>`` tag with the group name ``rosidl_interface_packages`` (`example <https://github.com/ros2/common_interfaces/blob/d685509e9cb9f80bd320a347f2db954a73397ae7/std_msgs/package.xml#L26>`__)
 
+   .. code-block:: xml
+
+      <member_of_group>rosidl_interface_packages</member_of_group>
 
 In your ``CMakeLists.txt``, replace the invocation of ``add_message_files``, ``add_service_files`` and ``generate_messages`` with `rosidl_generate_interfaces <https://github.com/ros2/rosidl/blob/{REPOS_FILE_BRANCH}/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake>`__.
 The first argument must be ``${PROJECT_NAME}`` due to `this bug <https://github.com/ros2/rosidl_typesupport/issues/120>`__.
@@ -326,7 +329,7 @@ Add ``<test_depend>ament_cmake_gtest</test_depend>`` to your ``package.xml`` (`e
 Linters
 ^^^^^^^
 
-The ROS 2 code :doc:`style guide <../../The-ROS2-Project/Contributing/Developer-Guide>`__ differs from ROS 1.
+The ROS 2 code :doc:`style guide <../../The-ROS2-Project/Contributing/Developer-Guide>` differs from ROS 1.
 
 If you choose to follow the ROS 2 style guide, then turn on automatic linter tests by adding these lines in a ``if(BUILD_TESTING)`` block:
 

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -844,23 +844,24 @@ Add a call to ``ament_package()`` at the bottom of the ``CMakeLists.txt``.
 
    ament_package()
 
-Delete the call to ``include_directories()``.
-Replace it with a call to ``target_include_directories()`` for your package's ``include`` directory.
-Don't add other package's ``*_INCLUDE_DIRS`` variables, those will be handled by depending on modern CMake targets.
-
-.. code-block:: cmake
-
-   target_include_directories(target PUBLIC
-      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-      "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-
-Use ``target_link_libraries`` to make the ``talker`` target depend on  the modern CMake targets provided by ``rclcpp`` and ``std_msgs``.
+Use ``target_link_libraries`` to make the ``talker`` target depend on the modern CMake targets provided by ``rclcpp`` and ``std_msgs``.
 
 .. code-block:: cmake
 
    target_link_libraries(talker PUBLIC
      rclcpp::rclcpp
      ${std_msgs_TARGETS})
+
+Delete the call to ``include_directories()``.
+Replace it with a call to ``target_include_directories()`` for your package's ``include`` directory.
+Don't pass variables like ``rclcpp_INCLUDE_DIRS`` into ``target_include_directories()``.
+The include directories were already handled by calling ``target_link_libraries()`` with modern CMake targets.
+
+.. code-block:: cmake
+
+   target_include_directories(target PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 Install the ``talker`` executable into a project specific directory so that it is discoverable by tools like ``ros2 run``.
 

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -29,7 +29,7 @@ Set the build type to ament_cmake
 
 Remove any dependencies on ``catkin`` from your ``package.xml``
 
-.. code-block:: none
+.. code-block::
 
    # Remove this!
    <buildtool_depend>catkin</buildtool_depend>
@@ -66,7 +66,7 @@ Replace the ``find_package(catkin COMPONENTS ...)``  call with individual ``find
 
 For example, change this:
 
-.. code-block:: none
+.. code-block::
 
    find_package(catkin REQUIRED COMPONENTS foo bar std_msgs)
    find_package(baz REQUIRED)
@@ -89,7 +89,7 @@ Prefer to use per-target CMake functions so that your package can export modern 
 
 If your ``CMakeLists.txt`` uses ``include_directories()``, then delete those calls.
 
-.. code-block:: none
+.. code-block::
 
    # Delete calls to include_directories like this one!
    include_directories(include ${catkin_INCLUDE_DIRS})
@@ -105,7 +105,7 @@ Add a call ``target_include_directories()`` for every library in your pacakage (
 Change all ``target_link_libraries()`` calls to use modern CMake targets.
 For example, if your package in ROS 1 uses old-style standard CMake variables like this.
 
-.. code-block:: none
+.. code-block::
 
    target_link_libraries(my_library ${catkin_LIBRARIES} ${baz_LIBRARIES})
 
@@ -126,7 +126,7 @@ Replace ``catkin_package()`` with various ament_cmake calls
 
 Imagine your ``CMakeLists.txt`` has a call to ``catkin_package`` like this:
 
-.. code-block:: none
+.. code-block::
 
    catkin_package(
        INCLUDE_DIRS include
@@ -243,7 +243,7 @@ The first argument must be ``${PROJECT_NAME}`` due to `this bug <https://github.
 
 For example, if your ROS 1 package looks like this:
 
-.. code-block:: none
+.. code-block::
 
    add_message_files(DIRECTORY msg FILES FooBar.msg Baz.msg)
    add_service_files(DIRECTORY srv FILES Ping.srv)
@@ -283,7 +283,7 @@ If your package uses `gtest <https://github.com/google/googletest>`__ then:
 
 For example, if your ROS 1 package adds tests like this:
 
-.. code-block:: none
+.. code-block::
 
       if (CATKIN_ENABLE_TESTING)
         find_package(GTest REQUIRED)

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -297,17 +297,18 @@ Add ``<test_depend>ament_cmake_gtest</test_depend>`` to your ``package.xml`` (`e
 Linters
 ^^^^^^^
 
-In ROS 2 we are working to maintain clean code using linters.
-The styles for different languages are defined in our :doc:`Developer Guide <../../The-ROS2-Project/Contributing/Developer-Guide>`.
+The ROS 2 code style guide is different than ROS 1 :doc:`Developer Guide <../../The-ROS2-Project/Contributing/Developer-Guide>`.
 
-If you are starting a project from scratch it is recommended to follow the style guide and turn on the automatic linter unit tests by adding these lines just below ``if(BUILD_TESTING)``:
+If you are starting a project from scratch, follow the ROS 2 style guide and turn on automatic linter tests by adding these lines in a ``if(BUILD_TESTING)`` block:
 
 .. code-block:: cmake
 
-   find_package(ament_lint_auto REQUIRED)
-   ament_lint_auto_find_test_dependencies()
+   if(BUILD_TESTING)
+      find_package(ament_lint_auto REQUIRED)
+      ament_lint_auto_find_test_dependencies()
+   endif()
 
-You will also need to add the following dependencies to your ``package.xml``:
+Then, add the following dependencies to your ``package.xml``:
 
 .. code-block:: xml
 

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -211,8 +211,8 @@ Add a call to ``ament_export_targets()`` with the same name you gave to the ``EX
 Replacing ``catkin_package(CATKIN_DEPENDS .. DEPENDS ..)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Downstream users also need to ``find_package()`` dependencies used in your public API.
-In ROS 1 this was done with ``CATKIN_DEPENDS`` and ``DEPENDS`` arguments.
+Your package's users must ``find_package()`` dependencies used by your package's public API.
+In ROS 1 this was done for downstream users with the ``CATKIN_DEPENDS`` and ``DEPENDS`` arguments.
 Use `ament_export_dependencies <https://github.com/ament/ament_cmake/blob/{REPOS_FILE_BRANCH}/ament_cmake_export_dependencies/cmake/ament_export_dependencies.cmake>`__ to do this in ROS 2.
 
 .. code-block:: cmake
@@ -326,9 +326,9 @@ Add ``<test_depend>ament_cmake_gtest</test_depend>`` to your ``package.xml`` (`e
 Linters
 ^^^^^^^
 
-The ROS 2 code style guide is different than ROS 1 :doc:`Developer Guide <../../The-ROS2-Project/Contributing/Developer-Guide>`.
+The ROS 2 code style guide differs from the ROS 1 :doc:`Style Guide <../../The-ROS2-Project/Contributing/Developer-Guide>`.
 
-If you are starting a project from scratch, follow the ROS 2 style guide, and turn on automatic linter tests by adding these lines in a ``if(BUILD_TESTING)`` block:
+If you choose to follow the ROS 2 style guide, then turn on automatic linter tests by adding these lines in a ``if(BUILD_TESTING)`` block:
 
 .. code-block:: cmake
 
@@ -338,7 +338,7 @@ If you are starting a project from scratch, follow the ROS 2 style guide, and tu
       # ...
    endif()
 
-Then, add the following dependencies to your ``package.xml``:
+Add the following dependencies to your ``package.xml``:
 
 .. code-block:: xml
 

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -690,10 +690,11 @@ argument.
    //    ROS_INFO("%s", msg.data.c_str());
        RCLCPP_INFO(node->get_logger(), "%s\n", msg.data.c_str());
 
-Publishing the message is the same as before:
+Change the publish call to use the ``->`` operator instead of ``.``.
 
 .. code-block:: cpp
 
+   //    chatter_pub.publish(msg);
        chatter_pub->publish(msg);
 
 Spinning (i.e., letting the communications system process any pending
@@ -737,6 +738,7 @@ Putting it all together, the new ``talker.cpp`` looks like this:
        msg.data = ss.str();
    //    ROS_INFO("%s", msg.data.c_str());
        RCLCPP_INFO(node->get_logger(), "%s\n", msg.data.c_str());
+   //    chatter_pub.publish(msg);
        chatter_pub->publish(msg);
    //    ros::spinOnce();
        rclcpp::spin_some(node);
@@ -760,7 +762,7 @@ Add a new dependency on ``ament_cmake_ros``:
 
 .. code-block:: xml
 
-     <buildtool_depend>ament_cmake</buildtool_depend>
+     <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
 ROS 2 C++ libraries use `rclcpp <https://index.ros.org/p/roscpp/#noetic>`__ instead of `roscpp <https://index.ros.org/p/roscpp/#noetic>`__.
 
@@ -817,7 +819,7 @@ Require a newer version of CMake so that ``ament_cmake`` functions work correctl
    cmake_minimum_required(VERSION 3.14.4)
 
 Use a newer C++ standard matching the version used by your target ROS distro in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`__.
-If you are using C++17, then set that version with the following snippet.
+If you are using C++17, then set that version with the following snippet after the ``project(talker)`` call.
 Add extra compiler checks too because it is a good practice.
 
 .. code-block:: cmake
@@ -837,14 +839,14 @@ Replace the ``find_package(catkin ...)`` call with individual calls for each dep
    find_package(rclcpp REQUIRED)
    find_package(std_msgs REQUIRED)
 
-
+Delete the call to ``catkin_package()``.
 Add a call to ``ament_package()`` at the bottom of the ``CMakeLists.txt``.
 
 .. code-block:: cmake
 
    ament_package()
 
-Use ``target_link_libraries`` to make the ``talker`` target depend on the modern CMake targets provided by ``rclcpp`` and ``std_msgs``.
+Make the ``target_link_libraries`` call modern CMake targets provided by ``rclcpp`` and ``std_msgs``.
 
 .. code-block:: cmake
 
@@ -853,17 +855,17 @@ Use ``target_link_libraries`` to make the ``talker`` target depend on the modern
      ${std_msgs_TARGETS})
 
 Delete the call to ``include_directories()``.
-Replace it with a call to ``target_include_directories()`` for your package's ``include`` directory.
+Add a call to ``target_include_directories()`` below ``add_executable(talker talker.cpp)``.
 Don't pass variables like ``rclcpp_INCLUDE_DIRS`` into ``target_include_directories()``.
-The include directories were already handled by calling ``target_link_libraries()`` with modern CMake targets.
+The include directories are already handled by calling ``target_link_libraries()`` with modern CMake targets.
 
 .. code-block:: cmake
 
-   target_include_directories(target PUBLIC
+   target_include_directories(talker PUBLIC
       "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
       "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-Install the ``talker`` executable into a project specific directory so that it is discoverable by tools like ``ros2 run``.
+Change the call to ``install()`` so that the ``talker`` executable is installed into a project specific directory.
 
 .. code-block:: cmake
 
@@ -886,7 +888,7 @@ The new ``CMakeLists.txt`` looks like this:
    find_package(rclcpp REQUIRED)
    find_package(std_msgs REQUIRED)
    add_executable(talker talker.cpp)
-   target_include_directories(target PUBLIC
+   target_include_directories(talker PUBLIC
       "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
       "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
    target_link_libraries(talker PUBLIC

--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.rst
@@ -326,7 +326,7 @@ Add ``<test_depend>ament_cmake_gtest</test_depend>`` to your ``package.xml`` (`e
 Linters
 ^^^^^^^
 
-The ROS 2 code style guide differs from the ROS 1 :doc:`Style Guide <../../The-ROS2-Project/Contributing/Developer-Guide>`.
+The ROS 2 code :doc:`style guide <../../The-ROS2-Project/Contributing/Developer-Guide>`__ differs from ROS 1.
 
 If you choose to follow the ROS 2 style guide, then turn on automatic linter tests by adding these lines in a ``if(BUILD_TESTING)`` block:
 


### PR DESCRIPTION
This updates the CMake portion of the ROS 1 to ROS 2 guide, and fixes one bug in the C++ code

* Included links to real examples in the core (Mostly tf2)
* Updated section headings to CMakeLists.txt steps appear in the ToC
* Used modern CMake targets instead of standard CMake variables
* Used Active voice and second person perspective
* Removed unnecessary code from example code in Unit tests section
* Make the example `package.xml` start with format 2 since that's different from migrating from ROS 1 to ROS 2.

C++ bug fix: use `->publish(` instead of `.publish(`

I have tried out all steps of the example part of the guide to make sure they work.
