### PR TITLE
add working groups section and fill-in client library details

### DIFF
--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -423,6 +423,22 @@ The following repositories are managed by the ROS PMC:
    * - https://github.com/ros2/yaml_cpp_vendor
      - Not Yet Available
 
+Working Groups (WGs)
+-------------------
+
+The following are the official working groups (WGs) that report to the ROS PMC.
+
+Client Library
+^^^^^^^^^^^^^^^^
+
+* Lead(s): Alberto Soragna
+* Resources:
+
+ * Meeting invite group: `ros-client-library-wg <https://groups.google.com/g/ros-2-client-library-wg>`_
+ * `Meeting minutes and agendas <https://docs.google.com/document/d/1-tU2AKoHKLCVHPBz0QchYownmZZvYjHmVUQXT2WBMOw/edit?usp=sharing>`_
+ * Working group charter: :doc:`Client Library WG Charter <./Working-Groups/charters/client-library-wg>`
+ * Discourse tag: `wg-client-libraries <https://discourse.ros.org/tags/wg-client-libraries>`_
+
 Upcoming ROS Events
 -------------------
 

--- a/source/The-ROS2-Project/Working-Groups/charters/client-library-wg.md
+++ b/source/The-ROS2-Project/Working-Groups/charters/client-library-wg.md
@@ -1,0 +1,50 @@
+# ROS 2 Client Library Working Group
+
+## Name
+
+ROS 2 Client Library Working Group
+
+
+## Chair
+
+The chair of the working group shall be Alberto Soragna.
+
+
+## Purpose
+
+The working group shall facilitate contributions to the ROS 2 client library-related repositories.
+Example activities are: design of new features, discussion and triage of tickets, resolution of controversial changes and requests, and more.
+
+The working group oversees the official ROS 2 client library interfaces (rclcpp and rclpy as of this writing) and the common ROS 2 client library, rcl.
+Community-supported client library interfaces fall outside the working group’s responsibility, but community members interested in them are welcome to attend meetings for support and guidance.
+
+
+## Tasks
+
+The Working Group shall perform the following tasks.
+
+1. Review open pull requests to client library repositories.
+1. Provide guidance to new developers on how to contribute to Client Library repositories.
+1. Discuss problems related to client libraries, and possible solutions.
+1. Design improvements and new features related to client library repositories.
+
+
+## Expected outputs
+
+The Working Group shall, upon completion of its tasks and as appropriate while performing them, provide to the ROS PMC the following.
+
+1. A monthly report to the ROS PMC on what the activities of the Working Group was.
+1. At the end date, a list of pull requests and issues discussed by or resolved by the Working Group.
+
+
+## Completion date
+
+This Working Group doesn't have a set completion date, but it will be reviewed and renewed as appropriate yearly by the ROS PMC at the first ROS PMC meeting of the calendar year (generally in early January).
+
+
+## Meetings
+
+The working group will usually meet every two weeks, on Friday at 8AM PST.
+Meetings could be cancelled if there are no new topics to discuss or could happen more frequently around key dates (such as when a new ROS 2 distribution is released).
+Meeting reminders will be posted a few days in advance via Discourse and Google Group.
+Meeting minutes will be posted on Discourse after every meeting.


### PR DESCRIPTION
This PR adds:
 - a section to list official WGs
 - an entry list for the client library WG
 - a directory where to store WG charters