### PR TITLE
Launch preferences update: XML-first, `.launch` extensions, Python launchfile declarative style

### DIFF
--- a/source/Concepts/Basic/About-Launch.rst
+++ b/source/Concepts/Basic/About-Launch.rst
@@ -17,4 +17,4 @@ This launch file can then be run using the ``ros2 launch`` command, and all of t
 
 To get started writing and using launch files, see `the launch tutorials <../../Tutorials/Intermediate/Launch/Launch-Main>`.
 
-The `design document <https://design.ros2.org/articles/roslaunch.html>`__ details the goal of the design of ROS 2's launch system (not all functionality is currently available).
+For more detailed information, see `the launch documentation <https://docs.ros.org/en/{DISTRO}/p/launch>`__.

--- a/source/Concepts/Basic/About-Launch.rst
+++ b/source/Concepts/Basic/About-Launch.rst
@@ -5,14 +5,16 @@ Launch
    :local:
 
 A ROS 2 system typically consists of many nodes running across many different processes (and even different machines).
-While it is possible to run each of these nodes separately, it gets cumbersome quite quickly.
+While it is possible to manually start each of these nodes, it gets cumbersome quite quickly.
 
 The launch system in ROS 2 is meant to automate the running of many nodes with a single command.
 It helps the user describe the configuration of their system and then executes it as described.
 The configuration of the system includes what programs to run, where to run them, what arguments to pass them, and ROS-specific conventions which make it easy to reuse components throughout the system by giving them each a different configuration.
 It is also responsible for monitoring the state of the processes launched, and reporting and/or reacting to changes in the state of those processes.
 
-All of the above is specified in a launch file, which can be written in XML, YAML, or Python.
+All of the above is specified in a "launch file", which can be written in XML, YAML, or Python.
 This launch file can then be run using the ``ros2 launch`` command, and all of the nodes specified will be run.
+
+To get started writing and using launch files, see `the launch tutorials <../../Tutorials/Intermediate/Launch/Launch-Main>`.
 
 The `design document <https://design.ros2.org/articles/roslaunch.html>`__ details the goal of the design of ROS 2's launch system (not all functionality is currently available).

--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -119,7 +119,7 @@ and a ``setup.py`` file that looks like:
            # Include our package.xml file
            (os.path.join('share', package_name), ['package.xml']),
            # Include all launch files.
-           (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+           (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*'))),
        ],
        # This is important as well
        install_requires=['setuptools'],

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -12,6 +12,32 @@ Using XML, YAML, and Python for ROS 2 Launch Files
 ROS 2 launch files can be written in XML, YAML, and Python.
 This guide shows how to use these different formats to accomplish the same task, as well as has some discussion on when to use each format.
 
+XML, YAML, or Python: Which should I use?
+-----------------------------------------
+
+.. note::
+
+  Launch files in ROS 1 were written in XML, so XML may be the most familiar to people coming from ROS 1.
+  To see what's changed, you can visit :doc:`Migrating-from-ROS1/Migrating-Launch-Files`.
+
+To achieve a more declarative self-documenting style, you should prefer XML or YAML launch files, between them it comes down to developer preference.
+
+However, if your launch file requires advanced functionality that you cannot achieve with XML or YAML, you can turn to the Python launch API.
+Using Python for ROS 2 launch allows far more flexibility because it is a full scripting language and has access to the underlying implementation -- not all of which is exposed to XML/YAML -- but using it comes with the drawback of being more verbose and harder to reason about the resulting launch description.
+
+Naming Launch Files
+-------------------
+
+While it is not required, we recommend that you name all launch files with the ``.launch`` extension, regardless of the language they are written in.
+
+There is historical content that uses the ``_launch.py``, ``_launch.xml``, and ``_launch.yaml`` extensions, but this is no longer necessary or recommended as it obfuscates the usage.
+
+Launch files should be considered part of the exposed interface of your package, and your users shouldn't have to know or care which language you used to implement a particular file, just like with your nodes.
+Nor should you be tied to keeping it in that format forever!
+As long as it has the ``.launch`` suffix with an informative name, the caller knows that it is a launch file, and the launch system will autodetect the format as needed.
+You can mix and match formats without any issues.
+
+
 Launch file examples
 --------------------
 
@@ -324,19 +350,3 @@ To test that the remapping is working, you can control the turtles by running th
 .. code-block:: console
 
   ros2 run turtlesim turtle_teleop_key --ros-args --remap __ns:=/turtlesim1
-
-
-.. _launch-file-different-formats-which:
-
-XML, YAML, or Python: Which should I use?
------------------------------------------
-
-.. note::
-
-  Launch files in ROS 1 were written in XML, so XML may be the most familiar to people coming from ROS 1.
-  To see what's changed, you can visit :doc:`Migrating-from-ROS1/Migrating-Launch-Files`.
-
-To achieve a more declarative self-documenting style, you should prefer XML or YAML launch files, between them it comes down to developer preference.
-
-However, if your launch file requires advanced functionality that you cannot achieve with XML or YAML, you can turn to the Python launch API.
-Using Python for ROS 2 launch allows far more flexibility because it is a full scripting language and has access to the underlying implementation -- not all of which is exposed to XML/YAML -- but using it comes with the drawback of being more verbose and harder to reason about the resulting launch description.

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -2,7 +2,7 @@
 
   Guides/Launch-file-different-formats
 
-Using Python, XML, and YAML for ROS 2 Launch Files
+Using XML, YAML, and Python for ROS 2 Launch Files
 ==================================================
 
 .. contents:: Table of Contents
@@ -31,8 +31,7 @@ Each launch file performs the following actions:
 
       .. code-block:: xml
 
-        <!-- example_launch.xml -->
-
+        <?xml version="1.0" encoding="UTF-8"?>
         <launch>
 
             <!-- args that can be set from the command line or a default will be used -->
@@ -83,8 +82,6 @@ Each launch file performs the following actions:
    .. group-tab:: YAML
 
       .. code-block:: yaml
-
-        # example_launch.yaml
 
         launch:
 
@@ -148,14 +145,11 @@ Each launch file performs the following actions:
             name: "sim"
             namespace: "turtlesim2"
             param:
-            -
-              name: "background_r"
+            - name: "background_r"
               value: "$(var background_r)"
-            -
-              name: "background_g"
+            - name: "background_g"
               value: "$(var background_g)"
-            -
-              name: "background_b"
+            - name: "background_b"
               value: "$(var background_b)"
 
         # perform remap so both turtles listen to the same command topic
@@ -164,19 +158,16 @@ Each launch file performs the following actions:
             exec: "mimic"
             name: "mimic"
             remap:
-            -
-                from: "/input/pose"
-                to: "/turtlesim1/turtle1/pose"
-            -
-                from: "/output/cmd_vel"
-                to: "/turtlesim2/turtle1/cmd_vel"
+            - from: "/input/pose"
+              to: "/turtlesim1/turtle1/pose"
+            - from: "/output/cmd_vel"
+              to: "/turtlesim2/turtle1/cmd_vel"
 
    .. group-tab:: Python
 
       .. code-block:: python
 
-        # example_launch.py
-
+        #!/usr/bin/env python3
         import os
 
         from ament_index_python import get_package_share_directory
@@ -185,133 +176,109 @@ Each launch file performs the following actions:
         from launch.actions import DeclareLaunchArgument
         from launch.actions import GroupAction
         from launch.actions import IncludeLaunchDescription
-        from launch.launch_description_sources import PythonLaunchDescriptionSource
+        from launch.launch_description_sources import AnyLaunchDescriptionSource
         from launch.substitutions import LaunchConfiguration
         from launch.substitutions import TextSubstitution
         from launch_ros.actions import Node
         from launch_ros.actions import PushROSNamespace
-        from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
-        from launch_yaml.launch_description_sources import YAMLLaunchDescriptionSource
-
 
         def generate_launch_description():
-
-            # args that can be set from the command line or a default will be used
-            background_r_launch_arg = DeclareLaunchArgument(
-                "background_r", default_value=TextSubstitution(text="0")
-            )
-            background_g_launch_arg = DeclareLaunchArgument(
-                "background_g", default_value=TextSubstitution(text="255")
-            )
-            background_b_launch_arg = DeclareLaunchArgument(
-                "background_b", default_value=TextSubstitution(text="0")
-            )
-            chatter_py_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_py_ns", default_value=TextSubstitution(text="chatter/py/ns")
-            )
-            chatter_xml_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_xml_ns", default_value=TextSubstitution(text="chatter/xml/ns")
-            )
-            chatter_yaml_ns_launch_arg = DeclareLaunchArgument(
-                "chatter_yaml_ns", default_value=TextSubstitution(text="chatter/yaml/ns")
-            )
-
-            # include another launch file
-            launch_include = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(
-                        get_package_share_directory('demo_nodes_cpp'),
-                        'launch/topics/talker_listener_launch.py'))
-            )
-            # include a Python launch file in the chatter_py_ns namespace
-            launch_py_include_with_namespace = GroupAction(
-                actions=[
-                    # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushROSNamespace('chatter_py_ns'),
-                    IncludeLaunchDescription(
-                        PythonLaunchDescriptionSource(
-                            os.path.join(
-                                get_package_share_directory('demo_nodes_cpp'),
-                                'launch/topics/talker_listener_launch.py'))
-                    ),
-                ]
-            )
-
-            # include a xml launch file in the chatter_xml_ns namespace
-            launch_xml_include_with_namespace = GroupAction(
-                actions=[
-                    # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushROSNamespace('chatter_xml_ns'),
-                    IncludeLaunchDescription(
-                        XMLLaunchDescriptionSource(
-                            os.path.join(
-                                get_package_share_directory('demo_nodes_cpp'),
-                                'launch/topics/talker_listener_launch.xml'))
-                    ),
-                ]
-            )
-
-            # include a yaml launch file in the chatter_yaml_ns namespace
-            launch_yaml_include_with_namespace = GroupAction(
-                actions=[
-                    # push_ros_namespace first to set namespace of included nodes for following actions
-                    PushROSNamespace('chatter_yaml_ns'),
-                    IncludeLaunchDescription(
-                        YAMLLaunchDescriptionSource(
-                            os.path.join(
-                                get_package_share_directory('demo_nodes_cpp'),
-                                'launch/topics/talker_listener_launch.yaml'))
-                    ),
-                ]
-            )
-
-            # start a turtlesim_node in the turtlesim1 namespace
-            turtlesim_node = Node(
-                package='turtlesim',
-                namespace='turtlesim1',
-                executable='turtlesim_node',
-                name='sim'
-            )
-
-            # start another turtlesim_node in the turtlesim2 namespace
-            # and use args to set parameters
-            turtlesim_node_with_parameters = Node(
-                package='turtlesim',
-                namespace='turtlesim2',
-                executable='turtlesim_node',
-                name='sim',
-                parameters=[{
-                    "background_r": LaunchConfiguration('background_r'),
-                    "background_g": LaunchConfiguration('background_g'),
-                    "background_b": LaunchConfiguration('background_b'),
-                }]
-            )
-
-            # perform remap so both turtles listen to the same command topic
-            forward_turtlesim_commands_to_second_turtlesim_node = Node(
-                package='turtlesim',
-                executable='mimic',
-                name='mimic',
-                remappings=[
-                    ('/input/pose', '/turtlesim1/turtle1/pose'),
-                    ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                ]
-            )
-
             return LaunchDescription([
-                background_r_launch_arg,
-                background_g_launch_arg,
-                background_b_launch_arg,
-                chatter_py_ns_launch_arg,
-                chatter_xml_ns_launch_arg,
-                chatter_yaml_ns_launch_arg,
-                launch_include,
-                launch_py_include_with_namespace,
-                launch_xml_include_with_namespace,
-                launch_yaml_include_with_namespace,
-                turtlesim_node,
-                turtlesim_node_with_parameters,
-                forward_turtlesim_commands_to_second_turtlesim_node,
+                # args that can be set from the command line or a default will be used
+                DeclareLaunchArgument(
+                    "background_r", default_value=TextSubstitution(text="0")
+                ),
+                DeclareLaunchArgument(
+                    "background_g", default_value=TextSubstitution(text="255")
+                ),
+                DeclareLaunchArgument(
+                    "background_b", default_value=TextSubstitution(text="0")
+                ),
+                DeclareLaunchArgument(
+                    "chatter_py_ns", default_value=TextSubstitution(text="chatter/py/ns")
+                ),
+                DeclareLaunchArgument(
+                    "chatter_xml_ns", default_value=TextSubstitution(text="chatter/xml/ns")
+                ),
+                DeclareLaunchArgument(
+                    "chatter_yaml_ns", default_value=TextSubstitution(text="chatter/yaml/ns")
+                ),
+                # include another launch file
+                IncludeLaunchDescription(
+                    AnyLaunchDescriptionSource(
+                        os.path.join(
+                            get_package_share_directory('demo_nodes_cpp'),
+                            'launch/topics/talker_listener_launch.py'))
+                ),
+                # include a Python launch file in the chatter_py_ns namespace
+                GroupAction(
+                    actions=[
+                        # push_ros_namespace first to set namespace of included nodes for following actions
+                        PushROSNamespace('chatter_py_ns'),
+                        IncludeLaunchDescription(
+                            AnyLaunchDescriptionSource(
+                                os.path.join(
+                                    get_package_share_directory('demo_nodes_cpp'),
+                                    'launch/topics/talker_listener_launch.py'))
+                        ),
+                    ]
+                ),
+                # include a xml launch file in the chatter_xml_ns namespace
+                GroupAction(
+                    actions=[
+                        # push_ros_namespace first to set namespace of included nodes for following actions
+                        PushROSNamespace('chatter_xml_ns'),
+                        IncludeLaunchDescription(
+                            AnyLaunchDescriptionSource(
+                                os.path.join(
+                                    get_package_share_directory('demo_nodes_cpp'),
+                                    'launch/topics/talker_listener_launch.xml'))
+                        ),
+                    ]
+                ),
+                # include a yaml launch file in the chatter_yaml_ns namespace
+                GroupAction(
+                    actions=[
+                        # push_ros_namespace first to set namespace of included nodes for following actions
+                        PushROSNamespace('chatter_yaml_ns'),
+                        IncludeLaunchDescription(
+                            AnyLaunchDescriptionSource(
+                                os.path.join(
+                                    get_package_share_directory('demo_nodes_cpp'),
+                                    'launch/topics/talker_listener_launch.yaml'))
+                        ),
+                    ]
+                ),
+                # start a turtlesim_node in the turtlesim1 namespace
+                Node(
+                    package='turtlesim',
+                    namespace='turtlesim1',
+                    executable='turtlesim_node',
+                    name='sim'
+                ),
+                # start another turtlesim_node in the turtlesim2 namespace
+                # and use args to set parameters
+                Node(
+                    package='turtlesim',
+                    namespace='turtlesim2',
+                    executable='turtlesim_node',
+                    name='sim',
+                    parameters=[{
+                        "background_r": LaunchConfiguration('background_r'),
+                        "background_g": LaunchConfiguration('background_g'),
+                        "background_b": LaunchConfiguration('background_b'),
+                    }]
+                ),
+                # perform remap so both turtles listen to the same command topic
+                Node(
+                    package='turtlesim',
+                    executable='mimic',
+                    name='mimic',
+                    remappings=[
+                        ('/input/pose', '/turtlesim1/turtle1/pose'),
+                        ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+                    ]
+                ),
             ])
 
 Using the Launch files from the command line
