### PR TITLE
apply one-sentence-per-line rule for rst files via github workflow.

### DIFF
--- a/.github/workflows/rst_check.yml
+++ b/.github/workflows/rst_check.yml
@@ -1,0 +1,29 @@
+name: grammar / rule check for .rst files
+
+on:
+  pull_request:
+    paths:
+      - "**/*.rst" # trigger only for .rst files
+
+jobs:
+  one_sentence_per_line:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Get changed lines in .rst files
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          git diff --unified=0 origin/${{ github.base_ref }} HEAD -- '*.rst' \
+            | grep '^[+-]' | grep -Ev '^(---|\+\+\+)' > /tmp/changed_lines.txt || true
+
+      - name: Run one-sentence-per-line checker on changed lines
+        run: |
+          python3 ./scripts/sentence_line_checker.py /tmp/changed_lines.txt

--- a/scripts/sentence_line_checker.py
+++ b/scripts/sentence_line_checker.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import re
+import sys
+
+def is_one_sentence_per_line(line) -> bool:
+    """
+    Check if a line contains only one complete sentence.
+    
+    :param line: The line of file to check.
+    """
+    # this assumes a sentence ends with a period, question mark, or exclamation mark.
+    sentence_endings = re.findall(r'[.!?]', line)
+    # allow empty lines or lines with only one sentence
+    return len(sentence_endings) <= 1
+
+def check_changed_lines(filename) -> None:
+    """
+    Check only changed lines for violations.
+
+    .. warning:: It checks only added / modified lines for the viaolation in the file,
+       and ignores everything else including removed lines.
+    
+    :param filename: The name of the file to check.
+    """
+    with open(filename, 'r', encoding='utf-8') as file:
+        lines = file.readlines()
+
+    violations = []
+    for lineno, line in enumerate(lines, start=1):
+        line = line.strip()
+        # check only added lines, ignore everything else
+        if line.startswith("+") and not is_one_sentence_per_line(line[1:]):
+            violations.append((lineno, line[1:]))
+
+    if violations:
+        print(f"\n⚠️ Found {len(violations)} violations: One sentence per line is required.")
+        for lineno, line in violations:
+            print(f"  ❌ Line {lineno}: {line}")
+        # exit with non-zero status code to fail github actions
+        sys.exit(1)
+    else:
+        print("✅ No violations found.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check if modified contents contain only one complete sentence per line.")
+    parser.add_argument(
+        'filename', type=str, help='The name of the file to check.')
+    args = parser.parse_args()
+
+    check_changed_lines(args.filename)


### PR DESCRIPTION
follow-up of https://github.com/ros2/ros2_documentation/pull/4990, that adds 
**please make sure to write only one sentence per line as it makes reviewing and modifying your file much easier.**

this is still good, but without checking it by system, eventually we could miss and extra iteration.
having this as custom rule using python script, possibly support this requirement and maintenance & developer friendly environment.

this can be still draft, there could be other way to explore. (AFAIK, sphinx-lint does not support this kind of rule.) any comments and suggestions are welcome 🤔 