### PR TITLE
Update Ubuntu install instructions for kilted

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -32,7 +32,7 @@ Set locale
 
 .. include:: _Ubuntu-Set-Locale.rst
 
-Enable required repositories
+Install ros-apt-source package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: _Apt-Repositories.rst

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -32,8 +32,8 @@ Set locale
 
 .. include:: _Ubuntu-Set-Locale.rst
 
-Install ros-apt-source package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Enable required repositories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: _Apt-Repositories.rst
 

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -33,7 +33,7 @@ Set locale
 .. include:: _Ubuntu-Set-Locale.rst
 
 Install ros-apt-source package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. include:: _Apt-Repositories.rst
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -7,7 +7,7 @@ First ensure that the `Ubuntu Universe repository <https://help.ubuntu.com/commu
    $ sudo apt install software-properties-common
    $ sudo add-apt-repository universe
 
-The package `ros-apt-source <https://github.com/ros-infrastructure/ros-apt-source/>`_ provides keys and source configuration for the ROS repositories.
+The `ros-apt-source <https://github.com/ros-infrastructure/ros-apt-source/>`_ packages provide keys and apt source configuration for the various ROS repositories.
 
 Installing the ros2-apt-source package will configure ROS 2 repositories for your system.
 Updates to repository configuration will occur automatically when new versions of this package are released to the ROS repositories.

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -1,4 +1,4 @@
-You will need to add the ROS 2 repository to your system.
+You will need to add the ROS 2 apt repository to your system.
 
 First ensure that the `Ubuntu Universe repository <https://help.ubuntu.com/community/Repositories/Ubuntu>`_ is enabled.
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -1,6 +1,6 @@
 The package `ros-apt-source <https://github.com/ros-infrastructure/ros-apt-source/>`_ provides keys and source configuration for the ROS repositories.
 
-You will need install this package con configure ROS repositories.
+You will need to install this package to configure ROS apt repositories.
 
 .. code-block:: console
 

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -1,21 +1,8 @@
-You will need to add the ROS 2 apt repository to your system.
+The package `ros-apt-source <https://github.com/ros-infrastructure/ros-apt-source/>`_ provides keys and source configuration for the ROS repositories.
 
-First ensure that the `Ubuntu Universe repository <https://help.ubuntu.com/community/Repositories/Ubuntu>`_ is enabled.
-
-.. code-block:: console
-
-   $ sudo apt install software-properties-common
-   $ sudo add-apt-repository universe
-
-Now add the ROS 2 GPG key with apt.
+You will need install this package con configure ROS repositories.
 
 .. code-block:: console
 
-   $ sudo apt update && sudo apt install curl -y
-   $ sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-
-Then add the repository to your sources list.
-
-.. code-block:: console
-
-   $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+   $ curl -O --output-dir /tmp/ https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2-testing/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb
+   $ sudo apt install /tmp/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -1,8 +1,18 @@
-The package `ros-apt-source <https://github.com/ros-infrastructure/ros-apt-source/>`_ provides keys and source configuration for the ROS repositories.
+You will need to add the ROS 2 repository to your system.
 
-You will need to install this package to configure ROS apt repositories.
+First ensure that the `Ubuntu Universe repository <https://help.ubuntu.com/community/Repositories/Ubuntu>`_ is enabled.
 
 .. code-block:: console
 
-   $ curl -O --output-dir /tmp/ https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2-testing/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb
-   $ sudo apt install /tmp/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb
+   $ sudo apt install software-properties-common
+   $ sudo add-apt-repository universe
+
+The package `ros-apt-source <https://github.com/ros-infrastructure/ros-apt-source/>`_ provides keys and source configuration for the ROS repositories.
+
+Installing the ros2-apt-source package will configure ROS 2 repositories for your system.
+Updates to repository configuration will occur automatically when new versions of this package are released to the ROS repositories.
+
+.. code-block:: console
+
+   $ curl -o /tmp/ros2-testing-apt-source.deb https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2-testing/ubuntu/pool/main/r/ros-apt-source/ros2-testing-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb
+   $ sudo apt install /tmp/ros2-testing-apt-source.deb


### PR DESCRIPTION
This PR changes the instructions from manually setting the repositories to use [ros-apt-source](https://github.com/ros-infrastructure/ros-apt-source/) package instead.

