### PR TITLE
Add macros to link to interface docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Test doc8
         run: make test
 
+      - name: Test doc tools
+        run: make test-tools
+
   lint:
     runs-on: ubuntu-22.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ lint:
 test:
 	doc8 --ignore D001 --ignore-path build
 
+test-tools:
+	$(PYTHON) -m pytest test/
+
 spellcheck:
 	git ls-files '*.md' '*.rst' | xargs codespell --config codespell.cfg
 
@@ -36,4 +39,4 @@ linkcheck:
 	@echo
 	@echo "Check finished. Report is in $(LINKCHECKDIR)."
 
-.PHONY: help Makefile multiversion test linkcheck
+.PHONY: help Makefile multiversion test test-unit linkcheck

--- a/conf.py
+++ b/conf.py
@@ -19,8 +19,11 @@
 
 import itertools
 import os
+import re
 import sys
 import time
+from typing import Dict
+from typing import Text
 
 from docutils.parsers.rst import Directive
 
@@ -316,8 +319,8 @@ def github_link_rewrite_branch(app, pagename, templatename, context, doctree):
 
 def expand_macros(app, docname, source):
     result = source[0]
-    for key, value in app.config.macros.items():
-        result = result.replace(f'{{{key}}}', value)
+    result = expand_interface_macros(result)
+    result = expand_text_macros(result, app.config.macros)
     source[0] = result
 
 def setup(app):
@@ -327,3 +330,60 @@ def setup(app):
     app.add_config_value('smv_eol_versions', [], 'html')
     app.add_config_value('macros', {}, True)
     RedirectFrom.register(app)
+
+# Regex to match 'pkg_msgs/msg/Msg' and extract (1) 'pkg_msgs' and (2) 'msg/Msg'
+interface_name_exp = r'([A-z0-9_]+)/((?:(msg|srv|action)/[A-z0-9_]+))'
+# Regex for '{interface_link(...)}' with an interface name
+interface_link_regex = re.compile(r'{interface_link\(' + interface_name_exp + r'\)}')
+# Regex for '{interface(...)}' with an interface name
+interface_regex = re.compile(r'{interface\(' + interface_name_exp + r'\)}')
+
+# Template for the link to the interface documentation (msg, srv, action)
+# See: https://github.com/ros-infrastructure/rosdoc2/blob/2aa71ea9582c31a553516b7273579e7733dc9673/rosdoc2/verbs/build/builders/sphinx_builder.py#L559-L564
+interface_link_templ = 'https://docs.ros.org/en/{{DISTRO}}/p/{pkg_name}/{interface_rel_name}.html'
+# Template for an RST link to the interface documentation
+interface_rst_link_templ = f'`{{interface_name}} <{interface_link_templ}>`_'
+
+def expand_interface_macros(text: Text) -> Text:
+    """
+    Expand `{interface()}` and `{interface_link()}` macros.
+
+    Uses the `{DISTRO}` macro in its expansion, so it has to be expanded after with
+    `expand_text_macros()`.
+
+    :param text: the text to expand
+    :return: the expanded text
+    """
+    def expand(text: Text, regex: re.Pattern, interface_tmpl: str) -> Text:
+        while match := regex.search(text):
+            pkg_name = match.group(1)
+            interface_rel_name = match.group(2)
+            interface_name = f'{pkg_name}/{interface_rel_name}'
+            link = interface_tmpl.format(
+                interface_name=interface_name,
+                pkg_name=pkg_name,
+                interface_rel_name=interface_rel_name,
+            )
+            text = text.replace(match.group(0), link)
+        return text
+
+    # {interface()}
+    text = expand(text, interface_regex, interface_rst_link_templ)
+    # {interface_link()}
+    text = expand(text, interface_link_regex, interface_link_templ)
+    return text
+
+def expand_text_macros(text: Text, macros: Dict[Text, Text]) -> Text:
+    """
+    Expand text macros.
+
+    For example, `{DISTRO}` gets expanded to `rolling` if `DISTRO` is set to `rolling`.
+
+    :param text: the text to expand
+    :param macros: the mapping from macro name to value to use for expansion
+    :return: the expanded text
+    """
+    # Expand simple {macros}
+    for key, value in macros.items():
+        text = text.replace(f'{{{key}}}', value)
+    return text

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,6 +13,7 @@ pbr==5.8.0
 polib==1.2.0
 Pygments==2.17.2
 pyparsing==2.4.7
