### PR TITLE
Explain event callbacks in "Monitoring for parameter changes"

### DIFF
--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -250,13 +250,11 @@ The terminal running the node will display a message similar to the following:
 The callback we set previously in the node has been invoked and has displayed the new updated value.
 You can now terminate the running parameter_event_handler sample using ^C in the terminal.
 
-
 Extensions
 ----------
 
 So far, we built and tested a small node that monitors a single parameter owned by the node itself.
-Using this node as a base, two other usecases where the ParameterEventHandler can be useful is presented below.
-
+Using this node as a base, two other usecases where the ParameterEventHandler can be useful are presented below.
 
 Monitor changes to another node's parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -346,7 +344,6 @@ Upon executing this command, you should see output in the parameter_event_handle
 
     [INFO] [1606952588.237531933] [node_with_parameters]: cb2: Received an update to parameter "a_double_param" of type: double: "3.45"
 
-
 Monitor all node parameters simultaneously
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -373,9 +370,8 @@ To do this, first update the SampleNodeWithParameters constructor to add the fol
       };
     event_cb_handle_ = param_subscriber_->add_parameter_event_callback(event_cb);
 
-
 This declares a new double parameter ``another_double_param`` and adds an event callback that will monitor both parameters.
-Note that the ``parameter_event`` is of type `rcl_interfaces/ParameterEvent <https://docs.ros.org/en/rolling/p/rcl_interfaces/msg/ParameterEvent.html>`_.
+Note that the ``parameter_event`` is of type {interface(rcl_interfaces/msg/ParameterEvent)}.
 Although it's not shown in this tutorial, event callbacks can also be used to monitor when parameters are added or deleted.
 
 Finally, don't forget to add the event callback handle as a private member:
@@ -385,7 +381,6 @@ Finally, don't forget to add the event callback handle as a private member:
     private:
       ...
       std::shared_ptr<rclcpp::ParameterEventCallbackHandle> event_cb_handle_;
-
 
 Navigate back to the root of your workspace, ``ros2_ws``, and rebuild your updated package as before:
 
@@ -415,14 +410,13 @@ Then source the setup files:
 
       $ call install\setup.bat
 
-
 To test the new event callback, first run the parameter_event_handler node:
 
 .. code-block:: console
 
      $ ros2 run cpp_parameter_event_handler parameter_event_handler
 
-Then, from a second terminal (with ROS initialized), let's set the original int parameter:
+Then, from a second terminal (with ROS sourced), let's set the original int parameter:
 
 .. code-block:: console
 
@@ -435,7 +429,6 @@ Upon executing this command, you should see both the single-parameter callback, 
       [INFO] [1747144403.418980063] [node_with_parameters]: cb: Received an update to parameter "an_int_param" of type integer: "44"
       [INFO] [1747144403.419086611] [node_with_parameters]: Received parameter event
       [INFO] [1747144403.419114103] [node_with_parameters]: Inside event: "an_int_param" changed to 44
-
 
 Now set the new double parameter:
 
@@ -454,8 +447,6 @@ Since no single-parameter callback was added (via ``add_parameter_callback``) fo
 
    When setting multiple parameters at once, it's best to use ``set_parameters_atomically``, explained in :doc:`../../Concepts/Basic/About-Parameters`.
    This way, the event callback is only fired once.
-
-
 
 Summary
 -------

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -250,8 +250,16 @@ The terminal running the node will display a message similar to the following:
 The callback we set previously in the node has been invoked and has displayed the new updated value.
 You can now terminate the running parameter_event_handler sample using ^C in the terminal.
 
-3.1 Monitor changes to another node's parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extensions
+----------
+
+So far, we built and tested a small node that monitors a single parameter owned by the node itself.
+Using this node as a base, two other usecases where the ParameterEventHandler can be useful is presented below.
+
+
+Monitor changes to another node's parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can also use the ParameterEventHandler to monitor parameter changes to another node's parameters.
 Let's update the SampleNodeWithParameters class to also monitor for changes to a parameter in another node.
@@ -338,11 +346,122 @@ Upon executing this command, you should see output in the parameter_event_handle
 
     [INFO] [1606952588.237531933] [node_with_parameters]: cb2: Received an update to parameter "a_double_param" of type: double: "3.45"
 
