### PR TITLE
Update Connext version in skipped rosdep keys

### DIFF
--- a/source/Installation/Alternatives/RHEL-Development-Setup.rst
+++ b/source/Installation/Alternatives/RHEL-Development-Setup.rst
@@ -106,7 +106,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-7.3.0 urdfdom_headers"
 
 Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -111,7 +111,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps iceoryx_binding_c rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps iceoryx_binding_c rti-connext-dds-7.3.0 urdfdom_headers"
 
 Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -79,7 +79,7 @@ Install dependencies using rosdep
 
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-7.3.0 urdfdom_headers"
 
 .. include:: ../_rosdep_Linux_Mint.rst
 

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -89,7 +89,7 @@ Install dependencies using rosdep
    sudo apt install -y python3-rosdep
    sudo rosdep init
    rosdep update
-   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps iceoryx_binding_c rmw_connextdds rti-connext-dds-6.0.1 urdfdom_headers"
+   rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
 .. include:: ../_rosdep_Linux_Mint.rst
 


### PR DESCRIPTION
Relates to #5226

Follow-up to #5180

This addresses the symptom reported in #5226: we should be ignoring the correct version here.