+pytest==8.3.5
 pytz==2022.1
 requests==2.25.1
 restructuredtext_lint==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ codespell
 doc8
 docutils
 pip
+pytest
 sphinx
 sphinx-copybutton
 sphinx-lint

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -106,6 +106,12 @@ You can run the documentation tests locally (using `doc8 <https://github.com/PyC
 
    make test
 
+You can run the Python documentation tools tests locally (using `pytest <https://docs.pytest.org/en/stable/>`_) with the following command:
+
+.. code-block:: console
+
+   make test-tools
+
 You can run the documentation linter locally (using `sphinx-lint <https://github.com/sphinx-contrib/sphinx-lint>`_) with the following command:
 
 .. code-block:: console
@@ -549,14 +555,29 @@ Macros can be used to simplify writing documentation that targets multiple distr
 Use a macro by including the macro name in curly braces.
 For example, when generating the docs for Rolling on the ``rolling`` branch:
 
+.. list-table::
+   :header-rows: 1
 
-=====================  =====================  ==================================
-Use                    Becomes (for Rolling)  Example
-=====================  =====================  ==================================
-\{DISTRO\}             rolling                ros-\{DISTRO\}-pkg
-\{DISTRO_TITLE\}       Rolling                ROS 2 \{DISTRO_TITLE\}
-\{DISTRO_TITLE_FULL\}  Rolling Ridley         ROS 2 \{DISTRO_TITLE_FULL\}
-\{REPOS_FILE_BRANCH\}  rolling                git checkout \{REPOS_FILE_BRANCH\}
-=====================  =====================  ==================================
+   * - Macro
+     - Example
+     - Becomes (for {DISTRO_TITLE})
+   * - \{DISTRO\}
+     - ros-\{DISTRO\}-pkg
+     - ros-{DISTRO}-pkg
+   * - \{DISTRO_TITLE\}
+     - ROS 2 \{DISTRO_TITLE\}
+     - ROS 2 {DISTRO_TITLE}
+   * - \{DISTRO_TITLE_FULL\}
+     - ROS 2 \{DISTRO_TITLE_FULL\}
+     - ROS 2 {DISTRO_TITLE_FULL}
+   * - \{REPOS_FILE_BRANCH\}
+     - git checkout \{REPOS_FILE_BRANCH\}
+     - git checkout {REPOS_FILE_BRANCH}
+   * - \{interface_link(std_msgs/msg/String)\}
+     - See: \{interface_link(std_msgs/msg/String)\}.
+     - See: {interface_link(std_msgs/msg/String)}.
+   * - \{interface(std_msgs/msg/String)\}
+     - Publish a \{interface(std_msgs/msg/String)\}.
+     - Publish a {interface(std_msgs/msg/String)}.
 
 The same file can be used on multiple branches (i.e., for multiple distros) and the generated content will be distro-specific.

--- a/source/Tutorials/Intermediate/Publishing-Messages-Using-YAML-Files.rst
+++ b/source/Tutorials/Intermediate/Publishing-Messages-Using-YAML-Files.rst
@@ -14,7 +14,7 @@ Publishing messages using YAML files
 Overview
 --------
 
-Publishing ROS 2 messages via CLI is straightforward for simple types like `std_msgs/msg/Bool <https://docs.ros.org/en/{DISTRO}/p/std_msgs/interfaces/msg/Bool.html>`_ or `std_msgs/msg/String <https://docs.ros.org/en/{DISTRO}/p/std_msgs/interfaces/msg/String.html>`_.
+Publishing ROS 2 messages via CLI is straightforward for simple types like {interface(std_msgs/msg/Bool)} or {interface(std_msgs/msg/String)}.
 However, it becomes tedious for complex message structures.
 This tutorial demonstrates how to use ``ros2 echo`` and ``ros2 pub`` with YAML files to record, edit, and replay topic data efficiently.
 
@@ -28,7 +28,7 @@ This tutorial uses concepts like ROS 2 topics and CLI tools covered in the follo
 Tasks
 -----
 
-We assume that an entity is publishing a ``geometry_msgs/msg/Twist`` message through a topic named ``cmd_vel`` and we want to capture the message, edit it and publish it to a topic.
+We assume that an entity is publishing a {interface(geometry_msgs/msg/Twist)} message through a topic named ``cmd_vel`` and we want to capture the message, edit it and publish it to a topic.
 We can use the ``echo`` verb to capture the message and save it in a YAML file ``cmd_vel.yaml`` using the output redirection operator ``>``.
 
 .. code-block:: console
@@ -50,7 +50,7 @@ This creates a ``cmd_vel.yaml`` file with the following content in the directory
     ---
 
 To publish a message, we utilize the ``--yaml-file`` option available with the ``pub`` verb of the ``ros2 topic`` command.
-First, we specify the target topic—in this case, ``/cmd_vel``, followed by the message type ``geometry_msgs/msg/Twist``.
+First, we specify the target topic—in this case, ``/cmd_vel``, followed by the message type {interface(geometry_msgs/msg/Twist)}.
 Lastly, we specify the YAML file containing the message data.
 The following command will publish the message contained in the ``YAML`` file to the designated ``topic`` once.
 

--- a/source/Tutorials/Intermediate/RViz/Marker-Display-types/Marker-Display-types.rst
+++ b/source/Tutorials/Intermediate/RViz/Marker-Display-types/Marker-Display-types.rst
@@ -132,7 +132,7 @@ The messages in this package include comments that are helpful in understanding 
 
 * ``lifetime``:
 
-    A `duration message value <https://docs.ros.org/en/ros2_packages/{DISTRO}/api/builtin_interfaces/interfaces/msg/Duration.html>`_ used to automatically delete the marker after this period of time.
+    A `duration message value <{interface_link(builtin_interfaces/msg/Duration)}>`_ used to automatically delete the marker after this period of time.
     The countdown resets if another marker of the same ``namespace`` / ``id`` is received.
 
 * ``frame_locked``:

--- a/test/test_macros.py
+++ b/test/test_macros.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+import sys
+
+# Workaround to be able to import conf without it being a proper module
+sys.path.append('..')
+
+from conf import expand_interface_macros
+from conf import expand_text_macros
+
+
+def test_text_macros() -> None:
+    macros = {
+        'DISTRO': 'rolling',
+        'some_macro_name': 'some_value',
+    }
+    text = textwrap.dedent("""
+        The current distro is: {DISTRO}.
+
+        This line does not use macros.
+        The value of some_macro_name is: {some_macro_name}.
+    """)
+    expected = textwrap.dedent("""
+        The current distro is: rolling.
+
+        This line does not use macros.
+        The value of some_macro_name is: some_value.
+    """)
+    assert expected == expand_text_macros(text, macros)
+
+
+def test_interface_macros() -> None:
+    macros = {
+        'DISTRO': 'rolling',
+    }
+    text = textwrap.dedent("""
+        Publish a {interface(pkg_msgs/msg/Msg)}.
+
+        For more information, refer to `its definition <{interface_link(pkg_msgs/msg/Msg)}>`_.
+    """)
+    expected = textwrap.dedent("""
+        Publish a `pkg_msgs/msg/Msg <https://docs.ros.org/en/rolling/p/pkg_msgs/msg/Msg.html>`_.
+
+        For more information, refer to `its definition <https://docs.ros.org/en/rolling/p/pkg_msgs/msg/Msg.html>`_.
+    """)
+    # Expanded interface macros use the DISTRO text macro, so those need to be expanded too
+    assert expected == expand_text_macros(expand_interface_macros(text), macros)


### PR DESCRIPTION
While reviewing #5034, I realized/remembered that we now have interface (e.g., message) docs in ROS 2 like we had in ROS 1:

* ROS 1: http://docs.ros.org/en/melodic/api/std_msgs/html/msg/String.html
* ROS 2: https://docs.ros.org/en/rolling/p/std_msgs/msg/String.html

Having this for ROS 2 is quite useful, and we can use it in many places instead of linking to the source files, like we currently do [in this tutorial](https://github.com/ros2/ros2_documentation/blob/b292465155f10e6125e308e22d8c53cd1fdcdb80/source/Tutorials/Intermediate/RViz/RViz-User-Guide/RViz-User-Guide.rst#L98-L162) (and others).

However, I also realized that the path was a bit different depending on the distro, see https://github.com/ros2/ros2_documentation/pull/5034#discussion_r1958656993. While that is probably just a result of a different version of `rosdoc2` being used for different distros at possibly different times (see [`rosdoc2/verbs/build/generate_interface_docs.py`](https://github.com/ros-infrastructure/rosdoc2/blob/cc5822aa53c44790b6d311701da2068bd5e5e2fb/rosdoc2/verbs/build/generate_interface_docs.py)), I think we could abstract the link away from the documentation writer using [macros similar to the ones we currently have](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.html#macros).

----

This PR introduces two macros: (1) `interface_link()` and (2) `interface()`. They each take the interface name as a parameter and expand to the (1) the link to the interface doc page and (2) the interface name hyperlinked to its interface doc page.

| Macro | Example | Becomes (for Rolling)* |
| -------- | ------------ | ------------------------------|
| `{interface_link(std_msgs/msg/String)}` | `See: {interface_link(std_msgs/msg/String)}.` | See: https://docs.ros.org/en/rolling/p/std_msgs/msg/String.html. |
| `{interface(std_msgs/msg/String)}` | `Publish a {interface(std_msgs/msg/String)}.` | Publish a [std_msgs/msg/String](https://docs.ros.org/en/rolling/p/std_msgs/msg/String.html). |

_(*) formatted as markdown in this PR description for demonstration purposes, but the result is the same_

`interface()` exists for simple links with the interface name only, while `interface_link()` could be used anywhere, including more complex RST links, such as:

```rst
Publish `a geometry_msgs/msg/Twist message <{interface_link(geometry_msgs/msg/Twist)}>`_.
```

See the changes to `source/Tutorials/Intermediate/Publishing-Messages-Using-YAML-Files.rst` and `source/Tutorials/Intermediate/RViz/Marker-Display-types/Marker-Display-types.rst` for concrete examples.

This is valid for messages, services, and actions:

* https://docs.ros.org/en/rolling/p/std_msgs/msg/Bool.html
* https://docs.ros.org/en/rolling/p/std_srvs/srv/Empty.html
* https://docs.ros.org/en/rolling/p/test_msgs/action/NestedMessage.html

Notes:

1. This is implemented using regexes that are slightly more complex than the existing macros, but I believe it's still quite manageable.
2. The link template (`interface_link_templ`) could be customized for each distro [like we do for the existing macros](https://github.com/ros2/ros2_documentation/blob/b292465155f10e6125e308e22d8c53cd1fdcdb80/conf.py#L135-L153).
   * ~~TBD, will check if we expect this to be fixed to be all the same for all non-EOL distros.~~
       * I believe this is because docs jobs for packages are only triggered when the code changes (e.g., new commit), so some packages may have documentation that was generated using an older `rosdoc2` version.
       * This does mean that the location of an interface file in the API docs could be different in a single distro, but I assume that this isn't really going to change.
3. Downsides/limitations:
   1. Due to an RST limitation, we cannot _easily_ make the interface name both a hyperlink and a `literal`, although we could find a way around it, especially if we hide away the ugly details.
   2. On its own, this doesn't actually check if the generated URL is valid, but it could be combined with a URL validation tool.

Future work:

1. Apply this to the rest of the docs
2. This could also be extended to link to package docs
    * Example: `See {package(rclcpp)}` expanding to "See [rclcpp](https://docs.ros.org/en/rolling/p/rclcpp/)"