@@ -361,7 +328,7 @@ To test that the remapping is working, you can control the turtles by running th
 
 .. _launch-file-different-formats-which:
 
-Python, XML, or YAML: Which should I use?
+XML, YAML, or Python: Which should I use?
 -----------------------------------------
 
 .. note::
@@ -369,11 +336,7 @@ Python, XML, or YAML: Which should I use?
   Launch files in ROS 1 were written in XML, so XML may be the most familiar to people coming from ROS 1.
   To see what's changed, you can visit :doc:`Migrating-from-ROS1/Migrating-Launch-Files`.
 
-For most applications the choice of which ROS 2 launch format comes down to developer preference.
-However, if your launch file requires flexibility that you cannot achieve with XML or YAML, you can use Python to write your launch file.
-Using Python for ROS 2 launch is more flexible because of following two reasons:
+To achieve a more declarative self-documenting style, you should prefer XML or YAML launch files, between them it comes down to developer preference.
 
-* Python is a scripting language, and thus you can leverage the language and its libraries in your launch files.
-* `ros2/launch <https://github.com/ros2/launch>`_ (general launch features) and `ros2/launch_ros <https://github.com/ros2/launch_ros>`_ (ROS 2 specific launch features) are written in Python and thus you have lower level access to launch features that may not be exposed by XML and YAML.
-
-That being said, a launch file written in Python may be more complex and verbose than one in XML or YAML.
+However, if your launch file requires advanced functionality that you cannot achieve with XML or YAML, you can turn to the Python launch API.
+Using Python for ROS 2 launch allows far more flexibility because it is a full scripting language and has access to the underlying implementation -- not all of which is exposed to XML/YAML -- but using it comes with the drawback of being more verbose and harder to reason about the resulting launch description.

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -331,35 +331,24 @@ If you look at the other terminal, you should see the output change to ``[INFO] 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can also set the parameter in a launch file, but first you will need to add the launch directory.
 Inside the ``ros2_ws/src/cpp_parameters/`` directory, create a new directory called ``launch``.
-In there, create a new file called ``cpp_parameters_launch.py``
+In there, create a new file called ``param_node.launch``
 
 
-.. code-block:: Python
+.. code-block:: xml
 
-  from launch import LaunchDescription
-  from launch_ros.actions import Node
-
-  def generate_launch_description():
-      return LaunchDescription([
-          Node(
-              package="cpp_parameters",
-              executable="minimal_param_node",
-              name="custom_minimal_param_node",
-              output="screen",
-              emulate_tty=True,
-              parameters=[
-                  {"my_parameter": "earth"}
-              ]
-          )
-      ])
+    <?xml version="1.0" encoding="UTF-8"?>
+    <launch>
+      <node pkg="cpp_parameters" exec="minimal_param_node" name="custom_minimal_param_node" output="screen" emulate_tty="true">
+        <param name="my_parameter" value="earth" />
+      </node>
+    </launch>
 
 Here you can see that we set ``my_parameter`` to ``earth`` when we launch our node ``minimal_param_node``.
-By adding the two lines below, we ensure our output is printed in our console.
+By adding the values below, we ensure our output is printed in our console.
 
 .. code-block:: console
 
-          output="screen",
-          emulate_tty=True,
+    output="screen" emulate_tty="true"
 
 Now open the ``CMakeLists.txt`` file.
 Below the lines you added earlier, add the following lines of code.
@@ -419,7 +408,7 @@ Now run the node using the launch file we have just created:
 
 .. code-block:: console
 
-     ros2 launch cpp_parameters cpp_parameters_launch.py
+     ros2 launch cpp_parameters param_node.launch
 
 The terminal should return the following message the first time:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -361,7 +361,7 @@ Add the ``import`` statements to the top of the file, and the other new statemen
       # ...
       data_files=[
           # ...
-          (os.path.join('share', package_name), glob('launch/*.launch')),
+          (os.path.join('share', package_name), glob('launch/*')),
         ]
       )
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -330,34 +330,23 @@ Since the node afterwards set the parameter back to ``world``, further outputs s
 
 You can also set parameters in a launch file, but first you will need to add a launch directory.
 Inside the ``ros2_ws/src/python_parameters/`` directory, create a new directory called ``launch``.
-In there, create a new file called ``python_parameters_launch.py``
+In there, create a new file called ``param_node.launch``
 
-.. code-block:: Python
+.. code-block:: xml
 
-  from launch import LaunchDescription
-  from launch_ros.actions import Node
+    <?xml version="1.0" encoding="UTF-8"?>
+    <launch>
+      <node pkg="python_parameters" exec="minimal_param_node" name="custom_minimal_param_node" output="screen" emulate_tty="true">
+        <param name="my_parameter" value="earth" />
+      </node>
+    </launch>
 
-  def generate_launch_description():
-      return LaunchDescription([
-          Node(
-              package='python_parameters',
-              executable='minimal_param_node',
-              name='custom_minimal_param_node',
-              output='screen',
-              emulate_tty=True,
-              parameters=[
-                  {'my_parameter': 'earth'}
-              ]
-          )
-      ])
-
-Here you can see that we set ``my_parameter`` to ``earth`` when we launch our node ``parameter_node``.
-By adding the two lines below, we ensure our output is printed in our console.
+Here you can see that we set ``my_parameter`` to ``earth`` when we launch our node ``minimal_param_node``.
+By adding the values below, we ensure our output is printed in our console.
 
 .. code-block:: console
 
-          output="screen",
-          emulate_tty=True,
+          output="screen" emulate_tty="true"
 
 Now open the ``setup.py`` file.
 Add the ``import`` statements to the top of the file, and the other new statement to the ``data_files`` parameter to include all launch files:
@@ -372,7 +361,7 @@ Add the ``import`` statements to the top of the file, and the other new statemen
       # ...
       data_files=[
           # ...
-          (os.path.join('share', package_name), glob('launch/*launch.[pxy][yma]*')),
+          (os.path.join('share', package_name), glob('launch/*.launch')),
         ]
       )
 
@@ -424,7 +413,7 @@ Now run the node using the launch file we have just created:
 
 .. code-block:: console
 
-     ros2 launch python_parameters python_parameters_launch.py
+     ros2 launch python_parameters param_node.launch
 
 The terminal should return the following message the first time:
 

--- a/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
+++ b/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
@@ -56,89 +56,24 @@ Create a new directory to store your launch files:
 Let's put together a ROS 2 launch file using the ``turtlesim`` package and its executables.
 As mentioned above, this can either be in XML, YAML, or Python.
 
+Copy and paste the complete code into the ``launch/turtlesim_mimic.launch`` file:
+
 .. tabs::
 
   .. group-tab:: XML
 
-    Copy and paste the complete code into the ``launch/turtlesim_mimic_launch.xml`` file:
-
-    .. code-block:: xml
-
-      <launch>
-        <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
-        <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
-        <node pkg="turtlesim" exec="mimic" name="mimic">
-          <remap from="/input/pose" to="/turtlesim1/turtle1/pose"/>
-          <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel"/>
-        </node>
-      </launch>
+    .. literalinclude:: code/turtlesim_mimic_xml.launch
+      :language: xml
 
   .. group-tab:: YAML
 
-    Copy and paste the complete code into the ``launch/turtlesim_mimic_launch.yaml`` file:
-
-    .. code-block:: yaml
-
-      launch:
-
-      - node:
-          pkg: "turtlesim"
-          exec: "turtlesim_node"
-          name: "sim"
-          namespace: "turtlesim1"
-
-      - node:
-          pkg: "turtlesim"
-          exec: "turtlesim_node"
-          name: "sim"
-          namespace: "turtlesim2"
-
-      - node:
-          pkg: "turtlesim"
-          exec: "mimic"
-          name: "mimic"
-          remap:
-          -
-              from: "/input/pose"
-              to: "/turtlesim1/turtle1/pose"
-          -
-              from: "/output/cmd_vel"
-              to: "/turtlesim2/turtle1/cmd_vel"
+    .. literalinclude:: code/turtlesim_mimic_yaml.launch
+      :language: yaml
 
   .. group-tab:: Python
 
-    Copy and paste the complete code into the ``launch/turtlesim_mimic_launch.py`` file:
-
-    .. code-block:: python
-
-      from launch import LaunchDescription
-      from launch_ros.actions import Node
-
-      def generate_launch_description():
-          return LaunchDescription([
-              Node(
-                  package='turtlesim',
-                  namespace='turtlesim1',
-                  executable='turtlesim_node',
-                  name='sim'
-              ),
-              Node(
-                  package='turtlesim',
-                  namespace='turtlesim2',
-                  executable='turtlesim_node',
-                  name='sim'
-              ),
-              Node(
-                  package='turtlesim',
-                  executable='mimic',
-                  name='mimic',
-                  remappings=[
-                      ('/input/pose', '/turtlesim1/turtle1/pose'),
-                      ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-                  ]
-              )
-          ])
-
+    .. literalinclude:: code/turtlesim_mimic_py.launch
+      :language: python
 
 2.1 Examine the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -163,132 +98,65 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 
     The first two actions launch the two turtlesim windows:
 
-    .. code-block:: xml
-
-      <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
-      <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
+    .. literalinclude:: code/turtlesim_mimic_xml.launch
+      :language: xml
+      :lines: 3-4
 
     The final action launches the mimic node with the remaps:
 
-    .. code-block:: xml
-
-      <node pkg="turtlesim" exec="mimic" name="mimic">
-        <remap from="/input/pose" to="/turtlesim1/turtle1/pose"/>
-        <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel"/>
-      </node>
+    .. literalinclude:: code/turtlesim_mimic_xml.launch
+      :language: xml
+      :lines: 5-8
 
   .. group-tab:: YAML
 
     The first two actions launch the two turtlesim windows:
 
-    .. code-block:: yaml
-
-      - node:
-          pkg: "turtlesim"
-          exec: "turtlesim_node"
-          name: "sim"
-          namespace: "turtlesim1"
-
-      - node:
-          pkg: "turtlesim"
-          exec: "turtlesim_node"
-          name: "sim"
-          namespace: "turtlesim2"
-
+    .. literalinclude:: code/turtlesim_mimic_yaml.launch
+      :language: yaml
+      :lines: 5-14
 
     The final action launches the mimic node with the remaps:
 
-    .. code-block:: yaml
-
-      - node:
-          pkg: "turtlesim"
-          exec: "mimic"
-          name: "mimic"
-          remap:
-          -
-              from: "/input/pose"
-              to: "/turtlesim1/turtle1/pose"
-          -
-              from: "/output/cmd_vel"
-              to: "/turtlesim2/turtle1/cmd_vel"
+    .. literalinclude:: code/turtlesim_mimic_yaml.launch
+      :language: yaml
+      :lines: 15-23
 
   .. group-tab:: Python
 
     These import statements pull in some Python ``launch`` modules.
 
-    .. code-block:: python
-
-      from launch import LaunchDescription
-      from launch_ros.actions import Node
+    .. literalinclude:: code/turtlesim_mimic_py.launch
+      :language: python
+      :lines: 2-3
 
     Next, the launch description itself begins:
 
-    .. code-block:: python
-
-      def generate_launch_description():
-         return LaunchDescription([
-
-         ])
+    .. literalinclude:: code/turtlesim_mimic_py.launch
+      :language: python
+      :lines: 5-6,28
 
     The first two actions in the launch description launch the two turtlesim windows:
 
-    .. code-block:: python
-
-      Node(
-          package='turtlesim',
-          namespace='turtlesim1',
-          executable='turtlesim_node',
-          name='sim'
-      ),
-      Node(
-          package='turtlesim',
-          namespace='turtlesim2',
-          executable='turtlesim_node',
-          name='sim'
-      ),
+    .. literalinclude:: code/turtlesim_mimic_py.launch
+      :language: python
+      :lines: 7-18
 
     The final action launches the mimic node with the remaps:
 
-    .. code-block:: python
-
-      Node(
-          package='turtlesim',
-          executable='mimic',
-          name='mimic',
-          remappings=[
-            ('/input/pose', '/turtlesim1/turtle1/pose'),
-            ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-          ]
-      )
-
+    .. literalinclude:: code/turtlesim_mimic_py.launch
+      :language: python
+      :lines: 19-27
 
 3 ros2 launch
 ^^^^^^^^^^^^^
 
 To run the launch file created above, enter into the directory you created earlier and run the following command:
 
-.. tabs::
+.. code-block:: console
 
-  .. group-tab:: XML
-
-    .. code-block:: console
-
-      cd launch
-      ros2 launch turtlesim_mimic_launch.xml
-
-  .. group-tab:: YAML
-
-    .. code-block:: console
-
-      cd launch
-      ros2 launch turtlesim_mimic_launch.yaml
-
-  .. group-tab:: Python
-
-    .. code-block:: console
-
-      cd launch
-      ros2 launch turtlesim_mimic_launch.py
+  cd launch
+  ros2 launch turtlesim_mimic.launch
 
 .. note::
 

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -67,13 +67,13 @@ Create a workspace for the package to live in:
 
     .. code-block:: console
 
-      ros2 pkg create --build-type ament_python --license Apache-2.0 py_launch_example
+      ros2 pkg create --build-type ament_python --license Apache-2.0 launch_example
 
   .. group-tab:: C++ package
 
     .. code-block:: console
 
-      ros2 pkg create --build-type ament_cmake --license Apache-2.0 cpp_launch_example
+      ros2 pkg create --build-type ament_cmake --license Apache-2.0 launch_example
 
 2 Creating the structure to hold launch files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,10 +90,10 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
     .. code-block:: console
 
       src/
-        py_launch_example/
+        launch_example/
           launch/
           package.xml
-          py_launch_example/
+          launch_example/
           resource/
           setup.cfg
           setup.py
@@ -108,14 +108,14 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
       from glob import glob
       # Other imports ...
 
-      package_name = 'py_launch_example'
+      package_name = 'launch_example'
 
       setup(
           # Other parameters ...
           data_files=[
               # ... Other data files
               # Include all launch files.
-              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*')))
+              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*.launch')))
           ]
       )
 
@@ -137,12 +137,12 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
 3 Writing the launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Inside your ``launch`` directory, create a new launch file called ``my_script.launch``.
+``.launch`` is recommended, but not required, as the file extension for all launch files.
+
 .. tabs::
 
   .. group-tab:: XML launch file
-
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.xml``.
-    ``_launch.xml`` is recommended, but not required, as the file suffix for XML launch files.
 
     .. code-block:: xml
 