+
+Monitor all node parameters simultaneously
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you need to monitor multiple nodes or parameters at the same time, it would be cumbersome to have to call ``add_parameter_callback`` once for each of them.
+In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* of the node's parameters change.
+
+To do this, first update the SampleNodeWithParameters constructor to add the following code:
+
+.. code-block:: C++
+
+    this->declare_parameter("another_double_param", 0.0);
+
+    ...
+
+    auto event_cb = [this](const rcl_interfaces::msg::ParameterEvent & parameter_event) {
+        RCLCPP_INFO(this->get_logger(), "Received parameter event");
+
+        for (const auto& p : parameter_event.changed_parameters) {
+          RCLCPP_INFO(
+            this->get_logger(), "Inside event: \"%s\" changed to %s",
+            p.name.c_str(),
+            rclcpp::Parameter::from_parameter_msg(p).value_to_string().c_str());
+        };
+      };
+    event_cb_handle_ = param_subscriber_->add_parameter_event_callback(event_cb);
+
+
+This declares a new double parameter ``another_double_param`` and adds an event callback that will monitor both parameters.
+Note that the ``parameter_event`` is of type `rcl_interfaces/ParameterEvent <https://docs.ros.org/en/rolling/p/rcl_interfaces/msg/ParameterEvent.html>`_.
+Although it's not shown in this tutorial, event callbacks can also be used to monitor when parameters are added or deleted.
+
+Finally, don't forget to add the event callback handle as a private member:
+
+.. code-block:: C++
+
+    private:
+      ...
+      std::shared_ptr<rclcpp::ParameterEventCallbackHandle> event_cb_handle_;
+
+
+Navigate back to the root of your workspace, ``ros2_ws``, and rebuild your updated package as before:
+
+.. code-block:: console
+
+    $ colcon build --packages-select cpp_parameter_event_handler
+
+Then source the setup files:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+      $ . install/setup.bash
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+      $ . install/setup.bash
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+      $ call install\setup.bat
+
+
+To test the new event callback, first run the parameter_event_handler node:
+
+.. code-block:: console
+
+     $ ros2 run cpp_parameter_event_handler parameter_event_handler
+
+Then, from a second terminal (with ROS initialized), let's set the original int parameter:
+
+.. code-block:: console
+
+     $ ros2 param set node_with_parameters an_int_param 44
+
+Upon executing this command, you should see both the single-parameter callback, as well as the event callback being fired:
+
+.. code-block:: console
+
+      [INFO] [1747144403.418980063] [node_with_parameters]: cb: Received an update to parameter "an_int_param" of type integer: "44"
+      [INFO] [1747144403.419086611] [node_with_parameters]: Received parameter event
+      [INFO] [1747144403.419114103] [node_with_parameters]: Inside event: "an_int_param" changed to 44
+
+
+Now set the new double parameter:
+
+.. code-block:: console
+
+     $ ros2 param set node_with_parameters another_double_param 4.4
+
+Since no single-parameter callback was added (via ``add_parameter_callback``) for the double parameter, we should see only the event callback fire:
+
+.. code-block:: console
+
+      [INFO] [1747144452.917437113] [node_with_parameters]: Received parameter event
+      [INFO] [1747144452.917591649] [node_with_parameters]: Inside event: "another_double_param" changed to 4.400000
+
+.. note::
+
+   When setting multiple parameters at once, it's best to use ``set_parameters_atomically``, explained in :doc:`../../Concepts/Basic/About-Parameters`.
+   This way, the event callback is only fired once.
+
+
+
 Summary
 -------
 
 You created a node with a parameter and used the ParameterEventHandler class to set a callback to monitor changes to that parameter.
-You also used the same class to monitor changes to a remote node.
+You also used the same class to monitor changes to a remote node, and to monitor all parameters in a single event callback.
 The ParameterEventHandler is a convenient way to monitor for parameter changes so that you can then respond to the updated values.
 
 Related content

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP.rst
@@ -348,7 +348,7 @@ Monitor all node parameters simultaneously
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you need to monitor multiple nodes or parameters at the same time, it would be cumbersome to have to call ``add_parameter_callback`` once for each of them.
-In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* of the node's parameters change.
+In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* parameters of *any* nodes change.
 
 To do this, first update the SampleNodeWithParameters constructor to add the following code:
 
