### PR TITLE
Added missing Output:  in Using-Node-Interfaces-Template-Class.rst 

### DIFF
--- a/source/Tutorials/Intermediate/Using-Node-Interfaces-Template-Class.rst
+++ b/source/Tutorials/Intermediate/Using-Node-Interfaces-Template-Class.rst
@@ -107,6 +107,8 @@ We then create two nodes of type ``rclcpp_lifecycle::LifecycleNode`` and ``rclcp
       node_info(lc_node->get_node_base_interface(),lc_node->get_node_logging_interface());
     }
 
+Output:
+
 .. code-block:: console
 
     [INFO] [Simple_Node]: Node name: Simple_Node


### PR DESCRIPTION
Added missing ``Output:`` before the console output for consistency.

```diff
+Output:
+
```
before 
```
[INFO] [Simple_Node]: Node name: Simple_Node 
[INFO] [Simple_LifeCycle_Node]: Node name: Simple_LifeCycle_Node
```