### PR TITLE
Changed refernce link for bash to bash manual

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -42,7 +42,7 @@ The commands used in this tutorial assume you followed the binary packages insta
 You can still follow along if you built from source, but the path to your setup files will likely be different.
 You also won't be able to use the ``sudo apt install ros-<distro>-<package>`` command (used frequently in the beginner level tutorials) if you install from source.
 
-If you are using Linux or macOS, but are not already familiar with the shell, `this tutorial <https://www.linux.com/training-tutorials/bash-101-working-cli/>`__ will help.
+If you are using Linux or macOS, but are not already familiar with the shell, `this tutorial <https://www.gnu.org/software/bash/manual/bash.html>`__ will help.
 
 Tasks
 -----


### PR DESCRIPTION
The provided link for bash:
https://www.linux.com/training-tutorials/bash-101-working-cli/

Is insufficient and barely any help


Replaced with:
https://www.gnu.org/software/bash/manual/bash.html

which is the official bash manual