### PR TITLE
Add Emerson Knapp to list of ROS Committers

### DIFF
--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -157,6 +157,10 @@ The ROS committers (who are not also part of the ROS PMC) consists of the follow
      - `Intrinsic <https://www.intrinsic.ai/>`_
      - `tfoote <https://github.com/tfoote>`_
      - PST (UTC-8)/PDT (UTC-7)
+   * - Emerson Knapp
+     - `Polymath Robotics <https://www.polymathrobotics.com/>`_
+     - `emersonknapp <https://github.com/emersonknapp/>`_
+     - PST (UTC-8)/PDT (UTC-7)
 
 Past ROS PMC Constituents
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -141,6 +141,10 @@ The ROS committers (who are not also part of the ROS PMC) consists of the follow
      - `Intrinsic <https://www.intrinsic.ai/>`_
      - `quarkytale <https://github.com/quarkytale>`_
      - PST (UTC-8)/PDT (UTC-7)
+   * - Emerson Knapp
+     - `Polymath Robotics <https://www.polymathrobotics.com/>`_
+     - `emersonknapp <https://github.com/emersonknapp/>`_
+     - PST (UTC-8)/PDT (UTC-7)
    * - Kat Scott
      - `Intrinsic <https://www.intrinsic.ai/>`_
      - `kscottz <https://github.com/kscottz>`_
@@ -156,10 +160,6 @@ The ROS committers (who are not also part of the ROS PMC) consists of the follow
    * - Tully Foote
      - `Intrinsic <https://www.intrinsic.ai/>`_
      - `tfoote <https://github.com/tfoote>`_
-     - PST (UTC-8)/PDT (UTC-7)
-   * - Emerson Knapp
-     - `Polymath Robotics <https://www.polymathrobotics.com/>`_
-     - `emersonknapp <https://github.com/emersonknapp/>`_
      - PST (UTC-8)/PDT (UTC-7)
 
 Past ROS PMC Constituents


### PR DESCRIPTION
I'm an approved committer on:

ros-tooling/keyboard_handler
ros-visualization/rqt_bag
ros2/rcl
ros2/rclcpp
ros2/rclpy
ros2/rosbag2
ros2/rosidl
ros2/rosidl_typesupport
ros2/rosidl_typesupport_fastrtps

But never got added to the website