### PR TITLE
Make XML/YAML launch file examples default over Python

### DIFF
--- a/source/Concepts/Basic/About-Launch.rst
+++ b/source/Concepts/Basic/About-Launch.rst
@@ -12,7 +12,7 @@ It helps the user describe the configuration of their system and then executes i
 The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS-specific conventions which make it easy to reuse components throughout the system by giving them each a different configuration.
 It is also responsible for monitoring the state of the processes launched, and reporting and/or reacting to changes in the state of those processes.
 
-All of the above is specified in a launch file, which can be written in Python, XML, or YAML.
+All of the above is specified in a launch file, which can be written in XML, YAML, or Python.
 This launch file can then be run using the ``ros2 launch`` command, and all of the nodes specified will be run.
 
 The `design document <https://design.ros2.org/articles/roslaunch.html>`__ details the goal of the design of ROS 2's launch system (not all functionality is currently available).

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -9,13 +9,13 @@ Using Python, XML, and YAML for ROS 2 Launch Files
    :depth: 1
    :local:
 
-ROS 2 launch files can be written in Python, XML, and YAML.
+ROS 2 launch files can be written in XML, YAML, and Python.
 This guide shows how to use these different formats to accomplish the same task, as well as has some discussion on when to use each format.
 
 Launch file examples
 --------------------
 
-Below is a launch file implemented in Python, XML, and YAML.
+Below is a launch file implemented in XML, YAML, and Python.
 Each launch file performs the following actions:
 
 * Setup command line arguments with defaults
@@ -26,150 +26,6 @@ Each launch file performs the following actions:
 * Create a node to remap messages from one topic to another
 
 .. tabs::
-
-   .. group-tab:: Python
-
-      .. code-block:: python
-
-        # example_launch.py
-
-        import os
-
-        from ament_index_python import get_package_share_directory
-
-        from launch import LaunchDescription
-        from launch.actions import DeclareLaunchArgument
-        from launch.actions import GroupAction
-        from launch.actions import IncludeLaunchDescription
-        from launch.launch_description_sources import PythonLaunchDescriptionSource
-        from launch.substitutions import LaunchConfiguration
-        from launch.substitutions import TextSubstitution
-        from launch_ros.actions import Node
-        from launch_ros.actions import PushROSNamespace
-        from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
-        from launch_yaml.launch_description_sources import YAMLLaunchDescriptionSource
-
-
-        def generate_launch_description():
-
-            # args that can be set from the command line or a default will be used
-            background_r_launch_arg = DeclareLaunchArgument(
-                "background_r", default_value=TextSubstitution(text="0")
-            )
-            background_g_launch_arg = DeclareLaunchArgument(
-                "background_g", default_value=TextSubstitution(text="255")
-            )
-            background_b_launch_arg = DeclareLaunchArgument(
-                "background_b", default_value=TextSubstitution(text="0")
-            )
-            chatter_py_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_py_ns", default_value=TextSubstitution(text="chatter/py/ns")
-            )
-            chatter_xml_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_xml_ns", default_value=TextSubstitution(text="chatter/xml/ns")
-            )
-            chatter_yaml_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_yaml_ns", default_value=TextSubstitution(text="chatter/yaml/ns")
-            )
-
-            # include another launch file
-            launch_include = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(
-                        get_package_share_directory('demo_nodes_cpp'),
-                        'launch/topics/talker_listener_launch.py'))
-            )
-            # include a Python launch file in the chatter_py_ns namespace
-            launch_py_include_with_namespace = GroupAction(
-                actions=[
-                    # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushROSNamespace('chatter_py_ns'),
-                    IncludeLaunchDescription(
-                        PythonLaunchDescriptionSource(
-                            os.path.join(
-                                get_package_share_directory('demo_nodes_cpp'),
-                                'launch/topics/talker_listener_launch.py'))
-                    ),
-                ]
-            )
-
-            # include a xml launch file in the chatter_xml_ns namespace
-            launch_xml_include_with_namespace = GroupAction(
-                actions=[
-                    # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushROSNamespace('chatter_xml_ns'),
-                    IncludeLaunchDescription(
-                        XMLLaunchDescriptionSource(
-                            os.path.join(
-                                get_package_share_directory('demo_nodes_cpp'),
-                                'launch/topics/talker_listener_launch.xml'))
-                    ),
-                ]
-            )
-
-            # include a yaml launch file in the chatter_yaml_ns namespace
-            launch_yaml_include_with_namespace = GroupAction(
-                actions=[
-                    # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushROSNamespace('chatter_yaml_ns'),
-                    IncludeLaunchDescription(
-                        YAMLLaunchDescriptionSource(
-                            os.path.join(
-                                get_package_share_directory('demo_nodes_cpp'),
-                                'launch/topics/talker_listener_launch.yaml'))
-                    ),
-                ]
-            )
-
-            # start a turtlesim_node in the turtlesim1 namespace
-            turtlesim_node = Node(
-                package='turtlesim',
-                namespace='turtlesim1',
-                executable='turtlesim_node',
-                name='sim'
-            )
-
-            # start another turtlesim_node in the turtlesim2 namespace
-            # and use args to set parameters
-            turtlesim_node_with_parameters = Node(
-                package='turtlesim',
-                namespace='turtlesim2',
-                executable='turtlesim_node',
-                name='sim',
-                parameters=[{
-                    "background_r": LaunchConfiguration('background_r'),
-                    "background_g": LaunchConfiguration('background_g'),
-                    "background_b": LaunchConfiguration('background_b'),
-                }]
-            )
-
-            # perform remap so both turtles listen to the same command topic
-            forward_turtlesim_commands_to_second_turtlesim_node = Node(
-                package='turtlesim',
-                executable='mimic',
-                name='mimic',
-                remappings=[
-                    ('/input/pose', '/turtlesim1/turtle1/pose'),
-                    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                ]
-            )
-
-            return LaunchDescription([
-                background_r_launch_arg,
-                background_g_launch_arg,
-                background_b_launch_arg,
-                chatter_py_ns_launch_arg,
-                chatter_xml_ns_launch_arg,
-                chatter_yaml_ns_launch_arg,
-                launch_include,
-                launch_py_include_with_namespace,
-                launch_xml_include_with_namespace,
-                launch_yaml_include_with_namespace,
-                turtlesim_node,
-                turtlesim_node_with_parameters,
-                forward_turtlesim_commands_to_second_turtlesim_node,
-            ])
-
 
    .. group-tab:: XML
 
