### PR TITLE
Minor RTI Connext DDS documentation improvements

### DIFF
--- a/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
+++ b/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
@@ -78,12 +78,25 @@ Clone the repository for ``rmw_connextdds`` into your ROS 2 workspace and select
    $ cd ros2_ws
    $ git clone -b {DISTRO} https://github.com/ros2/rmw_connextdds src/rmw_connextdds
 
+Then, install necessary packages for RTI Connext DDS.
+
+.. code-block:: console
+
+   $ cd ..
+   $ rosdep install --from src -i
+
 Set up the environment to help colcon discover where RTI Connext is installed.
 This can be done by manually setting the environment variable ``NDDSHOME`` to the location of the RTI Connext installation, or by using a script that comes with the RTI Connext installation:
 
 .. code-block:: console
 
    $ source ${RTI_CONNEXT_INSTALL_LOCATION}/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.bash
+
+If you can't find the location of the RTI Connext installation, run this to find all Connext installations in your system:
+
+.. code-block:: console
+
+   $ find /opt -name rtisetenv*.bash
 
 Make sure you have the ROS 2 environment set up:
 

--- a/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
+++ b/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
@@ -86,17 +86,22 @@ Then, install necessary packages for RTI Connext DDS.
    $ rosdep install --from src -i
 
 Set up the environment to help colcon discover where RTI Connext is installed.
-This can be done by manually setting the environment variable ``NDDSHOME`` to the location of the RTI Connext installation, or by using a script that comes with the RTI Connext installation:
+This can be done by manually setting the environment variable ``NDDSHOME`` to the location of the RTI Connext installation, or by using a script that comes with the RTI Connext installation. For example, for version 7.3.0, you can run the following code to execute the helper script:
 
 .. code-block:: console
 
-   $ source ${RTI_CONNEXT_INSTALL_LOCATION}/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.bash
+   $ source /opt/rti.com/rti_connext_dds-7.3.0/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.bash
 
-If you can't find the location of the RTI Connext installation, run this to find all Connext installations in your system:
+If the previous command failed, and you can't find the location of the RTI Connext installation, run this to find all Connext installations (and their corresponding helper scripts) in your system:
 
 .. code-block:: console
 
    $ find /opt -name rtisetenv*.bash
+
+.. note::
+
+   Replace ``.bash`` with your shell if you're not using bash.
+   Possible values are: ``rtisetenv*.bash``, ``rtisetenv*.sh``, ``rtisetenv*.zsh``, ``rtisetenv*.tcsh``.
 
 Make sure you have the ROS 2 environment set up:
 


### PR DESCRIPTION
Related to https://github.com/ros2/kilted_tutorial_party/issues/548

Added instructions to install dependencies for the package when building from source
Added a minor one-liner to find possible connext installations, in case you don't know where the package was installed 

tagging @fujitatomoya as you looked into the kilted tutorial party issue