### PR TITLE
Update Windows-Install-Binary.rst

### DIFF
--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -47,7 +47,7 @@ ROS 2 uses `conda-forge <https://conda-forge.org/>`__ as a backend for packages,
 
 .. note::
 
-The installation of conda-forge may trigger Windows Defender to treat it as a threat, but can be ignored by clicking "More info" and "Run anyway".
+   The installation of conda-forge may trigger Windows Defender to treat it as a threat, but can be ignored by clicking "More info" and "Run anyway".
 
 Install pixi
 ^^^^^^^^^^^^

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -47,7 +47,7 @@ ROS 2 uses `conda-forge <https://conda-forge.org/>`__ as a backend for packages,
 
 .. note::
 
-   The installation of conda-forge may trigger Windows Defender to treat it as a threat, but can be ignored by clicking "More info" and "Run anyway".
+   The installation of conda-forge may trigger Windows Defender to treat it as a threat, but this can be safely ignored by clicking "More info" and "Run anyway".
 
 Install pixi
 ^^^^^^^^^^^^

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -131,12 +131,6 @@ Start another command shell and run a Python ``listener``\ :
 
    $ ros2 run demo_nodes_py listener
 
-If you are using rmw_zenoh_cpp, you must also run the Zenoh router node:
-
-.. code-block:: console
-
-   $ ros2 run rmw_zenoh_cpp rmw_zenohd
-
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
 This verifies both the C++ and Python APIs are working properly.
 Hooray!

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -45,6 +45,10 @@ Install prerequisites
 
 ROS 2 uses `conda-forge <https://conda-forge.org/>`__ as a backend for packages, with `pixi <https://pixi.sh/latest/>`__ as the frontend.
 
+.. note::
+
+The installation of conda-forge may trigger Windows Defender to treat it as a threat, but can be ignored by clicking "More info" and "Run anyway".
+
 Install pixi
 ^^^^^^^^^^^^
 
@@ -126,6 +130,12 @@ Start another command shell and run a Python ``listener``\ :
 .. code-block:: console
 
    $ ros2 run demo_nodes_py listener
+
+If you are using rmw_zenoh_cpp, you must also run the Zenoh router node:
+
+.. code-block:: console
+
+   $ ros2 run rmw_zenoh_cpp rmw_zenohd
 
 You should see the ``talker`` saying that it's ``Publishing`` messages and the ``listener`` saying ``I heard`` those messages.
 This verifies both the C++ and Python APIs are working properly.


### PR DESCRIPTION
Adds a note warning users of conda-forge triggering Windows Defender and how to respond. Also adds a small section about running `ros2 run rmw_zenoh_cpp rmw_zenohd` alongside the talker/listener example if the user is using rmw_zenoh_cpp