### PR TITLE
Revert "Fix a typo in Writing-A-Simple-Cpp-Service-And-Client.rst (backport #4934)"

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -227,7 +227,7 @@ Inside the ``ros2_ws/src/cpp_srvcli/src`` directory, create a new file called ``
 
     auto result = client->async_send_request(request);
     // Wait for the result.
-    if (rclcpp::spin_until_future_complete(node, result) !=
+    if (rclcpp::spin_until_future_complete(node, result) ==
       rclcpp::FutureReturnCode::SUCCESS)
     {
       RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sum: %ld", result.get()->sum);


### PR DESCRIPTION
Reverts ros2/ros2_documentation#4937

The code on Rolling is different from the code on other branches, so the condition has to be different. #4934 should not have been backported.