### PR TITLE
Update fastrtps to fastdds

### DIFF
--- a/source/Installation/Alternatives/RHEL-Install-Binary.rst
+++ b/source/Installation/Alternatives/RHEL-Install-Binary.rst
@@ -111,7 +111,7 @@ Install dependencies using rosdep
 
    $ sudo rosdep init
    $ rosdep update
-   $ rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps iceoryx_binding_c rti-connext-dds-7.3.0 urdfdom_headers"
+   $ rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rti-connext-dds-7.3.0 urdfdom_headers"
 
 Install additional RMW implementations (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -89,7 +89,7 @@ Install dependencies using rosdep
    $ sudo apt install -y python3-rosdep
    $ sudo rosdep init
    $ rosdep update
-   $ rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastrtps iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
+   $ rosdep install --from-paths ~/ros2_{DISTRO}/ros2-linux/share --ignore-src -y --skip-keys "cyclonedds fastcdr fastdds iceoryx_binding_c rmw_connextdds rti-connext-dds-7.3.0 urdfdom_headers"
 
 .. include:: ../_rosdep_Linux_Mint.rst
 

--- a/source/Tutorials/Advanced/Security/Introducing-ros2-security.rst
+++ b/source/Tutorials/Advanced/Security/Introducing-ros2-security.rst
@@ -71,7 +71,7 @@ Fast DDS requires an additional CMake flag to build the security plugins, so the
 
 .. code-block:: console
 
-  $ colcon build --symlink-install --cmake-args -DSECURITY=ON --packages-select fastrtps rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
+  $ colcon build --symlink-install --cmake-args -DSECURITY=ON --packages-select fastdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
 
 
 Selecting an alternate middleware


### PR DESCRIPTION
The `fastrtps` package was renamed to `fastdds` in Kilted/Rolling, so update it.

This should only be backported to `kilted`.