### PR TITLE
Format action name in 'Managing large projects' tutorial

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -285,7 +285,7 @@ However, if the launch file contains a large number of nodes, defining namespace
 To solve that issue, the ``PushROSNamespace`` action can be used to define the global namespace for each launch file description.
 Every nested node will inherit that namespace automatically.
 
-.. attention:: PushROSNamespace has to be the first Action in the list for the following actions to apply the namespace
+.. attention:: ``PushROSNamespace`` has to be the first action in the list for the following actions to apply the namespace.
 
 To do that, firstly, we need to remove the ``namespace='turtlesim2'`` line from the ``turtlesim_world_2_launch.py`` file.
 Afterwards, we need to update the ``launch_turtlesim_launch.py`` to include the following lines:


### PR DESCRIPTION
Change "Action" to "action" and Add a period at the end, too.