### PR TITLE
Other sentence formatting

### DIFF
--- a/source/Concepts/Intermediate/About-Executors.rst
+++ b/source/Concepts/Intermediate/About-Executors.rst
@@ -114,7 +114,7 @@ Callback groups
 ROS 2 allows organizing the callbacks of a node in groups.
 In rclcpp, such a *callback group* can be created by the ``create_callback_group`` function of the Node class.
 In rclpy, the same is done by calling the constructor of the specific callback group type.
-The callback group must be stored throughout execution of the node (eg. as a class member), or otherwise the executor won't be able to trigger the callbacks.
+The callback group must be stored throughout execution of the node (e.g. as a class member), or otherwise the executor won't be able to trigger the callbacks.
 Then, this callback group can be specified when creating a subscription, timer, etc. - for example by the subscription options:
 
 .. tabs::

--- a/source/How-To-Guides/Releasing/Release-Track.rst
+++ b/source/How-To-Guides/Releasing/Release-Track.rst
@@ -63,7 +63,7 @@ The repository name is trivial, but it is recommended to set this to the name of
          Name of the repository (used in the archive name)
       ['upstream']:
 
-Type the name of your project (eg. ``my_project``) and press Enter.
+Type the name of your project (e.g. ``my_project``) and press Enter.
 
 .. _upstream-repository-uri:
 
@@ -82,7 +82,7 @@ This is most likely an https link to your project hosted on a git hosting servic
          where the :{version} token will be replaced with the version for this release.
       [None]:
 
