### PR TITLE
Custom ROS 2 Interfaces: Improved confusing wording

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -49,8 +49,8 @@ Since we will use the pub/sub and service/client packages created in earlier tut
   $ ros2 pkg create --build-type ament_cmake --license Apache-2.0 tutorial_interfaces
 
 ``tutorial_interfaces`` is the name of the new package.
-Note that it is, and can only be, a CMake package, but this doesn't restrict in which type of packages you can use your messages and services.
-You can create your own custom interfaces in a CMake package, and then use it in a C++ or Python node, which will be covered in the last section.
+Note that it is, and can only be, an ament_cmake package, but this doesn't restrict in which type of packages you can use your messages and services.
+You can create your own custom interfaces in an ament_cmake package, and then use it in a C++ or Python node, which will be covered in the last section.
 
 The ``.msg`` and ``.srv`` files are required to be placed in directories called ``msg`` and ``srv`` respectively.
 Create the directories in ``ros2_ws/src/tutorial_interfaces``:


### PR DESCRIPTION
There are 2 types of CMake packages: `cmake` and `ament_cmake`. IIUC interface packages need to be `ament_cmake`. This PR changes the confusing wording.