### PR TITLE
Document that removing the scope keyworld to target_link_libraries might be necessary

### DIFF
--- a/source/Releases/Release-Kilted-Kaiju.rst
+++ b/source/Releases/Release-Kilted-Kaiju.rst
@@ -333,8 +333,8 @@ The macro still works, but it emits a CMake deprecation warning at build time li
 Try replacing the ``ament_target_dependencies()`` call with the  ``target_link_libraries()`` call suggested by the warning.
 For more information see `ament/ament_cmake#572 <https://github.com/ament/ament_cmake/pull/572>`__ and `ament/ament_cmake#292 <https://github.com/ament/ament_cmake/issues/292>`__.
 
-Note that the deprecation warning may include a scope keyword like ``PUBLIC``, ``PRIVATE``, or ``INTERFACE``, when it shouldn't.
-If you have already used ``target_link_libraries()`` on this target without a scope keyword, then you must remove the scope keyword from the suggested call to ``target_link_libraries``.
+Note that the deprecation warning suggests a call to ``target_link_libraries`` with a scope keyword like ``PUBLIC``, ``PRIVATE``, or ``INTERFACE``.
+If you have already used ``target_link_libraries()`` on this target without a scope keyword, then you must remove the scope keyword from the suggested call.
 This can happen when using some ``ament_cmake`` macros, like ``ament_add_gtest``, which use the plain version of ``target_link_libraries`` internally.
 You will know if you need to remove the keyword because CMake will emit an error saying:
 

--- a/source/Releases/Release-Kilted-Kaiju.rst
+++ b/source/Releases/Release-Kilted-Kaiju.rst
@@ -331,9 +331,19 @@ The macro still works, but it emits a CMake deprecation warning at build time li
         )
 
 Try replacing the ``ament_target_dependencies()`` call with the  ``target_link_libraries()`` call suggested by the warning.
-Note that this will have to be combined with any other calls to ``target_link_libraries()`` with the same target.
-
 For more information see `ament/ament_cmake#572 <https://github.com/ament/ament_cmake/pull/572>`__ and `ament/ament_cmake#292 <https://github.com/ament/ament_cmake/issues/292>`__.
+
+Note that the deprecation warning may include a scope keyword like ``PUBLIC``, ``PRIVATE``, or ``INTERFACE``, when it shouldn't.
+If you have already used ``target_link_libraries()`` on this target without a scope keyword, then you must remove the scope keyword from the suggested call to ``target_link_libraries``.
+This can happen when using some ``ament_cmake`` macros, like ``ament_add_gtest``, which use the plain version of ``target_link_libraries`` internally.
+You will know if you need to remove the keyword because CMake will emit an error saying:
+
+.. code-block::
+
+   All uses of target_link_libraries with a target must be either all-keyword or all-plain.
+
+For more information, see `ament/ament_cmake#580 <https://github.com/ament/ament_cmake/issues/580>`__.
+
 
 ``launch``
 ^^^^^^^^^^


### PR DESCRIPTION
Follow up to https://github.com/ros2/ros2_documentation/pull/5583 and https://github.com/ament/ament_cmake/issues/580

First this removes the note that `target_link_libraries` calls must be combined. You do not need to combine them. In may cases you must separate them to use different scope keywords.

Second, the deprecation warning uses the scope keyword signature of `target_link_libraries()`, and CMake errors if both the keyword version and plain version of `target_link_libraries` are used on the same target. I read through both the [CMake target properties](https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#properties-on-targets) and the [CMake target_link_libraries source code](https://github.com/Kitware/CMake/blob/dd835c8b2ba3fedf167cbcdc482f22b0e46fa4c2/Source/cmTargetLinkLibrariesCommand.cxx#L392) and did not find a way to detect this, so I'm updating the documentation to warn that the scope keyword needs to be removed from the suggested call in some cases.