-Make sure you **use the https address** (eg. ``https://github.com/my_organization/my_repo.git``) and not the ssh address.
+Make sure you **use the https address** (e.g. ``https://github.com/my_organization/my_repo.git``) and not the ssh address.
 
 .. _upstream-vcs-type:
 
@@ -112,7 +112,7 @@ Most repositories will be using git, but some legacy repositories might be using
 Version
 ^^^^^^^
 
-This is the version of the package you are releasing. (eg. ``1.0.3``)
+This is the version of the package you are releasing. (e.g. ``1.0.3``)
 
 .. code-block:: bash
 

--- a/source/How-To-Guides/Releasing/_Bump-Package-Version.rst
+++ b/source/How-To-Guides/Releasing/_Bump-Package-Version.rst
@@ -8,9 +8,9 @@ Run:
 which performs the following:
 
 #. increases the package version in ``package.xml``
-#. replaces the heading ``Forthcoming`` with ``version (date)`` (eg. ``0.0.1 (2022-01-08)``) in ``CHANGELOG.rst``
+#. replaces the heading ``Forthcoming`` with ``version (date)`` (e.g. ``0.0.1 (2022-01-08)``) in ``CHANGELOG.rst``
 #. commits those changes
-#. creates a tag (eg. ``0.0.1``)
+#. creates a tag (e.g. ``0.0.1``)
 #. pushes the changes and the tag to your remote repository
 
 .. note::

--- a/source/How-To-Guides/Releasing/_Install-Dependencies.rst
+++ b/source/How-To-Guides/Releasing/_Install-Dependencies.rst
@@ -2,13 +2,13 @@ Install tools that you will use in the upcoming steps according to your platform
 
 .. tabs::
 
-   .. group-tab:: deb (eg. Ubuntu)
+   .. group-tab:: deb (e.g. Ubuntu)
 
       .. code-block:: bash
 
          sudo apt install python3-bloom python3-catkin-pkg
 
-   .. group-tab:: RPM (eg. RHEL)
+   .. group-tab:: RPM (e.g. RHEL)
 
       .. code-block:: bash
 

--- a/source/The-ROS2-Project/Contributing/Build-Farms.rst
+++ b/source/The-ROS2-Project/Contributing/Build-Farms.rst
@@ -82,7 +82,7 @@ Execution of the jobs depends on the type of the job:
 Frequency Asked Questions (FAQ) and Troubleshooting
 ---------------------------------------------------
 
-#. **I get Jenkins mails from failing build farm jobs. What do I do?**
+#. **I get Jenkins mails from failing build farm jobs; What do I do?**
 
    Go to the job that raised the issue.
    You find the link on top of the Jenkins email.

--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -76,11 +76,11 @@ Line Length
 File Extensions
 ~~~~~~~~~~~~~~~
 
-* Header files should use the .hpp extension.
+* Header files should use the ``.hpp`` extension.
 
   * rationale: Allow tools to determine content of files, C++ or C.
 
-* Implementation files should use the .cpp extension.
+* Implementation files should use the ``.cpp`` extension.
 
   * rationale: Allow tools to determine content of files, C++ or C.
 

--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -345,10 +345,10 @@ The pycodestyle configuration used in the linter is `here <https://github.com/am
 
 Integration with editors:
 
-* atom: https://atom.io/packages/linter-pycodestyle
-* emacs: https://www.emacswiki.org/emacs/PythonProgrammingInEmacs
-* Sublime Text: https://sublime.wbond.net/packages/SublimeLinter-flake8
-* vim: https://github.com/nvie/vim-flake8
+* `atom <https://atom.io/packages/linter-pycodestyle>`_
+* `emacs <https://www.emacswiki.org/emacs/PythonProgrammingInEmacs>`_
+* `Sublime Text <https://sublime.wbond.net/packages/SublimeLinter-flake8>`_
+* `vim <https://github.com/nvie/vim-flake8>`_
 
 CMake
 -----

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -198,11 +198,11 @@ This might include workflows for testing the code using something like ``python 
 
 Examples:
 
-* capabilities: https://docs.ros.org/hydro/api/capabilities/html/
+* `capabilities <https://docs.ros.org/hydro/api/capabilities/html/>`_
 
   * This one gives an example of docs which describe the public API
 
-* catkin_tools: https://catkin-tools.readthedocs.org/en/latest/development/extending_the_catkin_command.html
+* `catkin_tools <https://catkin-tools.readthedocs.org/en/latest/development/extending_the_catkin_command.html>`_
 
   * This is an example of describing an extension point for a package
 

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -897,7 +897,7 @@ Capture the lcov results with a similar command this time dropping the ``--initi
 
      lcov --no-external --capture --directory . --output-file ~/ros2.info
 
-Combine the trace .info files:
+Combine the trace ``.info`` files:
 
 .. code-block:: bash
 

--- a/source/The-ROS2-Project/Feature-Ideas.rst
+++ b/source/The-ROS2-Project/Feature-Ideas.rst
@@ -136,9 +136,9 @@ The trailing stars indicate the rough effort: 1 star for small, 2 stars for medi
   * Key storage security (right now, keys are just stored in the filesystem) [\*\*]
   * More user friendly interface (make it easier to specify security config).
     Maybe a Qt GUI?
-    This GUI could also assist in distributing keys somehow. [\*\*\*]
-  * A way to say "please secure this running system" with some UI that would auto-generate keys and policies for everything that is currently running. [\*\*\*]
-  * If there are hardware-specific features for securing keys or accelerating encryption/signing messages, that could be interesting to add to DDS/RTPS implementations that don't use it already. [\*\*\*]
+    This GUI could also assist in distributing keys somehow [\*\*\*]
+  * A way to say "please secure this running system" with some UI that would auto-generate keys and policies for everything that is currently running [\*\*\*]
+  * If there are hardware-specific features for securing keys or accelerating encryption/signing messages, that could be interesting to add to DDS/RTPS implementations that don't use it already [\*\*\*]
 
 Reducing Technical Debt
 -----------------------

--- a/source/Tutorials/Advanced/Allocator-Template-Tutorial.rst
+++ b/source/Tutorials/Advanced/Allocator-Template-Tutorial.rst
@@ -246,7 +246,7 @@ ROS 2 offers support for the TLSF (Two Level Segregate Fit) allocator, which was
 
 https://github.com/ros2/realtime_support/tree/{REPOS_FILE_BRANCH}/tlsf_cpp
 
-For more information about TLSF, see http://www.gii.upv.es/tlsf/
+For more information about TLSF, see `this page via Universitat Politècnica de València <http://www.gii.upv.es/tlsf/>`_.
 
 Note that the TLSF allocator is licensed under a dual-GPL/LGPL license.
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Installation-MacOS.rst
@@ -46,7 +46,7 @@ It is also possible to install it from sources.
 Install UTM on your macOS machine.
 The link can be found on the `official UTM website <https://mac.getutm.app/>`_.
 
-Download the .iso image of `Ubuntu 22.04 <https://cdimage.ubuntu.com/jammy/daily-live/current/>`_ for Humble and Rolling or `Ubuntu 20.04 <https://cdimage.ubuntu.com/focal/daily-live/pending/>`_ for Foxy.
+Download the ``.iso`` image of `Ubuntu 22.04 <https://cdimage.ubuntu.com/jammy/daily-live/current/>`_ for Humble and Rolling or `Ubuntu 20.04 <https://cdimage.ubuntu.com/focal/daily-live/pending/>`_ for Foxy.
 Be sure to download the image corresponding to your CPU architecture.
 
 In the UTM software:

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
@@ -96,7 +96,7 @@ Here is an example to import a simple Robot named ``imported_robot``:
     ros2 service call /Ros2Supervisor/spawn_node_from_string webots_ros2_msgs/srv/SpawnNodeFromString "data: Robot { name \"imported_robot\" }"
 
 .. note::
-    If you try to import some PROTOs in the node string, their respective URLs must be declared in the .wbt world file as EXTERNPROTO or as IMPORTABLE EXTERNPROTO.
+    If you try to import some PROTOs in the node string, their respective URLs must be declared in the ``.wbt`` world file as EXTERNPROTO or as IMPORTABLE EXTERNPROTO.
 
 .. _Remove a Webots imported node:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -149,7 +149,7 @@ Source an underlay
 ^^^^^^^^^^^^^^^^^^
 
 It is important that we have sourced the environment for an existing ROS 2 installation that will provide our workspace with the necessary build dependencies for the example packages.
-This is achieved by sourcing the setup script provided by a binary installation or a source installation, ie. another colcon workspace (see :doc:`Installation <../../Installation>`).
+This is achieved by sourcing the setup script provided by a binary installation or a source installation, i.e. another colcon workspace (see :doc:`Installation <../../Installation>`).
 We call this environment an **underlay**.
 
 Our workspace, ``ros2_ws``, will be an **overlay** on top of the existing ROS 2 installation.

--- a/source/Tutorials/Demos/Quality-of-Service.rst
+++ b/source/Tutorials/Demos/Quality-of-Service.rst
@@ -159,9 +159,9 @@ Add network traffic
 
    This next section is Linux-specific.
 
-   However, for macOS and Windows you can achieve a similar effect with the utilities "Network Link Conditioner" (part of the xcode tool suite) and "Clumsy" (http://jagt.github.io/clumsy/index.html), respectively, but they will not be covered in this tutorial.
+   However, for macOS and Windows you can achieve a similar effect with the utilities "Network Link Conditioner" (part of the xcode tool suite) and `"Clumsy" <http://jagt.github.io/clumsy/index.html>`_, respectively, but they will not be covered in this tutorial.
 
-We are going to use the Linux network traffic control utility, ``tc`` (http://linux.die.net/man/8/tc).
+We are going to use the Linux network traffic control utility, ``tc`` (`man page <http://linux.die.net/man/8/tc>`_) .
 
 .. code-block:: bash
 

--- a/source/Tutorials/Demos/dummy-robot-demo.rst
+++ b/source/Tutorials/Demos/dummy-robot-demo.rst
@@ -20,17 +20,21 @@ To start the demo, we execute the demo bringup launch file, which we are going t
 
   .. group-tab:: Source Build
 
-    mkdir -p ~/ros2_ws/src
-    cd ~/ros2_ws/src
-    git clone -b ${ROS_DISTRO} https://github.com/ros2/demos
-    cd .. && colcon build --packages-up-to dummy_robot_bringup
-    source ~/ros2_ws/install/setup.bash
-    ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
+    .. code-block:: bash
+
+       mkdir -p ~/ros2_ws/src
+       cd ~/ros2_ws/src
+       git clone -b ${ROS_DISTRO} https://github.com/ros2/demos
+       cd .. && colcon build --packages-up-to dummy_robot_bringup
+       source ~/ros2_ws/install/setup.bash
+       ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
 
   .. group-tab:: deb Package
 
-    sudo apt install ros-${ROS_DISTRO}-dummy-robot-bringup
-    ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
+    .. code-block:: bash
+
+       sudo apt install ros-${ROS_DISTRO}-dummy-robot-bringup
+       ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
 
 You should see some prints inside your terminal along the lines of the following:
 

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -235,7 +235,7 @@ Now run the node:
      ros2 run cpp_parameter_event_handler parameter_event_handler
 
 The node is now active and has a single parameter and will print a message whenever this parameter is updated.
-To test this, open up another terminal and source the ROS setup file as before (. install/setup.bash) and execute the following command:
+To test this, open up another terminal and source the ROS setup file as before (``. install/setup.bash``) and execute the following command:
 
 .. code-block:: console
 

--- a/source/Tutorials/Intermediate/URDF/Adding-Physical-and-Collision-Properties-to-a-URDF-Model.rst
+++ b/source/Tutorials/Intermediate/URDF/Adding-Physical-and-Collision-Properties-to-a-URDF-Model.rst
@@ -54,9 +54,9 @@ Here is the code for our new base link.
 In many cases, you’ll want the collision geometry and origin to be exactly the same as the visual geometry and origin.
 However, there are two main cases where you wouldn’t:
 
- * **Quicker Processing**. Doing collision detection for two meshes is a lot more computational complex than for two simple geometries.
+ * **Quicker Processing** Doing collision detection for two meshes is a lot more computational complex than for two simple geometries.
    Hence, you may want to replace the meshes with simpler geometries in the collision element.
- * **Safe Zones**. You may want to restrict movement close to sensitive equipment.
+ * **Safe Zones** You may want to restrict movement close to sensitive equipment.
    For instance, if we didn’t want anything to collide with R2D2’s head, we might define the collision geometry to be a cylinder encasing his head to prevent anything from getting too close to his head.
 
 Physical Properties

--- a/source/Tutorials/Intermediate/URDF/Building-a-Visual-Robot-Model-with-URDF-from-Scratch.rst
+++ b/source/Tutorials/Intermediate/URDF/Building-a-Visual-Robot-Model-with-URDF-from-Scratch.rst
@@ -187,7 +187,7 @@ We also rotate the leg so it is upright.
 * The launch file runs packages that will create TF frames for each link in your model based on your URDF.
   Rviz uses this information to figure out where to display each shape.
 * If a TF frame does not exist for a given URDF link, then it will be placed at the origin in white
-  (ref. `related question <http://answers.ros.org/question/207947/how-do-you-use-externally-defined-materials-in-a-urdfxacro-file/>`_).
+  (`related question <http://answers.ros.org/question/207947/how-do-you-use-externally-defined-materials-in-a-urdfxacro-file/>`_).
 
 Material Girl
 -------------

--- a/source/Tutorials/Miscellaneous/Building-Realtime-rt_preempt-kernel-for-ROS-2.rst
+++ b/source/Tutorials/Miscellaneous/Building-Realtime-rt_preempt-kernel-for-ROS-2.rst
@@ -10,7 +10,7 @@ This tutorial begins with a clean Ubuntu 20.04.1 install on Intel x86_64.
 Actual kernel is 5.4.0-54-generic, but we will install the Latest Stable RT_PREEMPT Version.
 To build the kernel you need at least 30GB free disk space.
 
-Check https://wiki.linuxfoundation.org/realtime/start for the latest stable version, at the time of writing this is "Latest Stable Version 5.4-rt".
+Check `this wiki <https://wiki.linuxfoundation.org/realtime/start>`_ for the latest stable version, at the time of writing this is "Latest Stable Version 5.4-rt".
 If we click on the `link <http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/>`_, we get the exact version.
 Currently it is patch-5.4.78-rt44.patch.gz.
 
@@ -28,7 +28,7 @@ and switch into it with
 
    cd ~/kernel
 
-We can go with a browser to https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/ and see if the version is there.
+We can go with a browser to `this page <https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/>`_ and see if the version is there.
 You can download it from the site and move it manually from /Downloads to the /kernel folder, or download it using wget by right clicking the link using "copy link location".
 Example:
 
@@ -42,7 +42,7 @@ unpack it with
 
    tar -xzf linux-5.4.78.tar.gz
 
-download rt_preempt patch matching the Kernel version we just downloaded over at http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/
+download rt_preempt patch matching the Kernel version we just downloaded over at `kernel.org <http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/>`_
 
 .. code-block:: bash
 

--- a/source/Tutorials/Miscellaneous/Deploying-ROS-2-on-IBM-Cloud.rst
+++ b/source/Tutorials/Miscellaneous/Deploying-ROS-2-on-IBM-Cloud.rst
@@ -226,7 +226,7 @@ Here, I used *ros2nasr*.
 IBM cloud has a lot of shortcuts that would help us get our container onto the cloud right away.
 The command below builds the container and tags it with the name **ros2foxy** and the version of **1**.
 Make sure you use the correct registry name you created and you are free to change the container name as you wish.
-The **.** at the end indicates that the *Dockerfile* is in the current directory (and it is important), if not,
+The ``.`` at the end indicates that the *Dockerfile* is in the current directory (and it is important), if not,
 change it to point to the directory containing the Dockerfile.
 
 .. code-block:: bash

--- a/source/Tutorials/Miscellaneous/Eclipse-Oxygen-with-ROS-2-and-rviz2.rst
+++ b/source/Tutorials/Miscellaneous/Eclipse-Oxygen-with-ROS-2-and-rviz2.rst
@@ -13,7 +13,7 @@ Using Eclipse Oxygen with ``rviz2`` [community-contributed]
 Setup
 -----
 
-This tutorial assumes Eclipse Oxygen, git, and Egit (http://www.eclipse.org/egit/download/) are already installed.
+This tutorial assumes Eclipse Oxygen, git, and `Egit <http://www.eclipse.org/egit/download/>`_ are already installed.
 
 Throughout the tutorial we name the eclipse workspace the same name as the ros2 package, but this is not required.
 


### PR DESCRIPTION
In order to get automated tooling for one-sentence-per-line checking to work, I've had to make a few other edits that aren't just whitespace based. 

 * Convert "eg." to "e.g."
 * Escape various file formats and commands, i.e. ".iso image" becomes "``.iso`` image"
 * Change raw link texts to actual links. 
 * Remove some added spurious periods just to limit corner cases. 
 * Add a missing formatting block

cc: @fujitatomoya 