### PR TITLE
Exclude literals parts from bold parts in 'Ament Lint CLI Utilities'

### DIFF
--- a/source/Tutorials/Advanced/Ament-Lint-For-Clean-Code.rst
+++ b/source/Tutorials/Advanced/Ament-Lint-For-Clean-Code.rst
@@ -34,7 +34,7 @@ Ament Lint CLI Tools
 All ament linting tools use a similar CLI pattern.
 They take in a directory, a list of directories, file, or list of files, analyze the input files, and generate a report.
 All ament linting tools have the following built-in options.
-**The most up to date and accurate documentation for a given ament tool can be found by using the tools built in ``--help`` functionality.**
+**The most up to date and accurate documentation for a given ament tool can be found by using the tools built in** ``--help`` **functionality.**
 
 * ``-h, --help`` - shows a help message and exit.
   The built-in help messages usually have the most accurate and up-to-date documentation of the tool.
@@ -290,9 +290,9 @@ For example, if you wish to scan just one package in your workspace you can call
 * ``-c CFG`` - The config file that Uncrustify should use if you would prefer to use your own settings.
   We recommend you stick to the defaults
 * ``--linelength N`` - The maximum line length.
-* ``--language`` - One of {C,C++,CPP}, passed to uncrustify as '-l <language>' to force a specific language rather then choosing one based on file extension.
-* ``--reformat`` -  Reformat the files in place, i.e. fix the formatting errors encountered.
-  **We recommend you use this option when running ``ament_uncrustify`` as it will save you quite a bit of time!**
+* ``--language`` - One of {C,C++,CPP}, passed to uncrustify as ``-l <language>`` to force a specific language rather then choosing one based on file extension.
+* ``--reformat`` - Reformat the files in place, i.e. fix the formatting errors encountered.
+  **We recommend you use this option when running** ``ament_uncrustify`` **as it will save you quite a bit of time!**
 
 5.3 ``ament_uncrustify`` Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
You can't do nested inline markup in RST:

**Can't do ``this`` in RST.**

The simplest solution is to just exclude the ``literal`` part.

Also, do some other minor fixes.