### PR TITLE
Fix a WARNING when building the Using-Python-Packages file.

### DIFF
--- a/source/How-To-Guides/Using-Python-Packages.rst
+++ b/source/How-To-Guides/Using-Python-Packages.rst
@@ -78,7 +78,7 @@ Then setup your virtual environment:
     # Make a virtual env and activate it
     virtualenv -p python3 ./venv
     source ./venv/bin/activate
-    # Make sure that colcon doesn't try to build the venv
+    # Make sure that colcon does not try to build the venv
     touch ./venv/COLCON_IGNORE
 
 Next, install the Python packages that you want in your virtual environment:


### PR DESCRIPTION
Sphinx doesn't seem to like an unclosed single-quote in the console text, and prints a "Lexing literal_block" warning. Fix that here by getting rid of the contraction.

This should fix the WARNING seen in e.g. https://build.ros.org/job/doc_ros2doc/1629/consoleFull