### PR TITLE
Upgrade stevedore

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -31,5 +31,5 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-mermaid==0.9.2
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.10
-stevedore==3.5.0
+stevedore==5.4.1
 urllib3==1.26.5


### PR DESCRIPTION
Following the contr guidelines i got cache problems with stevedore dep when running make test. This is resolved by upgrading the dep.