### PR TITLE
urdf_tutorial_cpp should use ament_cmake and depends on rclcpp.

### DIFF
--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-cpp.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-cpp.rst
@@ -45,7 +45,7 @@ Go to your ROS 2 workplace and create a package names ``urdf_tutorial_cpp``:
 .. code-block:: console
 
     cd src
-    ros2 pkg create --build-type ament_python --license Apache-2.0 urdf_tutorial_cpp --dependencies rclpy
+    ros2 pkg create --build-type ament_cmake --license Apache-2.0 urdf_tutorial_cpp --dependencies rclcpp
     cd urdf_tutorial_cpp
 
 You should now see a ``urdf_tutorial_cpp`` folder.


### PR DESCRIPTION
closes https://github.com/ros2/ros2_documentation/issues/5096

@jasonhouang @christophebedard can you review?