### PR TITLE
Link directly to pkg API docs to avoid redirect

### DIFF
--- a/source/Concepts/Basic/About-Client-Libraries.rst
+++ b/source/Concepts/Basic/About-Client-Libraries.rst
@@ -47,7 +47,7 @@ The ROS Client Library for C++ (``rclcpp``) is the user facing, C++ idiomatic in
 The ``rclcpp`` repository is located on GitHub at `ros2/rclcpp <https://github.com/ros2/rclcpp>`_ and contains the |package| ``rclcpp``.
 The generated |API| documentation is here:
 
-`api/rclcpp/index.html <http://docs.ros.org/en/{DISTRO}/p/rclcpp>`_
+`api/rclcpp/index.html <http://docs.ros.org/en/{DISTRO}/p/rclcpp/>`_
 
 The ``rclpy`` package
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Minor fix. I've been experimenting with a link checker for #5050. It pointed out that the link to:

* http://docs.ros.org/en/rolling/p/rclcpp

results in a redirect to:

* http://docs.ros.org/en/rolling/p/rclcpp/

so just change the link to http://docs.ros.org/en/rolling/p/rclcpp/.