### PR TITLE
[Jazzy] Switch back to mentioning Gazebo Harmonic

### DIFF
--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -37,11 +37,11 @@ Gazebo
 
 Gazebo and ROS support different combinations of versions.
 
-All supported combinations can be seen `here <https://gazebosim.org/docs/ionic/ros_installation#summary-of-compatible-ros-and-gazebo-combinations>`__.
+All supported combinations can be seen `here <https://gazebosim.org/docs/harmonic/ros_installation#summary-of-compatible-ros-and-gazebo-combinations>`__.
 
 `ROS REP-2000 <https://www.ros.org/reps/rep-2000.html>`__ standardizes what the default version of Gazebo is for each ROS distribution.
 
-If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by following the `installation instructions <https://gazebosim.org/docs/ionic/ros_installation>`__.
+If you haven't installed a version of Gazebo on your system yet, you can install Gazebo by following the `installation instructions <https://gazebosim.org/docs/harmonic/ros_installation>`__.
 
 Quick Check
 -----------
@@ -55,11 +55,11 @@ To verify your Gazebo installation is correct, check you can run it:
 Further Resources
 -----------------
 
-Once Gazebo is installed and is all clear on the last quick test, you can move to the `Gazebo tutorials <https://gazebosim.org/docs/ionic/tutorials>`__ to try out building your own robot!
+Once Gazebo is installed and is all clear on the last quick test, you can move to the `Gazebo tutorials <https://gazebosim.org/docs/harmonic/tutorials>`__ to try out building your own robot!
 
 If you use a different version of Gazebo than the recommended version, make sure to use the dropdown to select the correct version of documentation.
 
 Summary
 -------
 
-In this tutorial, you have installed Gazebo and set-up your workspace to start with the `Gazebo tutorials <https://gazebosim.org/docs/ionic/tutorials>`__.
+In this tutorial, you have installed Gazebo and set-up your workspace to start with the `Gazebo tutorials <https://gazebosim.org/docs/harmonic/tutorials>`__.


### PR DESCRIPTION
Follow-up to #5552, which backported #5549 that included pointing to Gazebo Ionic.

Jazzy should still point to Harmonic. See https://github.com/ros2/ros2_documentation/pull/5552#issuecomment-2853222010