### PR TITLE
Set correct code-block language in beginner CLI tutorials

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -336,7 +336,7 @@ In there, create a new file called ``cpp_parameters_launch.py``
 Here you can see that we set ``my_parameter`` to ``earth`` when we launch our node ``minimal_param_node``.
 By adding the two lines below, we ensure our output is printed in our console.
 
-.. code-block:: console
+.. code-block:: python
 
           output="screen",
           emulate_tty=True,

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.rst
@@ -243,21 +243,21 @@ Make sure to save the file.
 Now open the ``CMakeLists.txt`` file.
 Below the existing dependency ``find_package(ament_cmake REQUIRED)``, add the lines:
 
-.. code-block:: console
+.. code-block:: cmake
 
     find_package(rclcpp REQUIRED)
     find_package(std_msgs REQUIRED)
 
 After that, add the executable and name it ``talker`` so you can run your node using ``ros2 run``:
 
-.. code-block:: console
+.. code-block:: cmake
 
     add_executable(talker src/publisher_lambda_function.cpp)
     target_link_libraries(talker PUBLIC rclcpp::rclcpp ${std_msgs_TARGETS})
 
 Finally, add the ``install(TARGETS...)`` section so ``ros2 run`` can find your executable:
 
-.. code-block:: console
+.. code-block:: cmake
 
   install(TARGETS
     talker
@@ -265,7 +265,7 @@ Finally, add the ``install(TARGETS...)`` section so ``ros2 run`` can find your e
 
 You can clean up your ``CMakeLists.txt`` by removing some unnecessary sections and comments, so it looks like this:
 
-.. code-block:: console
+.. code-block:: cmake
 
   cmake_minimum_required(VERSION 3.5)
   project(cpp_pubsub)

--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -168,14 +168,14 @@ The ``main`` function accomplishes the following, line by line:
 The ``add_executable`` macro generates an executable you can run using ``ros2 run``.
 Add the following code block to ``CMakeLists.txt`` to create an executable named ``server``:
 
-.. code-block:: console
+.. code-block:: cmake
 
   add_executable(server src/add_two_ints_server.cpp)
   target_link_libraries(server PUBLIC rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 So ``ros2 run`` can find the executable, add the following lines to the end of the file, right before ``ament_package()``:
 
-.. code-block:: console
+.. code-block:: cmake
 
   install(TARGETS
       server
@@ -274,7 +274,7 @@ Then the client sends its request, and the node spins until it receives its resp
 Return to ``CMakeLists.txt`` to add the executable and target for the new node.
 After removing some unnecessary boilerplate from the automatically generated file, your ``CMakeLists.txt`` should look like this:
 
-.. code-block:: console
+.. code-block:: cmake
 
   cmake_minimum_required(VERSION 3.5)
   project(cpp_srvcli)


### PR DESCRIPTION
Switching from `console` to the right language makes the text copyable by the copy button, which is quite useful.

Found while going through https://docs.ros.org/en/kilted/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Publisher-And-Subscriber.html for https://github.com/ros2/kilted_tutorial_party/issues/551