### PR TITLE
Don't mention prelease Ubuntu binaries in Kilted docs

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -60,9 +60,7 @@ If you are going to build ROS packages or otherwise do development, you can also
 Install ROS 2
 -------------
 
-Binary releases of Rolling Ridley are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
-
+* Go to the `releases page <https://github.com/ros2/ros2/releases>`_
 * Download the latest package for Ubuntu; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.


### PR DESCRIPTION
This part only makes sense for Rolling, see https://github.com/ros2/kilted_tutorial_party/issues/293#issuecomment-2845258470. This is similar to the Jazzy docs: https://github.com/ros2/ros2_documentation/blob/jazzy/source/Installation/Alternatives/Ubuntu-Install-Binary.rst?plain=1#L58-L75.

I believe the Kilted docs mention it because they were created from the Rolling docs, which explains the "Binary releases of Rolling Ridley are not provided" part

This only applies to `kilted`