### PR TITLE
Add missing doc about using venv and conflating python interpreters

### DIFF
--- a/source/How-To-Guides/Using-Python-Packages.rst
+++ b/source/How-To-Guides/Using-Python-Packages.rst
@@ -86,6 +86,13 @@ Next, install the Python packages that you want in your virtual environment:
 
     python3 -m pip install gtsam pyserial… etc
 
+Next in your ``setup.cfg`` you must inform distutils of the virtual environment interpreter when installing entry points. Otherwise it will default to the system interpreter and fail to find any of the virtual environment's libraries.
+
+.. code-block:: ini
+
+   [build]
+   executable=/usr/bin/env python3
+
 Now you can build your workspace and run your python node that depends on packages installed in your virtual environment.
 
 .. code-block:: console


### PR DESCRIPTION
You must inform them of changing their setup.cfg otherwise this doc is useless. 
https://github.com/ros2/ros2/issues/1094