### PR TITLE
Launch file migration doc: remove note about substitution anon not available in ROS2

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
@@ -406,7 +406,6 @@ There are, however, some changes w.r.t. ROS 1:
 * ``arg`` has been replaced with ``var``.
   It looks at configurations defined either with ``arg`` or ``let`` tag.
 * ``eval`` and ``dirname`` substitutions require escape characters for string values, e.g. ``if="$(eval '\'$(var variable)\' == \'val1\'')"``.
-* ``anon`` substitution is not supported.
 
 Type inference rules
 --------------------


### PR DESCRIPTION
Support for anon substitution was added in https://github.com/ros2/launch/pull/384 and is available from ROS2 foxy.