### PR TITLE
Drop unsupported Python packages from instructions

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -64,7 +64,6 @@ Install development tools
      python3-colcon-common-extensions \
      python3-mypy \
      python3-pip \
-     python3-pydocstyle \
      python3-pytest \
      python3-pytest-cov \
      python3-pytest-mock \

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -68,7 +68,6 @@ If you are going to build ROS packages or otherwise do development, you can also
      python3-colcon-common-extensions \
      python3-mypy \
      python3-pip \
-     python3-pydocstyle \
      python3-pytest \
      python3-pytest-repeat \
      python3-pytest-rerunfailures \

--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -41,7 +41,7 @@ Install additional Python dependencies:
 
 .. code-block:: bash
 
-   pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes mock mypy==0.931 pep8 pydocstyle pytest pytest-cov pytest-mock pytest-repeat pytest-rerunfailures pytest-runner vcstool
+   pip install -U colcon-common-extensions coverage flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-import-order flake8-quotes mock mypy==0.931 pytest pytest-cov pytest-mock pytest-repeat pytest-rerunfailures pytest-runner vcstool
 
 Build ROS 2
 -----------

--- a/source/Installation/Alternatives/macOS-Development-Setup.rst
+++ b/source/Installation/Alternatives/macOS-Development-Setup.rst
@@ -92,9 +92,9 @@ You need the following things installed to build ROS 2:
         argcomplete catkin_pkg colcon-common-extensions coverage \
         cryptography empy flake8 flake8-blind-except==0.1.1 flake8-builtins \
         flake8-class-newline flake8-comprehensions flake8-deprecated \
-        flake8-docstrings flake8-import-order flake8-quotes \
+        flake8-import-order flake8-quotes \
         importlib-metadata jsonschema lark==1.1.1 lxml matplotlib mock mypy==0.931 netifaces \
-        nose pep8 psutil pydocstyle pydot pygraphviz pyparsing==2.4.7 \
+        psutil pydot pygraphviz pyparsing==2.4.7 \
         pytest-mock rosdep rosdistro setuptools==59.6.0 vcstool
 
    Please ensure that the ``$PATH`` environment variable contains the install location of the binaries (``$(brew --prefix)/bin``)

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -69,7 +69,6 @@ If you are going to build ROS packages or otherwise do development, you can also
      python3-colcon-common-extensions \
      python3-mypy \
      python3-pip \
-     python3-pydocstyle \
      python3-pytest \
      python3-pytest-repeat \
      python3-pytest-rerunfailures \


### PR DESCRIPTION
We no longer use or require the following Python packages:
- flake8-docstrings
- nose
- pep8
- pydocstyle