@@ -151,9 +151,6 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
       </launch>
 
   .. group-tab:: YAML launch file
-
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.yaml``.
-    ``_launch.yaml`` is recommended, but not required, as the file suffix for YAML launch files.
 
     .. code-block:: yaml
 
@@ -165,10 +162,6 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
           name: "talker"
 
   .. group-tab:: Python launch file
-
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.py``.
-    ``_launch.py`` is recommended, but not required, as the file suffix for Python launch files.
-    However, the launch file name needs to end with ``launch.py`` to be recognized and autocompleted by ``ros2 launch``.
 
     Your launch file should define the ``generate_launch_description()`` function which returns a ``launch.LaunchDescription()`` to be used by the ``ros2 launch`` verb.
 
@@ -197,51 +190,9 @@ Go to the top-level of the workspace, and build it:
 
 After the ``colcon build`` has been successful and you've sourced the workspace, you should be able to run the launch file as follows:
 
-.. tabs::
+.. code-block:: console
 
-  .. group-tab:: Python package
-
-    .. tabs::
-
-      .. group-tab:: XML launch file
-
-        .. code-block:: console
-
-          ros2 launch py_launch_example my_script_launch.xml
-
-      .. group-tab:: YAML launch file
-
-        .. code-block:: console
-
-          ros2 launch py_launch_example my_script_launch.yaml
-
-      .. group-tab:: Python launch file
-
-        .. code-block:: console
-
-          ros2 launch py_launch_example my_script_launch.py
-
-  .. group-tab:: C++ package
-
-    .. tabs::
-
-      .. group-tab:: XML launch file
-
-        .. code-block:: console
-
-          ros2 launch cpp_launch_example my_script_launch.xml
-
-      .. group-tab:: YAML launch file
-
-        .. code-block:: console
-
-          ros2 launch cpp_launch_example my_script_launch.yaml
-
-      .. group-tab:: Python launch file
-
-        .. code-block:: console
-
-          ros2 launch cpp_launch_example my_script_launch.py
+  ros2 launch launch_example my_script.launch
 
 
 Documentation

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -115,7 +115,7 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
           data_files=[
               # ... Other data files
               # Include all launch files.
-              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*.launch')))
+              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*')))
           ]
       )
 

--- a/source/Tutorials/Intermediate/Launch/Using-Event-Handlers.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Event-Handlers.rst
@@ -31,7 +31,7 @@ Prerequisites
 -------------
 
 This tutorial uses the :doc:`turtlesim <../../Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim>` package.
-This tutorial also assumes you have :doc:`created a new package <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>` of build type ``ament_python`` called ``launch_tutorial``.
+This tutorial also assumes you have :doc:`created a new package <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>` called ``launch_tutorial``.
 
 This tutorial extends the code shown in the :doc:`Using substitutions in launch files <./Using-Substitutions>` tutorial.
 
@@ -41,228 +41,49 @@ Using event handlers
 1 Event handlers example launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create a new file called ``example_event_handlers_launch.py`` file in the ``launch`` folder of the ``launch_tutorial`` package.
+Create a new file called ``example_event_handlers.launch`` file in the ``launch`` folder of the ``launch_tutorial`` package.
 
-.. code-block:: python
-
-    from launch_ros.actions import Node
-
-    from launch import LaunchDescription
-    from launch.actions import (DeclareLaunchArgument, EmitEvent, ExecuteProcess,
-                                LogInfo, RegisterEventHandler, TimerAction)
-    from launch.conditions import IfCondition
-    from launch.event_handlers import (OnExecutionComplete, OnProcessExit,
-                                    OnProcessIO, OnProcessStart, OnShutdown)
-    from launch.events import Shutdown
-    from launch.substitutions import (EnvironmentVariable, FindExecutable,
-                                    LaunchConfiguration, LocalSubstitution,
-                                    PythonExpression)
-
-
-    def generate_launch_description():
-        turtlesim_ns = LaunchConfiguration('turtlesim_ns')
-        use_provided_red = LaunchConfiguration('use_provided_red')
-        new_background_r = LaunchConfiguration('new_background_r')
-
-        turtlesim_ns_launch_arg = DeclareLaunchArgument(
-            'turtlesim_ns',
-            default_value='turtlesim1'
-        )
-        use_provided_red_launch_arg = DeclareLaunchArgument(
-            'use_provided_red',
-            default_value='False'
-        )
-        new_background_r_launch_arg = DeclareLaunchArgument(
-            'new_background_r',
-            default_value='200'
-        )
-
-        turtlesim_node = Node(
-            package='turtlesim',
-            namespace=turtlesim_ns,
-            executable='turtlesim_node',
-            name='sim'
-        )
-        spawn_turtle = ExecuteProcess(
-            cmd=[[
-                FindExecutable(name='ros2'),
-                ' service call ',
-                turtlesim_ns,
-                '/spawn ',
-                'turtlesim_msgs/srv/Spawn ',
-                '"{x: 2, y: 2, theta: 0.2}"'
-            ]],
-            shell=True
-        )
-        change_background_r = ExecuteProcess(
-            cmd=[[
-                FindExecutable(name='ros2'),
-                ' param set ',
-                turtlesim_ns,
-                '/sim background_r ',
-                '120'
-            ]],
-            shell=True
-        )
-        change_background_r_conditioned = ExecuteProcess(
-            condition=IfCondition(
-                PythonExpression([
-                    new_background_r,
-                    ' == 200',
-                    ' and ',
-                    use_provided_red
-                ])
-            ),
-            cmd=[[
-                FindExecutable(name='ros2'),
-                ' param set ',
-                turtlesim_ns,
-                '/sim background_r ',
-                new_background_r
-            ]],
-            shell=True
-        )
-
-        return LaunchDescription([
-            turtlesim_ns_launch_arg,
-            use_provided_red_launch_arg,
-            new_background_r_launch_arg,
-            turtlesim_node,
-            RegisterEventHandler(
-                OnProcessStart(
-                    target_action=turtlesim_node,
-                    on_start=[
-                        LogInfo(msg='Turtlesim started, spawning turtle'),
-                        spawn_turtle
-                    ]
-                )
-            ),
-            RegisterEventHandler(
-                OnProcessIO(
-                    target_action=spawn_turtle,
-                    on_stdout=lambda event: LogInfo(
-                        msg='Spawn request says "{}"'.format(
-                            event.text.decode().strip())
-                    )
-                )
-            ),
-            RegisterEventHandler(
-                OnExecutionComplete(
-                    target_action=spawn_turtle,
-                    on_completion=[
-                        LogInfo(msg='Spawn finished'),
-                        change_background_r,
-                        TimerAction(
-                            period=2.0,
-                            actions=[change_background_r_conditioned],
-                        )
-                    ]
-                )
-            ),
-            RegisterEventHandler(
-                OnProcessExit(
-                    target_action=turtlesim_node,
-                    on_exit=[
-                        LogInfo(msg=(EnvironmentVariable(name='USER'),
-                                ' closed the turtlesim window')),
-                        EmitEvent(event=Shutdown(
-                            reason='Window closed'))
-                    ]
-                )
-            ),
-            RegisterEventHandler(
-                OnShutdown(
-                    on_shutdown=[LogInfo(
-                        msg=['Launch was asked to shutdown: ',
-                            LocalSubstitution('event.reason')]
-                    )]
-                )
-            ),
-        ])
+.. literalinclude:: code/example_event_handlers_py.launch
+    :language: python
 
 ``RegisterEventHandler`` actions for the ``OnProcessStart``, ``OnProcessIO``, ``OnExecutionComplete``, ``OnProcessExit``, and ``OnShutdown`` events were defined in the launch description.
 
 The ``OnProcessStart`` event handler is used to register a callback function that is executed when the turtlesim node starts.
 It logs a message to the console and executes the ``spawn_turtle`` action when the turtlesim node starts.
 
-.. code-block:: python
-
-    RegisterEventHandler(
-        OnProcessStart(
-            target_action=turtlesim_node,
-            on_start=[
-                LogInfo(msg='Turtlesim started, spawning turtle'),
-                spawn_turtle
-            ]
-        )
-    ),
+.. literalinclude:: code/example_event_handlers_py.launch
+    :language: python
+    :lines: 60-68
 
 The ``OnProcessIO`` event handler is used to register a callback function that is executed when the ``spawn_turtle`` action writes to its standard output.
 It logs the result of the spawn request.
 
-.. code-block:: python
-
-    RegisterEventHandler(
-        OnProcessIO(
-            target_action=spawn_turtle,
-            on_stdout=lambda event: LogInfo(
-                msg='Spawn request says "{}"'.format(
-                    event.text.decode().strip())
-            )
-        )
-    ),
+.. literalinclude:: code/example_event_handlers_py.launch
+    :language: python
+    :lines: 69-77
 
 The ``OnExecutionComplete`` event handler is used to register a callback function that is executed when the ``spawn_turtle`` action completes.
-It logs a message to the console and executes the ``change_background_r`` and ``change_background_r_conditioned`` actions when the spawn action completes.
+It logs a message to the console and executes a process to set the ``background_r`` parameter, then conditionally set it again when the spawn action completes.
 
-.. code-block:: python
-
-    RegisterEventHandler(
-        OnExecutionComplete(
-            target_action=spawn_turtle,
-            on_completion=[
-                LogInfo(msg='Spawn finished'),
-                change_background_r,
-                TimerAction(
-                    period=2.0,
-                    actions=[change_background_r_conditioned],
-                )
-            ]
-        )
-    ),
+.. literalinclude:: code/example_event_handlers_py.launch
+    :language: python
+    :lines: 78-118
 
 The ``OnProcessExit`` event handler is used to register a callback function that is executed when the turtlesim node exits.
 It logs a message to the console and executes the ``EmitEvent`` action to emit a ``Shutdown`` event when the turtlesim node exits.
 It means that the launch process will shutdown when the turtlesim window is closed.
 
-.. code-block:: python
-
-    RegisterEventHandler(
-        OnProcessExit(
-            target_action=turtlesim_node,
-            on_exit=[
-                LogInfo(msg=(EnvironmentVariable(name='USER'),
-                        ' closed the turtlesim window')),
-                EmitEvent(event=Shutdown(
-                    reason='Window closed'))
-            ]
-        )
-    ),
+.. literalinclude:: code/example_event_handlers_py.launch
+    :language: python
+    :lines: 119-129
 
 Finally, the ``OnShutdown`` event handler is used to register a callback function that is executed when the launch file is asked to shutdown.
 It logs a message to the console why the launch file is asked to shutdown.
 It logs the message with a reason for shutdown like the closure of turtlesim window or :kbd:`ctrl-c` signal made by the user.
 
-.. code-block:: python
-
-    RegisterEventHandler(
-        OnShutdown(
-            on_shutdown=[LogInfo(
-                msg=['Launch was asked to shutdown: ',
-                    LocalSubstitution('event.reason')]
-            )]
-        )
-    ),
+.. literalinclude:: code/example_event_handlers_py.launch
+    :language: python
+    :lines: 130-137
 
 Build the package
 -----------------
@@ -278,11 +99,11 @@ Also remember to source the workspace after building.
 Launching example
 -----------------
 
-Now you can launch the ``example_event_handlers_launch.py`` file using the ``ros2 launch`` command.
+Now you can launch the ``example_event_handlers.launch`` file using the ``ros2 launch`` command.
 
 .. code-block:: console
 
-    ros2 launch launch_tutorial example_event_handlers_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
+    ros2 launch launch_tutorial example_event_handlers.launch turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
 This will do the following:
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -29,7 +29,7 @@ Prerequisites
 -------------
 
 This tutorial uses the :doc:`turtlesim <../../Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim>` and :doc:`turtle_tf2_py <../Tf2/Introduction-To-Tf2>` packages.
-This tutorial also assumes you have :doc:`created a new package <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>` of build type ``ament_python`` called ``launch_tutorial``.
+This tutorial also assumes you have :doc:`created a new package <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>` called ``launch_tutorial`` that installs its ``launch`` directory.
 
 Introduction
 ------------
@@ -39,7 +39,7 @@ Simulation of multiple turtles in the turtle simulator can serve as a good examp
 The turtle simulation consists of multiple turtle nodes, the world configuration, and the TF broadcaster and listener nodes.
 Between all of the nodes, there are a large number of ROS parameters that affect the behavior and appearance of these nodes.
 ROS 2 launch files allow us to start all nodes and set corresponding parameters in one place.
-By the end of a tutorial, you will build the ``launch_turtlesim_launch.py`` launch file in the ``launch_tutorial`` package.
+By the end of a tutorial, you will build the ``turtlesim_bringup.launch`` launch file in the ``launch_tutorial`` package.
 This launch file will bring up different nodes responsible for the simulation of two turtlesim simulations, starting TF broadcasters and listener, loading parameters, and launching an RViz configuration.
 In this tutorial, we'll go over this launch file and all related features used.
 
@@ -57,60 +57,19 @@ Even a change such as moving from a real robot to a simulated one can be done wi
 
 We will now go over the top-level launch file structure that makes this possible.
 Firstly, we will create a launch file that will call separate launch files.
-To do this, let's create a ``launch_turtlesim_launch.py`` file in the ``/launch`` folder of our ``launch_tutorial`` package.
+To do this, let's create a file ``launch/turtlesim_bringup.launch`` in our ``launch_tutorial`` package.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   import os
-
-   from ament_index_python.packages import get_package_share_directory
-
-   from launch import LaunchDescription
-   from launch.actions import IncludeLaunchDescription
-   from launch.launch_description_sources import PythonLaunchDescriptionSource
-
-
-   def generate_launch_description():
-      turtlesim_world_1 = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_world_1_launch.py'])
-         )
-      turtlesim_world_2 = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_world_2_launch.py'])
-         )
-      broadcaster_listener_nodes = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/broadcaster_listener_launch.py']),
-         launch_arguments={'target_frame': 'carrot1'}.items(),
-         )
-      mimic_node = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/mimic_launch.py'])
-         )
-      fixed_frame_node = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/fixed_broadcaster_launch.py'])
-         )
-      rviz_node = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_rviz_launch.py'])
-         )
-
-      return LaunchDescription([
-         turtlesim_world_1,
-         turtlesim_world_2,
-         broadcaster_listener_nodes,
-         mimic_node,
-         fixed_frame_node,
-         rviz_node
-      ])
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_world_1.launch" />
+      <include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_world_2.launch" />
+      <include file="$(find-pkg-share launch_tutorial)/launch/broadcast_listener.launch" />
+      <include file="$(find-pkg-share launch_tutorial)/launch/mimic.launch" />
+      <include file="$(find-pkg-share launch_tutorial)/launch/fixed_broadcaster.launch" />
+      <include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_rviz.launch" />
+   </launch>
 
 This launch file includes a set of other launch files.
 Each of these included launch files contains nodes, parameters, and possibly, nested includes, which pertain to one part of the system.