@@ -315,6 +171,149 @@ Each launch file performs the following actions:
                 from: "/output/cmd_vel"
                 to: "/turtlesim2/turtle1/cmd_vel"
 
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+        # example_launch.py
+
+        import os
+
+        from ament_index_python import get_package_share_directory
+
+        from launch import LaunchDescription
+        from launch.actions import DeclareLaunchArgument
+        from launch.actions import GroupAction
+        from launch.actions import IncludeLaunchDescription
+        from launch.launch_description_sources import PythonLaunchDescriptionSource
+        from launch.substitutions import LaunchConfiguration
+        from launch.substitutions import TextSubstitution
+        from launch_ros.actions import Node
+        from launch_ros.actions import PushROSNamespace
+        from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
+        from launch_yaml.launch_description_sources import YAMLLaunchDescriptionSource
+
+
+        def generate_launch_description():
+
+            # args that can be set from the command line or a default will be used
+            background_r_launch_arg = DeclareLaunchArgument(
+                "background_r", default_value=TextSubstitution(text="0")
+            )
+            background_g_launch_arg = DeclareLaunchArgument(
+                "background_g", default_value=TextSubstitution(text="255")
+            )
+            background_b_launch_arg = DeclareLaunchArgument(
+                "background_b", default_value=TextSubstitution(text="0")
+            )
+            chatter_py_ns_launch_arg = DeclareLaunchArgument(
+                "chatter_py_ns", default_value=TextSubstitution(text="chatter/py/ns")
+            )
+            chatter_xml_ns_launch_arg = DeclareLaunchArgument(
+                "chatter_xml_ns", default_value=TextSubstitution(text="chatter/xml/ns")
+            )
+            chatter_yaml_ns_launch_arg = DeclareLaunchArgument(
+                "chatter_yaml_ns", default_value=TextSubstitution(text="chatter/yaml/ns")
+            )
+
+            # include another launch file
+            launch_include = IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(
+                        get_package_share_directory('demo_nodes_cpp'),
+                        'launch/topics/talker_listener_launch.py'))
+            )
+            # include a Python launch file in the chatter_py_ns namespace
+            launch_py_include_with_namespace = GroupAction(
+                actions=[
+                    # push_ros_namespace first to set namespace of included nodes for following actions
+                    PushROSNamespace('chatter_py_ns'),
+                    IncludeLaunchDescription(
+                        PythonLaunchDescriptionSource(
+                            os.path.join(
+                                get_package_share_directory('demo_nodes_cpp'),
+                                'launch/topics/talker_listener_launch.py'))
+                    ),
+                ]
+            )
+
+            # include a xml launch file in the chatter_xml_ns namespace
+            launch_xml_include_with_namespace = GroupAction(
+                actions=[
+                    # push_ros_namespace first to set namespace of included nodes for following actions
+                    PushROSNamespace('chatter_xml_ns'),
+                    IncludeLaunchDescription(
+                        XMLLaunchDescriptionSource(
+                            os.path.join(
+                                get_package_share_directory('demo_nodes_cpp'),
+                                'launch/topics/talker_listener_launch.xml'))
+                    ),
+                ]
+            )
+
+            # include a yaml launch file in the chatter_yaml_ns namespace
+            launch_yaml_include_with_namespace = GroupAction(
+                actions=[
+                    # push_ros_namespace first to set namespace of included nodes for following actions
+                    PushROSNamespace('chatter_yaml_ns'),
+                    IncludeLaunchDescription(
+                        YAMLLaunchDescriptionSource(
+                            os.path.join(
+                                get_package_share_directory('demo_nodes_cpp'),
+                                'launch/topics/talker_listener_launch.yaml'))
+                    ),
+                ]
+            )
+
+            # start a turtlesim_node in the turtlesim1 namespace
+            turtlesim_node = Node(
+                package='turtlesim',
+                namespace='turtlesim1',
+                executable='turtlesim_node',
+                name='sim'
+            )
+
+            # start another turtlesim_node in the turtlesim2 namespace
+            # and use args to set parameters
+            turtlesim_node_with_parameters = Node(
+                package='turtlesim',
+                namespace='turtlesim2',
+                executable='turtlesim_node',
+                name='sim',
+                parameters=[{
+                    "background_r": LaunchConfiguration('background_r'),
+                    "background_g": LaunchConfiguration('background_g'),
+                    "background_b": LaunchConfiguration('background_b'),
+                }]
+            )
+
+            # perform remap so both turtles listen to the same command topic
+            forward_turtlesim_commands_to_second_turtlesim_node = Node(
+                package='turtlesim',
+                executable='mimic',
+                name='mimic',
+                remappings=[
+                    ('/input/pose', '/turtlesim1/turtle1/pose'),
+                    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+                ]
+            )
+
+            return LaunchDescription([
+                background_r_launch_arg,
+                background_g_launch_arg,
+                background_b_launch_arg,
+                chatter_py_ns_launch_arg,
+                chatter_xml_ns_launch_arg,
+                chatter_yaml_ns_launch_arg,
+                launch_include,
+                launch_py_include_with_namespace,
+                launch_xml_include_with_namespace,
+                launch_yaml_include_with_namespace,
+                turtlesim_node,
+                turtlesim_node_with_parameters,
+                forward_turtlesim_commands_to_second_turtlesim_node,
+            ])
+
 Using the Launch files from the command line
 --------------------------------------------
 
