### PR TITLE
Fix incorrect sourcing command for Linux in Creating-an-Action tutorial

### DIFF
--- a/source/Tutorials/Intermediate/Creating-an-Action.rst
+++ b/source/Tutorials/Intermediate/Creating-an-Action.rst
@@ -172,7 +172,7 @@ First source our workspace:
 
     .. code-block:: console
 
-      $ source install/local_setup.console
+      $ source install/local_setup.bash
 
   .. group-tab:: macOS
 


### PR DESCRIPTION
This PR addresses [#5527](https://github.com/ros2/ros2_documentation/issues/5527), which highlights an incorrect command in the "Creating an Action" tutorial for Linux.

Specifically, the line:

$ source install/local_setup.console

Has been replaced with:

$ source install/local_setup.bash

This change ensures correct workspace sourcing on Linux distributions.

While the macOS command may also require correction, this PR remains within the scope of the original reported issue.