@@ -132,43 +91,21 @@ However, there are cases when some nodes or launch files have to be launched sep
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We will begin by writing a launch file that will start our first turtlesim simulation.
-First, create a new file called ``turtlesim_world_1_launch.py``.
+First, create a new file called ``turtlesim_world_1.launch``.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   from launch import LaunchDescription
-   from launch.actions import DeclareLaunchArgument
-   from launch.substitutions import LaunchConfiguration, TextSubstitution
-
-   from launch_ros.actions import Node
-
-
-   def generate_launch_description():
-      background_r_launch_arg = DeclareLaunchArgument(
-         'background_r', default_value=TextSubstitution(text='0')
-      )
-      background_g_launch_arg = DeclareLaunchArgument(
-         'background_g', default_value=TextSubstitution(text='84')
-      )
-      background_b_launch_arg = DeclareLaunchArgument(
-         'background_b', default_value=TextSubstitution(text='122')
-      )
-
-      return LaunchDescription([
-         background_r_launch_arg,
-         background_g_launch_arg,
-         background_b_launch_arg,
-         Node(
-            package='turtlesim',
-            executable='turtlesim_node',
-            name='sim',
-            parameters=[{
-               'background_r': LaunchConfiguration('background_r'),
-               'background_g': LaunchConfiguration('background_g'),
-               'background_b': LaunchConfiguration('background_b'),
-            }]
-         ),
-      ])
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <arg name="background_r" default="0" />
+      <arg name="background_g" default="84" />
+      <arg name="background_b" default="122" />
+      <node pkg="turtlesim" exec="turtlesim_node" name="sim">
+         <param name="background_r" value="$(var background_r)" />
+         <param name="background_g" value="$(var background_g)" />
+         <param name="background_b" value="$(var background_b)" />
+      </node>
+   </launch>
 
 This launch file starts the ``turtlesim_node`` node, which starts the turtlesim simulation, with simulation configuration parameters that are defined and passed to the nodes.
 
@@ -178,34 +115,16 @@ This launch file starts the ``turtlesim_node`` node, which starts the turtlesim 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the second launch, we will start a second turtlesim simulation with a different configuration.
-Now create a ``turtlesim_world_2_launch.py`` file.
+Now create a ``turtlesim_world_2.launch`` file.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   import os
-
-   from ament_index_python.packages import get_package_share_directory
-
-   from launch import LaunchDescription
-   from launch_ros.actions import Node
-
-
-   def generate_launch_description():
-      config = os.path.join(
-         get_package_share_directory('launch_tutorial'),
-         'config',
-         'turtlesim.yaml'
-         )
-
-      return LaunchDescription([
-         Node(
-            package='turtlesim',
-            executable='turtlesim_node',
-            namespace='turtlesim2',
-            name='sim',
-            parameters=[config]
-         )
-      ])
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <node pkg="turtlesim" exec="turtlesim_node" namespace="turtlesim2" name="sim">
+         <param from="$(find-pkg-share launch_tutorial)/config/turtlesim.yaml" />
+      </node>
+   </launch>
 
 This launch file will launch the same ``turtlesim_node`` with parameter values that are loaded directly from the YAML configuration file.
 Defining arguments and parameters in YAML files make it easy to store and load a large number of variables.
@@ -232,18 +151,16 @@ These nodes could have different namespaces or names but still have the same par
 Defining separate YAML files that explicitly define namespaces and node names is not efficient.
 A solution is to use wildcard characters, which act as substitutions for unknown characters in a text value, to apply parameters to several different nodes.
 
-Now let's create a new ``turtlesim_world_3_launch.py`` file similar to ``turtlesim_world_2_launch.py`` to include one more ``turtlesim_node`` node.
+Now let's create a new ``turtlesim_world_3.launch`` file similar to ``turtlesim_world_2.launch`` to include one more ``turtlesim_node`` node.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   ...
-   Node(
-      package='turtlesim',
-      executable='turtlesim_node',
-      namespace='turtlesim3',
-      name='sim',
-      parameters=[config]
-   )
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <node pkg="turtlesim" exec="turtlesim_node" namespace="turtlesim3" name="sim">
+         <param from="$(find-pkg-share launch_tutorial)/config/turtlesim.yaml" />
+      </node>
+   </launch>
 
 Loading the same YAML file, however, will not affect the appearance of the third turtlesim world.
 The reason is that its parameters are stored under another namespace as shown below:
@@ -268,95 +185,55 @@ We will now update the ``turtlesim.yaml``, in the ``/config`` folder in the foll
          background_g: 86
          background_r: 150
 
-Now include the ``turtlesim_world_3_launch.py`` launch description in our main launch file.
+Now include the ``turtlesim_world_3.launch`` launch description in our main launch file.
 Using that configuration file in our launch descriptions will assign ``background_b``, ``background_g``, and ``background_r`` parameters to specified values in ``turtlesim3/sim`` and ``turtlesim2/sim`` nodes.
 
 3 Namespaces
 ^^^^^^^^^^^^
 
-As you may have noticed, we have defined the namespace for the turlesim world in the ``turtlesim_world_2_launch.py`` file.
+As you may have noticed, we have defined the namespace for the turlesim world in the ``turtlesim_world_2.launch`` file.
 Unique namespaces allow the system to start two similar nodes without node name or topic name conflicts.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   namespace='turtlesim2',
+   namespace="turtlesim2"
 
 However, if the launch file contains a large number of nodes, defining namespaces for each of them can become tedious.
-To solve that issue, the ``PushROSNamespace`` action can be used to define the global namespace for each launch file description.
+To solve that issue, the ``push-ros-namespace`` action can be used to define the global namespace for each launch file description.
 Every nested node will inherit that namespace automatically.
 
-.. attention:: ``PushROSNamespace`` has to be the first action in the list for the following actions to apply the namespace.
+.. attention:: ``push-ros-namespace`` has to be the first action, for the following actions to use that namespace.
 
-To do that, firstly, we need to remove the ``namespace='turtlesim2'`` line from the ``turtlesim_world_2_launch.py`` file.
-Afterwards, we need to update the ``launch_turtlesim_launch.py`` to include the following lines:
+To do that, firstly, we need to remove the ``namespace="turtlesim2"`` value from the ``turtlesim_world_2.launch`` file.
+Afterwards, we need to replace the ``<include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_world_2.launch" />`` action in ``turtlesim_bringup.launch`` with:
 
-.. code-block:: Python
+.. code-block:: xml
+   <group>
+      <push-ros-namespace namespace="turtlesim2"/>
+      <include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_world_2.launch" />
+   </group>
 
-   from launch.actions import GroupAction
-   from launch_ros.actions import PushROSNamespace
-
-      ...
-      turtlesim_world_2 = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_world_2_launch.py'])
-         )
-      turtlesim_world_2_with_namespace = GroupAction(
-        actions=[
-            PushROSNamespace('turtlesim2'),
-            turtlesim_world_2,
-         ]
-      )
-
-Finally, we replace the ``turtlesim_world_2`` to ``turtlesim_world_2_with_namespace`` in the ``return LaunchDescription`` statement.
-As a result, each node in the ``turtlesim_world_2_launch.py`` launch description will have a ``turtlesim2`` namespace.
 
 4 Reusing nodes
 ^^^^^^^^^^^^^^^
 
-Now create a ``broadcaster_listener_launch.py`` file.
+Now create a ``broadcaster_listener.launch`` file.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   from launch import LaunchDescription
-   from launch.actions import DeclareLaunchArgument
-   from launch.substitutions import LaunchConfiguration
-
-   from launch_ros.actions import Node
-
-
-   def generate_launch_description():
-      return LaunchDescription([
-         DeclareLaunchArgument(
-            'target_frame', default_value='turtle1',
-            description='Target frame name.'
-         ),
-         Node(
-            package='turtle_tf2_py',
-            executable='turtle_tf2_broadcaster',
-            name='broadcaster1',
-            parameters=[
-               {'turtlename': 'turtle1'}
-            ]
-         ),
-         Node(
-            package='turtle_tf2_py',
-            executable='turtle_tf2_broadcaster',
-            name='broadcaster2',
-            parameters=[
-               {'turtlename': 'turtle2'}
-            ]
-         ),
-         Node(
-            package='turtle_tf2_py',
-            executable='turtle_tf2_listener',
-            name='listener',
-            parameters=[
-               {'target_frame': LaunchConfiguration('target_frame')}
-            ]
-         ),
-      ])
-
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <arg name="target_frame" default="turtle1" />
+      <node pkg="turtle_tf2_py" exec="turtle_tf2_broadcaster" name="broadcaster1">
+         <param name="turtlename" value="turtle1" />
+      </node>
+      <node pkg="turtle_tf2_py" exec="turtle_tf2_broadcaster" name="broadcaster2">
+         <param name="turtlename" value="turtle2" />
+      </node>
+      <node pkg="turtle_tf2_py" exec="turtle_tf2_listener" name="listener">
+         <param name="target_frame" value="$(var target_frame)" />
+      </node>
+   </launch>
 
 In this file, we have declared the ``target_frame`` launch argument with a default value of ``turtle1``.
 The default value means that the launch file can receive an argument to forward to its nodes, or in case the argument is not provided, it will pass the default value to its nodes.
@@ -369,45 +246,33 @@ We also start a ``turtle_tf2_listener`` node and set its ``target_frame`` parame
 5 Parameter overrides
 ^^^^^^^^^^^^^^^^^^^^^
 
-Recall that we called the ``broadcaster_listener_launch.py`` file in our top-level launch file.
+Recall that we called the ``broadcaster_listener.launch`` file in our top-level launch file.
 In addition to that, we have passed it ``target_frame`` launch argument as shown below:
 
-.. code-block:: Python
+.. code-block:: xml
 
-   broadcaster_listener_nodes = IncludeLaunchDescription(
-      PythonLaunchDescriptionSource([os.path.join(
-         get_package_share_directory('launch_tutorial'), 'launch'),
-         '/broadcaster_listener_launch.py']),
-      launch_arguments={'target_frame': 'carrot1'}.items(),
-      )
+   <include file="$(find-pkg-share launch_tutorial)/launch/broadcast_listener.launch">
+      <arg name="target_frame" value="carrot1" />
+   </include>
 
 This syntax allows us to change the default goal target frame to ``carrot1``.
-If you would like ``turtle2`` to follow ``turtle1`` instead of the ``carrot1``, just remove the line that defines ``launch_arguments``.
+If you would like ``turtle2`` to follow ``turtle1`` instead of the ``carrot1``, just remove the ``<arg />``.
 This will assign ``target_frame`` its default value, which is ``turtle1``.
 
 6 Remapping
 ^^^^^^^^^^^
 
-Now create a ``mimic_launch.py`` file.
+Now create a ``mimic.launch`` file.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   from launch import LaunchDescription
-   from launch_ros.actions import Node
-
-
-   def generate_launch_description():
-      return LaunchDescription([
-         Node(
-            package='turtlesim',
-            executable='mimic',
-            name='mimic',
-            remappings=[
-               ('/input/pose', '/turtle2/pose'),
-               ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-            ]
-         )
-      ])
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <node pkg="turtlesim" exec="mimic" name="mimic">
+         <remap from="/input/pose" to="/turtle2/pose" />
+         <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel" />
+      </node>
+   </launch>
 
 This launch file will start the ``mimic`` node, which will give commands to one turtlesim to follow the other.
 The node is designed to receive the target pose on the topic ``/input/pose``.
@@ -418,33 +283,14 @@ This way ``turtle1`` in our ``turtlesim2`` simulation world will follow ``turtle
 7 Config files
 ^^^^^^^^^^^^^^
 
-Let's now create a file called ``turtlesim_rviz_launch.py``.
+Let's now create a file called ``turtlesim_rviz.launch``.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   import os
-
-   from ament_index_python.packages import get_package_share_directory
-
-   from launch import LaunchDescription
-   from launch_ros.actions import Node
-
-
-   def generate_launch_description():
-      rviz_config = os.path.join(
-         get_package_share_directory('turtle_tf2_py'),
-         'rviz',
-         'turtle_rviz.rviz'
-         )
-
-      return LaunchDescription([
-         Node(
-            package='rviz2',
-            executable='rviz2',
-            name='rviz2',
-            arguments=['-d', rviz_config]
-         )
-      ])
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <node pkg="rviz2" exec="rviz2" name="rviz2" args="-d $(find-pkg-share turtle_tf2_py)/rviz/turtle_rviz.rviz" />
+   </launch>
 
 This launch file will start the RViz with the configuration file defined in the ``turtle_tf2_py`` package.
 This RViz configuration will set the world frame, enable TF visualization, and start RViz with a top-down view.
@@ -452,34 +298,20 @@ This RViz configuration will set the world frame, enable TF visualization, and s
 8 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Let's now create the last launch file called ``fixed_broadcaster_launch.py`` in our package.
+Let's now create the last launch file called ``fixed_broadcaster.launch`` in our package.
 
-.. code-block:: Python
+.. code-block:: xml
 
-   from launch import LaunchDescription
-   from launch.actions import DeclareLaunchArgument
-   from launch.substitutions import EnvironmentVariable, LaunchConfiguration
-   from launch_ros.actions import Node
-
-
-   def generate_launch_description():
-      return LaunchDescription([
-         DeclareLaunchArgument(
-               'node_prefix',
-               default_value=[EnvironmentVariable('USER'), '_'],
-               description='prefix for node name'
-         ),
-         Node(
-               package='turtle_tf2_py',
-               executable='fixed_frame_tf2_broadcaster',
-               name=[LaunchConfiguration('node_prefix'), 'fixed_broadcaster'],
-         ),
-      ])
+   <?xml version="1.0" encoding="UTF-8"?>
+   <launch>
+      <arg name="node_prefix" default="$(env USER _)" description="prefix for node name" />
+      <node pkg="turtle_tf2_py" exec="fixed_frame_tf2_broadcaster" name="$(var node_prefix)fixed_broadcaster" />
+   </launch>
 
 This launch file shows the way environment variables can be called inside the launch files.
 Environment variables can be used to define or push namespaces for distinguishing nodes on different computers or robots.
 
-.. note:: If you are running the launch file where the ``USER`` environment variable is not defined (like in the ROS docker file), then you can replace the ``EnvironmentVariable('USER')`` above with any other word of your liking.
+.. note:: If you are running the launch file where the ``USER`` environment variable is not defined (like in the ROS docker file), then you can replace the ``$(env USER)`` above with any other variable.
 
 Running launch files
 --------------------