@@ -359,6 +358,8 @@ To test that the remapping is working, you can control the turtles by running th
 
   ros2 run turtlesim turtle_teleop_key --ros-args --remap __ns:=/turtlesim1
 
+
+.. _launch-file-different-formats-which:
 
 Python, XML, or YAML: Which should I use?
 -----------------------------------------

--- a/source/How-To-Guides/Launching-composable-nodes.rst
+++ b/source/How-To-Guides/Launching-composable-nodes.rst
@@ -21,50 +21,13 @@ If you downloaded the archive or built ROS 2 from source, it will already be par
 Launch file examples
 --------------------
 
-Below is a launch file that launches composable nodes in Python, XML, and YAML.
+Below is a launch file that launches composable nodes in XML, YAML, and Python.
 The launch files all do the following:
 
 * Instantiate a cam2image composable node with remappings, custom parameters, and extra arguments
 * Instantiate a showimage composable node with remappings, custom parameters, and extra arguments
 
 .. tabs::
-
-  .. group-tab:: Python
-
-    .. code-block:: python
-
-      import launch
-      from launch_ros.actions import ComposableNodeContainer
-      from launch_ros.descriptions import ComposableNode
-
-
-      def generate_launch_description():
-          """Generate launch description with multiple components."""
-          container = ComposableNodeContainer(
-                  name='image_container',
-                  namespace='',
-                  package='rclcpp_components',
-                  executable='component_container',
-                  composable_node_descriptions=[
-                      ComposableNode(
-                          package='image_tools',
-                          plugin='image_tools::Cam2Image',
-                          name='cam2image',
-                          remappings=[('/image', '/burgerimage')],
-                          parameters=[{'width': 320, 'height': 240, 'burger_mode': True, 'history': 'keep_last'}],
-                          extra_arguments=[{'use_intra_process_comms': True}]),
-                      ComposableNode(
-                          package='image_tools',
-                          plugin='image_tools::ShowImage',
-                          name='showimage',
-                          remappings=[('/image', '/burgerimage')],
-                          parameters=[{'history': 'keep_last'}],
-                          extra_arguments=[{'use_intra_process_comms': True}])
-                  ],
-                  output='both',
-          )
-
-          return launch.LaunchDescription([container])
 
   .. group-tab:: XML
 
@@ -134,6 +97,43 @@ The launch files all do the following:
                           - name: use_intra_process_comms
                             value: 'true'
 
+  .. group-tab:: Python
+
+    .. code-block:: python
+
+      import launch
+      from launch_ros.actions import ComposableNodeContainer
+      from launch_ros.descriptions import ComposableNode
+
+
+      def generate_launch_description():
+          """Generate launch description with multiple components."""
+          container = ComposableNodeContainer(
+                  name='image_container',
+                  namespace='',
+                  package='rclcpp_components',
+                  executable='component_container',
+                  composable_node_descriptions=[
+                      ComposableNode(
+                          package='image_tools',
+                          plugin='image_tools::Cam2Image',
+                          name='cam2image',
+                          remappings=[('/image', '/burgerimage')],
+                          parameters=[{'width': 320, 'height': 240, 'burger_mode': True, 'history': 'keep_last'}],
+                          extra_arguments=[{'use_intra_process_comms': True}]),
+                      ComposableNode(
+                          package='image_tools',
+                          plugin='image_tools::ShowImage',
+                          name='showimage',
+                          remappings=[('/image', '/burgerimage')],
+                          parameters=[{'history': 'keep_last'}],
+                          extra_arguments=[{'use_intra_process_comms': True}])
+                  ],
+                  output='both',
+          )
+
+          return launch.LaunchDescription([container])
+
 
 Loading composable nodes into an existing container
 ---------------------------------------------------
