### PR TITLE
Fix indentation in tf2 tutorials

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
@@ -234,13 +234,13 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 
   .. group-tab:: Windows
 
-        In a Windows command line prompt:
+    In a Windows command line prompt:
 
-        .. code-block:: console
+    .. code-block:: console
 
-            $ call install\setup.bat
+        $ call install\setup.bat
 
-        Or in powershell:
+    Or in powershell:
 
     .. code-block:: console
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Py.rst
@@ -373,19 +373,19 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 
         $ . install/setup.bash
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      In a Windows command line prompt:
+    In a Windows command line prompt:
 
-      .. code-block:: console
+    .. code-block:: console
 
-          $ call install\setup.bat
+        $ call install\setup.bat
 
-      Or in powershell:
+    Or in powershell:
 
-      .. code-block:: console
+    .. code-block:: console
 
-          $ .\install\setup.ps1
+        $ .\install\setup.ps1
 
 
 4 Run

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Listener-Py.rst
@@ -295,19 +295,19 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 
         $ . install/setup.bash
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      In a Windows command line prompt:
+    In a Windows command line prompt:
 
-      .. code-block:: console
+    .. code-block:: console
 
-          $ call install\setup.bat
+        $ call install\setup.bat
 
-      Or in powershell:
+    Or in powershell:
 
-      .. code-block:: console
+    .. code-block:: console
 
-          $ .\install\setup.ps1
+        $ .\install\setup.ps1
 
 
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -357,19 +357,19 @@ Open a new terminal, navigate to the root of your workspace, and source the setu
 
         $ . install/setup.bash
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
-      In a Windows command line prompt:
+    In a Windows command line prompt:
 
-      .. code-block:: console
+    .. code-block:: console
 
-          $ call install\setup.bat
+        $ call install\setup.bat
 
-      Or in powershell:
+    Or in powershell:
 
-      .. code-block:: console
+    .. code-block:: console
 
-          $ .\install\setup.ps1
+        $ .\install\setup.ps1
 
 
 


### PR DESCRIPTION
Follow-up to #5309. Some of the indentation was incorrect: even just one extra space before `.. group-tab:: Windows` makes the group group block not be properly displayed.