@@ -500,7 +332,7 @@ The ``data_files`` field should now look like this:
    data_files=[
          ...
          (os.path.join('share', package_name, 'launch'),
-            glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+            glob(os.path.join('launch', '*'))),
          (os.path.join('share', package_name, 'config'),
             glob(os.path.join('config', '*.yaml'))),
          (os.path.join('share', package_name, 'rviz'),
@@ -514,7 +346,7 @@ To finally see the result of our code, build the package and launch the top-leve
 
 .. code-block:: console
 
-   ros2 launch launch_tutorial launch_turtlesim_launch.py
+   ros2 launch launch_tutorial launch_turtlesim.launch
 
 You will now see the two turtlesim simulations started.
 There are two turtles in the first one and one in the second one.

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -208,6 +208,7 @@ To do that, firstly, we need to remove the ``namespace="turtlesim2"`` value from
 Afterwards, we need to replace the ``<include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_world_2.launch" />`` action in ``turtlesim_bringup.launch`` with:
 
 .. code-block:: xml
+
    <group>
       <push-ros-namespace namespace="turtlesim2"/>
       <include file="$(find-pkg-share launch_tutorial)/launch/turtlesim_world_2.launch" />

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -132,15 +132,15 @@ Copy and paste the complete code into the ``launch/example_main.launch`` file:
 
 .. tabs::
 
-  .. group-tab:: YAML
-
-    .. literalinclude:: code/example_main_yaml.launch
-      :language: yaml
-
   .. group-tab:: XML
 
     .. literalinclude:: code/example_main_xml.launch
       :language: xml
+
+  .. group-tab:: YAML
+
+    .. literalinclude:: code/example_main_yaml.launch
+      :language: yaml
 
   .. group-tab:: Python
 
@@ -150,21 +150,6 @@ Copy and paste the complete code into the ``launch/example_main.launch`` file:
 Step-by-step explanation:
 
 .. tabs::
-
-  .. group-tab:: YAML
-
-    The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
-    The path substitution is then joined with the ``example_substitutions.launch`` file name.
-
-    .. literalinclude:: code/example_main_yaml.launch
-      :language: yaml
-      :lines: 9
-
-    The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
-    The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
-
-    .. literalinclude:: code/example_main_yaml.launch
-      :lines: 10-16
 
   .. group-tab:: XML
 
@@ -181,6 +166,22 @@ Step-by-step explanation:
     .. literalinclude:: code/example_main_xml.launch
       :language: xml
       :lines: 5-7
+
+  .. group-tab:: YAML
+
+    The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The path substitution is then joined with the ``example_substitutions.launch`` file name.
+
+    .. literalinclude:: code/example_main_yaml.launch
+      :language: yaml
+      :lines: 9
+
+    The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
+    The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
+
+    .. literalinclude:: code/example_main_yaml.launch
+      :lines: 10-16
+
 
   .. group-tab:: Python
 
@@ -205,15 +206,15 @@ Now create the substitution launch file ``launch/example_substitutions.launch`` 
 
 .. tabs::
 
-  .. group-tab:: YAML
-
-    .. literalinclude:: code/example_substitutions_yaml.launch
-      :language: yaml
-
   .. group-tab:: XML
 
     .. literalinclude:: code/example_substitutions_xml.launch
       :language: xml
+
+  .. group-tab:: YAML
+
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
 
   .. group-tab:: Python
 
@@ -223,41 +224,6 @@ Now create the substitution launch file ``launch/example_substitutions.launch`` 
 Step-by-step explanation:
 
 .. tabs::
-
-  .. group-tab:: YAML
-
-    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-    They are used to store values of launch arguments in the above variables and to pass them to required actions.
-    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
-
-    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
-
-    .. literalinclude:: code/example_substitutions_yaml.launch
-      :language: yaml
-      :lines: 4-12
-
-    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
-
-    .. literalinclude:: code/example_substitutions_yaml.launch
-      :language: yaml
-      :lines: 14-18
-
-    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
-    This command makes a call to the spawn service of the turtlesim node.
-
-    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
-
-    .. literalinclude:: code/example_substitutions_yaml.launch
-      :language: yaml
-      :lines: 19-20
-
-    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
-    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
-    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
-
-    .. literalinclude:: code/example_substitutions_yaml.launch
-      :language: yaml
-      :lines: 21-
 
   .. group-tab:: XML
 
@@ -293,6 +259,41 @@ Step-by-step explanation:
     .. literalinclude:: code/example_substitutions_xml.launch
       :language: xml
       :lines: 9-15
+
+  .. group-tab:: YAML
+
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
+
+    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
+
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 4-12
+
+    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
+
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 14-18
+
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
+    This command makes a call to the spawn service of the turtlesim node.
+
+    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 19-20
+
+    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
+    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
+
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 21-
 
   .. group-tab:: Python
 

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -431,78 +431,79 @@ Now create the substitution launch file in the same folder:
 
 
         def generate_launch_description():
-            turtlesim_ns = LaunchConfiguration('turtlesim_ns')
-            use_provided_red = LaunchConfiguration('use_provided_red')
-            new_background_r = LaunchConfiguration('new_background_r')
+            turtlesim_ns_name = 'turtlesim_ns'
+            use_provided_red_name = 'use_provided_red'
+            new_background_r_name = 'new_background_r'
 
-            turtlesim_ns_launch_arg = DeclareLaunchArgument(
-                'turtlesim_ns',
-                default_value='turtlesim1'
-            )
-            use_provided_red_launch_arg = DeclareLaunchArgument(
-                'use_provided_red',
-                default_value='False'
-            )
-            new_background_r_launch_arg = DeclareLaunchArgument(
-                'new_background_r',
-                default_value='200'
-            )
+            turtlesim_ns_val = LaunchConfiguration(turtlesim_ns_name)
+            use_provided_red_val = LaunchConfiguration(use_provided_red_name)
+            new_background_r_val = LaunchConfiguration(new_background_r_name)
 
-            turtlesim_node = Node(
-                package='turtlesim',
-                namespace=turtlesim_ns,
-                executable='turtlesim_node',
-                name='sim'
-            )
-            spawn_turtle = ExecuteProcess(
-                cmd=[[
-                    'ros2 service call ',
-                    turtlesim_ns,
-                    '/spawn ',
-                    'turtlesim_msgs/srv/Spawn ',
-                    '"{x: 2, y: 2, theta: 0.2}"'
-                ]],
-                shell=True
-            )
-            change_background_r = ExecuteProcess(
-                cmd=[[
-                    'ros2 param set ',
-                    turtlesim_ns,
-                    '/sim background_r ',
-                    '120'
-                ]],
-                shell=True
-            )
-            change_background_r_conditioned = ExecuteProcess(
-                condition=IfCondition(
-                    PythonExpression([
-                        new_background_r,
-                        ' == 200',
-                        ' and ',
-                        use_provided_red
-                    ])
-                ),
-                cmd=[[
-                    'ros2 param set ',
-                    turtlesim_ns,
-                    '/sim background_r ',
-                    new_background_r
-                ]],
-                shell=True
-            )
 
             return LaunchDescription([
-                turtlesim_ns_launch_arg,
-                use_provided_red_launch_arg,
-                new_background_r_launch_arg,
-                turtlesim_node,
-                spawn_turtle,
-                change_background_r,
+                DeclareLaunchArgument(
+                    turtlesim_ns,
+                    default_value='turtlesim1',
+                ),
+                DeclareLaunchArgument(
+                    use_provided_red,
+                    default_value='False',
+                ),
+                DeclareLaunchArgument(
+                    new_background_r,
+                    default_value='200',
+                ),
+                Node(
+                    package='turtlesim',
+                    namespace=LaunchConfiguration(turtlesim_ns),
+                    executable='turtlesim_node',
+                    name='sim',
+                ),
+                ExecuteProcess(
+                    cmd=[[
+                        'ros2 service call ',
+                        LaunchConfiguration(turtlesim_ns),
+                        '/spawn ',
+                        'turtlesim_msgs/srv/Spawn ',
+                        '"{x: 2, y: 2, theta: 0.2}"',
+                    ]],
+                    shell=True,
+                ),
+                ExecuteProcess(
+                    cmd=[[
+                        'ros2 param set ',
+                        turtlesim_ns,
+                        '/sim background_r ',
+                        '120',
+                    ]],
+                    shell=True,
+                ),
                 TimerAction(
                     period=2.0,
-                    actions=[change_background_r_conditioned],
-                )
+                    actions=[
+                        ExecuteProcess(
+                            condition=IfCondition(
+                                PythonExpression([
+                                    new_background_r,
+                                    ' == 200',
+                                    ' and ',
+                                    use_provided_red
+                                ])
+                            ),
+                            cmd=[[
+                                'ros2 param set ',
+                                turtlesim_ns,
+                                '/sim background_r ',
+                                new_background_r
+                            ]],
+                            shell=True,
+                        ),
+                    ],
+                ),
             ])
+
+
+
 
     The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
     They are used to store values of launch arguments in the above variables and to pass them to required actions.

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -103,7 +103,7 @@ Finally, make sure to install the launch files:
           data_files=[
               # ... Other data files
               # Include all launch files.
-              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*')))
+              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*')))
           ]
       )
 

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -418,179 +418,42 @@ Now create the substitution launch file in the same folder:
 
   .. group-tab:: Python
 
-    Create the file ``launch/example_substitutions_launch.py`` and insert the following code:
+    Create the file ``launch/example_substitutions_py.launch`` and insert the following code:
 
-    .. code-block:: python
-
-        from launch_ros.actions import Node
-
-        from launch import LaunchDescription
-        from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
-        from launch.conditions import IfCondition
-        from launch.substitutions import LaunchConfiguration, PythonExpression
+    .. literalinclude:: substitution.launch.py
+      :language: python
 
 
-        def generate_launch_description():
-            turtlesim_ns_name = 'turtlesim_ns'
-            use_provided_red_name = 'use_provided_red'
-            new_background_r_name = 'new_background_r'
+    First we provide variables with our argument names so that we reduce room for error in mistyped strings.
+    They will be used to declare arguments, and by ``LaunchConfiguration`` substitutions to allow us to acquire the value of the launch argument.
 
-            turtlesim_ns_val = LaunchConfiguration(turtlesim_ns_name)
-            use_provided_red_val = LaunchConfiguration(use_provided_red_name)
-            new_background_r_val = LaunchConfiguration(new_background_r_name)
-
-
-            return LaunchDescription([
-                DeclareLaunchArgument(
-                    turtlesim_ns,
-                    default_value='turtlesim1',
-                ),
-                DeclareLaunchArgument(
-                    use_provided_red,
-                    default_value='False',
-                ),
-                DeclareLaunchArgument(
-                    new_background_r,
-                    default_value='200',
-                ),
-                Node(
-                    package='turtlesim',
-                    namespace=LaunchConfiguration(turtlesim_ns),
-                    executable='turtlesim_node',
-                    name='sim',
-                ),
-                ExecuteProcess(
-                    cmd=[[
-                        'ros2 service call ',
-                        LaunchConfiguration(turtlesim_ns),
-                        '/spawn ',
-                        'turtlesim_msgs/srv/Spawn ',
-                        '"{x: 2, y: 2, theta: 0.2}"',
-                    ]],
-                    shell=True,
-                ),
-                ExecuteProcess(
-                    cmd=[[
-                        'ros2 param set ',
-                        turtlesim_ns,
-                        '/sim background_r ',
-                        '120',
-                    ]],
-                    shell=True,
-                ),
-                TimerAction(
-                    period=2.0,
-                    actions=[
-                        ExecuteProcess(
-                            condition=IfCondition(
-                                PythonExpression([
-                                    new_background_r,
-                                    ' == 200',
-                                    ' and ',
-                                    use_provided_red
-                                ])
-                            ),
-                            cmd=[[
-                                'ros2 param set ',
-                                turtlesim_ns,
-                                '/sim background_r ',
-                                new_background_r
-                            ]],
-                            shell=True,
-                        ),
-                    ],
-                ),
-            ])
-
-
-
-
-    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-    They are used to store values of launch arguments in the above variables and to pass them to required actions.
-    These ``LaunchConfiguration`` substitutions allow us to acquire the value of the launch argument in any part of the launch description.
+    .. literalinclude:: substitution.launch.py
+      :lines: 11-13
 
     ``DeclareLaunchArgument`` is used to define the launch argument that can be passed from the above launch file or from the console.
 
-    .. code-block:: python
+    .. literalinclude:: substitution.launch.py
+      :lines: 16-27
 
-        turtlesim_ns = LaunchConfiguration('turtlesim_ns')
-        use_provided_red = LaunchConfiguration('use_provided_red')
-        new_background_r = LaunchConfiguration('new_background_r')
+    The ``turtlesim_node`` node named ``sim`` with ``namespace`` set to ``turtlesim_ns`` is created.
 
-        turtlesim_ns_launch_arg = DeclareLaunchArgument(
-            'turtlesim_ns',
-            default_value='turtlesim1'
-        )
-        use_provided_red_launch_arg = DeclareLaunchArgument(
-            'use_provided_red',
-            default_value='False'
-        )
-        new_background_r_launch_arg = DeclareLaunchArgument(
-            'new_background_r',
-            default_value='200'
-        )
+    .. literalinclude:: substitution.launch.py
+      :lines: 28-33
 