@@ -359,7 +359,9 @@ To do this, first update the SampleNodeWithParameters constructor to add the fol
     ...
 
     auto event_cb = [this](const rcl_interfaces::msg::ParameterEvent & parameter_event) {
-        RCLCPP_INFO(this->get_logger(), "Received parameter event");
+        RCLCPP_INFO(
+          this->get_logger(), "Received parameter event from node \"%s\"",
+          parameter_event.node.c_str());
 
         for (const auto& p : parameter_event.changed_parameters) {
           RCLCPP_INFO(
@@ -427,7 +429,7 @@ Upon executing this command, you should see both the single-parameter callback, 
 .. code-block:: console
 
       [INFO] [1747144403.418980063] [node_with_parameters]: cb: Received an update to parameter "an_int_param" of type integer: "44"
-      [INFO] [1747144403.419086611] [node_with_parameters]: Received parameter event
+      [INFO] [1747144403.419086611] [node_with_parameters]: Received parameter event from node "/node_with_parameters"
       [INFO] [1747144403.419114103] [node_with_parameters]: Inside event: "an_int_param" changed to 44
 
 Now set the new double parameter:
@@ -440,7 +442,7 @@ Since no single-parameter callback was added (via ``add_parameter_callback``) fo
 
 .. code-block:: console
 
-      [INFO] [1747144452.917437113] [node_with_parameters]: Received parameter event
+      [INFO] [1747144452.917437113] [node_with_parameters]: Received parameter event from node "/node_with_parameters"
       [INFO] [1747144452.917591649] [node_with_parameters]: Inside event: "another_double_param" changed to 4.400000
 
 .. note::

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -344,7 +344,7 @@ Monitor all node parameters simultaneously
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you need to monitor multiple nodes or parameters at the same time, it would be cumbersome to have to call ``add_parameter_callback`` once for each of them.
-In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* of the node's parameters change.
+In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* parameters of *any* nodes change.
 
 To do this, first update the SampleNodeWithParameters constructor to add the following code:
 
@@ -363,7 +363,7 @@ The event callback signature is different from that of regular single-parameter 
 .. code-block:: Python
 
     def event_callback(self, parameter_event):
-        self.get_logger().info("Received parameter event")
+        self.get_logger().info(f"Received parameter event from node {parameter_event.node}")
 
         for p in parameter_event.changed_parameters:
             self.get_logger().info(
@@ -418,7 +418,7 @@ Upon executing this command, you should see both the single-parameter callback, 
 .. code-block:: console
 
       [INFO] [1746414766.240101027] [node_with_parameters]: Received an update to parameter: an_int_param: 44
-      [INFO] [1746414766.243499816] [node_with_parameters]: Received parameter event
+      [INFO] [1746414766.243499816] [node_with_parameters]: Received parameter event from node /node_with_parameters
       [INFO] [1746414766.244271445] [node_with_parameters]: Inside event: an_int_param changed to: 4
 
 Now set the new double parameter:
@@ -431,7 +431,7 @@ Since no single-parameter callback was added (via ``add_parameter_callback``) fo
 
 .. code-block:: console
 
-      [INFO] [1746414962.604832196] [node_with_parameters]: Received parameter event
+      [INFO] [1746414962.604832196] [node_with_parameters]: Received parameter event from node /node_with_parameters
       [INFO] [1746414962.607429035] [node_with_parameters]: Inside event: another_double_param changed to: 4.4
 
 .. note::

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -87,6 +87,7 @@ Inside the ``ros2_ws/src/python_parameter_event_handler/python_parameter_event_h
 
             self.callback_handle = self.handler.add_parameter_callback(
                 parameter_name="an_int_param",
+                node_name="node_with_parameters",
                 callback=self.callback,
             )
 
@@ -141,6 +142,7 @@ Finally, we add a parameter callback and get a callback handler for the new call
 
             self.callback_handle = self.handler.add_parameter_callback(
                 parameter_name="an_int_param",
+                node_name="node_with_parameters",
                 callback=self.callback,
             )
 

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -346,7 +346,7 @@ Upon executing this command, you should see output in the parameter_event_handle
 Monitor all node parameters simultaneously
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have a node with lots of parameters, it would be cumbersome to have to call ``add_parameter_callback`` once for each parameter.
+If you need to monitor multiple nodes or parameters at the same time, it would be cumbersome to have to call ``add_parameter_callback`` once for each of them.
 In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* of the node's parameters change.
 
 To do this, first update the SampleNodeWithParameters constructor to add the following code:

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -262,13 +262,11 @@ The terminal running the node will display a message similar to the following:
 The callback we set previously in the node has been invoked and has displayed the new updated value.
 You can now terminate the running parameter_event_handler sample using ^C in the terminal.
 
-
 Extensions
 ----------
 
 So far, we built and tested a small node that monitors a single parameter owned by the node itself.
-Using this node as a base, two other usecases where the ParameterEventHandler can be useful is presented below.
-
+Using this node as a base, two other usecases where the ParameterEventHandler can be useful are presented below.
 
 Monitor changes to another node's parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -342,7 +340,6 @@ Upon executing this command, you should see output in the parameter_event_handle
 
       [INFO] [1699821958.757770223] [node_with_parameters]: Received an update to parameter: a_double_param: 3.45
 
-
 Monitor all node parameters simultaneously
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -373,10 +370,8 @@ The event callback signature is different from that of regular single-parameter 
                 f"Inside event: {p.name} changed to: {rclpy.parameter.parameter_value_to_python(p.value)}"
             )
 
-
-Note that the ``parameter_event`` is of type `rcl_interfaces/ParameterEvent <https://docs.ros.org/en/rolling/p/rcl_interfaces/msg/ParameterEvent.html>`_.
+Note that the ``parameter_event`` is of type {interface(rcl_interfaces/msg/ParameterEvent)}.
 Although it's not shown in this tutorial, event callbacks can also be used to monitor when parameters are added or deleted.
-
 
 Navigate back to the root of your workspace, ``ros2_ws``, and rebuild your updated package as before:
 
@@ -406,14 +401,13 @@ Then source the setup files:
 
       $ call install\setup.bat
 
-
 To test the new event callback, first run the parameter_event_handler node:
 
 .. code-block:: console
 
      $ ros2 run python_parameter_event_handler node_with_parameters
 
-Then, from a second terminal (with ROS initialized), let's set the original int parameter:
+Then, from a second terminal (with ROS sourced), let's set the original int parameter:
 
 .. code-block:: console
 
@@ -444,7 +438,6 @@ Since no single-parameter callback was added (via ``add_parameter_callback``) fo
 
    When setting multiple parameters at once, it's best to use ``set_parameters_atomically``, explained in :doc:`../../Concepts/Basic/About-Parameters`.
    This way, the event callback is only fired once.
-
 
 Summary
 -------

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -260,8 +260,16 @@ The terminal running the node will display a message similar to the following:
 The callback we set previously in the node has been invoked and has displayed the new updated value.
 You can now terminate the running parameter_event_handler sample using ^C in the terminal.
 
-3.1 Monitor changes to another node's parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extensions
+----------
+
+So far, we built and tested a small node that monitors a single parameter owned by the node itself.
+Using this node as a base, two other usecases where the ParameterEventHandler can be useful is presented below.
+
+
+Monitor changes to another node's parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can also use the ParameterEventHandler to monitor parameter changes to another node's parameters.
 Let's update the SampleNodeWithParameters class to monitor for changes to a parameter in another node.
@@ -332,11 +340,115 @@ Upon executing this command, you should see output in the parameter_event_handle
 
       [INFO] [1699821958.757770223] [node_with_parameters]: Received an update to parameter: a_double_param: 3.45
 
+
+Monitor all node parameters simultaneously
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have a node with lots of parameters, it would be cumbersome to have to call ``add_parameter_callback`` once for each parameter.
+In this case, you can use ``add_parameter_event_callback`` to register a single callback that fires when *any* of the node's parameters change.
+
+To do this, first update the SampleNodeWithParameters constructor to add the following code:
+
+.. code-block:: Python
+
+    def __init__(...):
+        self.declare_parameter("another_double_param", 0.0)
+        ...
+        self.event_calback_handle = self.handler.add_parameter_event_callback(
+            callback=self.event_callback,
+        )
+
+This declares a new double parameter ``another_double_param`` and adds an event callback that will monitor both parameters.
+The event callback signature is different from that of regular single-parameter callbacks, so we need to define a suitable callback as well:
+
+.. code-block:: Python
+
+    def event_callback(self, parameter_event):
+        self.get_logger().info("Received parameter event")
+
+        for p in parameter_event.changed_parameters:
+            self.get_logger().info(
+                f"Inside event: {p.name} changed to: {rclpy.parameter.parameter_value_to_python(p.value)}"
+            )
+
+
+Note that the ``parameter_event`` is of type `rcl_interfaces/ParameterEvent <https://docs.ros.org/en/rolling/p/rcl_interfaces/msg/ParameterEvent.html>`_.
+Although it's not shown in this tutorial, event callbacks can also be used to monitor when parameters are added or deleted.
+
+
+Navigate back to the root of your workspace, ``ros2_ws``, and rebuild your updated package as before:
+
+.. code-block:: console
+
+    $ colcon build --packages-select python_parameter_event_handler
+
+Then source the setup files:
+
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: console
+
+      $ . install/setup.bash
+
+  .. group-tab:: macOS
+
+    .. code-block:: console
+
+      $ . install/setup.bash
+
+  .. group-tab:: Windows
+
+    .. code-block:: console
+
+      $ call install\setup.bat
+
+
+To test the new event callback, first run the parameter_event_handler node:
+
+.. code-block:: console
+
+     $ ros2 run python_parameter_event_handler node_with_parameters
+
+Then, from a second terminal (with ROS initialized), let's set the original int parameter:
+
+.. code-block:: console
+
+     $ ros2 param set node_with_parameters an_int_param 44
+
+Upon executing this command, you should see both the single-parameter callback, as well as the event callback being fired:
+
+.. code-block:: console
+
+      [INFO] [1746414766.240101027] [node_with_parameters]: Received an update to parameter: an_int_param: 44
+      [INFO] [1746414766.243499816] [node_with_parameters]: Received parameter event
+      [INFO] [1746414766.244271445] [node_with_parameters]: Inside event: an_int_param changed to: 4
+
+Now set the new doble parameter:
+
+.. code-block:: console
+
+     $ ros2 param set node_with_parameters another_double_param 4.4
+
+Since no single-parameter callback was added (via ``add_parameter_callback``) for the double parameter, we should see only the event callback fire:
+
+.. code-block:: console
+
+      [INFO] [1746414962.604832196] [node_with_parameters]: Received parameter event
+      [INFO] [1746414962.607429035] [node_with_parameters]: Inside event: another_double_param changed to: 4.4
+
+.. note::
+
+   When setting multiple parameters at once, it's best to use ``set_parameters_atomically``, explained in :doc:`../../Concepts/Basic/About-Parameters`.
+   This way, the event callback is only fired once.
+
+
 Summary
 -------
 
 You created a node with a parameter and used the ParameterEventHandler class to set a callback to monitor changes to that parameter.
-You also used the same class to monitor changes to a remote node.
+You also used the same class to monitor changes to a remote node, and to monitor all the node's parameters in a single event callback.
 The ParameterEventHandler is a convenient way to monitor for parameter changes so that you can then respond to the updated values.
 
 Related content

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -87,7 +87,6 @@ Inside the ``ros2_ws/src/python_parameter_event_handler/python_parameter_event_h
 
             self.callback_handle = self.handler.add_parameter_callback(
                 parameter_name="an_int_param",
-                node_name="node_with_parameters",
                 callback=self.callback,
             )
 
@@ -132,7 +131,7 @@ Next, the code creates a ``ParameterEventHandler`` that will be used to monitor 
             self.handler = ParameterEventHandler(self)
 
 
-Finally, we add parameter callback and get callback handler for the new callback.
+Finally, we add a parameter callback and get a callback handler for the new callback.
 
 .. note::
 
@@ -142,7 +141,6 @@ Finally, we add parameter callback and get callback handler for the new callback
 
             self.callback_handle = self.handler.add_parameter_callback(
                 parameter_name="an_int_param",
-                node_name="node_with_parameters",
                 callback=self.callback,
             )
 
@@ -275,7 +273,7 @@ First update the constructor to add the following code after the existing code:
 
     def __init__(...):
         ...
-        self.callback_handle = self.handler.add_parameter_callback(
+        self.callback_handle2 = self.handler.add_parameter_callback(
             parameter_name="a_double_param",
             node_name="parameter_blackboard",
             callback=self.callback,

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -427,7 +427,7 @@ Upon executing this command, you should see both the single-parameter callback, 
       [INFO] [1746414766.243499816] [node_with_parameters]: Received parameter event
       [INFO] [1746414766.244271445] [node_with_parameters]: Inside event: an_int_param changed to: 4
 
-Now set the new doble parameter:
+Now set the new double parameter:
 
 .. code-block:: console
 

--- a/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
+++ b/source/Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python.rst
@@ -450,7 +450,7 @@ Summary
 -------
 
 You created a node with a parameter and used the ParameterEventHandler class to set a callback to monitor changes to that parameter.
-You also used the same class to monitor changes to a remote node, and to monitor all the node's parameters in a single event callback.
+You also used the same class to monitor changes to a remote node, and to monitor all parameters in a single event callback.
 The ParameterEventHandler is a convenient way to monitor for parameter changes so that you can then respond to the updated values.
 
 Related content


### PR DESCRIPTION
This PR has some change suggestions that came up in https://github.com/ros2/kilted_tutorial_party/issues/357#issuecomment-2848922147.

The main part of the PR is moving the already-existing explanation on monitoring parameters from remote nodes to a higher level section (so it's visible in the ToC), and **adding a new section** that explains [add_parameter_event_callback](https://github.com/ros2/rclpy/blob/kilted/rclpy/rclpy/parameter_event_handler.py#L147).

Here's a repo/commit that applies the steps that this new subsection explains, in case it's helpful for reviewers: https://github.com/danielcranston/ros2_testing_repo/commit/aff00eab9a3fa41ae967eaef0a040eaa246e8c8d

---

~So far I only updated the Python version of this document. If this gets positive feedback I can give the C++ version a similar treatment as well.~ C++ version added as well.