### PR TITLE
Remove ros/geometry2 from ROS PMC list

### DIFF
--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -277,8 +277,6 @@ The following repositories are managed by the ROS PMC:
      - Not Yet Available
    * - https://github.com/ros/geometry_tutorials
      - Not Yet Available
-   * - https://github.com/ros/geometry2
-     - Not Yet Available
    * - https://github.com/ros/kdl_parser
      - Not Yet Available
    * - https://github.com/ros/pluginlib


### PR DESCRIPTION
The repo https://github.com/ros/geometry2 is ROS 1 only, so I don't think it should be under the ROS PMC governance

The ROS 2 equivalent, https://github.com/ros2/geometry2 , is already in the list.