-    The ``turtlesim_node`` node with the ``namespace`` set to ``turtlesim_ns`` ``LaunchConfiguration`` substitution is defined.
-
-    .. code-block:: python
-
-        turtlesim_node = Node(
-            package='turtlesim',
-            namespace=turtlesim_ns,
-            executable='turtlesim_node',
-            name='sim'
-        )
-
-    Afterwards, the ``ExecuteProcess`` action called ``spawn_turtle`` is defined with the corresponding ``cmd`` argument.
+    Afterwards, an ``ExecuteProcess`` action is defined with the corresponding ``cmd`` argument.
     This command makes a call to the spawn service of the turtlesim node.
 
     Additionally, the ``LaunchConfiguration`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
 
-    .. code-block:: python
+    .. literalinclude:: substitution.launch.py
+      :lines: 34-43
 
-        spawn_turtle = ExecuteProcess(
-            cmd=[[
-                'ros2 service call ',
-                turtlesim_ns,
-                '/spawn ',
-                'turtlesim_msgs/srv/Spawn ',
-                '"{x: 2, y: 2, theta: 0.2}"'
-            ]],
-            shell=True
-        )
-
-    The same approach is used for the ``change_background_r`` and ``change_background_r_conditioned`` actions that change the turtlesim background's red color parameter.
-    The difference is that the ``change_background_r_conditioned`` action is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The same approach is used for the ``ExecuteProcess`` actions that change the turtlesim background's red color parameter.
+    The difference is that the action in the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
     The evaluation inside the ``IfCondition`` is done using the ``PythonExpression`` substitution.
 
-    .. code-block:: python
-
-        change_background_r = ExecuteProcess(
-            cmd=[[
-                'ros2 param set ',
-                turtlesim_ns,
-                '/sim background_r ',
-                '120'
-            ]],
-            shell=True
-        )
-        change_background_r_conditioned = ExecuteProcess(
-            condition=IfCondition(
-                PythonExpression([
-                    new_background_r,
-                    ' == 200',
-                    ' and ',
-                    use_provided_red
-                ])
-            ),
-            cmd=[[
-                'ros2 param set ',
-                turtlesim_ns,
-                '/sim background_r ',
-                new_background_r
-            ]],
-            shell=True
-        )
+    .. literalinclude:: substitution.launch.py
+      :lines: 44-74
 
 4 Build the package
 ^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -113,9 +113,9 @@ Finally, make sure to install the launch files:
 
     .. code-block:: cmake
 
-      install(DIRECTORY
-              launch
-              DESTINATION share/${PROJECT_NAME}/
+      install(
+        DIRECTORY launch
+        DESTINATION share/${PROJECT_NAME}/
       )
 
 
@@ -128,252 +128,103 @@ This launch file can either be in YAML, XML, or in Python.
 
 To do this, create following file in the ``launch`` folder of the ``launch_tutorial`` package.
 
+Copy and paste the complete code into the ``launch/example_main.launch`` file:
+
 .. tabs::
 
   .. group-tab:: YAML
 
-    Copy and paste the complete code into the ``launch/example_main_launch.yaml`` file:
-
-    .. code-block:: yaml
-
-      launch:
-        - let:
-            name: 'background_r'
-            value: '200'
-        - include:
-            file: '$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.yaml'
-            arg:
-              - name: 'turtlesim_ns'
-                value: 'turtlesim2'
-              - name: 'use_provided_red'
-                value: 'True'
-              - name: 'new_background_r'
-                value: '$(var background_r)'
-
-    The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
-    The path substitution is then joined with the ``example_substitutions_launch.yaml`` file name.
-
-    .. code-block:: yaml
-
-      file: '$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.yaml'
-
-    The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
-    The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
-
-    .. code-block:: yaml
-
-      arg:
-        - name: 'turtlesim_ns'
-          value: 'turtlesim2'
-        - name: 'use_provided_red'
-          value: 'True'
-        - name: 'new_background_r'
-          value: '$(var background_r)'
+    .. literalinclude:: code/example_main_yaml.launch
+      :language: yaml
 
   .. group-tab:: XML
 
-    Copy and paste the complete code into the ``launch/example_main_launch.xml`` file:
+    .. literalinclude:: code/example_main_xml.launch
+      :language: xml
 
-    .. code-block:: xml
+  .. group-tab:: Python
 
-      <launch>
-        <let name="background_r" value="200"/>
-        <include file="$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.xml">
-          <arg name="turtlesim_ns" value="turtlesim2" />
-          <arg name="use_provided_red" value="True" />
-          <arg name="new_background_r" value="$(var background_r)" />
-        </include>
-      </launch>
+    .. literalinclude:: code/example_main_py.launch
+      :language: python
+
+Step-by-step explanation:
+
+.. tabs::
+
+  .. group-tab:: YAML
 
     The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
-    The path substitution is then joined with the ``example_substitutions_launch.xml`` file name.
+    The path substitution is then joined with the ``example_substitutions.launch`` file name.
 
-    .. code-block:: xml
-
-      <include file="$(find-pkg-share launch_tutorial)/launch/example_substitutions_launch.xml">
+    .. literalinclude:: code/example_main_yaml.launch
+      :language: yaml
+      :lines: 9
 
     The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
     The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
 
-    .. code-block:: xml
+    .. literalinclude:: code/example_main_yaml.launch
+      :lines: 10-16
 
-      <arg name="turtlesim_ns" value="turtlesim2" />
-      <arg name="use_provided_red" value="True" />
-      <arg name="new_background_r" value="$(var background_r)" />
+  .. group-tab:: XML
+
+    The ``$(find-pkg-share launch_tutorial)`` substitution is used to find the path to the ``launch_tutorial`` package.
+    The path substitution is then joined with the ``example_substitutions.launch`` file name.
+
+    .. literalinclude:: code/example_main_xml.launch
+      :language: xml
+      :lines: 4
+
+    The ``background_r`` variable with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``include`` action.
+    The ``$(var background_r)`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` variable.
+
+    .. literalinclude:: code/example_main_xml.launch
+      :language: xml
+      :lines: 5-7
 
   .. group-tab:: Python
 
-    Copy and paste the complete code into the ``launch/example_main_launch.py`` file:
-
-    .. code-block:: python
-
-      from launch_ros.substitutions import FindPackageShare
-
-      from launch import LaunchDescription
-      from launch.actions import IncludeLaunchDescription
-      from launch.launch_description_sources import PythonLaunchDescriptionSource
-      from launch.substitutions import PathJoinSubstitution, TextSubstitution
-
-
-      def generate_launch_description():
-          colors = {
-              'background_r': '200'
-          }
-
-          return LaunchDescription([
-              IncludeLaunchDescription(
-                  PythonLaunchDescriptionSource([
-                      PathJoinSubstitution([
-                          FindPackageShare('launch_tutorial'),
-                          'launch',
-                          'example_substitutions_launch.py'
-                      ])
-                  ]),
-                  launch_arguments={
-                      'turtlesim_ns': 'turtlesim2',
-                      'use_provided_red': 'True',
-                      'new_background_r': TextSubstitution(text=str(colors['background_r']))
-                  }.items()
-              )
-          ])
-
-
     The ``FindPackageShare`` substitution is used to find the path to the ``launch_tutorial`` package.
-    The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions_launch.py`` file name.
+    The ``PathJoinSubstitution`` substitution is then used to join the path to that package path with the ``example_substitutions.launch`` file name.
 
-    .. code-block:: python
-
-      PathJoinSubstitution([
-          FindPackageShare('launch_tutorial'),
-          'launch',
-          'example_substitutions_launch.py'
-      ])
+    .. literalinclude:: code/example_main_py.launch
+      :language: python
+      :lines: 18-22
 
     The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
     The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.
 
-    .. code-block:: python
-
-      launch_arguments={
-          'turtlesim_ns': 'turtlesim2',
-          'use_provided_red': 'True',
-          'new_background_r': TextSubstitution(text=str(colors['background_r']))
-      }.items()
+    .. literalinclude:: code/example_main_py.launch
+      :language: python
+      :lines: 24-28
 
 3 Substitutions example launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Now create the substitution launch file in the same folder:
+Now create the substitution launch file ``launch/example_substitutions.launch`` in the same folder:
 
 .. tabs::
 
   .. group-tab:: YAML
 
-    Create the file ``launch/example_substitutions_launch.yaml`` and insert the following code:
-
-    .. code-block:: yaml
-
-      launch:
-        - arg:
-            name: 'turtlesim_ns'
-            default: 'turtlesim1'
-        - arg:
-            name: 'use_provided_red'
-            default: 'False'
-        - arg:
-            name: 'new_background_r'
-            default: '200'
-
-        - node:
-            pkg: 'turtlesim'
-            namespace: '$(var turtlesim_ns)'
-            exec: 'turtlesim_node'
-            name: 'sim'
-        - executable:
-            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
-        - executable:
-            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
-        - timer:
-            period: 2.0
-            children:
-              - executable:
-                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
-                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
-
-    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-    They are used to store values of launch arguments in the above variables and to pass them to required actions.
-    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
-
-    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
-
-    .. code-block:: yaml
-
-      - arg:
-          name: 'turtlesim_ns'
-          default: 'turtlesim1'
-      - arg:
-          name: 'use_provided_red'
-          default: 'False'
-      - arg:
-          name: 'new_background_r'
-          default: '200'
-
-    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
-
-    .. code-block:: yaml
-
-      - node:
-          pkg: 'turtlesim'
-          namespace: '$(var turtlesim_ns)'
-          exec: 'turtlesim_node'
-          name: 'sim'
-
-    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
-    This command makes a call to the spawn service of the turtlesim node.
-
-    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
-
-    .. code-block:: yaml
-
-        - executable:
-            cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
-
-    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
-    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
-    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
-
-    .. code-block:: yaml
-
-        - executable:
-            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
-        - timer:
-            period: 2.0
-            children:
-              - executable:
-                  cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
-                  if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
 
   .. group-tab:: XML
 
-    Create the file ``launch/example_substitutions_launch.xml`` and insert the following code:
+    .. literalinclude:: code/example_substitutions_xml.launch
+      :language: xml
 
-    .. code-block:: xml
+  .. group-tab:: Python
 
-      <launch>
-        <arg name="turtlesim_ns" default="turtlesim1" />
-        <arg name="use_provided_red" default="False" />
-        <arg name="new_background_r" default="200" />
+    .. literalinclude:: code/example_substitutions_py.launch
+      :language: python
 
-        <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
-        <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
-        <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
-        <timer period="2.0">
-          <executable
-            cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
-            if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
-          />
-        </timer>
-      </launch>
+Step-by-step explanation:
+
+.. tabs::
+
+  .. group-tab:: YAML
 
     The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
     They are used to store values of launch arguments in the above variables and to pass them to required actions.
@@ -381,79 +232,105 @@ Now create the substitution launch file in the same folder:
 
     The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
 
-    .. code-block:: xml
-
-      <arg name="turtlesim_ns" default="turtlesim1" />
-      <arg name="use_provided_red" default="False" />
-      <arg name="new_background_r" default="200" />
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 4-12
 
     The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
 
-    .. code-block:: xml
-
-      <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 14-18
 
     Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
     This command makes a call to the spawn service of the turtlesim node.
 
     Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
 
-    .. code-block:: xml
-
-      <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 19-20
 
     The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
     The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
     The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
 
-    .. code-block:: xml
+    .. literalinclude:: code/example_substitutions_yaml.launch
+      :language: yaml
+      :lines: 21-
 
-      <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
-      <timer period="2.0">
-        <executable
-          cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
-          if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
-        />
-      </timer>
+  .. group-tab:: XML
+
+    The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
+    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    The launch configuration arguments can later be used with the ``$(var <name>)`` substitution to acquire the value of the launch argument in any part of the launch description.
+
+    The ``arg`` tag is used to define the launch argument that can be passed from the above launch file or from the console.
+
+    .. literalinclude:: code/example_substitutions_xml.launch
+      :language: xml
+      :lines: 3-5
+
+    The ``turtlesim_node`` node with the ``namespace`` set to the ``turtlesim_ns`` launch configuration value using the ``$(var <name>)`` substitution is defined.
+
+    .. literalinclude:: code/example_substitutions_xml.launch
+      :language: xml
+      :lines: 7
+
+    Afterwards, an ``executable`` action is defined with the corresponding ``cmd`` tag.
+    This command makes a call to the spawn service of the turtlesim node.
+
+    Additionally, the ``$(var <name>)`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+
+    .. literalinclude:: code/example_substitutions_xml.launch
+      :language: xml
+      :lines: 8
+
+    The same approach is used for the ``ros2 param`` ``executable`` actions that change the turtlesim background's red color parameter.
+    The difference is that the second action inside of the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The evaluation of the ``if`` predicate is done using the ``$(eval <python-expression>)`` substitution.
+
+    .. literalinclude:: code/example_substitutions_xml.launch
+      :language: xml
+      :lines: 9-15
 
   .. group-tab:: Python
 
-    Create the file ``launch/example_substitutions_py.launch`` and insert the following code:
-
-    .. literalinclude:: substitution.launch.py
-      :language: python
-
-
-    First we provide variables with our argument names so that we reduce room for error in mistyped strings.
+    First we provide variables with our argument names so that we reduce room for typo error.
     They will be used to declare arguments, and by ``LaunchConfiguration`` substitutions to allow us to acquire the value of the launch argument.
 
-    .. literalinclude:: substitution.launch.py
+    .. literalinclude:: code/example_substitutions_py.launch
+      :language: python
       :lines: 11-13
 
     ``DeclareLaunchArgument`` is used to define the launch argument that can be passed from the above launch file or from the console.
 
-    .. literalinclude:: substitution.launch.py
-      :lines: 16-27
+    .. literalinclude:: code/example_substitutions_py.launch
+      :language: python
+      :lines: 16-18
 
     The ``turtlesim_node`` node named ``sim`` with ``namespace`` set to ``turtlesim_ns`` is created.
 
