### PR TITLE
Fix line range of literalinclude in 'Using substitutions'

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -185,7 +185,7 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
 
     .. literalinclude:: launch/example_main_launch.py
       :language: python
-      :lines: 16-21
+      :lines: 16-20
 
     The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
     The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.


### PR DESCRIPTION
Current version in the Jazzy docs (since the changes have not been deployed there yet):

![Screenshot from 2025-03-28 14-51-53](https://github.com/user-attachments/assets/1aee9423-8f29-4f10-9174-6194364f20ea)

Before:

![Screenshot from 2025-03-28 14-51-45](https://github.com/user-attachments/assets/cf543c52-e930-4a17-ad3c-da9ebe46925f)

After:

![Screenshot from 2025-03-28 14-52-35](https://github.com/user-attachments/assets/d39a6344-1ee4-4bae-8d74-1a073fc6cd7b)
