### PR TITLE
Remove Ubuntu 22.04 Jammy from list of Debian-based target platforms

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -16,7 +16,6 @@ System requirements
 The current Debian-based target platforms for {DISTRO_TITLE_FULL} are:
 
 - Tier 1: Ubuntu Linux - Noble (24.04) 64-bit
-- Tier 3: Ubuntu Linux - Jammy (22.04) 64-bit
 - Tier 3: Debian Linux - Bookworm (12) 64-bit
 
 As defined in `REP 2000 <https://www.ros.org/reps/rep-2000.html>`_.


### PR DESCRIPTION
I found out that we list Ubuntu 22.04 Jammy as a tier 3 platform for Rolling (and Jazzy) in the Ubuntu source build instructions. However, the source of truth is REP 2000, and Jammy is not listed there:

* Jazzy: https://www.ros.org/reps/rep-2000.html#jazzy-jalisco-may-2024-may-2029
* Kilted: https://www.ros.org/reps/rep-2000.html#kilted-kaiju-may-2025-november-2026

This line was added here in https://github.com/ros2/ros2_documentation/pull/4342, but, looking at the original discussion on Discourse, I don't think it was really the real intention of the PR: https://discourse.ros.org/t/jazzy-jalisco-testing-tutorial-kickoff-party-instructions/37501/4.

The last ROS 2 distro that included the previous Ubuntu distro as a tier 3 platform was Humble (tier 1 was 22.04, with 20.04 as tier 3): https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027. (I believe this was intentionally done so that Humble could work with reasonable efforts on the target platform of the last ROS 1 distro, Noetic.)