### PR TITLE
Correct shebang

### DIFF
--- a/plugins/ros_checkers.py
+++ b/plugins/ros_checkers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from sphinxlint.checkers import checker
 import subprocess
 import yaml

--- a/source/Tutorials/Advanced/Discovery-Server/scripts/discovery_packets.py
+++ b/source/Tutorials/Advanced/Discovery-Server/scripts/discovery_packets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 discovery_server
+#!/usr/bin/env python3 discovery_server
 
 """Script to count number of rtps packages in a tcpdump capture."""
 import os

--- a/sphinx-lint-with-ros
+++ b/sphinx-lint-with-ros
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import plugins.ros_checkers
 import sys


### PR DESCRIPTION
The shebang points to the wrong Python interpreter when using a virtual environment. This PR fixes import errors that occur when following the contribution guidelines and running make lint.