### PR TITLE
Switch to ros2-testing for Kilted pre-release testing

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -45,7 +45,7 @@ Next, download the ROS 2 ``.repo`` file:
 .. code-block:: console
 
    $ sudo dnf install curl
-   $ sudo curl --output /etc/yum.repos.d/ros2.repo http://packages.ros.org/ros2/rhel/ros2.repo
+   $ sudo curl --output /etc/yum.repos.d/ros2.repo http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo
 
 Then, update your metadata cache.
 DNF may prompt you to verify the GPG key, which should match the location ``https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc``.

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -68,7 +68,7 @@ Install ROS 2
 Binary releases of {DISTRO_TITLE_FULL} are not provided.
 Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
 
-* Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
+* Download the latest package for Windows, e.g., ``ros2-{DISTRO}-*-windows-AMD64.zip``.
 
 .. note::
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -18,4 +18,4 @@ Then add the repository to your sources list.
 
 .. code-block:: console
 
-   $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+   $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null


### PR DESCRIPTION
Get binaries from ros2-testing repo for Kilted tutorial party.

We'll need to revert https://github.com/ros2/ros2_documentation/commit/17660910db36071108532921b5fe9ed8be36a640 before `kilted` is released. The other commit is a touch-up we can keep. 