### PR TITLE
Add XML & YAML example static tf publisher launch files

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.rst
@@ -412,8 +412,22 @@ The following command publishes a static coordinate transform to tf2 using an x/
 ``static_transform_publisher`` is designed both as a command-line tool for manual use, as well as for use within ``launch`` files for setting static transforms.
 For example:
 
-.. literalinclude:: launch/static_transform_publisher_launch.py
-   :language: python
+.. tabs::
+
+   .. group-tab:: XML
+
+      .. literalinclude:: launch/static_transform_publisher_launch.xml
+         :language: xml
+
+   .. group-tab:: YAML
+
+      .. literalinclude:: launch/static_transform_publisher_launch.yaml
+         :language: yaml
+
+   .. group-tab:: Python
+
+      .. literalinclude:: launch/static_transform_publisher_launch.py
+         :language: python
 
 Note that all arguments except for ``--frame-id`` and ``--child-frame-id`` are optional; if a particular option isn't specified, then the identity will be assumed.
 

--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Py.rst
@@ -431,8 +431,22 @@ The following command publishes a static coordinate transform to tf2 using an x/
 ``static_transform_publisher`` is designed both as a command-line tool for manual use, as well as for use within ``launch`` files for setting static transforms.
 For example:
 
-.. literalinclude:: launch/static_transform_publisher_launch.py
-   :language: python
+.. tabs::
+
+   .. group-tab:: XML
+
+      .. literalinclude:: launch/static_transform_publisher_launch.xml
+         :language: xml
+
+   .. group-tab:: YAML
+
+      .. literalinclude:: launch/static_transform_publisher_launch.yaml
+         :language: yaml
+
+   .. group-tab:: Python
+
+      .. literalinclude:: launch/static_transform_publisher_launch.py
+         :language: python
 
 Note that all arguments except for ``--frame-id`` and ``--child-frame-id`` are optional; if a particular option isn't specified, then the identity will be assumed.
 

--- a/source/Tutorials/Intermediate/Tf2/launch/static_transform_publisher_launch.xml
+++ b/source/Tutorials/Intermediate/Tf2/launch/static_transform_publisher_launch.xml
@@ -1,0 +1,6 @@
+<launch>
+  <node
+    pkg="tf2_ros" exec="static_transform_publisher"
+    args="--x 0 --y 0 --z 1 --yaw 0 --pitch 0 --roll 0 --frame-id world --child-frame-id mystaticturtle"
+  />
+</launch>

--- a/source/Tutorials/Intermediate/Tf2/launch/static_transform_publisher_launch.yaml
+++ b/source/Tutorials/Intermediate/Tf2/launch/static_transform_publisher_launch.yaml
@@ -1,0 +1,5 @@
+launch:
+  - node:
+      pkg: "tf2_ros"
+      exec: "static_transform_publisher"
+      args: "--x 0 --y 0 --z 1 --yaw 0 --pitch 0 --roll 0 --frame-id world --child-frame-id mystaticturtle"


### PR DESCRIPTION
In line with the ongoing move towards making XML/YAML the preferred/default kinds of launch files over Python: #5100, #5093, #5104, #5143, etc.