### PR TITLE
Fix internal links and document image target links

### DIFF
--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -414,6 +414,16 @@ Images can be inserted using the ``.. image::`` directive.
 
    .. image:: images/turtlesim_follow1.png
 
+In this case, the image file (``turtlesim_follow1.png``) is located in the ``images/`` directory relative to the ``.rst`` file that uses the image.
+
+However, all image files end up in an ``_images/`` directory relative to the root of the docs.
+Therefore, when using ``:target:`` to add a hyperlink to the image file, use a relative link going up to the root directory and then down to the ``_images/`` directory.
+
+.. code-block:: rst
+
+   .. image:: images/turtlesim_follow1.png
+      :target: ../../_images/turtlesim_follow1.png
+
 Charts, Graphs, and Diagrams
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.rst
+++ b/source/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.rst
@@ -191,21 +191,21 @@ You should be able to add your new plugin by clicking ``Add`` in the bottom left
 
 
 .. image:: images/Step1A.png
-   :target: images/Step1A.png
+   :target: ../../../../_images/Step1A.png
    :alt: screenshot of adding display
 
 
 Initially, the display will be in an error state because you have yet to assign a topic.
 
 .. image:: images/Step1B.png
-   :target: images/Step1B.png
+   :target: ../../../../_images/Step1B.png
    :alt: screenshot of error state
 
 
 If we put the topic ``/point`` in, it should load fine but not display anything.
 
 .. image:: images/Step1C.png
-   :target: images/Step1C.png
+   :target: ../../../../_images/Step1C.png
    :alt: screenshot of functioning empty display
 
 
@@ -280,7 +280,7 @@ We also update our ``processMessage`` method:
 The result should look like this:
 
 .. image:: images/Step2A.png
-   :target: images/Step2A.png
+   :target: ../../../../_images/Step2A.png
    :alt: screenshot of functioning display
 
 
@@ -344,14 +344,14 @@ Cpp Updates
 The result should look like this:
 
 .. image:: images/Step3A.png
-   :target: images/Step3A.png
+   :target: ../../../../_images/Step3A.png
    :alt: screenshot with color property
 
 
 Ooh, pink!
 
 .. image:: images/Step3B.png
-   :target: images/Step3B.png
+   :target: ../../../../_images/Step3B.png
    :alt: screenshot with changed color
 
 
@@ -379,13 +379,13 @@ In ``processMessage``:
 
 
 .. image:: images/Step4A.png
-   :target: images/Step4A.png
+   :target: ../../../../_images/Step4A.png
    :alt: screenshot with ok status
 
 
 
 .. image:: images/Step4B.png
-   :target: images/Step4B.png
+   :target: ../../../../_images/Step4B.png
    :alt: screenshot with warning status
 
 
@@ -431,7 +431,7 @@ Now when you add the display, it should show up with an icon and description.
 
 
 .. image:: images/Step5A.png
-   :target: images/Step5A.png
+   :target: ../../../../_images/Step5A.png
    :alt: screenshot with added icon and description
 
 
@@ -439,7 +439,7 @@ Here is the display when attempting to add by topic:
 
 
 .. image:: images/Step5B.png
-   :target: images/Step5B.png
+   :target: ../../../../_images/Step5B.png
    :alt: screenshot with add by topic dialog
 
 
@@ -447,7 +447,7 @@ And finally, here's the icon in the standard interface:
 
 
 .. image:: images/Step5C.png
-   :target: images/Step5C.png
+   :target: ../../../../_images/Step5C.png
    :alt: screenshot with icon in standard interface
 
 

--- a/source/Tutorials/Intermediate/RViz/RViz-Custom-Panel/RViz-Custom-Panel.rst
+++ b/source/Tutorials/Intermediate/RViz/RViz-Custom-Panel/RViz-Custom-Panel.rst
@@ -156,7 +156,7 @@ In the top Menu bar, there should be a "Panels" menu.
 Select "Add New Panel" from that menu.
 
 .. image:: images/Select0.png
-   :target: images/Select0.png
+   :target: ../../../../_images/Select0.png
    :alt: screenshot of Add New Panel dialog
 
 A dialog will pop up showing all the panels accessible in your ROS environment, grouped into folders based on their ROS package.
@@ -165,7 +165,7 @@ Create a new instance of your panel by either double clicking on its name, or se
 This should create a new panel in your RViz window, albeit with nothing but a title bar with the name of your panel.
 
 .. image:: images/RViz0.png
