### PR TITLE
Move comment to the right code line in code-block

### DIFF
--- a/source/How-To-Guides/Using-Python-Packages.rst
+++ b/source/How-To-Guides/Using-Python-Packages.rst
@@ -76,8 +76,8 @@ Then setup your virtual environment:
 .. code-block:: console
 
     $ virtualenv -p python3 ./venv # Make a virtual env and activate it
-    $ source ./venv/bin/activate # Make sure that colcon does not try to build the venv
-    $ touch ./venv/COLCON_IGNORE
+    $ source ./venv/bin/activate
+    $ touch ./venv/COLCON_IGNORE # Make sure that colcon does not try to build the venv
 
 Next, install the Python packages that you want in your virtual environment:
 


### PR DESCRIPTION
Follow-up to #5322, see https://github.com/ros2/ros2_documentation/pull/5322#discussion_r2061032520

This was originally:

```rst
.. code-block:: console

    # Make a virtual env and activate it
    virtualenv -p python3 ./venv
    source ./venv/bin/activate
    # Make sure that colcon does not try to build the venv
    touch ./venv/COLCON_IGNORE
```

So the second comment belongs to the last line, not the second line.