### PR TITLE
Fix title underline

### DIFF
--- a/source/Tutorials/Advanced/Reading-From-A-Bag-File-Python.rst
+++ b/source/Tutorials/Advanced/Reading-From-A-Bag-File-Python.rst
@@ -69,7 +69,7 @@ Also be sure to add this information to the ``setup.py`` file as well.
    license='Apache-2.0',
 
 2 Write the Python Reader
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Inside the ``ros2_ws/src/bag_reader_node_py/bag_reader_node_py`` directory, create a new file called ``simple_bag_reader.py`` and paste the following code into it.
 


### PR DESCRIPTION
Follow-up to #4946, see https://github.com/ros2/ros2_documentation/pull/4946#discussion_r1918938844

```
/home/christophe.bedard/ros2_documentation/source/Tutorials/Advanced/Reading-From-A-Bag-File-Python.rst:72: WARNING: Title underline too short.

2 Write the Python Reader
^^^^^^^^^^^^^^^^^^^^^^
```