-   :target: images/RViz0.png
+   :target: ../../../../_images/RViz0.png
    :alt: screenshot of the whole RViz window showing the new simple panel
 
 Filling in the Panel
@@ -297,7 +297,7 @@ Compile and launch RViz2 with your panel again.
 You should see your label and button in the panel now.
 
 .. image:: images/RViz1.png
-   :target: images/RViz1.png
+   :target: ../../../../_images/RViz1.png
    :alt: screenshot of the RViz panel in its default state
 
 To change the label, we simply have to publish a message on the ``/input`` topic, which you can do with this command:
@@ -309,7 +309,7 @@ To change the label, we simply have to publish a message on the ``/input`` topic
 Since the widget is subscribed to this topic, it will trigger the callback and change the text of the label.
 
 .. image:: images/RViz2.png
-   :target: images/RViz2.png
+   :target: ../../../../_images/RViz2.png
    :alt: screenshot of the RViz panel with custom string message displayed
 
 
@@ -342,11 +342,11 @@ We need to install the image file in the CMake.
 Now when you add the panel, it should show up with an icon and description.
 
 .. image:: images/Select1.png
-   :target: images/Select1.png
+   :target: ../../../../_images/Select1.png
    :alt: screenshot of Add New Panel dialog with our custom icon and description
 
 The panel will also have an updated icon.
 
 .. image:: images/RViz3.png
-   :target: images/RViz3.png
+   :target: ../../../../_images/RViz3.png
    :alt: screenshot of the RViz panel with custom icon

--- a/source/Tutorials/Intermediate/Testing/Integration.rst
+++ b/source/Tutorials/Intermediate/Testing/Integration.rst
@@ -163,7 +163,7 @@ The package `launch_testing_ros <https://docs.ros.org/en/{DISTRO}/p/launch_testi
 such as `WaitForTopics <https://docs.ros.org/en/{DISTRO}/p/launch_testing_ros/launch_testing_ros.wait_for_topics.html>`_.
 
 If you want to go further, you can implement a third test that publishes a twist message, asking the turtle to move, and subsequently checks that it moved by asserting that the pose message changed.
-This effectively automates part of the `Turtlesim introduction tutorial <../../Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim>`_.
+This effectively automates part of the :doc:`Turtlesim introduction tutorial <../../Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim>`.
 
 1.4 Post-shutdown tests
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Tutorials/Miscellaneous/Building-ROS2-Package-with-eclipse-2021-06.rst
+++ b/source/Tutorials/Miscellaneous/Building-ROS2-Package-with-eclipse-2021-06.rst
@@ -17,24 +17,24 @@ After you created your project, you can edit the source code and build it with e
 We start eclipse and select a eclipse-workspace.
 
 .. image:: images/eclipse_work_dir.png
-   :target: images/eclipse_work_dir.png
+   :target: ../../_images/eclipse_work_dir.png
    :alt: eclipse_work_dir
 
 We create a C++ project
 
 .. image:: images/eclipse_create_c++_project.png
-   :target: images/eclipse_create_c++_project.png
+   :target: ../../_images/eclipse_create_c++_project.png
    :alt: eclipse_create_c++_project
 
 
 .. image:: images/eclipse_c++_project_select_type.png
-   :target: images/eclipse_c++_project_select_type.png
+   :target: ../../_images/eclipse_c++_project_select_type.png
    :alt: eclipse_c++_project_select_type
 
 We see that we got C++ includes.
 
 .. image:: images/eclipse_c++_project_includes.png
-   :target: images/eclipse_c++_project_includes.png
+   :target: ../../_images/eclipse_c++_project_includes.png
    :alt: eclipse_c++_project_includes
 
 
@@ -42,17 +42,17 @@ We now import our ROS 2 project.
 The code is still in the old place.
 
 .. image:: images/eclipse_import_project.png
-   :target: images/eclipse_import_project.png
+   :target: ../../_images/eclipse_import_project.png
    :alt: eclipse_import_project
 
 .. image:: images/eclipse_import_filesystem.png
-   :target: images/eclipse_import_filesystem.png
+   :target: ../../_images/eclipse_import_filesystem.png
    :alt: eclipse_import_filesystem
 
 Click the Advanced in the Options and check the **Create links in worksapce**.
 
 .. image:: images/eclipse_import_select_my_package.png
