### PR TITLE
In setuptools packages, install everything in launch directory

### DIFF
--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -119,7 +119,7 @@ and a ``setup.py`` file that looks like:
            # Include our package.xml file
            (os.path.join('share', package_name), ['package.xml']),
            # Include all launch files.
-           (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+           (os.path.join('share', package_name, 'launch'), glob('launch/*')),
        ],
        # This is important as well
        install_requires=['setuptools'],

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -372,7 +372,7 @@ Add the ``import`` statements to the top of the file, and the other new statemen
       # ...
       data_files=[
           # ...
-          (os.path.join('share', package_name), glob('launch/*launch.[pxy][yma]*')),
+          (os.path.join('share', package_name), glob('launch/*')),
         ]
       )
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -372,7 +372,7 @@ Add the ``import`` statements to the top of the file, and the other new statemen
       # ...
       data_files=[
           # ...
-          (os.path.join('share', package_name), glob('launch/*')),
+          (os.path.join('share', package_name, 'launch'), glob('launch/*')),
         ]
       )
 

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -115,7 +115,7 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
           data_files=[
               # ... Other data files
               # Include all launch files.
-              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*')))
+              (os.path.join('share', package_name, 'launch'), glob('launch/*'))
           ]
       )
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -500,11 +500,11 @@ The ``data_files`` field should now look like this:
    data_files=[
          ...
          (os.path.join('share', package_name, 'launch'),
-            glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+            glob('launch/*')),
          (os.path.join('share', package_name, 'config'),
-            glob(os.path.join('config', '*.yaml'))),
+            glob('config/*.yaml')),
          (os.path.join('share', package_name, 'rviz'),
-            glob(os.path.join('config', '*.rviz'))),
+            glob('config/*.rviz')),
       ],
 
 2 Build and run

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -103,7 +103,7 @@ Finally, make sure to install the launch files:
           data_files=[
               # ... Other data files
               # Include all launch files.
-              (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*')))
+              (os.path.join('share', package_name, 'launch'), glob('launch/*'))
           ]
       )
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -333,7 +333,7 @@ The ``data_files`` field should now look like this:
 
     data_files=[
         ...
-        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*')),
     ],
 
 Also add the appropriate imports at the top of the file:

--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-py.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-py.rst
@@ -266,7 +266,7 @@ Edit the ``second_ros2_ws/src/urdf_tutorial_r2d2/setup.py`` file as follows:
 
   data_files=[
     ...
-    (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+    (os.path.join('share', package_name, 'launch'), glob('launch/*')),
     (os.path.join('share', package_name), glob('urdf/*')),
   ],
 


### PR DESCRIPTION
Part of https://github.com/ros2/ros2_documentation/pull/5143

Instead of using "clever" glob pattern to match `launch.xml`, `launch.yaml`, `launch.py`  - just copy what we already recommend for CMake packages, and install everything from `launch/` directory. Benefit of consistency between package types, and potentially leaving the door open for other launch suffixes/frontends.

(also, make our usage of `glob` consistent across the repo - we were some places using `os.path.join` inside it, and sometimes not. I opted for the simpler syntax)