### PR TITLE
Accessing parameters loaded from YAML file

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-Parameters.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-Parameters.rst
@@ -21,7 +21,7 @@ In ROS 2, parameters are associated per node and are configurable at runtime wit
 Migrating YAML Parameter Files
 ------------------------------
 
-This guide describes how to adapt ROS 1 parameters files for ROS 2.
+This guide describes how to adapt ROS 1 parameters files for ROS 2 and illustrates the difference in the way parameters can be accessed from the node level.
 
 YAML file example
 ^^^^^^^^^^^^^^^^^
@@ -59,6 +59,13 @@ We would construct our ROS 2 parameters file as follows:
        debug: true
 
 Note the use of wildcards (``/**``) to indicate that the parameter ``debug`` should be set on any node in any namespace.
+
+Accessing parameters inside node
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Let's say we want to use ``lidar_name`` parameter inside C++/Python node.
+In ROS 1, we used slashes to separate node name and namespaces - ``"lidar_ns/lidar_node_name/lidar_name"``.
+In ROS 2, we use dots instead of slashes - ``"lidar_ns.lidar_node_name.lidar_name"``.
 
 Feature parity
 ^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.rst
@@ -85,6 +85,8 @@ You will see the node namespaces, ``/teleop_turtle`` and ``/turtlesim``, followe
     qos_overrides./parameter_events.publisher.reliability
     use_sim_time
 
+The namespaces of the parameter and its name are separated using dots as you can see, for example, in ``parameter_events.publisher.depth``.
+
 Every node has the parameter ``use_sim_time``; it's not unique to turtlesim.
 
 Based on their names, it looks like ``/turtlesim``'s parameters determine the background color of the turtlesim window using RGB color values.

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.rst
@@ -214,6 +214,8 @@ Your terminal will return the message:
 
   Read-only parameters can only be modified at startup and not afterwards, that is why there are some warnings for the "qos_overrides" parameters.
 
+.. _LoadParameterFileOnNodeStartup:
+
 7 Load parameter file on node startup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -560,7 +560,7 @@ Modify ``cpp_parameters_node.cpp`` by changing all occurrences of ``"my_paramete
 3.4 Change via passing YAML file as an argument at node startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a reminder from the :doc:`tutoral about parameters <../Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters>`, you can also load parameter file at node startup.
+As a reminder from the :ref:`tutorial about parameters <LoadParameterFileOnNodeStartup>`, you can also load parameter file at node startup.
 
 .. code-block:: console
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -454,3 +454,9 @@ Next steps
 ----------
 
 Now that you have some packages and ROS 2 systems of your own, the :doc:`next tutorial <./Getting-Started-With-Ros2doctor>` will show you how to examine issues in your environment and systems in case you have problems.
+
+Related content
+---------------
+
+* For more detailed information about using YAML files to load parameters, please refer to :ref:`this section <Parameters>` of Managing large projects tutorial.
+* If you want to learn, how to monitor and respond to parameter changes, check out :doc:`Monitoring for parameter changes (C++) <../Intermediate/Monitoring-For-Parameter-Changes-CPP>` tutorial.

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -432,139 +432,17 @@ Further outputs should show  ``[INFO] [minimal_param_node]: Hello world!`` every
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Instead of listing parameters and their values in launch file, you can create a separate YAML file that will be loaded in launch file.
-First, you will need to add a config directory.
-Inside the ``ros2_ws/src/cpp_parameters/`` directory, create a new directory called ``config``.
-In there, create a new file called ``cpp_parameters_config.yaml``.
+Placing parameters in a YAML file makes it easier to organize them, for example, by assigning them to different namespaces.
+You can read more about it :ref:`here <LoadingParametersFromYAMLFile>`.
 
-.. code-block:: yaml
+.. note::
 
-  custom_minimal_param_node:
-    ros__parameters:
-        my_parameter: "earth"
-
-Now, you will have to edit ``cpp_parameters_launch.py``.
-Add the import statements to the top of the file and add a variable containing the path to the configuration file.
-Then replace the dictionary containing the parameter name and value with a path to YAML file.
-
-.. code-block:: Python
-
-    import os
-    from ament_index_python.packages import get_package_share_directory
-    # ...
-
-    def generate_launch_description():
-        config = os.path.join(
-            get_package_share_directory("cpp_parameters"), "config", "cpp_parameters_config.yaml"
-        )
-
-        return LaunchDescription(
-            [
-                Node(
-                    # ...
-                    parameters=[config],
-                )
-            ]
-        )
-
-Now open the ``CMakeLists.txt`` file. Below the lines you added earlier, add the following lines of code.
-
-.. code-block:: console
-
-    install(
-      DIRECTORY config
-      DESTINATION share/${PROJECT_NAME}
-    )
-
-Open a console and navigate to the root of your workspace, ``ros2_ws``, and build the package:
-
-.. tabs::
-
-  .. group-tab:: Linux
-
-    .. code-block:: console
-
-      colcon build --packages-select cpp_parameters
-
-  .. group-tab:: macOS
-
-    .. code-block:: console
-
-      colcon build --packages-select cpp_parameters
-
-  .. group-tab:: Windows
-
-    .. code-block:: console
-
-      colcon build --merge-install --packages-select cpp_parameters
-
-Then source the setup files in a new terminal:
-
-.. tabs::
-
-  .. group-tab:: Linux
-
-    .. code-block:: console
-
-      source install/setup.bash
-
-  .. group-tab:: macOS
-
-    .. code-block:: console
-
-      . install/setup.bash
-
-  .. group-tab:: Windows
-
-    .. code-block:: console
-
-      call install/setup.bat
-
-Now run the node using the modified version of launch file:
-
-.. code-block:: console
-
-     ros2 launch cpp_parameters cpp_parameters_launch.py
-
-The terminal should return the following message the first time:
-
-.. code-block:: console
-
-    [INFO] [custom_minimal_param_node]: Hello earth!
-
-Further outputs should show  ``[INFO] [minimal_param_node]: Hello world!`` every second.
-
-Parameter listed in ``cpp_parameters_config.yaml`` file will be set only for ``custom_minimal_param_node`` node.
-If you want to indicate that the parameter ``my_parameter`` should be set on any node in any namespace, then you should use wildcards (``/**``).
-
-.. code-block:: yaml
-
-  /**:
-    ros__parameters:
-        my_parameter: "earth"
-
-You can also use your parameter under namespace, but it will require some changes in ``cpp_parameters_node.cpp`` file.
-First, edit config file to look like the one below.
-
-.. code-block:: yaml
-
-  custom_minimal_param_node:
-    my_namespace:
-      ros__parameters:
-          my_parameter: "earth"
-
-
-While declaring, getting and setting parameter value inside your C++ node, you should also add namespace to parameter name and use dot as a separator.
-Modify ``cpp_parameters_node.cpp`` by changing all occurrences of ``"my_parameter"`` into ``"my_namespace.my_parameter"``.
-
+  While declaring, getting and setting parameter value inside your C++ node, you should use dot as a separator between parameter's namespace and name.
 
 3.4 Change via passing YAML file as an argument at node startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a reminder from the :ref:`tutorial about parameters <LoadParameterFileOnNodeStartup>`, you can also load parameter file at node startup.
-
-.. code-block:: console
-
-    ros2 run cpp_parameters minimal_param_node --ros-args --params-file ~/ros2_ws/src/cpp_parameters/config/cpp_parameters_config.yaml
+Return to :ref:`tutorial about parameters <LoadParameterFileOnNodeStartup>` to remind yourself, how to load parameters file at node startup using CLI.
 
 Summary
 -------

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -438,143 +438,17 @@ Further outputs should show  ``[INFO] [minimal_param_node]: Hello world!`` every
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Instead of listing parameters and their values in launch file, you can create a separate YAML file that will be loaded in launch file.
-First, you will need to add a config directory.
-Inside the ``ros2_ws/src/python_parameters/`` directory, create a new directory called ``config``.
-In there, create a new file called ``python_parameters_config.yaml``.
+Placing parameters in a YAML file makes it easier to organize them, for example, by assigning them to different namespaces.
+You can read more about it :ref:`here <LoadingParametersFromYAMLFile>`.
 
-.. code-block:: yaml
+.. note::
 
-  custom_minimal_param_node:
-    ros__parameters:
-        my_parameter: "earth"
-
-Now, you will have to edit ``python_parameters_launch.py``.
-Add the import statements to the top of the file and add a variable containing the path to the configuration file.
-Then replace the dictionary containing the parameter name and value with a path to YAML file.
-
-.. code-block:: Python
-
-    from ament_index_python.packages import get_package_share_directory
-    # ...
-
-    def generate_launch_description():
-        config = os.path.join(
-            get_package_share_directory("python_parameters"), "config", "python_parameters_config.yaml"
-        )
-
-        return LaunchDescription(
-            [
-                Node(
-                    # ...
-                    parameters=[config],
-                )
-            ]
-        )
-
-You have to also modify ``setup.py`` by adding new statement to the ``data_files`` parameter to include all YAML config files:
-
-.. code-block:: Python
-
-    # ...
-
-    setup(
-      # ...
-      data_files=[
-          # ...
-          (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
-        ]
-      )
-
-Open a console and navigate to the root of your workspace, ``ros2_ws``, and build the package:
-
-.. tabs::
-
-  .. group-tab:: Linux
-
-    .. code-block:: console
-
-      colcon build --packages-select python_parameters
-
-  .. group-tab:: macOS
-
-    .. code-block:: console
-
-      colcon build --packages-select python_parameters
-
-  .. group-tab:: Windows
-
-    .. code-block:: console
-
-      colcon build --merge-install --packages-select python_parameters
-
-Then source the setup files in a new terminal:
-
-.. tabs::
-
-  .. group-tab:: Linux
-
-    .. code-block:: console
-
-      source install/setup.bash
-
-  .. group-tab:: macOS
-
-    .. code-block:: console
-
-      . install/setup.bash
-
-  .. group-tab:: Windows
-
-    .. code-block:: console
-
-      call install/setup.bat
-
-Now run the node using the modified version of launch file:
-
-.. code-block:: console
-
-     ros2 launch python_parameters python_parameters_launch.py
-
-The terminal should return the following message the first time:
-
-.. code-block:: console
-
-    [INFO] [custom_minimal_param_node]: Hello earth!
-
-Further outputs should show  ``[INFO] [minimal_param_node]: Hello world!`` every second.
-
-Parameter listed in ``python_parameters_config.yaml`` file will be set only for ``custom_minimal_param_node`` node.
-If you want to indicate that the parameter ``my_parameter`` should be set on any node in any namespace, then you should use wildcards (``/**``).
-
-.. code-block:: yaml
-
-  /**:
-    ros__parameters:
-        my_parameter: "earth"
-
-You can also use your parameter under namespace, but it will require some changes in ``python_parameters_node.py`` file.
-First, edit config file to look like the one below.
-
-.. code-block:: yaml
-
-  custom_minimal_param_node:
-    my_namespace:
-      ros__parameters:
-          my_parameter: "earth"
-
-
-While declaring, getting and setting parameter value inside your Python node, you should also add namespace to parameter name and use dot as a separator.
-Modify ``python_parameters_node.py`` by changing all occurrences of ``'my_parameter'`` into ``'my_namespace.my_parameter'``.
-
+  While declaring, getting and setting parameter value inside your Python node, you should use dot as a separator between parameter's namespace and name.
 
 3.4 Change via passing YAML file as an argument at node startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a reminder from the :ref:`tutorial about parameters <LoadParameterFileOnNodeStartup>`, you can also load parameter file at node startup.
-
-.. code-block:: console
-
-    ros2 run python_parameters minimal_param_node --ros-args --params-file ~/ros2_ws/src/python_parameters/config/python_parameters_config.yaml
+Return to :ref:`tutorial about parameters <LoadParameterFileOnNodeStartup>` to remind yourself, how to load parameters file at node startup using CLI.
 
 Summary
 -------

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -460,3 +460,9 @@ Next steps
 ----------
 
 Now that you have some packages and ROS 2 systems of your own, the :doc:`next tutorial <./Getting-Started-With-Ros2doctor>` will show you how to examine issues in your environment and systems in case you have problems.
+
+Related content
+---------------
+
+* For more detailed information about using YAML files to load parameters, please refer to :ref:`this section <Parameters>` of Managing large projects tutorial.
+* If you want to learn, how to monitor and respond to parameter changes, check out :doc:`Monitoring for parameter changes (Python) <../Intermediate/Monitoring-For-Parameter-Changes-Python>` tutorial.

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -570,7 +570,7 @@ Modify ``python_parameters_node.py`` by changing all occurrences of ``'my_parame
 3.4 Change via passing YAML file as an argument at node startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As a reminder from the :doc:`tutoral about parameters <../Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters>`, you can also load parameter file at node startup.
+As a reminder from the :ref:`tutorial about parameters <LoadParameterFileOnNodeStartup>`, you can also load parameter file at node startup.
 
 .. code-block:: console
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -123,6 +123,8 @@ However, there are cases when some nodes or launch files have to be launched sep
 
 .. note:: Design tip: Be aware of the tradeoffs when deciding how many top-level launch files your application requires.
 
+.. _Parameters:
+
 2 Parameters
 ^^^^^^^^^^^^
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -170,6 +170,8 @@ First, create a new file called ``turtlesim_world_1_launch.py``.
 
 This launch file starts the ``turtlesim_node`` node, which starts the turtlesim simulation, with simulation configuration parameters that are defined and passed to the nodes.
 
+.. _LoadingParametersFromYAMLFile:
+
 2.2 Loading parameters from YAML file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR extends C++ and Python tutorials regarding **Using parameters in a class** with examples of accessing parameters loaded from a YAML file. This topic was discussed in https://github.com/ros2/ros2_documentation/issues/4927. I've also added a hint in [Migrating Parameters](https://docs.ros.org/en/rolling/How-To-Guides/Migrating-from-ROS1/Migrating-Parameters.html) guide regarding syntax (in ROS 2 we use dots instead of slashes while accessing parameters defined under namespaces). 

Resolves https://github.com/ros2/ros2_documentation/issues/4927