### PR TITLE
Removed deprecated StaticSingleThreadedExecutor

### DIFF
--- a/source/Concepts/Intermediate/About-Executors.rst
+++ b/source/Concepts/Intermediate/About-Executors.rst
@@ -72,26 +72,15 @@ Currently, rclcpp provides three Executor types, derived from a shared parent cl
 
       Executor -> SingleThreadedExecutor [dir = back, arrowtail = empty];
       Executor -> MultiThreadedExecutor [dir = back, arrowtail = empty];
-      Executor -> StaticSingleThreadedExecutor [dir = back, arrowtail = empty];
       Executor  [shape=polygon,sides=4];
       SingleThreadedExecutor  [shape=polygon,sides=4];
       MultiThreadedExecutor  [shape=polygon,sides=4];
-      StaticSingleThreadedExecutor  [shape=polygon,sides=4];
 
       }
 
 The *Multi-Threaded Executor* creates a configurable number of threads to allow for processing multiple messages or events in parallel.
 
-.. note::
-
-   The *Static Single-Threaded Executor* has been deprecated, and *Single-Threaded Executor* is recommended instead.
-   The *Static Single-Threaded Executor* was developed to reduce the the runtime costs for scanning the entities of a node in terms of subscriptions, timers, service servers, action servers, etc.
-   These runtime improvements are now available also in all the other *Executor*.
-   Besides, the *Static Single-Threaded Executor* has a few issues such as `max duration is not respected in spin_some <https://github.com/ros2/rclcpp/issues/2462>`__.
-   Because of these unstable issues, some unit tests are skipped for *Static Single-Threaded Executor*.
-   You can see more details for `ROS Discourse: The ROS 2 C++ Executors <https://discourse.ros.org/t/the-ros-2-c-executors/38296>`__.
-
-All three executors can be used with multiple nodes by calling ``add_node(..)`` for each node.
+All executors can be used with multiple nodes by calling ``add_node(..)`` for each node.
 
 .. code-block:: cpp
 


### PR DESCRIPTION
along with https://github.com/ros2/rclcpp/pull/2835

> [!NOTE]
> No backport required, because we only remove StaticSingleThreadedExecutor from rolling for next turtle-L.