### PR TITLE
Use console code-blocks if using $

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -42,21 +42,21 @@ Create a workspace for the package to live in:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ mkdir -p launch_ws/src
       $ cd launch_ws/src
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ mkdir -p launch_ws/src
       $ cd launch_ws/src
 
   .. group-tab:: Windows
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ md launch_ws\src
       $ cd launch_ws\src

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -66,19 +66,19 @@ Inside of that package, create a directory called ``launch``:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ mkdir launch_tutorial/launch
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ mkdir launch_tutorial/launch
 
   .. group-tab:: Windows
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ md launch_tutorial/launch
 


### PR DESCRIPTION
Follow-up to #5287

Since a `$` was added to the command lines of these code-blocks, they need to be updated to `console`