-   :target: images/eclipse_import_select_my_package.png
+   :target: ../../_images/eclipse_import_select_my_package.png
    :alt: eclipse_import_select_my_package
 
 
@@ -60,55 +60,55 @@ Click the Advanced in the Options and check the **Create links in worksapce**.
 We see in the source code that the C++ includes got resolved but not the ROS 2 ones.
 
 .. image:: images/eclipse_c++_wo_ros_includes.png
-   :target: images/eclipse_c++_wo_ros_includes.png
+   :target: ../../_images/eclipse_c++_wo_ros_includes.png
    :alt: eclipse_c++_wo_ros_includes
 
 
 .. image:: images/eclipse_c++_path_and_symbols.png
-   :target: images/eclipse_c++_path_and_symbols.png
+   :target: ../../_images/eclipse_c++_path_and_symbols.png
    :alt: eclipse_c++_path_and_symbols
 
 Add include paths of needed packages.
 (e.g. **/opt/ros/iron/include/rclcpp**, **/opt/ros/iron/include/std_msgs**, etc.)
 
 .. image:: images/eclipse_c++_add_directory_path.png
-   :target: images/eclipse_c++_add_directory_path.png
+   :target: ../../_images/eclipse_c++_add_directory_path.png
    :alt: eclipse_c++_add_directory_path
 
 
 We now see that the ROS 2 includes got resolved too.
 
 .. image:: images/eclipse_c++_indexer_ok.png
-   :target: images/eclipse_c++_indexer_ok.png
+   :target: ../../_images/eclipse_c++_indexer_ok.png
    :alt: eclipse_c++_indexer_ok
 
 
 Adding Builder colcon, so that we can build with right-click on project and "Build project".
 
 .. image:: images/eclipse_c++_properties_builders.png
-   :target: images/eclipse_c++_properties_builders.png
+   :target: ../../_images/eclipse_c++_properties_builders.png
    :alt: eclipse_c++_properties_builders
 
 
 .. image:: images/eclipse_c++_builder_main.png
-   :target: images/eclipse_c++_builder_main.png
+   :target: ../../_images/eclipse_c++_builder_main.png
    :alt: eclipse_c++_builder_main
 
 
 With PYTHONPATH you can also build python projects.
 
 .. image:: images/eclipse_c++_builder_env.png
-   :target: images/eclipse_c++_builder_env.png
+   :target: ../../_images/eclipse_c++_builder_env.png
    :alt: eclipse_c++_builder_env
 
 
 .. image:: images/eclipse_c++_properties_builders_with_colcon.png
-   :target: images/eclipse_c++_properties_builders_with_colcon.png
+   :target: ../../_images/eclipse_c++_properties_builders_with_colcon.png
    :alt: eclipse_c++_properties_builders_with_colcon
 
 
 Right-click on the project and select "Build Project".
 
 .. image:: images/eclipse_c++_build_project_with_colcon.png
-   :target: images/eclipse_c++_build_project_with_colcon.png
+   :target: ../../_images/eclipse_c++_build_project_with_colcon.png
    :alt: eclipse_c++_build_project_with_colcon


### PR DESCRIPTION
I've been playing with a link checker as part of #5050 and I found some broken links.

Except for the link using the wrong RST format, it's all image links. Clicking on any images in the following articles leads to a 404:

* https://docs.ros.org/en/rolling/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.html
* https://docs.ros.org/en/rolling/Tutorials/Intermediate/RViz/RViz-Custom-Panel/RViz-Custom-Panel.html
* https://docs.ros.org/en/rolling/Tutorials/Miscellaneous/Building-ROS2-Package-with-eclipse-2021-06.html

It turns out that Sphinx moves all images to an `_images/` directory relative to the root of the docs website. So the following does not work:

```rst
.. image:: images/Step1A.png
   :target: images/Step1A.png
```

I've tried to get `:target: /_images/turtlesim_follow1.png` to work, but it ends up being relative to the absolute root of the website, not the root of the docs. The only other solution is to use a relative link:

```rst
.. image:: images/Step1A.png
   :target: ../../../../_images/Step1A.png
```

I've fixed all instances and mentioned this in the documentation.

----

These were found with [`linkchecker`](https://linkchecker.github.io/linkchecker/index.html):

```console
$ cd ~/ros2_documentation
$ source .venv/bin/activate
$ pip3 install linkchecker
$ linkchecker ./build/html/
```