@@ -144,46 +144,6 @@ For this, you may use ``LoadComposableNodes`` to load components into a given co
 The below example launches the same nodes as above.
 
 .. tabs::
-
-  .. group-tab:: Python
-
-    .. code-block:: python
-
-      from launch import LaunchDescription
-      from launch_ros.actions import LoadComposableNodes, Node
-      from launch_ros.descriptions import ComposableNode
-
-      def generate_launch_description():
-          container = Node(
-              name='image_container',
-              package='rclcpp_components',
-              executable='component_container',
-              output='both',
-          )
-
-          load_composable_nodes = LoadComposableNodes(
-              target_container='image_container',
-              composable_node_descriptions=[
-                  ComposableNode(
-                       package='image_tools',
-                      plugin='image_tools::Cam2Image',
-                      name='cam2image',
-                      remappings=[('/image', '/burgerimage')],
-                      parameters=[{'width': 320, 'height': 240, 'burger_mode': True, 'history': 'keep_last'}],
-                      extra_arguments=[{'use_intra_process_comms': True}],
-                  ),
-                  ComposableNode(
-                      package='image_tools',
-                      plugin='image_tools::ShowImage',
-                      name='showimage',
-                      remappings=[('/image', '/burgerimage')],
-                      parameters=[{'history': 'keep_last'}],
-                      extra_arguments=[{'use_intra_process_comms': True}]
-                  ),
-              ],
-          )
-
-          return LaunchDescription([container, load_composable_nodes])
 
   .. group-tab:: XML
 
@@ -254,6 +214,46 @@ The below example launches the same nodes as above.
                           - name: use_intra_process_comms
                             value: 'true'
 
+  .. group-tab:: Python
+
+    .. code-block:: python
+
+      from launch import LaunchDescription
+      from launch_ros.actions import LoadComposableNodes, Node
+      from launch_ros.descriptions import ComposableNode
+
+      def generate_launch_description():
+          container = Node(
+              name='image_container',
+              package='rclcpp_components',
+              executable='component_container',
+              output='both',
+          )
+
+          load_composable_nodes = LoadComposableNodes(
+              target_container='image_container',
+              composable_node_descriptions=[
+                  ComposableNode(
+                       package='image_tools',
+                      plugin='image_tools::Cam2Image',
+                      name='cam2image',
+                      remappings=[('/image', '/burgerimage')],
+                      parameters=[{'width': 320, 'height': 240, 'burger_mode': True, 'history': 'keep_last'}],
+                      extra_arguments=[{'use_intra_process_comms': True}],
+                  ),
+                  ComposableNode(
+                      package='image_tools',
+                      plugin='image_tools::ShowImage',
+                      name='showimage',
+                      remappings=[('/image', '/burgerimage')],
+                      parameters=[{'history': 'keep_last'}],
+                      extra_arguments=[{'use_intra_process_comms': True}]
+                  ),
+              ],
+          )
+
+          return LaunchDescription([container, load_composable_nodes])
+
 
 Using the Launch files from the command-line
 --------------------------------------------
