### PR TITLE
Refer to target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -177,33 +177,16 @@ In the case that a package has both libraries and executables, make sure to comb
 Linking to dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-There are two ways to link your targets against a dependency.
+Link to your dependencies using [target_link_libraries](https://cmake.org/cmake/help/latest/command/target_link_libraries.html)
+It will give your target the necessary headers, libraries, and all their dependencies.
 
-The first and recommended way is to use the ament macro ``ament_target_dependencies``.
 As an example, suppose we want to link ``my_library`` against the linear algebra library Eigen3.
+``Eigen3`` defines the target ``Eigen3::Eigen``.
 
 .. code-block:: cmake
 
     find_package(Eigen3 REQUIRED)
-    ament_target_dependencies(my_library PUBLIC Eigen3)
-
-It includes the necessary headers and libraries and their dependencies to be correctly found by the project.
-
-The second way is to use ``target_link_libraries``.
-
-Modern CMake prefers to use only targets, exporting and linking against them.
-CMake targets may be namespaced, similar to C++.
-Prefer to use the namespaced targets if they are available.
-For instance, ``Eigen3`` defines the target ``Eigen3::Eigen``.
-
-In the example of Eigen3, the call should then look like
-
-.. code-block:: cmake
-
     target_link_libraries(my_library PUBLIC Eigen3::Eigen)
-
-This will also include necessary headers, libraries and their dependencies.
-Note that this dependency must have been previously discovered via a call to ``find_package``.
 
 Installing
 ^^^^^^^^^^
@@ -262,7 +245,7 @@ Installing
         - The ``EXPORT`` notation of the install call requires additional attention:
           It installs the CMake files for the ``my_library`` target.
           It must be named exactly the same as the argument in ``ament_export_targets``.
-          To ensure that it can be used via ``ament_target_dependencies``, it should not be named exactly the same as the library name, but instead should have a prefix like ``export_`` (as shown above).
+          By convention the export name is given a prefix like ``export_``, but this prefix is not critical.
 
         - All install paths are relative to ``CMAKE_INSTALL_PREFIX``, which is already set correctly by colcon/ament.
 

--- a/source/How-To-Guides/Developing-a-ROS-2-Package.rst
+++ b/source/How-To-Guides/Developing-a-ROS-2-Package.rst
@@ -59,7 +59,7 @@ You will mostly use the ``add_executable()`` CMake macro along with
 
 .. code-block:: cmake
 
-   ament_target_dependencies(<executable-name> [dependencies])
+   target_link_libraries(<executable-name> PUBLIC [targets from your dependencies])
 
 to create executable nodes and link dependencies.
 

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -170,7 +170,7 @@ Now open the ``CMakeLists.txt`` file and add a new executable and name it ``Sync
 .. code-block:: cmake
 
     add_executable(SyncAsyncWriter src/sync_async_writer.cpp)
-    ament_target_dependencies(SyncAsyncWriter rclcpp std_msgs)
+    target_link_libraries(SyncAsyncWriter PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
 
@@ -201,7 +201,7 @@ You can clean up your ``CMakeLists.txt`` by removing some unnecessary sections a
     find_package(std_msgs REQUIRED)
 
     add_executable(SyncAsyncWriter src/sync_async_writer.cpp)
-    ament_target_dependencies(SyncAsyncWriter rclcpp std_msgs)
+    target_link_libraries(SyncAsyncWriter PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
     install(TARGETS
         SyncAsyncWriter
@@ -370,7 +370,7 @@ Open the ``CMakeLists.txt`` file and add a new executable and name it ``SyncAsyn
 .. code-block:: cmake
 
     add_executable(SyncAsyncReader src/sync_async_reader.cpp)
-    ament_target_dependencies(SyncAsyncReader rclcpp std_msgs)
+    target_link_libraries(SyncAsyncReader PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
     install(TARGETS
         SyncAsyncReader
@@ -689,10 +689,10 @@ Open the ``CMakeLists.txt`` file and add two new executables ``ping_service`` an
     find_package(example_interfaces REQUIRED)
 
     add_executable(ping_service src/ping_service.cpp)
-    ament_target_dependencies(ping_service example_interfaces rclcpp)
+    target_link_libraries(ping_service PUBLIC ${example_interfaces_TARGETS} rclcpp::rclcpp)
 
     add_executable(ping_client src/ping_client.cpp)
-    ament_target_dependencies(ping_client example_interfaces rclcpp)
+    target_link_libraries(ping_client PUBLIC ${example_interfaces_TARGETS} rclcpp::rclcpp)
 
     install(TARGETS
         ping_service

--- a/source/Tutorials/Advanced/Reading-From-A-Bag-File-CPP.rst
+++ b/source/Tutorials/Advanced/Reading-From-A-Bag-File-CPP.rst
@@ -253,7 +253,7 @@ Below the dependencies block, which contains ``find_package(rosbag2_transport RE
 .. code-block:: console
 
     add_executable(simple_bag_reader src/simple_bag_reader.cpp)
-    ament_target_dependencies(simple_bag_reader rclcpp rosbag2_transport turtlesim)
+    target_link_libraries(simple_bag_reader PUBLIC rclcpp::rclcpp rosbag2_transport::rosbag2_transport ${turtlesim_msgs_TARGETS})
 
     install(TARGETS
       simple_bag_reader

--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
@@ -223,7 +223,7 @@ Below the dependencies block, which contains ``find_package(rosbag2_cpp REQUIRED
 .. code-block:: console
 
     add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
-    ament_target_dependencies(simple_bag_recorder rclcpp rosbag2_cpp std_msgs)
+    target_link_libraries(simple_bag_recorder rclcpp::rclcpp rosbag2_cpp::rosbag2_cpp ${std_msgs_TARGETS})
 
     install(TARGETS
       simple_bag_recorder
@@ -433,7 +433,7 @@ Open the ``CMakeLists.txt`` file and add the following lines after the previousl
 .. code-block:: console
 
     add_executable(data_generator_node src/data_generator_node.cpp)
-    ament_target_dependencies(data_generator_node rclcpp rosbag2_cpp example_interfaces)
+    target_link_libraries(data_generator_node PUBLIC rclcpp::rclcpp rosbag2_cpp::rosbag2_cpp ${example_interfaces_TARGETS})
 
     install(TARGETS
       data_generator_node
@@ -593,7 +593,7 @@ Open the ``CMakeLists.txt`` file and add the following lines after the previousl
 .. code-block:: console
 
     add_executable(data_generator_executable src/data_generator_executable.cpp)
-    ament_target_dependencies(data_generator_executable rclcpp rosbag2_cpp example_interfaces)
+    target_link_libraries(data_generator_executable PUBLIC rclcpp::rclcpp rosbag2_cpp::rosbag2_cpp ${example_interfaces_TARGETS})
 
     install(TARGETS
       data_generator_executable

--- a/source/Tutorials/Advanced/Simulators/Webots/Setting-Up-Simulation-Webots-Basic.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Setting-Up-Simulation-Webots-Basic.rst
@@ -428,7 +428,7 @@ Finally, an optional part is added in order to shutdown all the nodes once Webot
         .. literalinclude:: Code/CMakeLists.txt
             :language: cmake
 
-        The CMakeLists.txt exports the plugin configuration file with the ``pluginlib_export_plugin_description_file()``, defines a shared library of the C++ plugin ``src/MyRobotDriver.cpp``, and sets the include and library dependencies using ``ament_target_dependencies()``.
+        The CMakeLists.txt exports the plugin configuration file with the ``pluginlib_export_plugin_description_file()``, defines a shared library of the C++ plugin ``src/MyRobotDriver.cpp``, and sets the include and library dependencies using ``target_link_libraries()``.
 
         The file then installs the library, the directories ``launch``, ``resource``, and ``worlds`` to the ``share/my_package`` directory.
         Finally, it exports the include directories and libraries using ``ament_export_include_directories()`` and ``ament_export_libraries()``, respectively, and declares the package using ``ament_package()``.

--- a/source/Tutorials/Advanced/Topic-Statistics-Tutorial/Topic-Statistics-Tutorial.rst
+++ b/source/Tutorials/Advanced/Topic-Statistics-Tutorial/Topic-Statistics-Tutorial.rst
@@ -164,7 +164,7 @@ Add the executable and name it ``listener_with_topic_statistics`` so you can run
 .. code-block:: console
 
     add_executable(listener_with_topic_statistics src/member_function_with_topic_statistics.cpp)
-    ament_target_dependencies(listener_with_topic_statistics rclcpp std_msgs)
+    target_link_libraries(listener_with_topic_statistics rclcpp::rclcpp ${std_msgs_TARGETS})
 
     install(TARGETS
       talker

--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -427,10 +427,10 @@ Add the following lines (C++ only):
     find_package(tutorial_interfaces REQUIRED)                      # CHANGE
 
     add_executable(talker src/publisher_member_function.cpp)
-    ament_target_dependencies(talker rclcpp tutorial_interfaces)    # CHANGE
+    target_link_libraries(talker PUBLIC rclcpp::rclcpp ${tutorial_interfaces_TARGETS})    # CHANGE
 
     add_executable(listener src/subscriber_member_function.cpp)
-    ament_target_dependencies(listener rclcpp tutorial_interfaces)  # CHANGE
+    target_link_libraries(listener PUBLIC rclcpp::rclcpp ${tutorial_interfaces_TARGETS})  # CHANGE
 
     install(TARGETS
       talker
@@ -718,12 +718,10 @@ Add the following lines (C++ only):
     find_package(tutorial_interfaces REQUIRED)         # CHANGE
 
     add_executable(server src/add_two_ints_server.cpp)
-    ament_target_dependencies(server
-      rclcpp tutorial_interfaces)                      # CHANGE
+    target_link_libraries(server PUBLIC rclcpp::rclcpp ${tutorial_interfaces_TARGETS})  # CHANGE
 
     add_executable(client src/add_two_ints_client.cpp)
-    ament_target_dependencies(client
-      rclcpp tutorial_interfaces)                      # CHANGE
+    target_link_libraries(client PUBLIC rclcpp::rclcpp ${tutorial_interfaces_TARGETS})
 
     install(TARGETS
       server

--- a/source/Tutorials/Beginner-Client-Libraries/Pluginlib.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Pluginlib.rst
@@ -74,7 +74,7 @@ One thing to notice is the presence of the initialize method.
 With ``pluginlib``, a constructor without parameters is required, so if any parameters to the class are needed, we use the initialize method to pass them to the object.
 
 We need to make this header available to other classes, so open ``ros2_ws/src/polygon_base/CMakeLists.txt`` for editing.
-Add the following lines after the ``ament_target_dependencies`` command:
+Add the following lines after the ``target_link_libraries`` command:
 
 .. code-block:: cmake
 

--- a/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
@@ -258,7 +258,7 @@ We need to create a new target for this node in the ``CMakeLists.txt``:
    find_package(rclcpp REQUIRED)
 
    add_executable(publish_address_book src/publish_address_book.cpp)
-   ament_target_dependencies(publish_address_book rclcpp)
+   target_link_libraries(publish_address_book rclcpp::rclcpp)
 
    install(TARGETS
        publish_address_book

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -212,7 +212,7 @@ Below the dependency ``find_package(rclcpp REQUIRED)`` add the following lines o
 .. code-block:: cmake
 
     add_executable(minimal_param_node src/cpp_parameters_node.cpp)
-    ament_target_dependencies(minimal_param_node rclcpp)
+    target_link_libraries(minimal_param_node rclcpp::rclcpp)
 
     install(TARGETS
         minimal_param_node

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -253,7 +253,7 @@ After that, add the executable and name it ``talker`` so you can run your node u
 .. code-block:: console
 
     add_executable(talker src/publisher_lambda_function.cpp)
-    ament_target_dependencies(talker rclcpp std_msgs)
+    target_link_libraries(talker PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
 Finally, add the ``install(TARGETS...)`` section so ``ros2 run`` can find your executable:
 
@@ -284,7 +284,7 @@ You can clean up your ``CMakeLists.txt`` by removing some unnecessary sections a
   find_package(std_msgs REQUIRED)
 
   add_executable(talker src/publisher_lambda_function.cpp)
-  ament_target_dependencies(talker rclcpp std_msgs)
+  target_link_libraries(talker PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
   install(TARGETS
     talker
@@ -415,7 +415,7 @@ Reopen ``CMakeLists.txt`` and add the executable and target for the subscriber n
 .. code-block:: cmake
 
   add_executable(listener src/subscriber_lambda_function.cpp)
-  ament_target_dependencies(listener rclcpp std_msgs)
+  target_link_libraries(talker PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
   install(TARGETS
     talker

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -171,7 +171,7 @@ Add the following code block to ``CMakeLists.txt`` to create an executable named
 .. code-block:: console
 
   add_executable(server src/add_two_ints_server.cpp)
-  ament_target_dependencies(server rclcpp example_interfaces)
+  target_link_libraries(server PUBLIC rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 So ``ros2 run`` can find the executable, add the following lines to the end of the file, right before ``ament_package()``:
 
@@ -284,10 +284,10 @@ After removing some unnecessary boilerplate from the automatically generated fil
   find_package(example_interfaces REQUIRED)
 
   add_executable(server src/add_two_ints_server.cpp)
-  ament_target_dependencies(server rclcpp example_interfaces)
+  target_link_libraries(server PUBLIC rclcpp::rclcpp ${example_interfaces_TARGETS})
 
   add_executable(client src/add_two_ints_client.cpp)
-  ament_target_dependencies(client rclcpp example_interfaces)
+  target_link_libraries(server PUBLIC rclcpp::rclcpp ${example_interfaces_TARGETS})
 
   install(TARGETS
     server

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -172,7 +172,7 @@ To build this code, first open the ``CMakeLists.txt`` file and add the following
 .. code-block:: console
 
     add_executable(parameter_event_handler src/parameter_event_handler.cpp)
-    ament_target_dependencies(parameter_event_handler rclcpp)
+    target_link_libraries(parameter_event_handler PUBLIC rclcpp::rclcpp)
 
     install(TARGETS
       parameter_event_handler

--- a/source/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.rst
+++ b/source/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.rst
@@ -146,10 +146,10 @@ Add the following lines to the top of the standard boilerplate.
      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
      $<INSTALL_INTERFACE:include>
    )
-   ament_target_dependencies(point_display
-     pluginlib
-     rviz_common
-     rviz_plugin_tutorial_msgs
+   target_link_libraries(point_display PUBLIC
+     pluginlib::pluginlib
+     rviz_common::rviz_common
+     ${rviz_plugin_tutorial_msgs_TARGETS}
    )
    install(TARGETS point_display
            EXPORT export_rviz_plugin_tutorial

--- a/source/Tutorials/Intermediate/RViz/RViz-Custom-Panel/RViz-Custom-Panel.rst
+++ b/source/Tutorials/Intermediate/RViz/RViz-Custom-Panel/RViz-Custom-Panel.rst
@@ -117,9 +117,9 @@ Add the following lines to the top of the standard boilerplate.
      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
      $<INSTALL_INTERFACE:include>
    )
-   ament_target_dependencies(demo_panel
-     pluginlib
-     rviz_common
+   target_link_libraries(demo_panel PUBLIC
+     pluginlib::pluginlib
+     rviz_common::rviz_common
    )
    install(TARGETS demo_panel
            EXPORT export_rviz_panel_tutorial

--- a/source/Tutorials/Intermediate/Testing/Cpp.rst
+++ b/source/Tutorials/Intermediate/Testing/Cpp.rst
@@ -54,7 +54,7 @@ CMakeLists.txt
     endif()
 
 The testing code is wrapped in the ``if/endif`` block to avoid building tests where possible.
-``ament_add_gtest`` functions much like ``add_executable`` so you'll need to call ``target_include_directories``, ``ament_target_dependencies`` and ``target_link_libraries`` as you normally would.
+``ament_add_gtest`` functions much like ``add_executable`` so you'll need to call ``target_include_directories`` and ``target_link_libraries`` as you normally would.
 
 
 Running Tests

--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
@@ -163,11 +163,11 @@ Now open the ``CMakeLists.txt`` add the executable and name it ``fixed_frame_tf2
 .. code-block:: console
 
     add_executable(fixed_frame_tf2_broadcaster src/fixed_frame_tf2_broadcaster.cpp)
-    ament_target_dependencies(
-        fixed_frame_tf2_broadcaster
-        geometry_msgs
-        rclcpp
-        tf2_ros
+    target_link_libraries(
+        fixed_frame_tf2_broadcaster PUBLIC
+        ${geometry_msgs_TARGETS}
+        rclcpp::rclcpp
+        tf2_ros::tf2_ros
     )
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:
@@ -420,11 +420,11 @@ Now open the ``CMakeLists.txt`` add the executable and name it ``dynamic_frame_t
 .. code-block:: console
 
     add_executable(dynamic_frame_tf2_broadcaster src/dynamic_frame_tf2_broadcaster.cpp)
-    ament_target_dependencies(
-        dynamic_frame_tf2_broadcaster
-        geometry_msgs
-        rclcpp
-        tf2_ros
+    target_link_libraries(
+        dynamic_frame_tf2_broadcaster PUBLIC
+        ${geometry_msgs_TARGETS}
+        rclcpp::rclcpp
+        tf2_ros::tf2_ros
     )
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:

--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -526,14 +526,14 @@ After that, add the executable and name it ``turtle_tf2_message_filter``, which 
 .. code-block:: console
 
     add_executable(turtle_tf2_message_filter src/turtle_tf2_message_filter.cpp)
-    ament_target_dependencies(
-      turtle_tf2_message_filter
-      geometry_msgs
-      message_filters
-      rclcpp
-      tf2
-      tf2_geometry_msgs
-      tf2_ros
+    target_link_libraries(
+      turtle_tf2_message_filter PUBLIC
+      ${geometry_msgs_TARGETS}
+      message_filters::message_filters
+      rclcpp::rclcpp
+      tf2::tf2
+      ${tf2_geometry_msgs_TARGETS}
+      tf2_ros::tf2_ros
     )
 
     if(EXISTS ${TF2_CPP_HEADERS})

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -224,13 +224,13 @@ Now open the ``CMakeLists.txt`` add the executable and name it ``turtle_tf2_broa
 .. code-block:: console
 
     add_executable(turtle_tf2_broadcaster src/turtle_tf2_broadcaster.cpp)
-    ament_target_dependencies(
-        turtle_tf2_broadcaster
-        geometry_msgs
-        rclcpp
-        tf2
-        tf2_ros
-        turtlesim
+    target_link_libraries(
+        turtle_tf2_broadcaster PUBLIC
+        ${geometry_msgs_TARGETS}
+        rclcpp::rclcpp
+        tf2::tf2
+        tf2_ros::tf2_ros
+        ${turtlesim_msgs_TARGETS}
     )
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -258,13 +258,13 @@ Now open the ``CMakeLists.txt`` add the executable and name it ``turtle_tf2_list
 .. code-block:: console
 
     add_executable(turtle_tf2_listener src/turtle_tf2_listener.cpp)
-    ament_target_dependencies(
-        turtle_tf2_listener
-        geometry_msgs
-        rclcpp
-        tf2
-        tf2_ros
-        turtlesim
+    target_link_libraries(
+        turtle_tf2_listener PUBLIC
+        ${geometry_msgs_TARGETS}
+        rclcpp::rclcpp
+        tf2::tf2
+        tf2_ros::tf2_ros
+        ${turtlesim_msgs_TARGETS}
     )
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -263,12 +263,12 @@ Add the executable to the CMakeLists.txt and name it ``static_turtle_tf2_broadca
 .. code-block:: console
 
     add_executable(static_turtle_tf2_broadcaster src/static_turtle_tf2_broadcaster.cpp)
-    ament_target_dependencies(
-       static_turtle_tf2_broadcaster
-       geometry_msgs
-       rclcpp
-       tf2
-       tf2_ros
+    target_link_libraries(
+       static_turtle_tf2_broadcaster PUBLIC
+       ${geometry_msgs_TARGETS}
+       rclcpp::rclcpp
+       tf2::tf2
+       tf2_ros::tf2_ros
     )
 
 Finally, add the ``install(TARGETS…)`` section so ``ros2 run`` can find your executable:

--- a/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-cpp.rst
+++ b/source/Tutorials/Intermediate/URDF/Using-URDF-with-Robot-State-Publisher-cpp.rst
@@ -236,12 +236,12 @@ Edit the ``CMakeLists.txt`` file as follows:
 
   add_executable(urdf_tutorial_cpp src/urdf_tutorial.cpp)
 
-  ament_target_dependencies(urdf_tutorial_cpp
-    geometry_msgs
-    sensor_msgs
-    tf2_ros
-    tf2_geometry_msgs
-    rclcpp
+  target_link_libraries(urdf_tutorial_cpp PUBLIC
+    ${geometry_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    tf2_ros::tf2_ros
+    ${tf2_geometry_msgs_TARGETS}
+    rclcpp::rclcpp
   )
 
   install(TARGETS

--- a/source/Tutorials/Intermediate/Writing-a-Composable-Node.rst
+++ b/source/Tutorials/Intermediate/Writing-a-Composable-Node.rst
@@ -96,7 +96,7 @@ Second, we're going to replace our ``add_executable`` with a ``add_library`` wit
     add_library(vincent_driver_component src/vincent_driver.cpp)
 
 Third, replace other build commands that used the old target to act on the new target.
-i.e. ``ament_target_dependencies(vincent_driver ...)`` becomes ``ament_target_dependencies(vincent_driver_component ...)``
+i.e. ``target_link_libraries(vincent_driver ...)`` becomes ``target_link_libraries(vincent_driver_component ...)``
 
 Fourth, add a new command to declare your component.
 

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -225,7 +225,7 @@ Open up ``custom_action_cpp/CMakeLists.txt``, and add the following right after 
     ${custom_action_interfaces_TARGETS}
     rclcpp::rclcpp
     rclcpp_action::rclcpp_action
-    rclcpp_components::components)
+    rclcpp_components::component)
   rclcpp_components_register_node(action_server PLUGIN "custom_action_cpp::FibonacciActionServer" EXECUTABLE fibonacci_action_server)
   install(TARGETS
     action_server

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -355,7 +355,7 @@ Open up ``custom_action_cpp/CMakeLists.txt``, and add the following right after 
     ${custom_action_interfaces_TARGETS}
     rclcpp::rclcpp
     rclcpp_action::rclcpp_action
-    rclcpp_components::components)
+    rclcpp_components::component)
   rclcpp_components_register_node(action_client PLUGIN "custom_action_cpp::FibonacciActionClient" EXECUTABLE fibonacci_action_client)
   install(TARGETS
     action_client

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Cpp.rst
@@ -221,11 +221,11 @@ Open up ``custom_action_cpp/CMakeLists.txt``, and add the following right after 
     $<INSTALL_INTERFACE:include>)
   target_compile_definitions(action_server
     PRIVATE "CUSTOM_ACTION_CPP_BUILDING_DLL")
-  ament_target_dependencies(action_server
-    "custom_action_interfaces"
-    "rclcpp"
-    "rclcpp_action"
-    "rclcpp_components")
+  target_link_libraries(action_server PUBLIC
+    ${custom_action_interfaces_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rclcpp_components::components)
   rclcpp_components_register_node(action_server PLUGIN "custom_action_cpp::FibonacciActionServer" EXECUTABLE fibonacci_action_server)
   install(TARGETS
     action_server
@@ -351,11 +351,11 @@ Open up ``custom_action_cpp/CMakeLists.txt``, and add the following right after 
     $<INSTALL_INTERFACE:include>)
   target_compile_definitions(action_client
     PRIVATE "CUSTOM_ACTION_CPP_BUILDING_DLL")
-  ament_target_dependencies(action_client
-    "custom_action_interfaces"
-    "rclcpp"
-    "rclcpp_action"
-    "rclcpp_components")
+  target_link_libraries(action_client PUBLIC
+    ${custom_action_interfaces_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rclcpp_components::components)
   rclcpp_components_register_node(action_client PLUGIN "custom_action_cpp::FibonacciActionClient" EXECUTABLE fibonacci_action_client)
   install(TARGETS
     action_client


### PR DESCRIPTION
I think this is complete, but I haven't self-reviewed it yet. Leaving as a draft for now.