### PR TITLE
Add macros to link to package API docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -320,6 +320,7 @@ def github_link_rewrite_branch(app, pagename, templatename, context, doctree):
 def expand_macros(app, docname, source):
     result = source[0]
     result = expand_interface_macros(result)
+    result = expand_package_macros(result)
     result = expand_text_macros(result, app.config.macros)
     source[0] = result
 
@@ -371,6 +372,43 @@ def expand_interface_macros(text: Text) -> Text:
     text = expand(text, interface_regex, interface_rst_link_templ)
     # {interface_link()}
     text = expand(text, interface_link_regex, interface_link_templ)
+    return text
+
+# Regex to match a package name and extract it
+package_name_exp = r'([a-z0-9_]+)'
+# Regex for '{package_link(...)}' with a package name
+package_link_regex = re.compile(r'{package_link\(' + package_name_exp + r'\)}')
+# Regex for '{package(...)}' with a package name
+package_regex = re.compile(r'{package\(' + package_name_exp + r'\)}')
+
+# Template for the link to the package API documentation
+package_link_templ = 'https://docs.ros.org/en/{{DISTRO}}/p/{pkg_name}/'
+# Template for an RST link to the package API documentation
+package_rst_link_templ = f'`{{pkg_name}} <{package_link_templ}>`_'
+
+def expand_package_macros(text: Text) -> Text:
+    """
+    Expand `{package()}` and `{package_link()}` macros.
+
+    Uses the `{DISTRO}` macro in its expansion, so it has to be expanded after with
+    `expand_text_macros()`.
+
+    :param text: the text to expand
+    :return: the expanded text
+    """
+    def expand(text: Text, regex: re.Pattern, package_tmpl: str) -> Text:
+        while match := regex.search(text):
+            pkg_name = match.group(1)
+            link = package_tmpl.format(
+                pkg_name=pkg_name,
+            )
+            text = text.replace(match.group(0), link)
+        return text
+
+    # {package()}
+    text = expand(text, package_regex, package_rst_link_templ)
+    # {package_link()}
+    text = expand(text, package_link_regex, package_link_templ)
     return text
 
 def expand_text_macros(text: Text, macros: Dict[Text, Text]) -> Text:

--- a/source/Concepts/Basic/About-Client-Libraries.rst
+++ b/source/Concepts/Basic/About-Client-Libraries.rst
@@ -45,9 +45,7 @@ The ROS Client Library for C++ (``rclcpp``) is the user facing, C++ idiomatic in
 ``rclcpp`` makes use of all the features of C++ and C++17 to make the interface as easy to use as possible, but since it reuses the implementation in ``rcl`` it is able maintain a consistent behavior with the other client libraries that use the ``rcl`` |API|.
 
 The ``rclcpp`` repository is located on GitHub at `ros2/rclcpp <https://github.com/ros2/rclcpp>`_ and contains the |package| ``rclcpp``.
-The generated |API| documentation is here:
-
-`api/rclcpp/index.html <http://docs.ros.org/en/{DISTRO}/p/rclcpp/>`_
+The generated |API| documentation is at {package_link(rclcpp)}.
 
 The ``rclpy`` package
 ~~~~~~~~~~~~~~~~~~~~~
@@ -63,10 +61,7 @@ All operations happen on the Python version of the messages until they need to b
 This is avoided if possible when communicating between publishers and subscriptions in the same process to cut down on the conversion into and out of Python.
 
 The ``rclpy`` repository is located on GitHub at `ros2/rclpy <https://github.com/ros2/rclpy>`_ and contains the |package| ``rclpy``.
-The generated |API| documentation is here:
-
-`api/rclpy/index.html <https://docs.ros.org/en/{DISTRO}/p/rclpy/>`_
-
+The generated |API| documentation is at {package_link(rclpy)}.
 
 Community-maintained
 ~~~~~~~~~~~~~~~~~~~~
@@ -103,7 +98,7 @@ In addition to making the client libraries light-weight, an advantage of having 
 If any changes are made to the logic/behavior of the functionality in the core RCL -- namespaces, for example -- all client libraries that use the RCL will have these changes reflected.
 Furthermore, having the common core means that maintaining multiple client libraries becomes less work when it comes to bug fixes.
 
-The API documentation for ``rcl`` can be found `here <https://docs.ros.org/en/{DISTRO}/p/rcl/>`__.
+The API documentation for ``rcl`` can be found `here <{package_link(rcl)}>`__.
 
 Language-specific functionality
 -------------------------------

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -579,5 +579,11 @@ For example, when generating the docs for Rolling on the ``rolling`` branch:
    * - \{interface(std_msgs/msg/String)\}
      - Publish a \{interface(std_msgs/msg/String)\}.
      - Publish a {interface(std_msgs/msg/String)}.
+   * - \{package_link(rclcpp)\}
+     - See: \{package_link(rclcpp)\}.
+     - See: {package_link(rclcpp)}.
+   * - \{package(rclcpp)\}
+     - Use \{package(rclcpp)\}.
+     - Use {package(rclcpp)}.
 
 The same file can be used on multiple branches (i.e., for multiple distros) and the generated content will be distro-specific.

--- a/test/test_macros.py
+++ b/test/test_macros.py
@@ -20,6 +20,7 @@ import sys
 sys.path.append('..')
 
 from conf import expand_interface_macros
+from conf import expand_package_macros
 from conf import expand_text_macros
 
 
@@ -59,3 +60,21 @@ def test_interface_macros() -> None:
     """)
     # Expanded interface macros use the DISTRO text macro, so those need to be expanded too
     assert expected == expand_text_macros(expand_interface_macros(text), macros)
+
+
+def test_package_macros() -> None:
+    macros = {
+        'DISTRO': 'rolling',
+    }
+    text = textwrap.dedent("""
+        Add a dependency on {package(my_pkg_name)} to your package's ``package.xml`` file.
+
+        For more information, refer to the `API documentation <{package_link(my_pkg_name)}>`_.
+    """)
+    expected = textwrap.dedent("""
+        Add a dependency on `my_pkg_name <https://docs.ros.org/en/rolling/p/my_pkg_name/>`_ to your package's ``package.xml`` file.
+
+        For more information, refer to the `API documentation <https://docs.ros.org/en/rolling/p/my_pkg_name/>`_.
+    """)
+    # Expanded package macros use the DISTRO text macro, so those need to be expanded too
+    assert expected == expand_text_macros(expand_package_macros(text), macros)


### PR DESCRIPTION
Follow-up to #5050

This adds macros to link to package API documentation: (1) `package_link()` and (2) `package()`. They each take the package name as a parameter and expand to the (1) the link to the package API docs page and (2) the package name hyperlinked to its API docs page.

| Macro | Example | Becomes (for Rolling)* |
| -------- | ------------ | ------------------------------|
| `{package_link(rclcpp)}` | `See: {package_link(rclcpp)}.` | See: https://docs.ros.org/en/rolling/p/rclcpp/. |
| `{package(rclcpp)}` | `Use {package(rclcpp)}.` | Use [rclcpp](https://docs.ros.org/en/rolling/p/rclcpp/). |

_(*) formatted as markdown in this PR description for demonstration purposes, but the result is the same_

`package()` exists for simple links with the package name only, while `package_link()` could be used anywhere, including more complex RST links, such as:

```rst
Use `the rclcpp package <{package_link(rclcpp)}>`_.
```

See the changes to `source/Concepts/Basic/About-Client-Libraries.rst` for concrete examples.

After this PR, we can apply it to the rest of the docs.