### PR TITLE
Removed argument requesting "if" block for custom msg and srv testing

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.rst
@@ -606,11 +606,6 @@ Since you'll be changing the original two integer request srv to a three integer
       {
         rclcpp::init(argc, argv);
 
-        if (argc != 4) { // CHANGE
-            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: add_three_ints_client X Y Z");      // CHANGE
-            return 1;
-        }
-
         std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("add_three_ints_client");  // CHANGE
         rclcpp::Client<tutorial_interfaces::srv::AddThreeInts>::SharedPtr client =                // CHANGE
           node->create_client<tutorial_interfaces::srv::AddThreeInts>("add_three_ints");          // CHANGE


### PR DESCRIPTION
As @christophebedard in https://github.com/ros2/ros2_documentation/pull/5506#issuecomment-2848812733, the documentation now has below block removed for custom service/msg works as intended in https://github.com/ros2/kilted_tutorial_party/issues/114

```
        if (argc != 4) { // CHANGE
            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "usage: add_three_ints_client X Y Z");      // CHANGE
            return 1;
        } 
```