-    .. literalinclude:: substitution.launch.py
-      :lines: 28-33
+    .. literalinclude:: code/example_substitutions_py.launch
+      :language: python
+      :lines: 19-24
 
     Afterwards, an ``ExecuteProcess`` action is defined with the corresponding ``cmd`` argument.
     This command makes a call to the spawn service of the turtlesim node.
 
     Additionally, the ``LaunchConfiguration`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
 
-    .. literalinclude:: substitution.launch.py
-      :lines: 34-43
+    .. literalinclude:: code/example_substitutions_py.launch
+      :language: python
+      :lines: 25-34
 
     The same approach is used for the ``ExecuteProcess`` actions that change the turtlesim background's red color parameter.
     The difference is that the action in the timer is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
     The evaluation inside the ``IfCondition`` is done using the ``PythonExpression`` substitution.
 
-    .. literalinclude:: substitution.launch.py
-      :lines: 44-74
+    .. literalinclude:: code/example_substitutions_py.launch
+      :language: python
+      :lines: 35-65
 
 4 Build the package
 ^^^^^^^^^^^^^^^^^^^
@@ -471,25 +348,9 @@ Launching example
 
 Now you can launch using the ``ros2 launch`` command.
 
-.. tabs::
+.. code-block:: console
 
-  .. group-tab:: YAML
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_main_launch.yaml
-
-  .. group-tab:: XML
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_main_launch.xml
-
-  .. group-tab:: Python
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_main_launch.py
+  ros2 launch launch_tutorial example_main.launch
 
 This will do the following:
 
@@ -501,34 +362,12 @@ This will do the following:
 Modifying launch arguments
 --------------------------
 
-.. tabs::
+If you want to change the provided launch arguments, you can either update the ``background_r`` variable in the ``example_main.launch`` or launch the ``example_substitutions.launch`` with preferred arguments.
+To see arguments that may be given to the launch file, run the following command:
 
-  .. group-tab:: YAML
+.. code-block:: console
 
-    If you want to change the provided launch arguments, you can either update the ``background_r`` variable in the ``example_main_launch.yaml`` or launch the ``example_substitutions_launch.yaml`` with preferred arguments.
-    To see arguments that may be given to the launch file, run the following command:
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.yaml --show-args
-
-  .. group-tab:: XML
-
-    If you want to change the provided launch arguments, you can either update the ``background_r`` variable in the ``example_main_launch.xml`` or launch the ``example_substitutions_launch.xml`` with preferred arguments.
-    To see arguments that may be given to the launch file, run the following command:
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.xml --show-args
-
-  .. group-tab:: Python
-
-    If you want to change the provided launch arguments, you can either update them in ``launch_arguments`` dictionary in the ``example_main_launch.py`` or launch the ``example_substitutions_launch.py`` with preferred arguments.
-    To see arguments that may be given to the launch file, run the following command:
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.py --show-args
+    ros2 launch launch_tutorial example_substitutions.launch --show-args
 
 This will show the arguments that may be given to the launch file and their default values.
 
@@ -550,25 +389,10 @@ This will show the arguments that may be given to the launch file and their defa
 
 Now you can pass the desired arguments to the launch file as follows:
 
-.. tabs::
+.. code-block:: console
 
-  .. group-tab:: YAML
+    ros2 launch launch_tutorial example_substitutions.launch turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.yaml turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
-
-  .. group-tab:: XML
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.xml turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
-
-  .. group-tab:: Python
-
-    .. code-block:: console
-
-        ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
 Documentation
 -------------

--- a/source/Tutorials/Intermediate/Launch/code/example_event_handlers_py.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_event_handlers_py.launch
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from launch_ros.actions import Node
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    EmitEvent,
+    ExecuteProcess,
+    LogInfo,
+    RegisterEventHandler,
+    TimerAction
+)
+from launch.conditions import IfCondition
+from launch.event_handlers import (
+    OnExecutionComplete,
+    OnProcessExit,
+    OnProcessIO,
+    OnProcessStart,
+    OnShutdown
+)
+from launch.events import Shutdown
+from launch.substitutions import (
+    EnvironmentVariable,
+    FindExecutable,
+    LaunchConfiguration,
+    LocalSubstitution,
+    PythonExpression
+)
+
+
+def generate_launch_description():
+    turtlesim_ns = LaunchConfiguration('turtlesim_ns')
+    use_provided_red = LaunchConfiguration('use_provided_red')
+    new_background_r = LaunchConfiguration('new_background_r')
+
+
+    turtlesim_node = Node(
+        package='turtlesim',
+        namespace=turtlesim_ns,
+        executable='turtlesim_node',
+        name='sim'
+    )
+    spawn_turtle = ExecuteProcess(
+        cmd=[[
+            FindExecutable(name='ros2'),
+            ' service call ',
+            turtlesim_ns,
+            '/spawn ',
+            'turtlesim_msgs/srv/Spawn ',
+            '"{x: 2, y: 2, theta: 0.2}"'
+        ]],
+        shell=True
+    )
+
+    return LaunchDescription([
+        DeclareLaunchArgument('turtlesim_ns', default_value='turtlesim1'),
+        DeclareLaunchArgument('use_provided_red', default_value='False'),
+        DeclareLaunchArgument('new_background_r', default_value='200'),
+        turtlesim_node,
+        RegisterEventHandler(
+            OnProcessStart(
+                target_action=turtlesim_node,
+                on_start=[
+                    LogInfo(msg='Turtlesim started, spawning turtle'),
+                    spawn_turtle
+                ]
+            )
+        ),
+        RegisterEventHandler(
+            OnProcessIO(
+                target_action=spawn_turtle,
+                on_stdout=lambda event: LogInfo(
+                    msg='Spawn request says "{}"'.format(
+                        event.text.decode().strip())
+                )
+            )
+        ),
+        RegisterEventHandler(
+            OnExecutionComplete(
+                target_action=spawn_turtle,
+                on_completion=[
+                    LogInfo(msg='Spawn finished'),
+                    ExecuteProcess(
+                        cmd=[[
+                            FindExecutable(name='ros2'),
+                            ' param set ',
+                            turtlesim_ns,
+                            '/sim background_r ',
+                            '120'
+                        ]],
+                        shell=True
+                    ),
+                    TimerAction(
+                        period=2.0,
+                        actions=[
+                            ExecuteProcess(
+                                condition=IfCondition(
+                                    PythonExpression([
+                                        new_background_r,
+                                        ' == 200',
+                                        ' and ',
+                                        use_provided_red
+                                    ])
+                                ),
+                                cmd=[[
+                                    FindExecutable(name='ros2'),
+                                    ' param set ',
+                                    turtlesim_ns,
+                                    '/sim background_r ',
+                                    new_background_r
+                                ]],
+                                shell=True
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ),
+        RegisterEventHandler(
+            OnProcessExit(
+                target_action=turtlesim_node,
+                on_exit=[
+                    LogInfo(msg=(EnvironmentVariable(name='USER'),
+                            ' closed the turtlesim window')),
+                    EmitEvent(event=Shutdown(
+                        reason='Window closed'))
+                ]
+            )
+        ),
+        RegisterEventHandler(
+            OnShutdown(
+                on_shutdown=[LogInfo(
+                    msg=['Launch was asked to shutdown: ',
+                        LocalSubstitution('event.reason')]
+                )]
+            )
+        ),
+    ])

--- a/source/Tutorials/Intermediate/Launch/code/example_main_py.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_main_py.launch
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from launch_ros.substitutions import FindPackageShare
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, TextSubstitution
+
+
+def generate_launch_description():
+    colors = {
+        'background_r': '200'
+    }
+
+    return LaunchDescription([
+        IncludeLaunchDescription(
+            AnyLaunchDescriptionSource([
+                PathJoinSubstitution([
+                    FindPackageShare('launch_tutorial'),
+                    'launch',
+                    'example_substitutions.launch',
+                ])
+            ]),
+            launch_arguments=[
+                ('turtlesim_ns', 'turtlesim2'),
+                ('use_provided_red', 'True'),
+                ('new_background_r', TextSubstitution(text=str(colors['background_r']))),
+            ],
+        ),
+    ])

--- a/source/Tutorials/Intermediate/Launch/code/example_main_xml.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_main_xml.launch
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <let name="background_r" value="200"/>
+  <include file="$(find-pkg-share launch_tutorial)/launch/example_substitutions.launch">
+    <arg name="turtlesim_ns" value="turtlesim2" />
+    <arg name="use_provided_red" value="True" />
+    <arg name="new_background_r" value="$(var background_r)" />
+  </include>
+</launch>

--- a/source/Tutorials/Intermediate/Launch/code/example_main_yaml.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_main_yaml.launch
@@ -1,0 +1,16 @@
+%YAML 1.2
+---
+
+launch:
+  - let:
+      name: 'background_r'
+      value: '200'
+  - include:
+      file: '$(find-pkg-share launch_tutorial)/launch/example_substitutions.launch'
+      arg:
+        - name: 'turtlesim_ns'
+          value: 'turtlesim2'
+        - name: 'use_provided_red'
+          value: 'True'
+        - name: 'new_background_r'
+          value: '$(var background_r)'

--- a/source/Tutorials/Intermediate/Launch/code/example_substitutions_py.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_substitutions_py.launch
@@ -13,18 +13,9 @@ def generate_launch_description():
     arg_new_background_r = 'new_background_r'
 
     return LaunchDescription([
-        DeclareLaunchArgument(
-            arg_turtlesim_ns,
-            default_value='turtlesim1',
-        ),
-        DeclareLaunchArgument(
-            arg_use_provided_red,
-            default_value='False',
-        ),
-        DeclareLaunchArgument(
-            arg_new_background_r,
-            default_value='200',
-        ),
+        DeclareLaunchArgument(arg_turtlesim_ns, default_value='turtlesim1'),
+        DeclareLaunchArgument(arg_use_provided_red, default_value='False'),
+        DeclareLaunchArgument(arg_new_background_r, default_value='200'),
         Node(
             package='turtlesim',
             namespace=LaunchConfiguration(arg_turtlesim_ns),

--- a/source/Tutorials/Intermediate/Launch/code/example_substitutions_xml.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_substitutions_xml.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="turtlesim_ns" default="turtlesim1" />
+  <arg name="use_provided_red" default="False" />
+  <arg name="new_background_r" default="200" />
+
+  <node pkg="turtlesim" namespace="$(var turtlesim_ns)" exec="turtlesim_node" name="sim" />
+  <executable cmd="ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn '{x: 5, y: 2, theta: 0.2}'" />
+  <executable cmd="ros2 param set $(var turtlesim_ns)/sim background_r 120" />
+  <timer period="2.0">
+    <executable
+      cmd="ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)"
+      if="$(eval '$(var new_background_r) == 200 and $(var use_provided_red)')"
+    />
+  </timer>
+</launch>

--- a/source/Tutorials/Intermediate/Launch/code/example_substitutions_yaml.launch
+++ b/source/Tutorials/Intermediate/Launch/code/example_substitutions_yaml.launch
@@ -1,0 +1,28 @@
+%YAML 1.2
+---
+launch:
+  - arg:
+      name: 'turtlesim_ns'
+      default: 'turtlesim1'
+  - arg:
+      name: 'use_provided_red'
+      default: 'False'
+  - arg:
+      name: 'new_background_r'
+      default: '200'
+
+  - node:
+      pkg: 'turtlesim'
+      namespace: '$(var turtlesim_ns)'
+      exec: 'turtlesim_node'
+      name: 'sim'
+  - executable:
+      cmd: 'ros2 service call $(var turtlesim_ns)/spawn turtlesim_msgs/srv/Spawn "{x: 5, y: 2, theta: 0.2}"'
+  - executable:
+      cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r 120'
+  - timer:
+      period: 2.0
+      children:
+        - executable:
+            cmd: 'ros2 param set $(var turtlesim_ns)/sim background_r $(var new_background_r)'
+            if: '$(eval "$(var new_background_r) == 200 and $(var use_provided_red)")'

--- a/source/Tutorials/Intermediate/Launch/code/turtlesim_mimic_py.launch
+++ b/source/Tutorials/Intermediate/Launch/code/turtlesim_mimic_py.launch
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='turtlesim',
+            namespace='turtlesim1',
+            executable='turtlesim_node',
+            name='sim'
+        ),
+        Node(
+            package='turtlesim',
+            namespace='turtlesim2',
+            executable='turtlesim_node',
+            name='sim'
+        ),
+        Node(
+            package='turtlesim',
+            executable='mimic',
+            name='mimic',
+            remappings=[
+                ('/input/pose', '/turtlesim1/turtle1/pose'),
+                ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+            ]
+        )
+    ])

--- a/source/Tutorials/Intermediate/Launch/code/turtlesim_mimic_xml.launch
+++ b/source/Tutorials/Intermediate/Launch/code/turtlesim_mimic_xml.launch
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1"/>
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2"/>
+  <node pkg="turtlesim" exec="mimic" name="mimic">
+    <remap from="/input/pose" to="/turtlesim1/turtle1/pose"/>
+    <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel"/>
+  </node>
+</launch>

--- a/source/Tutorials/Intermediate/Launch/code/turtlesim_mimic_yaml.launch
+++ b/source/Tutorials/Intermediate/Launch/code/turtlesim_mimic_yaml.launch
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+
+launch:
+  - node:
+      pkg: "turtlesim"
+      exec: "turtlesim_node"
+      name: "sim"
+      namespace: "turtlesim1"
+  - node:
+      pkg: "turtlesim"
+      exec: "turtlesim_node"
+      name: "sim"
+      namespace: "turtlesim2"
+  - node:
+      pkg: "turtlesim"
+      exec: "mimic"
+      name: "mimic"
+      remap:
+        - from: "/input/pose"
+          to: "/turtlesim1/turtle1/pose"
+        - from: "/output/cmd_vel"
+          to: "/turtlesim2/turtle1/cmd_vel"

--- a/source/Tutorials/Intermediate/Launch/substitution.launch.py
+++ b/source/Tutorials/Intermediate/Launch/substitution.launch.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from launch_ros.actions import Node
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PythonExpression
+
+
+def generate_launch_description():
+    arg_turtlesim_ns = 'turtlesim_ns'
+    arg_use_provided_red = 'use_provided_red'
+    arg_new_background_r = 'new_background_r'
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            arg_turtlesim_ns,
+            default_value='turtlesim1',
+        ),
+        DeclareLaunchArgument(
+            arg_use_provided_red,
+            default_value='False',
+        ),
+        DeclareLaunchArgument(
+            arg_new_background_r,
+            default_value='200',
+        ),
+        Node(
+            package='turtlesim',
+            namespace=LaunchConfiguration(arg_turtlesim_ns),
+            executable='turtlesim_node',
+            name='sim',
+        ),
+        ExecuteProcess(
+            cmd=[[
+                'ros2 service call ',
+                LaunchConfiguration(arg_turtlesim_ns),
+                '/spawn ',
+                'turtlesim_msgs/srv/Spawn ',
+                '"{x: 2, y: 2, theta: 0.2}"',
+            ]],
+            shell=True,
+        ),
+        ExecuteProcess(
+            cmd=[[
+                'ros2 param set ',
+                LaunchConfiguration(arg_turtlesim_ns),
+                '/sim background_r ',
+                '120',
+            ]],
+            shell=True,
+        ),
+        TimerAction(
+            period=2.0,
+            actions=[
+                ExecuteProcess(
+                    condition=IfCondition(
+                        PythonExpression([
+                            LaunchConfiguration(arg_new_background_r),
+                            ' == 200',
+                            ' and ',
+                            LaunchConfiguration(arg_use_provided_red),
+                        ])
+                    ),
+                    cmd=[[
+                        'ros2 param set ',
+                        LaunchConfiguration(arg_turtlesim_ns),
+                        '/sim background_r ',
+                        LaunchConfiguration(arg_new_background_r),
+                    ]],
+                    shell=True,
+                ),
+            ],
+        ),
+    ])

--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
@@ -182,7 +182,7 @@ Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your e
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now let's create a launch file for this example.
-With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo_launch.py`` in the ``src/learning_tf2_cpp/launch`` directory, and add the following lines:
+With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo.launch`` in the ``src/learning_tf2_cpp/launch`` directory, and add the following lines:
 
 .. code-block:: python
 
@@ -192,16 +192,16 @@ With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo_la
 
     from launch import LaunchDescription
     from launch.actions import IncludeLaunchDescription
-    from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch.launch_description_sources import AnyLaunchDescriptionSource
 
     from launch_ros.actions import Node
 
 
     def generate_launch_description():
         demo_nodes = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([os.path.join(
+            AnyLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('learning_tf2_cpp'), 'launch'),
-                '/turtle_tf2_demo_launch.py']),
+                '/turtle_tf2_demo.launch']),
             )
 
         return LaunchDescription([
@@ -302,7 +302,7 @@ Now you can start the turtle broadcaster demo:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo_launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch
 
 You should notice that the new ``carrot1`` frame appeared in the transformation tree.
 
@@ -317,10 +317,10 @@ One way is to pass the ``target_frame`` argument to the launch file directly fro
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo_launch.py target_frame:=carrot1
+    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch target_frame:=carrot1
 
 The second way is to update the launch file.
-To do so, open the ``turtle_tf2_fixed_frame_demo_launch.py`` file, and add the ``'target_frame': 'carrot1'`` parameter via ``launch_arguments`` argument.
+To do so, open the ``turtle_tf2_fixed_frame_demo.launch`` file, and add the ``'target_frame': 'carrot1'`` parameter via ``launch_arguments`` argument.
 
 .. code-block:: python
 
@@ -330,7 +330,7 @@ To do so, open the ``turtle_tf2_fixed_frame_demo_launch.py`` file, and add the `
             launch_arguments={'target_frame': 'carrot1'}.items(),
             )
 
-Now rebuild the package, restart the ``turtle_tf2_fixed_frame_demo_launch.py``, and you'll see the second turtle following the carrot instead of the first turtle!
+Now rebuild the package, restart the ``turtle_tf2_fixed_frame_demo.launch``, and you'll see the second turtle following the carrot instead of the first turtle!
 
 .. image:: images/carrot_static.png
 
