### PR TITLE
Split 'rosdep install' command output to separate codeblock again

### DIFF
--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -270,8 +270,12 @@ Running the ``rosdep`` command should now execute normally:
 .. code-block:: console
 
    $ rosdep install -i --from-path src --rosdistro {DISTRO} -y
-   All required rosdeps installed successfully
 
+The command should return:
+
+.. code-block:: text
+
+   #All required rosdeps installed successfully
 
 .. _windows-troubleshooting:
 

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -173,7 +173,7 @@ Here are the :ref:`from-source rosdep section <linux-development-setup-install-d
 
 If you already have all your dependencies, the console will return:
 
-.. code-block:: console
+.. code-block:: text
 
   #All required rosdeps installed successfully
 


### PR DESCRIPTION
Follow-up to #5322, see https://github.com/ros2/ros2_documentation/pull/5322#discussion_r2061013193

This is closer to how it was before. `rosdep install` literally prints `#All required rosdeps installed successfully`, so we should keep the exact output. To avoid having the line be interpreted as a command line because of the leading `#`, move it to a separate `text` code-block.

Also, make another similar `rosdep install` output code-block a `text` code-block too so that the text is not formatted like a bash comment.