### PR TITLE
Double quote ros-apt-source pkg URL

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -44,7 +44,7 @@ Next, download the ``ros2-release`` package and install it:
 
 .. code-block:: console
 
-   $ sudo dnf install https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/rhel/$(rpm -E %rhel)/x86_64/Packages/r/ros2-release-1.0.0-1.noarch.rpm
+   $ sudo dnf install "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/rhel/$(rpm -E %rhel)/x86_64/Packages/r/ros2-release-1.0.0-1.noarch.rpm"
    # Necessary for the tutorial party
    $ sudo dnf config-manager --set-disabled ros2
    $ sudo dnf config-manager --set-enabled ros2-testing

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,5 +15,5 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ curl -o /tmp/ros2-testing-apt-source.deb https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2-testing/ubuntu/pool/main/r/ros-apt-source/ros2-testing-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb
+   $ curl -o /tmp/ros2-testing-apt-source.deb "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2-testing/ubuntu/pool/main/r/ros-apt-source/ros2-testing-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
    $ sudo apt install /tmp/ros2-testing-apt-source.deb


### PR DESCRIPTION
Fixes #5462

zsh auto-escapes characters when pasting something that looks like a URL, which adds ~~unnecessary~~ bad escape characters that break the command. See https://github.com/ros2/ros2_documentation/issues/5462#issuecomment-2847862418. Double-quoting the URL prevents that.