### PR TITLE
Update Windows-Development-Setup.rst with note about very long build times

### DIFF
--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -166,6 +166,10 @@ To build the ``\{DISTRO}`` folder tree:
    We're using ``--merge-install`` here to avoid a ``PATH`` variable that is too long at the end of the build.
    If you're adapting these instructions to build a smaller workspace then you might be able to use the default behavior which is isolated install, i.e. where each package is installed to a different folder.
 
+.. note::
+
+   Source installation can take a long time given the large number of packages being pulled into the workspace.
+
 Setup environment
 -----------------
 


### PR DESCRIPTION
I tested the source installation on Windows 10 machine with ROS2 Kilted as part of https://github.com/ros2/kilted_tutorial_party/issues/297 where the `colcon build --merge-install` took forever that I had to leave the installation overnight. It might be good to add a brief note about this in the installation instructions.

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Identified while working on # [(issue)](https://github.com/ros2/kilted_tutorial_party/issues/297)

### Did you use Generative AI?
No.
<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
