### PR TITLE
Update ROS 2 testing repository setup instructions for Kilted.

### DIFF
--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -23,13 +23,12 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 1. Make sure you have a working ROS 2 installation from deb packages (see :doc:`../Installation`).
 
-2. Edit (with sudo) the file ``/etc/apt/sources.list.d/ros2.list`` and change ``ros2`` with ``ros2-testing``.
-   For example, on Ubuntu Noble the contents should look like the following:
+2. Install the ``ros2-testing-apt-source`` package
+   This will automatically uninstall the ``ros2-apt-source`` package since only one repository may be enabled at a time.
 
    .. code-block:: bash
 
-      # deb http://packages.ros.org/ros2/ubuntu noble main
-      deb http://packages.ros.org/ros2-testing/ubuntu noble main
+      $ sudo apt install -y ros2-testing-apt-source
 
 3. Update the ``apt`` index:
 
@@ -49,12 +48,11 @@ For Debian-based operating systems, you can install binary packages from the **r
 
       $ sudo apt dist-upgrade
 
-6. Once you are finished testing, you can switch back to the normal repository by changing back the contents of ``/etc/apt/sources.list.d/ros2.list``:
+6. Once you are finished testing, you can switch back to the normal repository by re-installing the ``ros-apt-source`` package:
 
    .. code-block:: bash
 
-      deb http://packages.ros.org/ros2/ubuntu noble main
-      # deb http://packages.ros.org/ros2-testing/ubuntu noble main
+      $ sudo apt install -y ros-apt-source
 
    and doing an update and upgrade:
 


### PR DESCRIPTION
After some time in the tutorial party these docs will be mergify-backported to other distros.

We've updated the installation instructions for the tutorial party in #5443 #5427 but we link directly to these testing repo setup instructions in the [Discourse post](https://discourse.ros.org/t/ros-2-kilted-beta-and-call-for-testing/43477) and those haven't been updated yet.