### PR TITLE
spin_until_future_complete should wait on future, but result.

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -215,7 +215,7 @@ Inside the ``ros2_ws/src/cpp_srvcli/src`` directory, create a new file called ``
     request->a = 41;
     request->b = 1;
     auto result_future = client->async_send_request(request);
-    if (rclcpp::spin_until_future_complete(node, result) ==
+    if (rclcpp::spin_until_future_complete(node, result_future) ==
       rclcpp::FutureReturnCode::SUCCESS)
     {
       RCLCPP_ERROR(node->get_logger(), "service call failed :(");


### PR DESCRIPTION
closes https://github.com/ros2/ros2_documentation/issues/4916

> [!NOTE]  
> We do not need to backport this to Jazzy or earlier distros.