### PR TITLE
Prefer XML/YAML over Python in 'Migrating Launch Files' guide

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
@@ -13,14 +13,16 @@ Migrating Launch Files
    :depth: 1
    :local:
 
-While launch files in ROS 1 are always specified using `xml <https://wiki.ros.org/roslaunch/XML>`__ files, ROS 2 supports Python scripts to enable more flexibility (see `launch package <https://github.com/ros2/launch/tree/{REPOS_FILE_BRANCH}/launch>`__) as well as XML and YAML files.
+While launch files in ROS 1 are always specified using `XML <https://wiki.ros.org/roslaunch/XML>`__ files, ROS 2 supports both XML and YAML files.
+ROS 2 also supports Python launch scripts to enable more flexibility (see `launch package <https://github.com/ros2/launch/tree/{REPOS_FILE_BRANCH}/launch>`__).
+However, for typical use cases, XML and YAML should be preferred over Python.
 
 This guide describes how to write ROS 2 XML launch files for an easy migration from ROS 1.
 
 Background
 ----------
 
-A description of the ROS 2 launch system and its Python API can be found in :doc:`Launch System tutorial <../../../Tutorials/Intermediate/Launch/Launch-system>`.
+A description of the ROS 2 launch system can be found in :doc:`Launch System tutorial <../../../Tutorials/Intermediate/Launch/Launch-system>`.
 
 
 Migrating tags


### PR DESCRIPTION
This is part of a general move towards making XML and YAML the "preferred" kinds of launch files over Python, since users generally find the Python API to be pretty complex, especially coming from ROS 1. For example: https://github.com/ros2/launch/issues/832#issuecomment-2718711722.

This PR changes the introduction of the "Migrating Launch Files" guide to be clear about XML and YAML being preferred over Python.