### PR TITLE
Keep information before command prompt symbol in misc tutorial

### DIFF
--- a/source/Tutorials/Miscellaneous/Deploying-ROS-2-on-IBM-Cloud.rst
+++ b/source/Tutorials/Miscellaneous/Deploying-ROS-2-on-IBM-Cloud.rst
@@ -574,12 +574,12 @@ parameters of your cluster as well as its CPU and Memory Usage.
 
 Now you are inside your docker image!
 You can source your workspace (if needed) and run ROS 2!
-For example (assuming you cd to ``root@ros2-deployment-xxxxxxxx:/opt/ros/overlay_ws#``):
+For example:
 
 .. code-block:: console
 
-   $ . install/setup.sh
-   $ ros2 launch demo_nodes_cpp talker_listener_launch.py
+   root@ros2-deployment-xxxxxxxx:/opt/ros/overlay_ws# . install/setup.sh
+   root@ros2-deployment-xxxxxxxx:/opt/ros/overlay_ws# ros2 launch demo_nodes_cpp talker_listener_launch.py
 
 Final Remarks
 ---------------


### PR DESCRIPTION
Follow-up to #5310

Since the `console` code-block properly formats everything before the `#` symbol and the copy button excludes it, we can keep it there:

![image](https://github.com/user-attachments/assets/80440d0c-f532-4283-9b3d-d40318d8531b)

Also, you don't really "cd to `root@ros2-deployment-xxxxxxxx:/opt/ros/overlay_ws#`"