@@ -274,4 +274,4 @@ For more information on what intra-process communications are, see the :doc:`int
 Python, XML, or YAML: Which should I use?
 -----------------------------------------
 
-See the discussion in :doc:`Launch-file-different-formats` for more information.
+See the :ref:`discussion <launch-file-different-formats-which>` in :doc:`Launch-file-different-formats` for more information.

--- a/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
+++ b/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
@@ -32,7 +32,7 @@ The launch system in ROS 2 is responsible for helping the user describe the conf
 The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS-specific conventions which make it easy to reuse components throughout the system by giving them each a different configuration.
 It is also responsible for monitoring the state of the processes launched, and reporting and/or reacting to changes in the state of those processes.
 
-Launch files written in Python, XML, or YAML can start and stop different nodes as well as trigger and act on various events.
+Launch files written in XML, YAML, or Python can start and stop different nodes as well as trigger and act on various events.
 See :doc:`../../../How-To-Guides/Launch-file-different-formats` for a description of the different formats.
 The package providing this framework is ``launch_ros``, which uses the non-ROS-specific ``launch`` framework underneath.
 
@@ -54,43 +54,9 @@ Create a new directory to store your launch files:
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Let's put together a ROS 2 launch file using the ``turtlesim`` package and its executables.
-As mentioned above, this can either be in Python, XML, or YAML.
+As mentioned above, this can either be in XML, YAML, or Python.
 
 .. tabs::
-
-  .. group-tab:: Python
-
-    Copy and paste the complete code into the ``launch/turtlesim_mimic_launch.py`` file:
-
-    .. code-block:: python
-
-      from launch import LaunchDescription
-      from launch_ros.actions import Node
-
-      def generate_launch_description():
-          return LaunchDescription([
-              Node(
-                  package='turtlesim',
-                  namespace='turtlesim1',
-                  executable='turtlesim_node',
-                  name='sim'
-              ),
-              Node(
-                  package='turtlesim',
-                  namespace='turtlesim2',
-                  executable='turtlesim_node',
-                  name='sim'
-              ),
-              Node(
-                  package='turtlesim',
-                  executable='mimic',
-                  name='mimic',
-                  remappings=[
-                      ('/input/pose', '/turtlesim1/turtle1/pose'),
-                      ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                  ]
-              )
-          ])
 
   .. group-tab:: XML
 
@@ -139,6 +105,40 @@ As mentioned above, this can either be in Python, XML, or YAML.
               from: "/output/cmd_vel"
               to: "/turtlesim2/turtle1/cmd_vel"
 
+  .. group-tab:: Python
+
+    Copy and paste the complete code into the ``launch/turtlesim_mimic_launch.py`` file:
+
+    .. code-block:: python
+
+      from launch import LaunchDescription
+      from launch_ros.actions import Node
+
+      def generate_launch_description():
+          return LaunchDescription([
+              Node(
+                  package='turtlesim',
+                  namespace='turtlesim1',
+                  executable='turtlesim_node',
+                  name='sim'
+              ),
+              Node(
+                  package='turtlesim',
+                  namespace='turtlesim2',
+                  executable='turtlesim_node',
+                  name='sim'
+              ),
+              Node(
+                  package='turtlesim',
+                  executable='mimic',
+                  name='mimic',
+                  remappings=[
+                      ('/input/pose', '/turtlesim1/turtle1/pose'),
+                      ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+                  ]
+              )
+          ])
+
 
 2.1 Examine the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -158,55 +158,6 @@ This means ``mimic`` will subscribe to ``/turtlesim1/sim``'s pose topic and repu
 In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 
 .. tabs::
-
-  .. group-tab:: Python
-
-    These import statements pull in some Python ``launch`` modules.
-
-    .. code-block:: python
-
-      from launch import LaunchDescription
-      from launch_ros.actions import Node
-
-    Next, the launch description itself begins:
-
-    .. code-block:: python
-
-      def generate_launch_description():
-         return LaunchDescription([
-
-         ])
-
-    The first two actions in the launch description launch the two turtlesim windows:
-
-    .. code-block:: python
-
-      Node(
-          package='turtlesim',
-          namespace='turtlesim1',
-          executable='turtlesim_node',
-          name='sim'
-      ),
-      Node(
-          package='turtlesim',
-          namespace='turtlesim2',
-          executable='turtlesim_node',
-          name='sim'
-      ),
-
-    The final action launches the mimic node with the remaps:
-
-    .. code-block:: python
-
-      Node(
-          package='turtlesim',
-          executable='mimic',
-          name='mimic',
-          remappings=[
-            ('/input/pose', '/turtlesim1/turtle1/pose'),
-            ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-          ]
-      )
 
   .. group-tab:: XML
 
@@ -261,6 +212,55 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
               from: "/output/cmd_vel"
               to: "/turtlesim2/turtle1/cmd_vel"
 
+  .. group-tab:: Python
+
+    These import statements pull in some Python ``launch`` modules.
+
+    .. code-block:: python
+
+      from launch import LaunchDescription
+      from launch_ros.actions import Node
+
+    Next, the launch description itself begins:
+
+    .. code-block:: python
+
+      def generate_launch_description():
+         return LaunchDescription([
+
+         ])
+
+    The first two actions in the launch description launch the two turtlesim windows:
+
+    .. code-block:: python
+
+      Node(
+          package='turtlesim',
+          namespace='turtlesim1',
+          executable='turtlesim_node',
+          name='sim'
+      ),
+      Node(
+          package='turtlesim',
+          namespace='turtlesim2',
+          executable='turtlesim_node',
+          name='sim'
+      ),
+
+    The final action launches the mimic node with the remaps:
+
+    .. code-block:: python
+
+      Node(
+          package='turtlesim',
+          executable='mimic',
+          name='mimic',
+          remappings=[
+            ('/input/pose', '/turtlesim1/turtle1/pose'),
+            ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+          ]
+      )
+
 
 3 ros2 launch
 ^^^^^^^^^^^^^
@@ -268,13 +268,6 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 To run the launch file created above, enter into the directory you created earlier and run the following command:
 
 .. tabs::
-
-  .. group-tab:: Python
-
-    .. code-block:: console
-
-      cd launch
-      ros2 launch turtlesim_mimic_launch.py
 
   .. group-tab:: XML
 
@@ -289,6 +282,13 @@ To run the launch file created above, enter into the directory you created earli
 
       cd launch
       ros2 launch turtlesim_mimic_launch.yaml
+
+  .. group-tab:: Python
+
+    .. code-block:: console
+
+      cd launch
+      ros2 launch turtlesim_mimic_launch.py
 
 .. note::
 
@@ -351,4 +351,4 @@ Summary
 -------
 
 Launch files simplify running complex systems with many nodes and specific configuration details.
-You can create launch files using Python, XML, or YAML, and run them using the ``ros2 launch`` command.
+You can create launch files using XML, YAML, or Python, and run them using the ``ros2 launch`` command.

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -139,27 +139,6 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
 
 .. tabs::
 
-  .. group-tab:: Python launch file
-
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.py``.
-    ``_launch.py`` is recommended, but not required, as the file suffix for Python launch files.
-    However, the launch file name needs to end with ``launch.py`` to be recognized and autocompleted by ``ros2 launch``.
-
-    Your launch file should define the ``generate_launch_description()`` function which returns a ``launch.LaunchDescription()`` to be used by the ``ros2 launch`` verb.
-
-    .. code-block:: python
-
-      import launch
-      import launch_ros.actions
-
-      def generate_launch_description():
-          return launch.LaunchDescription([
-              launch_ros.actions.Node(
-                  package='demo_nodes_cpp',
-                  executable='talker',
-                  name='talker'),
-        ])
-
   .. group-tab:: XML launch file
 
     Inside your ``launch`` directory, create a new launch file called ``my_script_launch.xml``.
@@ -185,6 +164,27 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
           exec: "talker"
           name: "talker"
 
+  .. group-tab:: Python launch file
+
+    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.py``.
+    ``_launch.py`` is recommended, but not required, as the file suffix for Python launch files.
+    However, the launch file name needs to end with ``launch.py`` to be recognized and autocompleted by ``ros2 launch``.
+
+    Your launch file should define the ``generate_launch_description()`` function which returns a ``launch.LaunchDescription()`` to be used by the ``ros2 launch`` verb.
+
+    .. code-block:: python
+
+      import launch
+      import launch_ros.actions
+
+      def generate_launch_description():
+          return launch.LaunchDescription([
+              launch_ros.actions.Node(
+                  package='demo_nodes_cpp',
+                  executable='talker',
+                  name='talker'),
+        ])
+
 
 4 Building and running the launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,12 +203,6 @@ After the ``colcon build`` has been successful and you've sourced the workspace,
 
     .. tabs::
 
-      .. group-tab:: Python launch file
-
-        .. code-block:: console
-
-          ros2 launch py_launch_example my_script_launch.py
-
       .. group-tab:: XML launch file
 
         .. code-block:: console
@@ -221,15 +215,15 @@ After the ``colcon build`` has been successful and you've sourced the workspace,
 
           ros2 launch py_launch_example my_script_launch.yaml
 
-  .. group-tab:: C++ package
-
-    .. tabs::
-
       .. group-tab:: Python launch file
 
         .. code-block:: console
 
-          ros2 launch cpp_launch_example my_script_launch.py
+          ros2 launch py_launch_example my_script_launch.py
+
+  .. group-tab:: C++ package
+
+    .. tabs::
 
       .. group-tab:: XML launch file
 
@@ -242,6 +236,12 @@ After the ``colcon build`` has been successful and you've sourced the workspace,
         .. code-block:: console
 
           ros2 launch cpp_launch_example my_script_launch.yaml
+
+      .. group-tab:: Python launch file
+
+        .. code-block:: console
+
+          ros2 launch cpp_launch_example my_script_launch.py
 
 
 Documentation

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -124,74 +124,13 @@ Finally, make sure to install the launch files:
 ^^^^^^^^^^^^^^^^^^^^
 
 Let's create a launch file that will call and pass arguments to another launch file.
-This launch file can either be in Python, or in YAML.
+This launch file can either be in YAML, XML, or in Python.
 
 To do this, create following file in the ``launch`` folder of the ``launch_tutorial`` package.
 
 .. tabs::
 
-  .. group-tab:: Python
-
-
-    Copy and paste the complete code into the ``launch/example_main_launch.py`` file:
-
-    .. code-block:: python
-
-      from launch_ros.substitutions import FindPackageShare
-
-      from launch import LaunchDescription
-      from launch.actions import IncludeLaunchDescription
-      from launch.launch_description_sources import PythonLaunchDescriptionSource
-      from launch.substitutions import PathJoinSubstitution, TextSubstitution
-
-
-      def generate_launch_description():
-          colors = {
-              'background_r': '200'
-          }
-
-          return LaunchDescription([
-              IncludeLaunchDescription(
-                  PythonLaunchDescriptionSource([
-                      PathJoinSubstitution([
-                          FindPackageShare('launch_tutorial'),
-                          'launch',
-                          'example_substitutions_launch.py'
-                      ])
-                  ]),
-                  launch_arguments={
-                      'turtlesim_ns': 'turtlesim2',
-                      'use_provided_red': 'True',
-                      'new_background_r': TextSubstitution(text=str(colors['background_r']))
-                  }.items()
-              )
-          ])
-
-
-    The ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
-    The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions_launch.py`` file name.
-
-    .. code-block:: python
-
-      PathJoinSubstitution([
-          FindPackageShare('launch_tutorial'),
-          'launch',
-          'example_substitutions_launch.py'
-      ])
-
-    The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
-    The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.
-
-    .. code-block:: python
-
-      launch_arguments={
-          'turtlesim_ns': 'turtlesim2',
-          'use_provided_red': 'True',
-          'new_background_r': TextSubstitution(text=str(colors['background_r']))
-      }.items()
-
   .. group-tab:: YAML
-
 
     Copy and paste the complete code into the ``launch/example_main_launch.yaml`` file:
 
@@ -262,12 +201,220 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
       <arg name="use_provided_red" value="True" />
       <arg name="new_background_r" value="$(var background_r)" />
 
+  .. group-tab:: Python
+
+    Copy and paste the complete code into the ``launch/example_main_launch.py`` file:
+
+    .. code-block:: python
+
+      from launch_ros.substitutions import FindPackageShare
+
+      from launch import LaunchDescription
+      from launch.actions import IncludeLaunchDescription
+      from launch.launch_description_sources import PythonLaunchDescriptionSource
+      from launch.substitutions import PathJoinSubstitution, TextSubstitution
+
+
+      def generate_launch_description():
+          colors = {
+              'background_r': '200'
+          }
+
+          return LaunchDescription([
+              IncludeLaunchDescription(
+                  PythonLaunchDescriptionSource([
+                      PathJoinSubstitution([
+                          FindPackageShare('launch_tutorial'),
+                          'launch',
+                          'example_substitutions_launch.py'
+                      ])
+                  ]),
+                  launch_arguments={
+                      'turtlesim_ns': 'turtlesim2',
+                      'use_provided_red': 'True',
+                      'new_background_r': TextSubstitution(text=str(colors['background_r']))
+                  }.items()
+              )
+          ])
+
+
+    The ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions_launch.py`` file name.
+
+    .. code-block:: python
+
+      PathJoinSubstitution([
+          FindPackageShare('launch_tutorial'),
+          'launch',
+          'example_substitutions_launch.py'
+      ])
+
+    The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
+    The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.
+
+    .. code-block:: python
+
+      launch_arguments={
+          'turtlesim_ns': 'turtlesim2',
+          'use_provided_red': 'True',
+          'new_background_r': TextSubstitution(text=str(colors['background_r']))
+      }.items()
+
 3 Substitutions example launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Now create the substitution launch file in the same folder:
 
 .. tabs::
+
+  .. group-tab:: YAML
+
+    Create the file ``launch/example_substitutions_launch.yaml`` and insert the following code:
+
+    .. code-block:: yaml
+
+      launch:
+        - arg:
+            name: 'turtlesim_ns'
+            default: 'turtlesim1'
+        - arg:
+            name: 'use_provided_red'
+            default: 'False'
+        - arg:
+            name: 'new_background_r'
+            default: '200'
+
+        - node:
+            pkg: 'turtlesim'
+            namespace: '$(var turtlesim_ns)'
+            exec: 'turtlesim_node'
+            name: 'sim'
+        - executable:
+            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
+        - executable:
+            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
+        - timer:
+            period: 2.0
+            children:
+              - executable:
+                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
+                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
+
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
+
+    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
+
+    .. code-block:: yaml
+
+      - arg:
+          name: 'turtlesim_ns'
+          default: 'turtlesim1'
+      - arg:
+          name: 'use_provided_red'
+          default: 'False'
+      - arg:
+          name: 'new_background_r'
+          default: '200'
+
+    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
+
+    .. code-block:: yaml
+
+      - node:
+          pkg: 'turtlesim'
+          namespace: '$(var turtlesim_ns)'
+          exec: 'turtlesim_node'
+          name: 'sim'
+
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
+    This command makes a call to the spawn service of the turtlesim node.
+
+    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+
+    .. code-block:: yaml
+
+        - executable:
+            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
+
+    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
+    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
+
+    .. code-block:: yaml
+
+        - executable:
+            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
+        - timer:
+            period: 2.0
+            children:
+              - executable:
+                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
+                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
+
+  .. group-tab:: XML
+
+    Create the file ``launch/example_substitutions_launch.xml`` and insert the following code:
+
+    .. code-block:: xml
+
+      <launch>
+        <arg name="turtlesim_ns" default="turtlesim1" />
+        <arg name="use_provided_red" default="False" />
+        <arg name="new_background_r" default="200" />
+
+        <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
+        <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
+        <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
+        <timer period="2.0">
+          <executable
+            cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
+            if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
+          />
+        </timer>
+      </launch>
+
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
+
+    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
+
+    .. code-block:: xml
+
+      <arg name="turtlesim_ns" default="turtlesim1" />
+      <arg name="use_provided_red" default="False" />
+      <arg name="new_background_r" default="200" />
+
+    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
+
+    .. code-block:: xml
+
+      <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
+
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
+    This command makes a call to the spawn service of the turtlesim node.
+
+    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+
+    .. code-block:: xml
+
+      <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
+
+    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
+    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
+
+    .. code-block:: xml
+
+      <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
+      <timer period="2.0">
+        <executable
+          cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
+          if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
+        />
+      </timer>
 
   .. group-tab:: Python
 
@@ -444,155 +591,6 @@ Now create the substitution launch file in the same folder:
             shell=True
         )
 
-  .. group-tab:: YAML
-
-    Create the file ``launch/example_substitutions_launch.yaml`` and insert the following code:
-
-    .. code-block:: yaml
-
-      launch:
-        - arg:
-            name: 'turtlesim_ns'
-            default: 'turtlesim1'
-        - arg:
-            name: 'use_provided_red'
-            default: 'False'
-        - arg:
-            name: 'new_background_r'
-            default: '200'
-
-        - node:
-            pkg: 'turtlesim'
-            namespace: '$(var turtlesim_ns)'
-            exec: 'turtlesim_node'
-            name: 'sim'
-        - executable:
-            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
-        - executable:
-            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
-        - timer:
-            period: 2.0
-            children:
-              - executable:
-                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
-                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
-
-    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-    They are used to store values of launch arguments in the above variables and to pass them to required actions.
-    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
-
-    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
-
-    .. code-block:: yaml
-
-      - arg:
-          name: 'turtlesim_ns'
-          default: 'turtlesim1'
-      - arg:
-          name: 'use_provided_red'
-          default: 'False'
-      - arg:
-          name: 'new_background_r'
-          default: '200'
-
-    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
-
-    .. code-block:: yaml
-
-      - node:
-          pkg: 'turtlesim'
-          namespace: '$(var turtlesim_ns)'
-          exec: 'turtlesim_node'
-          name: 'sim'
-
-    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
-    This command makes a call to the spawn service of the turtlesim node.
-
-    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
-
-    .. code-block:: yaml
-
-        - executable:
-            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
-
-    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
-    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
-    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
-
-    .. code-block:: yaml
-
-        - executable:
-            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
-        - timer:
-            period: 2.0
-            children:
-              - executable:
-                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
-                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
-
-  .. group-tab:: XML
-
-    Create the file ``launch/example_substitutions_launch.xml`` and insert the following code:
-
-    .. code-block:: xml
-
-      <launch>
-        <arg name="turtlesim_ns" default="turtlesim1" />
-        <arg name="use_provided_red" default="False" />
-        <arg name="new_background_r" default="200" />
-
-        <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
-        <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
-        <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
-        <timer period="2.0">
-          <executable
-            cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
-            if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
-          />
-        </timer>
-      </launch>
-
-    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-    They are used to store values of launch arguments in the above variables and to pass them to required actions.
-    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
-
-    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
-
-    .. code-block:: xml
-
-      <arg name="turtlesim_ns" default="turtlesim1" />
-      <arg name="use_provided_red" default="False" />
-      <arg name="new_background_r" default="200" />
-
-    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
-
-    .. code-block:: xml
-
-      <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
-
-    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
-    This command makes a call to the spawn service of the turtlesim node.
-
-    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
-
-    .. code-block:: xml
-
-      <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
-
-    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
-    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
-    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
-
-    .. code-block:: xml
-
-      <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
-      <timer period="2.0">
-        <executable
-          cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
-          if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
-        />
-      </timer>
-
 4 Build the package
 ^^^^^^^^^^^^^^^^^^^
 
@@ -611,12 +609,6 @@ Now you can launch using the ``ros2 launch`` command.
 
 .. tabs::
 
-  .. group-tab:: Python
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_main_launch.py
-
   .. group-tab:: YAML
 
     .. code-block:: console
@@ -629,6 +621,12 @@ Now you can launch using the ``ros2 launch`` command.
 
         ros2 launch launch_tutorial example_main_launch.xml
 
+  .. group-tab:: Python
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_main_launch.py
+
 This will do the following:
 
 #. Start a turtlesim node with a blue background
@@ -640,15 +638,6 @@ Modifying launch arguments
 --------------------------
 
 .. tabs::
-
-  .. group-tab:: Python
-
-    If you want to change the provided launch arguments, you can either update them in ``launch_arguments`` dictionary in the ``example_main_launch.py`` or launch the ``example_substitutions_launch.py`` with preferred arguments.
-    To see arguments that may be given to the launch file, run the following command:
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.py --show-args
 
   .. group-tab:: YAML
 
@@ -667,6 +656,15 @@ Modifying launch arguments
     .. code-block:: console
 
         ros2 launch launch_tutorial example_substitutions_launch.xml --show-args
+
+  .. group-tab:: Python
+
+    If you want to change the provided launch arguments, you can either update them in ``launch_arguments`` dictionary in the ``example_main_launch.py`` or launch the ``example_substitutions_launch.py`` with preferred arguments.
+    To see arguments that may be given to the launch file, run the following command:
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.py --show-args
 
 This will show the arguments that may be given to the launch file and their default values.
 
@@ -690,12 +688,6 @@ Now you can pass the desired arguments to the launch file as follows:
 
 .. tabs::
 
-  .. group-tab:: Python
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
-
   .. group-tab:: YAML
 
     .. code-block:: console
@@ -707,6 +699,12 @@ Now you can pass the desired arguments to the launch file as follows:
     .. code-block:: console
 
         ros2 launch launch_tutorial example_substitutions_launch.xml turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
+
+  .. group-tab:: Python
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
 Documentation
 -------------


### PR DESCRIPTION
This is a follow-up to #5093. It's part of a general move towards making XML and YAML the "preferred" kinds of launch files over Python, whenever possible. This PR updates examples to show & mention XML and YAML over Python.

I did not change "Python" to be last in the [*Using Python, XML, and YAML for ROS 2 Launch Files* guide](https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html) or its [*Python, XML, or YAML: Which should I use?* section](https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html#python-xml-or-yaml-which-should-i-use) to not be too disruptive, but I could do it if that's preferred.