### PR TITLE
Streamline Python launchfiles to promote best practices

### DIFF
--- a/source/How-To-Guides/launch/different_formats_launch.py
+++ b/source/How-To-Guides/launch/different_formats_launch.py
@@ -1,136 +1,86 @@
-import os
-
-from ament_index_python import get_package_share_directory
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import GroupAction
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import TextSubstitution
-from launch_ros.actions import Node
-from launch_ros.actions import PushROSNamespace
-from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
-from launch_yaml.launch_description_sources import YAMLLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node, PushROSNamespace
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-
-    # args that can be set from the command line or a default will be used
-    background_r_launch_arg = DeclareLaunchArgument(
-        'background_r', default_value=TextSubstitution(text='0')
-    )
-    background_g_launch_arg = DeclareLaunchArgument(
-        'background_g', default_value=TextSubstitution(text='255')
-    )
-    background_b_launch_arg = DeclareLaunchArgument(
-        'background_b', default_value=TextSubstitution(text='0')
-    )
-    chatter_py_ns_launch_arg = DeclareLaunchArgument(
-        'chatter_py_ns', default_value=TextSubstitution(text='chatter/py/ns')
-    )
-    chatter_xml_ns_launch_arg = DeclareLaunchArgument(
-        'chatter_xml_ns', default_value=TextSubstitution(text='chatter/xml/ns')
-    )
-    chatter_yaml_ns_launch_arg = DeclareLaunchArgument(
-        'chatter_yaml_ns', default_value=TextSubstitution(text='chatter/yaml/ns')
-    )
-
-    # include another launch file
-    launch_include = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory('demo_nodes_cpp'),
-                'launch/topics/talker_listener_launch.py'))
-    )
-    # include a Python launch file in the chatter_py_ns namespace
-    launch_py_include_with_namespace = GroupAction(
-        actions=[
-            # push_ros_namespace first to set namespace of included nodes for following actions
-            PushROSNamespace('chatter_py_ns'),
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(
-                        get_package_share_directory('demo_nodes_cpp'),
-                        'launch/topics/talker_listener_launch.py'))
-            ),
-        ]
-    )
-
-    # include a xml launch file in the chatter_xml_ns namespace
-    launch_xml_include_with_namespace = GroupAction(
-        actions=[
-            # push_ros_namespace first to set namespace of included nodes for following actions
-            PushROSNamespace('chatter_xml_ns'),
-            IncludeLaunchDescription(
-                XMLLaunchDescriptionSource(
-                    os.path.join(
-                        get_package_share_directory('demo_nodes_cpp'),
-                        'launch/topics/talker_listener_launch.xml'))
-            ),
-        ]
-    )
-
-    # include a yaml launch file in the chatter_yaml_ns namespace
-    launch_yaml_include_with_namespace = GroupAction(
-        actions=[
-            # push_ros_namespace first to set namespace of included nodes for following actions
-            PushROSNamespace('chatter_yaml_ns'),
-            IncludeLaunchDescription(
-                YAMLLaunchDescriptionSource(
-                    os.path.join(
-                        get_package_share_directory('demo_nodes_cpp'),
-                        'launch/topics/talker_listener_launch.yaml'))
-            ),
-        ]
-    )
-
-    # start a turtlesim_node in the turtlesim1 namespace
-    turtlesim_node = Node(
-        package='turtlesim',
-        namespace='turtlesim1',
-        executable='turtlesim_node',
-        name='sim'
-    )
-
-    # start another turtlesim_node in the turtlesim2 namespace
-    # and use args to set parameters
-    turtlesim_node_with_parameters = Node(
-        package='turtlesim',
-        namespace='turtlesim2',
-        executable='turtlesim_node',
-        name='sim',
-        parameters=[{
-            'background_r': LaunchConfiguration('background_r'),
-            'background_g': LaunchConfiguration('background_g'),
-            'background_b': LaunchConfiguration('background_b'),
-        }]
-    )
-
-    # perform remap so both turtles listen to the same command topic
-    forward_turtlesim_commands_to_second_turtlesim_node = Node(
-        package='turtlesim',
-        executable='mimic',
-        name='mimic',
-        remappings=[
-            ('/input/pose', '/turtlesim1/turtle1/pose'),
-            ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
-        ]
-    )
-
+    launch_dir = PathJoinSubstitution([FindPackageShare('demo_nodes_cpp'), 'launch', 'topics'])
     return LaunchDescription([
-        background_r_launch_arg,
-        background_g_launch_arg,
-        background_b_launch_arg,
-        chatter_py_ns_launch_arg,
-        chatter_xml_ns_launch_arg,
-        chatter_yaml_ns_launch_arg,
-        launch_include,
-        launch_py_include_with_namespace,
-        launch_xml_include_with_namespace,
-        launch_yaml_include_with_namespace,
-        turtlesim_node,
-        turtlesim_node_with_parameters,
-        forward_turtlesim_commands_to_second_turtlesim_node,
+        # args that can be set from the command line or a default will be used
+        DeclareLaunchArgument('background_r', default_value='0'),
+        DeclareLaunchArgument('background_g', default_value='255'),
+        DeclareLaunchArgument('background_b', default_value='0'),
+        DeclareLaunchArgument( 'chatter_py_ns', default_value='chatter/py/ns'),
+        DeclareLaunchArgument('chatter_xml_ns', default_value='chatter/xml/ns'),
+        DeclareLaunchArgument('chatter_yaml_ns', default_value='chatter/yaml/ns'),
+
+        # include another launch file
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'talker_listener_launch.py'])
+        ),
+
+        # include a Python launch file in the chatter_py_ns namespace
+        GroupAction(
+            actions=[
+                # push_ros_namespace first to set namespace of included nodes for following actions
+                PushROSNamespace('chatter_py_ns'),
+                IncludeLaunchDescription(
+                    PathJoinSubstitution([launch_dir, 'talker_listener_launch.py'])),
+            ]
+        ),
+
+        # include a xml launch file in the chatter_xml_ns namespace
+        GroupAction(
+            actions=[
+                # push_ros_namespace first to set namespace of included nodes for following actions
+                PushROSNamespace('chatter_xml_ns'),
+                IncludeLaunchDescription(
+                    PathJoinSubstitution([launch_dir, 'talker_listener_launch.xml'])),
+            ]
+        ),
+
+        # include a yaml launch file in the chatter_yaml_ns namespace
+        GroupAction(
+            actions=[
+                # push_ros_namespace first to set namespace of included nodes for following actions
+                PushROSNamespace('chatter_yaml_ns'),
+                IncludeLaunchDescription(
+                    PathJoinSubstitution([launch_dir, 'talker_listener_launch.yaml'])),
+            ]
+        ),
+
+        # start a turtlesim_node in the turtlesim1 namespace
+        Node(
+            package='turtlesim',
+            namespace='turtlesim1',
+            executable='turtlesim_node',
+            name='sim'
+        ),
+
+        # start another turtlesim_node in the turtlesim2 namespace
+        # and use args to set parameters
+        Node(
+            package='turtlesim',
+            namespace='turtlesim2',
+            executable='turtlesim_node',
+            name='sim',
+            parameters=[{
+                'background_r': LaunchConfiguration('background_r'),
+                'background_g': LaunchConfiguration('background_g'),
+                'background_b': LaunchConfiguration('background_b'),
+            }]
+        ),
+
+        # perform remap so both turtles listen to the same command topic
+        Node(
+            package='turtlesim',
+            executable='mimic',
+            name='mimic',
+            remappings=[
+                ('/input/pose', '/turtlesim1/turtle1/pose'),
+                ('/output/cmd_vel', '/turtlesim2/turtle1/cmd_vel'),
+            ]
+        ),
     ])

