### PR TITLE
add github issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Robotics Stack Exchange
+    url: https://robotics.stackexchange.com/
+    about: Our centralized QA site, please ask questions here.
+  - name: Documentation for Active ROS Distributions
+    url: https://docs.ros.org/
+    about: Official ROS documentation.
+  - name: ROS Discourse
+    url: https://discourse.ros.org/
+    about: Discussion on ROS and ROS-related things.
+  - name: ROS Discord
+    url: https://discord.com/servers/open-robotics-1077825543698927656
+    about: ROS & Gazebo Discord Server.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Robotics Stack Exchange
+  - name: 🔗 Have a question on how to use ROS?
     url: https://robotics.stackexchange.com/
-    about: Our centralized QA site, please ask questions here.
-  - name: Documentation for Active ROS Distributions
+    about: We use Robotics Stack Exchange for general project questions.
+  - name: 🔗 Looking for documentation on active ROS distros?
     url: https://docs.ros.org/
-    about: Official ROS documentation.
-  - name: ROS Discourse
+    about: The ROS documentation is available at docs.ros.org
+  - name: 🔗 Want to discuss a ROS feature or get the latest ROS news?
     url: https://discourse.ros.org/
-    about: Discussion on ROS and ROS-related things.
-  - name: ROS Discord
+    about: ROS Discourse is our community discussion forum.
+  - name: 🔗 Do you need real time support from other ROS users?
     url: https://discord.com/servers/open-robotics-1077825543698927656
-    about: ROS & Gazebo Discord Server.
+    about: Visit our community Discord server. ROS questions belong in "#ros-help" channel.

--- a/.github/ISSUE_TEMPLATE/issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/issue_report.yml
@@ -1,0 +1,62 @@
+name: 📝 Documentation Issue
+description: Report an issue with the ROS 2 documentation
+title: "📝 <Brief Title>"
+labels: ["documentation", "issue"]
+body:
+  - type: markdown
+    attributes:
+      value: "**Required Info:**"
+  - type: checkboxes
+    id: issue_type
+    attributes:
+      label: "Issue Type"
+      description: "Select the type of documentation issue"
+      options:
+        - label: "🐛 Bug / Problem"
+        - label: "✏️ Typo / Grammar"
+        - label: "📖 Outdated Content"
+        - label: "🚀 Enhancement"
+  - type: input
+    id: distribution
+    attributes:
+      label: "Distribution"
+      description: |
+        ROS 2 distribution that you found the problem in.
+        e.g) Humble, Jazzy, Rolling, ...
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Provide a detailed description of the issue"
+    validations:
+      required: true
+  - type: input
+    id: affected_pages
+    attributes:
+      label: "Affected Pages/Sections"
+      description: "Provide links to the affected documentation pages, if applicable"
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "Screenshots or Examples (if applicable)"
+      description: "Add any supporting screenshots or logs"
+    validations:
+      required: false
+  - type: textarea
+    id: suggested_fix
+    attributes:
+      label: "Suggested Fix"
+      description: "If you have an idea for a fix, please describe it here"
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: "Additional Context"
+      description: "Any other relevant information"
+    validations:
+      required: false


### PR DESCRIPTION
related to https://github.com/ros2/.github/pull/3

https://github.com/ros2/.github/pull/3 tries to add project global issue template in default.
This PR aims to have documentation specific template to override the global one because global template is more like software component issue template.

see more details for https://github.com/ros2/.github/pull/3#issuecomment-2597571169