### PR TITLE
Fix incorrect directory path in workspace setup instructions

### DIFF
--- a/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
+++ b/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
@@ -44,7 +44,7 @@ Then create a workspace, import the ROS 2 {DISTRO_TITLE} code, and clone ``perfo
 
   cd ~/
   mkdir -p tracing_ws/src
-  cd tracing_ws/src/
+  cd tracing_ws/
   vcs import src/ --input https://raw.githubusercontent.com/ros2/ros2/{DISTRO}/ros2.repos
   cd src/
   git clone https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
This PR fixes a small but important error in the workspace setup instructions. The command:
- `cd tracing_ws/src/`

was incorrect, since the `vcs import` command needs to be run from the `tracing_ws` root directory. It has been corrected to:

- `cd tracing_ws/`