--- a/source/How-To-Guides/launch/different_formats_launch.py
+++ b/source/How-To-Guides/launch/different_formats_launch.py
@@ -12,7 +12,7 @@ def generate_launch_description():
         DeclareLaunchArgument('background_r', default_value='0'),
         DeclareLaunchArgument('background_g', default_value='255'),
         DeclareLaunchArgument('background_b', default_value='0'),
-        DeclareLaunchArgument( 'chatter_py_ns', default_value='chatter/py/ns'),
+        DeclareLaunchArgument('chatter_py_ns', default_value='chatter/py/ns'),
         DeclareLaunchArgument('chatter_xml_ns', default_value='chatter/xml/ns'),
         DeclareLaunchArgument('chatter_yaml_ns', default_value='chatter/yaml/ns'),
 

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Reset-Handler.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Reset-Handler.rst
@@ -152,7 +152,8 @@ This launch file contains all other nodes, including robot controllers/plugins, 
       )
 
       nav2_node = IncludeLaunchDescription(
-          PathJoinSubstitution([FindPackageShare('nav2_bringup'), 'launch', 'bringup_launch.py']),
+          PythonLaunchDescriptionSource(os.path.join(
+              get_package_share_directory('nav2_bringup'), 'launch', 'bringup_launch.py')),
           launch_arguments=[
               ('map', nav2_map),
               ('params_file', nav2_params),

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Reset-Handler.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Reset-Handler.rst
@@ -152,8 +152,7 @@ This launch file contains all other nodes, including robot controllers/plugins, 
       )
 
       nav2_node = IncludeLaunchDescription(
-          PythonLaunchDescriptionSource(os.path.join(
-              get_package_share_directory('nav2_bringup'), 'launch', 'bringup_launch.py')),
+          PathJoinSubstitution([FindPackageShare('nav2_bringup'), 'launch', 'bringup_launch.py']),
           launch_arguments=[
               ('map', nav2_map),
               ('params_file', nav2_params),

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -174,7 +174,7 @@ Every nested node will inherit that namespace automatically.
 .. attention:: ``PushROSNamespace`` has to be the first action in the list for the following actions to apply the namespace.
 
 To do that, firstly, we need to remove the ``namespace='turtlesim2'`` line from the ``turtlesim_world_2_launch.py`` file.
-Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the ``turtlesim_world_2 = `` value to the following:
+Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the ``turtlesim_world_2 =`` value to the following:
 
 .. code-block:: Python
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -174,7 +174,7 @@ Every nested node will inherit that namespace automatically.
 .. attention:: ``PushROSNamespace`` has to be the first action in the list for the following actions to apply the namespace.
 
 To do that, firstly, we need to remove the ``namespace='turtlesim2'`` line from the ``turtlesim_world_2_launch.py`` file.
-Afterwards, we need to update the ``launch_turtlesim_launch.py`` to include the following lines:
+Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the ``turtlesim_world_2 = `` value to the following:
 
 .. code-block:: Python
 
@@ -182,19 +182,13 @@ Afterwards, we need to update the ``launch_turtlesim_launch.py`` to include the 
    from launch_ros.actions import PushROSNamespace
 
       ...
-      turtlesim_world_2 = IncludeLaunchDescription(
-         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_world_2_launch.py'])
-         )
-      turtlesim_world_2_with_namespace = GroupAction(
+      turtlesim_world_2 = GroupAction(
         actions=[
             PushROSNamespace('turtlesim2'),
-            turtlesim_world_2,
+            IncludeLaunchDescription(PathJoinSubstitution([launch_dir, 'turtlesim_world_2_launch.py']),
          ]
       )
 
-Finally, we replace the ``turtlesim_world_2`` to ``turtlesim_world_2_with_namespace`` in the ``return LaunchDescription`` statement.
 As a result, each node in the ``turtlesim_world_2_launch.py`` launch description will have a ``turtlesim2`` namespace.
 
 4 Reusing nodes

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -129,7 +129,7 @@ Now let's create a new ``turtlesim_world_3_launch.py`` file similar to ``turtles
 
 .. literalinclude:: launch/turtlesim_world_3_launch.py
    :language: python
-   :emphasize-lines: 16
+   :emphasize-lines: 12
 
 Loading the same YAML file, however, will not affect the appearance of the third turtlesim world.
 The reason is that its parameters are stored under another namespace as shown below:
@@ -185,7 +185,7 @@ Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the `
       GroupAction(
         actions=[
             PushROSNamespace('turtlesim2'),
-            IncludeLaunchDescription(PathJoinSubstitution([launch_dir, 'turtlesim_world_2_launch.py']),
+            IncludeLaunchDescription(PathJoinSubstitution([launch_dir, 'turtlesim_world_2_launch.py'])),
          ]
       ),
 

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -129,7 +129,7 @@ Now let's create a new ``turtlesim_world_3_launch.py`` file similar to ``turtles
 
 .. literalinclude:: launch/turtlesim_world_3_launch.py
    :language: python
-   :emphasize-lines: 19
+   :emphasize-lines: 16
 
 Loading the same YAML file, however, will not affect the appearance of the third turtlesim world.
 The reason is that its parameters are stored under another namespace as shown below:
@@ -174,7 +174,7 @@ Every nested node will inherit that namespace automatically.
 .. attention:: ``PushROSNamespace`` has to be the first action in the list for the following actions to apply the namespace.
 
 To do that, firstly, we need to remove the ``namespace='turtlesim2'`` line from the ``turtlesim_world_2_launch.py`` file.
-Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the ``turtlesim_world_2 =`` value to the following:
+Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the ``IncludeLaunchDescription(... 'turtlesim_world_2_launch.py' ...)`` value to the following:
 
 .. code-block:: Python
 
@@ -182,12 +182,12 @@ Afterwards, we need to update the ``launch_turtlesim_launch.py`` to change the `
    from launch_ros.actions import PushROSNamespace
 
       ...
-      turtlesim_world_2 = GroupAction(
+      GroupAction(
         actions=[
             PushROSNamespace('turtlesim2'),
             IncludeLaunchDescription(PathJoinSubstitution([launch_dir, 'turtlesim_world_2_launch.py']),
          ]
-      )
+      ),
 
 As a result, each node in the ``turtlesim_world_2_launch.py`` launch description will have a ``turtlesim2`` namespace.
 
@@ -215,7 +215,7 @@ In addition to that, we have passed it ``target_frame`` launch argument as shown
 
 .. literalinclude:: launch/launch_turtlesim_launch.py
    :language: python
-   :lines: 21-26
+   :lines: 16-19
 
 This syntax allows us to change the default goal target frame to ``carrot1``.
 If you would like ``turtle2`` to follow ``turtle1`` instead of the ``carrot1``, just remove the line that defines ``launch_arguments``.

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -185,7 +185,7 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
 
     .. literalinclude:: launch/example_main_launch.py
       :language: python
-      :lines: 16-20
+      :lines: 14-18
 
     .. tip::
 
@@ -211,7 +211,7 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
 
     .. literalinclude:: launch/example_main_launch.py
       :language: python
-      :lines: 22-26
+      :lines: 19-23
 
 
 3 Substitutions example launch file
@@ -309,14 +309,14 @@ Now create the substitution launch file in the same folder:
       :language: python
 
     The ``turtlesim_ns``, ``use_provided_red``, and ``new_background_r`` launch configurations are defined.
-    They are used to store values of launch arguments in the above variables and to pass them to required actions.
+    They are used to represent values of launch arguments in the above variables and to pass them to required actions.
     These ``LaunchConfiguration`` substitutions allow us to acquire the value of the launch argument in any part of the launch description.
 
     ``DeclareLaunchArgument`` is used to define the launch argument that can be passed from the above launch file or from the console.
 
     .. literalinclude:: launch/example_substitutions_launch.py
       :language: python
-      :lines: 13-24
+      :lines: 14-25
 
     The ``turtlesim_node`` node with the ``namespace`` set to ``turtlesim_ns`` ``LaunchConfiguration`` substitution is defined.
 
@@ -324,22 +324,21 @@ Now create the substitution launch file in the same folder:
       :language: python
       :lines: 26-31
 
-    Afterwards, the ``ExecuteProcess`` action called ``spawn_turtle`` is defined with the corresponding ``cmd`` argument.
-    This command makes a call to the spawn service of the turtlesim node.
+    The next action, ``ExecuteProcess``,  is defined with the corresponding ``cmd`` argument to call the spawn service of the turtlesim node.
 
-    Additionally, the ``LaunchConfiguration`` substitution is used to get the value of the ``turtlesim_ns`` launch argument to construct a command string.
+    Additionally, the ``LaunchConfiguration`` substitution is used to provide the value of the ``turtlesim_ns`` launch argument in the command string.
 
     .. literalinclude:: launch/example_substitutions_launch.py
       :language: python
       :lines: 32-41
 
     The same approach is used for the ``change_background_r`` and ``change_background_r_conditioned`` actions that change the turtlesim background's red color parameter.
-    The difference is that the ``change_background_r_conditioned`` action is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
+    The difference is that the next action is only executed if the provided ``new_background_r`` argument equals ``200`` and the ``use_provided_red`` launch argument is set to ``True``.
     The evaluation inside the ``IfCondition`` is done using the ``PythonExpression`` substitution.
 
     .. literalinclude:: launch/example_substitutions_launch.py
       :language: python
-      :lines: 42-67
+      :lines: 51-72
 
 4 Build the package
 ^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -208,7 +208,6 @@ To do this, create following file in the ``launch`` folder of the ``launch_tutor
       In this case, by default, the last path component provided to ``PathJoinSubstitution`` would resolve to ``example_substitutions_launch.py`` and would then be joined with the other path components.
 
     The ``launch_arguments`` dictionary with ``turtlesim_ns`` and ``use_provided_red`` arguments is passed to the ``IncludeLaunchDescription`` action.
-    The ``TextSubstitution`` substitution is used to define the ``new_background_r`` argument with the value of the ``background_r`` key in the ``colors`` dictionary.
 
     .. literalinclude:: launch/example_main_launch.py
       :language: python

--- a/source/Tutorials/Intermediate/Launch/launch/example_main_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/example_main_launch.py
@@ -1,7 +1,6 @@
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -12,17 +11,15 @@ def generate_launch_description():
 
     return LaunchDescription([
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([
-                PathJoinSubstitution([
-                    FindPackageShare('launch_tutorial'),
-                    'launch',
-                    'example_substitutions_launch.py'
-                ])
+            PathJoinSubstitution([
+                FindPackageShare('launch_tutorial'),
+                'launch',
+                'example_substitutions_launch.py'
             ]),
             launch_arguments={
                 'turtlesim_ns': 'turtlesim2',
                 'use_provided_red': 'True',
-                'new_background_r': TextSubstitution(text=str(colors['background_r']))
+                'new_background_r': colors['background_r'],
             }.items()
         )
     ])

--- a/source/Tutorials/Intermediate/Launch/launch/example_substitutions_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/example_substitutions_launch.py
@@ -10,71 +10,64 @@ def generate_launch_description():
     use_provided_red = LaunchConfiguration('use_provided_red')
     new_background_r = LaunchConfiguration('new_background_r')
 
-    turtlesim_ns_launch_arg = DeclareLaunchArgument(
-        'turtlesim_ns',
-        default_value='turtlesim1'
-    )
-    use_provided_red_launch_arg = DeclareLaunchArgument(
-        'use_provided_red',
-        default_value='False'
-    )
-    new_background_r_launch_arg = DeclareLaunchArgument(
-        'new_background_r',
-        default_value='200'
-    )
-
-    turtlesim_node = Node(
-        package='turtlesim',
-        namespace=turtlesim_ns,
-        executable='turtlesim_node',
-        name='sim'
-    )
-    spawn_turtle = ExecuteProcess(
-        cmd=[[
-            'ros2 service call ',
-            turtlesim_ns,
-            '/spawn ',
-            'turtlesim_msgs/srv/Spawn ',
-            '"{x: 2, y: 2, theta: 0.2}"'
-        ]],
-        shell=True
-    )
-    change_background_r = ExecuteProcess(
-        cmd=[[
-            'ros2 param set ',
-            turtlesim_ns,
-            '/sim background_r ',
-            '120'
-        ]],
-        shell=True
-    )
-    change_background_r_conditioned = ExecuteProcess(
-        condition=IfCondition(
-            PythonExpression([
-                new_background_r,
-                ' == 200',
-                ' and ',
-                use_provided_red
-            ])
-        ),
-        cmd=[[
-            'ros2 param set ',
-            turtlesim_ns,
-            '/sim background_r ',
-            new_background_r
-        ]],
-        shell=True
-    )
-
     return LaunchDescription([
-        turtlesim_ns_launch_arg,
-        use_provided_red_launch_arg,
-        new_background_r_launch_arg,
-        turtlesim_node,
-        spawn_turtle,
-        change_background_r,
+        DeclareLaunchArgument(
+            'turtlesim_ns',
+            default_value='turtlesim1'
+        ),
+        DeclareLaunchArgument(
+            'use_provided_red',
+            default_value='False'
+        ),
+        DeclareLaunchArgument(
+            'new_background_r',
+            default_value='200'
+        ),
+        Node(
+            package='turtlesim',
+            namespace=turtlesim_ns,
+            executable='turtlesim_node',
+            name='sim'
+        ),
+        ExecuteProcess(
+            cmd=[[
+                'ros2 service call ',
+                turtlesim_ns,
+                '/spawn ',
+                'turtlesim_msgs/srv/Spawn ',
+                '"{x: 2, y: 2, theta: 0.2}"'
+            ]],
+            shell=True
+        ),
+        ExecuteProcess(
+            cmd=[[
+                'ros2 param set ',
+                turtlesim_ns,
+                '/sim background_r ',
+                '120'
+            ]],
+            shell=True
+        ),
         TimerAction(
             period=2.0,
-            actions=[change_background_r_conditioned],
+            actions=[
+                ExecuteProcess(
+                    condition=IfCondition(
+                        PythonExpression([
+                            new_background_r,
+                            ' == 200',
+                            ' and ',
+                            use_provided_red
+                        ])
+                    ),
+                    cmd=[[
+                        'ros2 param set ',
+                        turtlesim_ns,
+                        '/sim background_r ',
+                        new_background_r
+                    ]],
+                    shell=True
+                ),
+            ],
         )
     ])

--- a/source/Tutorials/Intermediate/Launch/launch/launch_turtlesim_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/launch_turtlesim_launch.py
@@ -1,50 +1,29 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    turtlesim_world_1 = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_world_1_launch.py'])
-        )
-    turtlesim_world_2 = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_world_2_launch.py'])
-        )
-    broadcaster_listener_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/broadcaster_listener_launch.py']),
-        launch_arguments={'target_frame': 'carrot1'}.items(),
-        )
-    mimic_node = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/mimic_launch.py'])
-        )
-    fixed_frame_node = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/fixed_broadcaster_launch.py'])
-        )
-    rviz_node = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('launch_tutorial'), 'launch'),
-            '/turtlesim_rviz_launch.py'])
-        )
-
+    launch_dir = PathJoinSubstitution([FindPackageShare('launch_tutorial'), 'launch']),
     return LaunchDescription([
-        turtlesim_world_1,
-        turtlesim_world_2,
-        broadcaster_listener_nodes,
-        mimic_node,
-        fixed_frame_node,
-        rviz_node
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'turtlesim_world_1_launch.py'])
+        ),
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'turtlesim_world_2_launch.py'])
+        ),
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'broadcaster_listener_launch.py']),
+            launch_arguments={'target_frame': 'carrot1'}.items()
+        ),
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'mimic_launch.py'])
+        ),
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'fixed_broadcaster_launch.py'])
+        ),
+        IncludeLaunchDescription(
+            PathJoinSubstitution([launch_dir, 'turtlesim_rviz_launch.py'])
+        ),
     ])

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_rviz_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_rviz_launch.py
@@ -5,13 +5,12 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    rviz_config = PathJoinSubstitution([
-        FindPackageShare('turtle_tf2_py'), 'rviz', 'turtle_rviz.rviz'])
     return LaunchDescription([
         Node(
             package='rviz2',
             executable='rviz2',
             name='rviz2',
-            arguments=['-d', rviz_config]
-        )
+            arguments=['-d', PathJoinSubstitution([
+                FindPackageShare('turtle_tf2_py'), 'rviz', 'turtle_rviz.rviz'])],
+        ),
     ])

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_rviz_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_rviz_launch.py
@@ -1,18 +1,12 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    rviz_config = os.path.join(
-        get_package_share_directory('turtle_tf2_py'),
-        'rviz',
-        'turtle_rviz.rviz'
-    )
-
+    rviz_config = PathJoinSubstitution([
+        FindPackageShare('turtle_tf2_py'), 'rviz', 'turtle_rviz.rviz'])
     return LaunchDescription([
         Node(
             package='rviz2',

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_1_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_1_launch.py
@@ -1,25 +1,14 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, TextSubstitution
-
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    background_r_launch_arg = DeclareLaunchArgument(
-        'background_r', default_value=TextSubstitution(text='0')
-    )
-    background_g_launch_arg = DeclareLaunchArgument(
-        'background_g', default_value=TextSubstitution(text='84')
-    )
-    background_b_launch_arg = DeclareLaunchArgument(
-        'background_b', default_value=TextSubstitution(text='122')
-    )
-
     return LaunchDescription([
-        background_r_launch_arg,
-        background_g_launch_arg,
-        background_b_launch_arg,
+        DeclareLaunchArgument('background_r', default_value='0'),
+        DeclareLaunchArgument('background_g', default_value='84'),
+        DeclareLaunchArgument('background_b', default_value='122'),
         Node(
             package='turtlesim',
             executable='turtlesim_node',

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_2_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_2_launch.py
@@ -5,16 +5,14 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    config = PathJoinSubstitution([
-        FindPackageShare('launch_tutorial'), 'config', 'turtlesim.yaml'
-    ])
-
     return LaunchDescription([
         Node(
             package='turtlesim',
             executable='turtlesim_node',
             namespace='turtlesim2',
             name='sim',
-            parameters=[config]
-        )
+            parameters=[PathJoinSubstitution([
+                FindPackageShare('launch_tutorial'), 'config', 'turtlesim.yaml'])
+            ],
+        ),
     ])

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_2_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_2_launch.py
@@ -1,16 +1,13 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    config = os.path.join(
-        get_package_share_directory('launch_tutorial'),
-        'config',
-        'turtlesim.yaml')
+    config = PathJoinSubstitution([
+        FindPackageShare('launch_tutorial'), 'config', 'turtlesim.yaml'
+    ])
 
     return LaunchDescription([
         Node(

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_3_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_3_launch.py
@@ -5,16 +5,15 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    config = PathJoinSubstitution([
-        FindPackageShare('launch_tutorial'), 'config', 'turtlesim.yaml'
-    ])
-
     return LaunchDescription([
         Node(
             package='turtlesim',
             executable='turtlesim_node',
             namespace='turtlesim3',
             name='sim',
-            parameters=[config]
-        )
+            parameters=[
+                PathJoinSubstitution([
+                    FindPackageShare('launch_tutorial'), 'config', 'turtlesim.yaml']),
+            ],
+        ),
     ])

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_3_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_world_3_launch.py
@@ -1,16 +1,13 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    config = os.path.join(
-        get_package_share_directory('launch_tutorial'),
-        'config',
-        'turtlesim.yaml')
+    config = PathJoinSubstitution([
+        FindPackageShare('launch_tutorial'), 'config', 'turtlesim.yaml'
+    ])
 
     return LaunchDescription([
         Node(

--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Cpp.rst
@@ -193,7 +193,7 @@ The last part of the code will add our fixed ``carrot1`` frame to the turtlesim 
 
 .. literalinclude:: launch/turtle_tf2_fixed_frame_demo_launch.py
     :language: python
-    :lines: 21-25
+    :lines: 14-18
 
 1.4 Build
 ~~~~~~~~~

--- a/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Adding-A-Frame-Py.rst
@@ -171,7 +171,7 @@ The last part of the code will add our fixed ``carrot1`` frame to the turtlesim 
 
 .. literalinclude:: launch/py_turtle_tf2_fixed_frame_demo_launch.py
     :language: python
-    :lines: 22-26
+    :lines: 14-18
 
 1.4 Build
 ~~~~~~~~~

--- a/source/Tutorials/Intermediate/Tf2/launch/py_turtle_tf2_dynamic_frame_demo_launch.py
+++ b/source/Tutorials/Intermediate/Tf2/launch/py_turtle_tf2_dynamic_frame_demo_launch.py
@@ -1,24 +1,17 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    demo_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('learning_tf2_py'), 'launch'),
-            '/turtle_tf2_demo_launch.py']),
-        launch_arguments={'target_frame': 'carrot1'}.items(),
-        )
-
     return LaunchDescription([
-        demo_nodes,
+        IncludeLaunchDescription(
+            PathJoinSubstitution([
+                FindPackageShare('learning_tf2_py'), 'launch', 'turtle_tf2_demo_launch.py']),
+            launch_arguments={'target_frame': 'carrot1'}.items(),
+        ),
         Node(
             package='learning_tf2_py',
             executable='dynamic_frame_tf2_broadcaster',

--- a/source/Tutorials/Intermediate/Tf2/launch/py_turtle_tf2_fixed_frame_demo_launch.py
+++ b/source/Tutorials/Intermediate/Tf2/launch/py_turtle_tf2_fixed_frame_demo_launch.py
@@ -1,23 +1,16 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    demo_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('learning_tf2_py'), 'launch'),
-            '/turtle_tf2_demo_launch.py']),
-        )
-
     return LaunchDescription([
-        demo_nodes,
+        IncludeLaunchDescription(
+            PathJoinSubstitution([
+                FindPackageShare('learning_tf2_py'), 'launch', 'turtle_tf2_demo_launch.py'])
+        ),
         Node(
             package='learning_tf2_py',
             executable='fixed_frame_tf2_broadcaster',

--- a/source/Tutorials/Intermediate/Tf2/launch/turtle_tf2_dynamic_frame_demo_launch.py
+++ b/source/Tutorials/Intermediate/Tf2/launch/turtle_tf2_dynamic_frame_demo_launch.py
@@ -1,24 +1,17 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    demo_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('learning_tf2_cpp'), 'launch'),
-            '/turtle_tf2_demo_launch.py']),
-        launch_arguments={'target_frame': 'carrot1'}.items(),
-        )
-
     return LaunchDescription([
-        demo_nodes,
+        IncludeLaunchDescription(
+            PathJoinSubstitution([
+                FindPackageShare('learning_tf2_cpp'), 'launch', 'turtle_tf2_demo_launch.py']),
+            launch_arguments={'target_frame': 'carrot1'}.items(),
+        ),
         Node(
             package='learning_tf2_cpp',
             executable='dynamic_frame_tf2_broadcaster',

--- a/source/Tutorials/Intermediate/Tf2/launch/turtle_tf2_fixed_frame_demo_launch.py
+++ b/source/Tutorials/Intermediate/Tf2/launch/turtle_tf2_fixed_frame_demo_launch.py
@@ -1,23 +1,16 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    demo_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('learning_tf2_cpp'), 'launch'),
-            '/turtle_tf2_demo_launch.py']),
-        )
-
     return LaunchDescription([
-        demo_nodes,
+        IncludeLaunchDescription(
+            PathJoinSubstitution([
+                FindPackageShare('learning_tf2_cpp'), 'launch', 'turtle_tf2_demo_launch.py'])
+        ),
         Node(
             package='learning_tf2_cpp',
             executable='fixed_frame_tf2_broadcaster',

--- a/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
+++ b/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
@@ -1,21 +1,14 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import FileContent, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
-
-    urdf_file_name = 'r2d2.urdf.xml'
-    urdf = os.path.join(
-        get_package_share_directory('urdf_tutorial_r2d2'),
-        urdf_file_name)
-    with open(urdf, 'r') as infp:
-        robot_desc = infp.read()
+    urdf = FileContent(
+        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2', 'r2d2.urdf.xml')]))
 
     return LaunchDescription([
         DeclareLaunchArgument(
@@ -27,7 +20,7 @@ def generate_launch_description():
             executable='robot_state_publisher',
             name='robot_state_publisher',
             output='screen',
-            parameters=[{'use_sim_time': use_sim_time, 'robot_description': robot_desc}],
+            parameters=[{'use_sim_time': use_sim_time, 'robot_description': urdf}],
             arguments=[urdf]),
         Node(
             package='urdf_tutorial_r2d2',

--- a/source/Tutorials/Intermediate/URDF/launch/launch.py
+++ b/source/Tutorials/Intermediate/URDF/launch/launch.py
@@ -1,45 +1,32 @@
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import FileContent, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-
     # ''use_sim_time'' is used to  determine whether ros2 use simulation time provided by simulation environment (Gazebo).
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
 
-    urdf_file_name = 'r2d2.urdf.xml'
+    urdf = FileContent(
+        PathJoinSubstitution([FindPackageShare('urdf_tutorial_cpp'), 'urdf', 'r2d2.urdf.xml']))
 
-    # urdf is path of urdf_file_name file. we use define it as the follow due to the CMakeLists.txt file.
-    urdf = os.path.join(
-        get_package_share_directory('urdf_tutorial_cpp'),
-        'urdf',
-        urdf_file_name
-    )
-
-    # open the whole urdf_file_name file and read it content to robot_desc
-    with open(urdf, 'r') as infp:
-        robot_desc = infp.read()
-
-        return LaunchDescription([
-            DeclareLaunchArgument(
-                'use_sim_time',
-                default_value='false',
-                description='Use simulation (Gazebo) clock if true'),
-            Node(
-                package='robot_state_publisher',
-                executable='robot_state_publisher',
-                name='robot_state_publisher',
-                output='screen',
-                parameters=[{'use_sim_time': use_sim_time, 'robot_description': robot_desc}],
-                arguments=[urdf]),
-            Node(
-                package='urdf_tutorial_cpp',
-                executable='urdf_tutorial_cpp',
-                name='urdf_tutorial_cpp',
-                output='screen'),
-        ])
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value='false',
+            description='Use simulation (Gazebo) clock if true'),
+        Node(
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            name='robot_state_publisher',
+            output='screen',
+            parameters=[{'use_sim_time': use_sim_time, 'robot_description': urdf}],
+            arguments=[urdf]),
+        Node(
+            package='urdf_tutorial_cpp',
+            executable='urdf_tutorial_cpp',
+            name='urdf_tutorial_cpp',
+            output='screen'),
+    ])

--- a/source/Tutorials/Intermediate/URDF/launch/launch.py
+++ b/source/Tutorials/Intermediate/URDF/launch/launch.py
@@ -6,7 +6,7 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    # ''use_sim_time'' is used to  determine whether ros2 use simulation time provided by simulation environment (Gazebo).
+    # ''use_sim_time'' is used to have ros2 use /clock topic for the time source
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
 
     urdf = FileContent(


### PR DESCRIPTION
Closes robograph-project/docs#9

The changes included in this PR are meant to produce shorter, clearer, and more flexible Python launchfiles. By showing these examples to users, we encourage them to also follow best practices for a better experience and more correct results.

## Changes

- Remove all direct use of `PythonLaunchDescriptionSource` (and xml, yaml versions) in favor of encoding less explicit knowledge into user facing API

This makes the code shorter and therefore easier to read, and makes it easier to change out launchfile frontends.

- Make launchfiles into a declarative style, with as much included in `return LaunchDescription([...` as possible

This matches the XML/YAML style, and removes room for programming errors in launchfiles. I have seen plenty of cases where declared variables are then used out of order, or accidentally missed entirely. When simply declaring everything into the Action list, you can't make those mistakes.

- Replace `os.path.join` with `PathJoinSubstitution` 

This allows for extension to uses with other Substitutions, such as `LaunchConfiguration` etc. The more flexible and correct way to write launchfiles.

- Replace `get_package_share_directory` with `FindPackageShare`

This allows the package name to be a substitution, such as from a launch arg. That's a use case I have seen. Plus the pattern allows parsing launchfiles in a context where the package prefix may not yet be known, like in build and tooling scenarios.

- Remove all direct use of `TextSubstitution`

It's not needed, and therefore is more confusion!

