### PR TITLE
Increase page max width to show more content when possible

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -169,10 +169,13 @@ html_favicon = 'favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['source/_static']
 
 # Drop any source link suffix
 html_sourcelink_suffix = ''
+
+# Relative to html_static_path
+html_css_files = ['custom.css']
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: 1000px !important;
+}

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,3 +1,3 @@
 .wy-nav-content {
-    max-width: 1000px !important;
+    max-width: 1000px;
 }

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,3 +1,3 @@
 .wy-nav-content {
-    max-width: 1000px;
+    max-width: 64rem;
 }


### PR DESCRIPTION
This aims to increase the page's _maximum_ width so that it can show more content when possible.

From what I could tell, the current max width is 800px. It's a bit funny to have to scroll horizontally for somewhat-long commands when there's plenty of space, e.g., on an ultrawide 3840×1600 monitor:

![image](https://github.com/user-attachments/assets/6c8ba716-9972-4c30-80f4-b560cb91d677)

This PR adds a custom CSS file that sets the max width to 1000px. The page still correctly adapts if the width is less than that, and this allows us to see more content without having to scroll horizontally.

![image](https://github.com/user-attachments/assets/0ba4d17a-96c0-45b0-a309-bbf8c3696f06)

----

I found this relevant issue/discussion: https://github.com/readthedocs/sphinx_rtd_theme/issues/295. There are some valid points _against_ increasing the max width. One of them is that a wider page might decrease reading comprehension: https://github.com/readthedocs/sphinx_rtd_theme/issues/295#issuecomment-456231694. I think this is true, but increasing the width from 800px to 1000px might not be that bad and could help a lot.

It _could_ break things that rely on a specific width, but I've taken a quick look and don't see anything obviously broken.

I opened this as a prototype so that we could discuss it. We could make it bigger if we want, e.g., 1200px, but that might be too much. I thought this might've been discussed before (I sort of vaguely remember something about increasing the page width), but I couldn't find any issue here.