### PR TITLE
Add XML examples to 'Using substitutions' tutorial

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -231,6 +231,37 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
         - name: 'new_background_r'
           value: '$(var background_r)'
 
+  .. group-tab:: XML
+
+    Copy and paste the complete code into the ``launch/example_main_launch.xml`` file:
+
+    .. code-block:: xml
+
+      <launch>
+        <let name="background_r" value="200"/>
+        <include file="$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.xml">
+          <arg name="turtlesim_ns" value="turtlesim2" />
+          <arg name="use_provided_red" value="True" />
+          <arg name="new_background_r" value="$(var background_r)" />
+        </include>
+      </launch>
+
+    The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The path substitution is then joined with the ``example_substitutions_launch.xml`` file name.
+
+    .. code-block:: xml
+
+      <include file="$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.xml">
+
+    The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
+    The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
+
+    .. code-block:: xml
+
+      <arg name="turtlesim_ns" value="turtlesim2" />
+      <arg name="use_provided_red" value="True" />
+      <arg name="new_background_r" value="$(var background_r)" />
+
 3 Substitutions example launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -499,6 +530,69 @@ Now create the substitution launch file in the same folder:
                   cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
                   if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
 
+  .. group-tab:: XML
+
+    Create the file ``launch/example_substitutions_launch.xml`` and insert the following code:
+
+    .. code-block:: xml
+
+      <launch>
+        <arg name="turtlesim_ns" default="turtlesim1" />
+        <arg name="use_provided_red" default="False" />
+        <arg name="new_background_r" default="200" />
+
+        <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
+        <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
+        <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
+        <timer period="2.0">
+          <executable
+            cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
+            if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
+          />
+        </timer>
+      </launch>
+
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
+
+    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
+
+    .. code-block:: xml
+
+      <arg name="turtlesim_ns" default="turtlesim1" />
+      <arg name="use_provided_red" default="False" />
+      <arg name="new_background_r" default="200" />
+
+    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
+
+    .. code-block:: xml
+
+      <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
+
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
+    This command makes a call to the spawn service of the turtlesim node.
+
+    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+
+    .. code-block:: xml
+
+      <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
+
+    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
+    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
+
+    .. code-block:: xml
+
+      <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
+      <timer period="2.0">
+        <executable
+          cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
+          if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
+        />
+      </timer>
+
 4 Build the package
 ^^^^^^^^^^^^^^^^^^^
 
@@ -529,6 +623,12 @@ Now you can launch using the ``ros2 launch`` command.
 
         ros2 launch launch_tutorial example_main_launch.yaml
 
+  .. group-tab:: XML
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_main_launch.xml
+
 This will do the following:
 
 #. Start a turtlesim node with a blue background
@@ -558,6 +658,15 @@ Modifying launch arguments
     .. code-block:: console
 
         ros2 launch launch_tutorial example_substitutions_launch.yaml --show-args
+
+  .. group-tab:: XML
+
+    If you want to change the provided launch arguments, you can either update the ``background_r`` variable in the ``example_main_launch.xml`` or launch the ``example_substitutions_launch.xml`` with preferred arguments.
+    To see arguments that may be given to the launch file, run the following command:
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.xml --show-args
 
 This will show the arguments that may be given to the launch file and their default values.
 
@@ -592,6 +701,12 @@ Now you can pass the desired arguments to the launch file as follows:
     .. code-block:: console
 
         ros2 launch launch_tutorial example_substitutions_launch.yaml turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
+
+  .. group-tab:: XML
+
+    .. code-block:: console
+
+        ros2 launch launch_tutorial example_substitutions_launch.xml turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
 Documentation
 -------------


### PR DESCRIPTION
I originally thought there were no XML examples because the `<include>` action didn't support declaring a list of args, but it does.