@@ -469,7 +469,7 @@ Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your e
 2.3 Write the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo_launch.py`` in the ``src/learning_tf2_cpp/launch`` directory and paste the following code:
+To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo.launch`` in the ``src/learning_tf2_cpp/launch`` directory and paste the following code:
 
 .. code-block:: python
 
@@ -479,16 +479,16 @@ To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo_laun
 
     from launch import LaunchDescription
     from launch.actions import IncludeLaunchDescription
-    from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch.launch_description_sources import AnyLaunchDescriptionSource
 
     from launch_ros.actions import Node
 
 
     def generate_launch_description():
         demo_nodes = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([os.path.join(
+            AnyLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('learning_tf2_cpp'), 'launch'),
-                '/turtle_tf2_demo_launch.py']),
+                '/turtle_tf2_demo.launch']),
             launch_arguments={'target_frame': 'carrot1'}.items(),
             )
 
@@ -577,7 +577,7 @@ Now you can start the dynamic frame demo:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_dynamic_frame_demo_launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_dynamic_frame_demo.launch
 
 You should see that the second turtle is following the carrot's position that is constantly changing.
 

--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
@@ -159,7 +159,7 @@ Add the following line between the ``'console_scripts':`` brackets:
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now let's create a launch file for this example.
-With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo_launch.py`` in the ``src/learning_tf2_py/launch`` directory, and add the following lines:
+With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo.launch`` in the ``src/learning_tf2_py/launch`` directory, and add the following lines:
 
 .. code-block:: python
 
@@ -169,16 +169,16 @@ With your text editor, create a new file called ``turtle_tf2_fixed_frame_demo_la
 
     from launch import LaunchDescription
     from launch.actions import IncludeLaunchDescription
-    from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch.launch_description_sources import AnyLaunchDescriptionSource
 
     from launch_ros.actions import Node
 
 
     def generate_launch_description():
         demo_nodes = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([os.path.join(
+            AnyLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('learning_tf2_py'), 'launch'),
-                '/turtle_tf2_demo_launch.py']),
+                '/turtle_tf2_demo.launch']),
             )
 
         return LaunchDescription([
@@ -279,7 +279,7 @@ Now you can start the turtle broadcaster demo:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo_launch.py
+    ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo.launch
 
 You should notice that the new ``carrot1`` frame appeared in the transformation tree.
 
@@ -294,10 +294,10 @@ One way is to pass the ``target_frame`` argument to the launch file directly fro
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo_launch.py target_frame:=carrot1
+    ros2 launch learning_tf2_py turtle_tf2_fixed_frame_demo.launch target_frame:=carrot1
 
 The second way is to update the launch file.
-To do so, open the ``turtle_tf2_fixed_frame_demo_launch.py`` file, and add the ``'target_frame': 'carrot1'`` parameter via ``launch_arguments`` argument.
+To do so, open the ``turtle_tf2_fixed_frame_demo.launch`` file, and add the ``'target_frame': 'carrot1'`` parameter via ``launch_arguments`` argument.
 
 .. code-block:: python
 
@@ -307,7 +307,7 @@ To do so, open the ``turtle_tf2_fixed_frame_demo_launch.py`` file, and add the `
             launch_arguments={'target_frame': 'carrot1'}.items(),
             )
 
-Now rebuild the package, restart the ``turtle_tf2_fixed_frame_demo_launch.py``, and you'll see the second turtle following the carrot instead of the first turtle!
+Now rebuild the package, restart the ``turtle_tf2_fixed_frame_demo.launch``, and you'll see the second turtle following the carrot instead of the first turtle!
 
 .. image:: images/carrot_static.png
 
@@ -424,7 +424,7 @@ Add the following line between the ``'console_scripts':`` brackets:
 2.3 Write the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo_launch.py`` in the ``src/learning_tf2_py/launch`` directory and paste the following code:
+To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo.launch`` in the ``src/learning_tf2_py/launch`` directory and paste the following code:
 
 .. code-block:: python
 
@@ -434,16 +434,16 @@ To test this code, create a new launch file ``turtle_tf2_dynamic_frame_demo_laun
 
     from launch import LaunchDescription
     from launch.actions import IncludeLaunchDescription
-    from launch.launch_description_sources import PythonLaunchDescriptionSource
+    from launch.launch_description_sources import AnyLaunchDescriptionSource
 
     from launch_ros.actions import Node
 
 
     def generate_launch_description():
         demo_nodes = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([os.path.join(
+            AnyLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('learning_tf2_py'), 'launch'),
-                '/turtle_tf2_demo_launch.py']),
+                '/turtle_tf2_demo.launch']),
            launch_arguments={'target_frame': 'carrot1'}.items(),
            )
 
@@ -532,7 +532,7 @@ Now you can start the dynamic frame demo:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_py turtle_tf2_dynamic_frame_demo_launch.py
+    ros2 launch learning_tf2_py turtle_tf2_dynamic_frame_demo.launch
 
 You should see that the second turtle is following the carrot's position that is constantly changing.
 

--- a/source/Tutorials/Intermediate/Tf2/Debugging-Tf2-Problems.rst
+++ b/source/Tutorials/Intermediate/Tf2/Debugging-Tf2-Problems.rst
@@ -70,7 +70,7 @@ to
     } catch (const tf2::TransformException & ex) {
 
 And save changes to the file.
-In order to run this demo, we need to create a launch file ``start_tf2_debug_demo_launch.py`` in the ``launch`` subdirectory of package ``learning_tf2_cpp``:
+In order to run this demo, we need to create a launch file ``start_tf2_debug_demo.launch`` in the ``launch`` subdirectory of package ``learning_tf2_cpp``:
 
 .. code-block:: python
 
@@ -124,7 +124,7 @@ Now let's run it to see what happens:
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_cpp start_tf2_debug_demo_launch.py
+   ros2 launch learning_tf2_cpp start_tf2_debug_demo.launch
 
 You will now see that the turtlesim came up.
 At the same time, if you run the ``turtle_teleop_key`` in another terminal window, you can use the arrow keys to drive the ``turtle1`` around.
@@ -205,7 +205,7 @@ And now stop the running demo, build it, and run it again:
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_cpp start_tf2_debug_demo_launch.py
+   ros2 launch learning_tf2_cpp start_tf2_debug_demo.launch
 
 And right away we run into the next problem:
 
@@ -261,7 +261,7 @@ Stop the demo, build and run:
 
 .. code-block:: console
 
-   ros2 launch turtle_tf2 start_tf2_debug_demo_launch.py
+   ros2 launch turtle_tf2 start_tf2_debug_demo.launch
 
 And you should finally see the turtle move!
 

--- a/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
@@ -70,7 +70,7 @@ Now build the package and try to run the launch file.
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_cpp turtle_tf2_demo_launch.py
+   ros2 launch learning_tf2_cpp turtle_tf2_demo.launch
 
 You will notice that it fails and outputs something similar to this:
 
@@ -115,7 +115,7 @@ You can now build the package and run the launch file.
 
 .. code-block:: console
 
-   ros2 launch learning_tf2_cpp turtle_tf2_demo_launch.py
+   ros2 launch learning_tf2_cpp turtle_tf2_demo.launch
 
 You should notice that ``lookupTransform()`` will actually block until the transform between the two turtles becomes available (this will usually take a few milliseconds).
 Once the timeout has been reached (fifty milliseconds in this case), an exception will be raised only if the transform is still not available.

--- a/source/Tutorials/Intermediate/Tf2/Time-Travel-With-Tf2-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Time-Travel-With-Tf2-Cpp.rst
@@ -53,7 +53,7 @@ Build the package then let's just give it a try:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo_launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch
 
 .. image:: images/turtlesim_delay1.png
 
@@ -112,7 +112,7 @@ Build the package then let's run the simulation again, this time with the advanc
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo_launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_fixed_frame_demo.launch
 
 .. image:: images/turtlesim_delay2.png
 

--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -211,7 +211,7 @@ Then we fill up the ``PointStamped`` messages of ``turtle3`` with incoming ``Pos
 1.2 Write the launch file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to run this demo, we need to create a launch file ``turtle_tf2_sensor_message_launch.py`` in the ``launch`` subdirectory of package ``learning_tf2_py``:
+In order to run this demo, we need to create a launch file ``turtle_tf2_sensor_message.launch`` in the ``launch`` subdirectory of package ``learning_tf2_py``:
 
 .. code-block:: python
 
@@ -659,11 +659,11 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 3 Run
 ^^^^^
 
-First we need to run several nodes (including the broadcaster node of PointStamped messages) by launching the launch file ``turtle_tf2_sensor_message_launch.py``:
+First we need to run several nodes (including the broadcaster node of PointStamped messages) by launching the launch file ``turtle_tf2_sensor_message.launch``:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_py turtle_tf2_sensor_message_launch.py
+    ros2 launch learning_tf2_py turtle_tf2_sensor_message.launch
 
 This will bring up the ``turtlesim`` window with two turtles, where ``turtle3`` is moving along a circle, while ``turtle1`` isn't moving at first.
 But you can run the ``turtle_teleop_key`` node in another terminal to drive ``turtle1`` to move:

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -246,7 +246,7 @@ Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your e
 
 Now create a launch file for this demo.
 Create a ``launch`` folder in the ``src/learning_tf2_cpp`` directory.
-With your text editor, create a new file called ``turtle_tf2_demo_launch.py`` in the ``launch`` folder, and add the following lines:
+With your text editor, create a new file called ``turtle_tf2_demo.launch`` in the ``launch`` folder, and add the following lines:
 
 .. code-block:: python
 
@@ -405,7 +405,7 @@ Now run the launch file that will start the turtlesim simulation node and ``turt
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_demo_launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_demo.launch
 
 In the second terminal window type the following command:
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -252,7 +252,7 @@ Add the following line between the ``'console_scripts':`` brackets:
 
 Now create a launch file for this demo.
 Create a ``launch`` folder in the ``src/learning_tf2_py`` directory.
-With your text editor, create a new file called ``turtle_tf2_demo_launch.py`` in the ``launch`` folder, and add the following lines:
+With your text editor, create a new file called ``turtle_tf2_demo.launch`` in the ``launch`` folder, and add the following lines:
 
 .. code-block:: python
 
@@ -421,7 +421,7 @@ Now run the launch file that will start the turtlesim simulation node and ``turt
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_py turtle_tf2_demo_launch.py
+    ros2 launch learning_tf2_py turtle_tf2_demo.launch
 
 In the second terminal window type the following command:
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -333,7 +333,7 @@ The ``data_files`` field should now look like this:
 
     data_files=[
         ...
-        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*'))),
     ],
 
 Also add the appropriate imports at the top of the file:

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -278,7 +278,7 @@ Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your e
 2 Update the launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Open the launch file called ``turtle_tf2_demo_launch.py`` in the ``src/learning_tf2_cpp/launch`` directory with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports.
+Open the launch file called ``turtle_tf2_demo.launch`` in the ``src/learning_tf2_cpp/launch`` directory with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports.
 The resulting file should look like:
 
 .. code-block:: python
@@ -405,7 +405,7 @@ Now you're ready to start your full turtle demo:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_cpp turtle_tf2_demo_launch.py
+    ros2 launch learning_tf2_cpp turtle_tf2_demo.launch
 
 You should see the turtle sim with two turtles.
 In the second terminal window type the following command:

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
@@ -227,7 +227,7 @@ Add the following line between the ``'console_scripts':`` brackets:
 2 Update the launch file
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Open the launch file called ``turtle_tf2_demo_launch.py`` in the ``src/learning_tf2_py/launch`` directory with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports.
+Open the launch file called ``turtle_tf2_demo.launch`` in the ``src/learning_tf2_py/launch`` directory with your text editor, add two new nodes to the launch description, add a launch argument, and add the imports.
 The resulting file should look like:
 
 .. code-block:: python
@@ -354,7 +354,7 @@ Now you're ready to start your full turtle demo:
 
 .. code-block:: console
 
-    ros2 launch learning_tf2_py turtle_tf2_demo_launch.py
+    ros2 launch learning_tf2_py turtle_tf2_demo.launch
 
 You should see the turtle sim with two turtles.
 In the second terminal window type the following command:

--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-py.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-py.rst
@@ -266,7 +266,7 @@ Edit the ``second_ros2_ws/src/urdf_tutorial_r2d2/setup.py`` file as follows:
 
   data_files=[
     ...
-    (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+    (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*'))),
     (os.path.join('share', package_name), glob('urdf/*')),
   ],
 

--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-py.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-py.rst
@@ -203,7 +203,7 @@ Fire up your favorite editor and paste the following code into ``second_ros2_ws/
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Create a new ``second_ros2_ws/src/urdf_tutorial_r2d2/launch`` folder.
-Open your editor and paste the following code, saving it as ``second_ros2_ws/src/urdf_tutorial_r2d2/launch/demo_launch.py``
+Open your editor and paste the following code, saving it as ``second_ros2_ws/src/urdf_tutorial_r2d2/launch/demo.launch``
 
 .. code-block:: python
 
@@ -318,7 +318,7 @@ Launch the package
 
 .. code-block:: console
 
-  ros2 launch urdf_tutorial_r2d2 demo_launch.py
+  ros2 launch urdf_tutorial_r2d2 demo.launch
 
 Open a new terminal, the run Rviz using
 


### PR DESCRIPTION
Make a fairly opinionated pass on the Launch documentation and tutorials.
Works  in progress

- [x]  Reduce repetition, use `literalinclude` to include large blocks especially ones that are repeated in explanations
    - Done in https://github.com/ros2/ros2_documentation/pull/5155
- [ ]  Recommend and apply the `.launch` extension in all uses except references to actual existing demo files in other packages.
    - May not do this, in favor of https://github.com/ros2/launch/issues/849
- [ ]  Move trivial launch examples in tutorials to XML and/or YAML, instead of Python
- [ ] Remove use of `PythonLaunchDescriptionSource` as a user-facing thing in all Python cases to match XML/YAML usage and move toward a less opinionated default launch usage pattern

### Justification on .launch extension

I believe the potentially most contentious part will be the `.launch` extension, my justification is stated in [Launch File Different Formats](./source/How-To-Guides/Launch-file-different-formats.rst)

> While it is not required, we recommend that you name all launch files with the ``.launch`` extension, regardless of the language they are written in.
>
> There is historical content that uses the ``_launch.py``, ``_launch.xml``, and ``_launch.yaml`` extensions, but this is no longer necessary or recommended as it obfuscates the usage.
>
> Launch files should be considered part of the exposed interface of your package, and your users shouldn't have to know or care which language you used to implement a particular file, just like with your nodes.
> Nor should you be tied to keeping it in that format forever!
> As long as it has the ``.launch`` suffix with an informative name, the caller knows that it is a launch file, and the launch system will autodetect the format as needed.
> You can mix and match formats without any issues.