### PR TITLE
Don't copy console prompt symbol or output, document bash vs console

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -98,6 +98,14 @@ intersphinx_mapping = {
     'vcstools':      ('http://docs.ros.org/en/independent/api/vcstools/html', None)
 }
 
+# sphinx-copybutton config
+
+# Configure sphinx-copybutton to not copy the following lines in console code-blocks:
+#   1. Prompt lines ($): '.linenos, .gp'
+#   2. Command output lines: '.go'
+# See: https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies
+copybutton_exclude = '.linenos, .gp, .go'
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/source/Concepts/Basic/About-Command-Line-Tools.rst
+++ b/source/Concepts/Basic/About-Command-Line-Tools.rst
@@ -52,7 +52,7 @@ To produce the typical talker-listener example using command-line tools, the ``t
 
 Publish messages in one terminal with:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ ros2 topic pub /chatter std_msgs/msg/String "data: Hello world"
    publisher: beginning loop
@@ -62,7 +62,7 @@ Publish messages in one terminal with:
 
 Echo messages received in another terminal with:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ ros2 topic echo /chatter
    data: Hello world

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -37,11 +37,8 @@ Start by creating `venv <https://docs.python.org/3/library/venv.html>`__ to buil
 
 .. code-block:: console
 
-   # activate the venv
-   python3 -m venv ros2doc
-
-   # activate venv
-   source ros2doc/bin/activate
+   $ python3 -m venv ros2doc  # create venv
+   $ source ros2doc/bin/activate  # activate venv
 
 And install requirements located in the ``requirements.txt`` file:
 
@@ -389,7 +386,7 @@ In-text code can be formatted using ``backticks`` for showing ``highlighted`` co
 
    In-text code can be formatted using ``backticks`` for showing ``highlighted`` code.
 
-Code blocks inside a page need to be captured using ``.. code-block::`` directive.
+Code blocks inside a page need to be captured using ``.. code-block::`` `directives <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block>`_.
 ``.. code-block::`` supports code highlighting for syntaxes like ``C++``, ``YAML``, ``console``, ``bash``, and more.
 Code inside the directive needs to be indented.
 
@@ -404,6 +401,43 @@ Code inside the directive needs to be indented.
          rclcpp::shutdown();
          return 0;
       }
+
+Code blocks: ``bash`` vs. ``console``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``bash`` and ``console`` are similar, but they serve two different purposes.
+
+``bash`` is meant for bash scripts, e.g., for bash commands from a script file.
+Example result:
+
+.. code-block:: bash
+
+   export ROS_DOMAIN_ID=42
+   ros2 run turtlesim turtlesim_node
+
+``console`` is meant for commands to be run in a terminal, optionally including their output.
+This makes it clear that the given commands need to be run in a terminal.
+It also allows separating command lines from output lines using prompt symbols such as ``$`` or ``#``.
+Command lines are formatted as bash commands while output lines are formatted as normal text.
+The prompt symbol is not selectable, and clicking on the copy button in the upper right-hand corner copies *only* the commands, not the outputs nor the prompt symbols.
+In general, the prompt symbol (``$``) can be omitted if the code block does not contain any output lines.
+Example result:
+
+.. code-block:: console
+
+   $ export ROS_DOMAIN_ID=42
+   $ ros2 run turtlesim turtlesim_node --ros-args --remap "__node:=my_turtle"
+   [INFO] [1742150439.022947971] [my_turtle]: Starting turtlesim with node name /my_turtle
+   [INFO] [1742150439.026043867] [my_turtle]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
+
+Compare the above with a ``bash`` ``code-block``:
+
+.. code-block:: bash
+
+   $ export ROS_DOMAIN_ID=42
+   $ ros2 run turtlesim turtlesim_node --ros-args --remap "__node:=my_turtle"
+   [INFO] [1742150439.022947971] [my_turtle]: Starting turtlesim with node name /my_turtle
+   [INFO] [1742150439.026043867] [my_turtle]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
 
 Images
 ^^^^^^


### PR DESCRIPTION
This PR documents `bash` vs. `console` code blocks so that contributors know which one they should use and why, depending on the use case.

This PR also configures the `sphinx-copybutton` extension to exclude the prompt symbol (`$`) and the output lines from being copied with the copy button: https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies.

----

For example, take this section of the [_Introspection with command line tools_ concepts article](https://docs.ros.org/en/rolling/Concepts/Basic/About-Command-Line-Tools.html#example) that contains commands and their outputs:

![image](https://github.com/user-attachments/assets/32c3e5c2-3817-4d08-ad18-b23478482d8f)

1. _All_ lines are formatted as if they were bash commands (note the `#` being interpreted as bash comments)
2. Manually selecting the text (e.g., to copy and then paste it into a terminal) selects the prompt symbol (`$`)
    - ![image](https://github.com/user-attachments/assets/8fa47679-6d4d-492b-837a-38b325a33ffb)
3. Clicking on the copy button in the upper right-hand corner copies the command, which we want, but it also copies the `$` and the output lines, which we don't want

If we make it a `console` code block, which this PR does:

![image](https://github.com/user-attachments/assets/0ce36ee1-7837-4c55-b3a5-00e0fd1e4021)

1. Only the command line (`$`) is formatted as a bash command, the rest is just text
2. The `$` symbol cannot be selected
    - ![image](https://github.com/user-attachments/assets/ce9a882f-69ac-434d-8485-c1dd82d2c145)
3. Clicking on the copy button only copies the command line, excluding the `$` and the output lines