### PR TITLE
Fix small typo in Zenoh documentation

### DIFF
--- a/source/Installation/RMW-Implementations/Non-DDS-Implementations/Working-with-Zenoh.rst
+++ b/source/Installation/RMW-Implementations/Non-DDS-Implementations/Working-with-Zenoh.rst
@@ -27,7 +27,7 @@ Then install rmw_zenoh binaries using the command
 Build from source code
 ----------------------
 
-Built from source, recommended if latest features are needed.
+Building from source is only recommended if latest features are needed.
 
 By default, we vendor and compile ``zenoh-cpp`` with a subset of zenoh features.
 The ``ZENOHC_CARGO_FLAGS`` CMake argument may be overwritten with other features included if required.

--- a/source/Installation/RMW-Implementations/Non-DDS-Implementations/Working-with-Zenoh.rst
+++ b/source/Installation/RMW-Implementations/Non-DDS-Implementations/Working-with-Zenoh.rst
@@ -74,7 +74,7 @@ Start the Zenoh router
 .. code-block:: bash
 
    # terminal 1
-   ros2 run rmw_zenoh_cpp talker rmw_zenohd
+   ros2 run rmw_zenoh_cpp rmw_zenohd
 
 .. note:: Without the Zenoh router, nodes will not be able to discover each other since multicast discovery is disabled by default in the node's session config.
     Instead, nodes will receive discovery information about other peers via the Zenoh router's gossip functionality.


### PR DESCRIPTION
A small follow-up to https://github.com/ros2/ros2_documentation/pull/5231, fixing a typo in the command to start the Zenoh router.

Spotted during Kilted beta testing: https://github.com/ros2/kilted_tutorial_party/issues/300#issuecomment-2846653844

Also includes a small wording change, but it's optional.