### PR TITLE
Clarify rosidl_generate_interfaces lib name note

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -116,7 +116,8 @@ To convert the interfaces you defined into language-specific code (like C++ and 
 
 .. note::
 
-  The first argument (library name) in the rosidl_generate_interfaces must match ${PROJECT_NAME} (see https://github.com/ros2/rosidl/issues/441#issuecomment-591025515).
+  The first argument (library name) in the ``rosidl_generate_interfaces`` must start with the name of the package, e.g., simply ``${PROJECT_NAME}`` or ``${PROJECT_NAME}_suffix``.
+  See https://github.com/ros2/rosidl/issues/441#issuecomment-591025515.
 
 4 ``package.xml``
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The comment (https://github.com/ros2/rosidl/issues/441#issuecomment-591025515) specifically says "must have the basename," so it would be more helpful to explicitly say "must start with" here.