### PR TITLE
Remove underscored objects from rosbag_py tutorial

### DIFF
--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-Py.rst
@@ -103,13 +103,13 @@ Inside the ``ros2_ws/src/bag_recorder_nodes_py/bag_recorder_nodes_py`` directory
            super().__init__('simple_bag_recorder')
            self.writer = rosbag2_py.SequentialWriter()
 
-           storage_options = rosbag2_py._storage.StorageOptions(
+           storage_options = rosbag2_py.StorageOptions(
                uri='my_bag',
                storage_id='sqlite3')
-           converter_options = rosbag2_py._storage.ConverterOptions('', '')
+           converter_options = rosbag2_py.ConverterOptions('', '')
            self.writer.open(storage_options, converter_options)
 
-           topic_info = rosbag2_py._storage.TopicMetadata(
+           topic_info = rosbag2_py.TopicMetadata(
                name='chatter',
                type='std_msgs/msg/String',
                serialization_format='cdr')
@@ -159,10 +159,10 @@ The default conversion options are used, which will perform no conversion and st
 
 .. code-block:: Python
 
-   storage_options = rosbag2_py._storage.StorageOptions(
+   storage_options = rosbag2_py.StorageOptions(
        uri='my_bag',
        storage_id='sqlite3')
-   converter_options = rosbag2_py._storage.ConverterOptions('', '')
+   converter_options = rosbag2_py.ConverterOptions('', '')
    self.writer.open(storage_options, converter_options)
 
 Next, we need to tell the writer about the topics we wish to store.
@@ -171,7 +171,7 @@ This object specifies the topic name, topic data type, and serialization format 
 
 .. code-block:: Python
 
-   topic_info = rosbag2_py._storage.TopicMetadata(
+   topic_info = rosbag2_py.TopicMetadata(
        name='chatter',
        type='std_msgs/msg/String',
        serialization_format='cdr')
@@ -338,13 +338,13 @@ Inside the ``ros2_ws/src/bag_recorder_nodes_py/bag_recorder_nodes_py`` directory
            self.data.data = 0
            self.writer = rosbag2_py.SequentialWriter()
 
-           storage_options = rosbag2_py._storage.StorageOptions(
+           storage_options = rosbag2_py.StorageOptions(
                uri='timed_synthetic_bag',
                storage_id='sqlite3')
-           converter_options = rosbag2_py._storage.ConverterOptions('', '')
+           converter_options = rosbag2_py.ConverterOptions('', '')
            self.writer.open(storage_options, converter_options)
 
-           topic_info = rosbag2_py._storage.TopicMetadata(
+           topic_info = rosbag2_py.TopicMetadata(
                name='synthetic',
                type='example_interfaces/msg/Int32',
                serialization_format='cdr')
@@ -380,7 +380,7 @@ First, the name of the bag is changed.
 
 .. code-block:: Python
 
-   storage_options = rosbag2_py._storage.StorageOptions(
+   storage_options = rosbag2_py.StorageOptions(
        uri='timed_synthetic_bag',
        storage_id='sqlite3')
 
@@ -388,7 +388,7 @@ The name of the topic is also changed, as is the data type stored.
 
 .. code-block:: Python
 
-   topic_info = rosbag2_py._storage.TopicMetadata(
+   topic_info = rosbag2_py.TopicMetadata(
        name='synthetic',
        type='example_interfaces/msg/Int32',
        serialization_format='cdr')
@@ -519,13 +519,13 @@ Inside the ``ros2_ws/src/bag_recorder_nodes_py/bag_recorder_nodes_py`` directory
    def main(args=None):
        writer = rosbag2_py.SequentialWriter()
 
-       storage_options = rosbag2_py._storage.StorageOptions(
+       storage_options = rosbag2_py.StorageOptions(
            uri='big_synthetic_bag',
            storage_id='sqlite3')
-       converter_options = rosbag2_py._storage.ConverterOptions('', '')
+       converter_options = rosbag2_py.ConverterOptions('', '')
        writer.open(storage_options, converter_options)
 
-       topic_info = rosbag2_py._storage.TopicMetadata(
+       topic_info = rosbag2_py.TopicMetadata(
            name='synthetic',
            type='example_interfaces/msg/Int32',
            serialization_format='cdr')


### PR DESCRIPTION
Some objects that are available directly from the rosbag2_py root module are imported from the underscored modules they live in. This change removes the underscore modules and uses the objects from the root module.