### PR TITLE
Mark Iron Irwini as end-of-life

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       backport:
         branches:
           - jazzy
-          - iron
           - humble
 
   - name: backport at reviewers discretion
@@ -18,7 +17,6 @@ pull_request_rules:
       backport:
         branches:
           - jazzy
-          - iron
           - humble
 
   - name: backport to jazzy at reviewers discretion
@@ -29,15 +27,6 @@ pull_request_rules:
       backport:
         branches:
           - jazzy
-
-  - name: backport to iron at reviewers discretion
-    conditions:
-      - base=rolling
-      - "label=backport-iron"
-    actions:
-      backport:
-        branches:
-          - iron
 
   - name: backport to humble at reviewers discretion
     conditions:

--- a/conf.py
+++ b/conf.py
@@ -130,7 +130,7 @@ smv_branch_whitelist = r'^(rolling|jazzy|iron|humble|galactic|foxy|eloquent|dash
 smv_released_pattern = r'^refs/(heads|remotes/[^/]+)/(jazzy|iron|humble|galactic|foxy|eloquent|dashing|crystal).*$'
 smv_remote_whitelist = r'^(origin)$'
 smv_latest_version = 'jazzy'
-smv_eol_versions = ['crystal', 'dashing', 'eloquent', 'foxy', 'galactic']
+smv_eol_versions = ['crystal', 'dashing', 'eloquent', 'foxy', 'galactic', 'iron']
 
 distro_full_names = {
     'crystal': 'Crystal Clemmys',

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -24,7 +24,6 @@ Rows in the table marked in green are the currently supported distributions.
    :hidden:
 
    Releases/Release-Jazzy-Jalisco
-   Releases/Release-Iron-Irwini
    Releases/Release-Humble-Hawksbill
    Releases/Release-Rolling-Ridley
    Releases/Development
@@ -49,7 +48,6 @@ Rows in the table marked in green are the currently supported distributions.
    <style>
      .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
      .rst-content table.docutils:not(.field-list) tr:nth-child(3) td {background-color: #33cc66;}
-     .rst-content tr:nth-child(2) {background-color: #33cc66;}
      .rst-content tr:nth-child(3) {background-color: #33cc66;}
    </style>
 
@@ -104,7 +102,7 @@ Rows in the table marked in green are the currently supported distributions.
    * - :doc:`Iron Irwini <Releases/Release-Iron-Irwini>`
      - May 23, 2023
      - |iron|
-     - November 2024
+     - December 4, 2024
      - `Yadunund Vijay <https://github.com/Yadunund>`_
    * - :doc:`Humble Hawksbill <Releases/Release-Humble-Hawksbill>`
      - May 23, 2022

--- a/source/Releases/End-of-Life.rst
+++ b/source/Releases/End-of-Life.rst
@@ -6,6 +6,7 @@ Below is a list of historic ROS 2 distributions that are no longer supported.
 .. toctree::
    :maxdepth: 1
 
+   Release-Iron-Irwini
    Release-Galactic-Geochelone
    Release-Foxy-Fitzroy
    Release-Eloquent-Elusor


### PR DESCRIPTION
From my local testing, the distribution table correctly removes the green fill for the Iron row.

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/01e3d41a-8741-4afe-9ec0-c97843488c12">



