### PR TITLE
Deprecating tf2 C Headers

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
+++ b/source/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.rst
@@ -45,7 +45,7 @@ The commonly-used unit quaternion that yields no rotation about the x/y/z axes i
 
 .. code-block:: C++
 
-   #include <tf2/LinearMath/Quaternion.h>
+   #include <tf2/LinearMath/Quaternion.hpp>
    ...
 
    tf2::Quaternion q;

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -78,7 +78,7 @@ Open the file using your preferred text editor.
 
     #include "geometry_msgs/msg/transform_stamped.hpp"
     #include "rclcpp/rclcpp.hpp"
-    #include "tf2/LinearMath/Quaternion.h"
+    #include "tf2/LinearMath/Quaternion.hpp"
     #include "tf2_ros/transform_broadcaster.h"
     #include "turtlesim_msgs/msg/pose.hpp"
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -78,7 +78,7 @@ Open the file using your preferred text editor.
     #include "geometry_msgs/msg/transform_stamped.hpp"
     #include "geometry_msgs/msg/twist.hpp"
     #include "rclcpp/rclcpp.hpp"
-    #include "tf2/exceptions.h"
+    #include "tf2/exceptions.hpp"
     #include "tf2_ros/transform_listener.h"
     #include "tf2_ros/buffer.h"
     #include "turtlesim_msgs/srv/spawn.hpp"

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -94,7 +94,7 @@ Open the file using your preferred text editor.
 
     #include "geometry_msgs/msg/transform_stamped.hpp"
     #include "rclcpp/rclcpp.hpp"
-    #include "tf2/LinearMath/Quaternion.h"
+    #include "tf2/LinearMath/Quaternion.hpp"
     #include "tf2_ros/static_transform_broadcaster.h"
 
     class StaticFramePublisher : public rclcpp::Node
@@ -186,7 +186,7 @@ We also include ``tf2_ros/static_transform_broadcaster.h`` to use the ``StaticTr
 
 .. code-block:: C++
 
-    #include "tf2/LinearMath/Quaternion.h"
+    #include "tf2/LinearMath/Quaternion.hpp"
     #include "tf2_ros/static_transform_broadcaster.h"
 
 The ``StaticFramePublisher`` class constructor initializes the node with the name ``static_turtle_tf2_broadcaster``.


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.

Edit: I should mention this is meant to be a preemptive PR for if/when the related pull request gets approved. I'm also working on a backport so there won't be distribution issues