### PR TITLE
Document that cross-distro communications are not guaranteed

### DIFF
--- a/source/Concepts/Intermediate/About-Different-Middleware-Vendors.rst
+++ b/source/Concepts/Intermediate/About-Different-Middleware-Vendors.rst
@@ -89,6 +89,8 @@ If ``rmw_fastrtps_cpp`` is ever installed, it would be the default.
 
 See the :doc:`guide <../../How-To-Guides/Working-with-multiple-RMW-implementations>` for how to specify which RMW implementation is to be used when running the ROS 2 examples.
 
+.. _different-middleware-vendors-cross-vendor-communication:
+
 Cross-Vendor Communication
 --------------------------
 

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -205,3 +205,11 @@ We recommend that most people use the most recent stable distribution instead (s
 
 Packages released into the Rolling distribution will be automatically released into future stable distributions of ROS 2.
 :doc:`Releasing a ROS 2 package <../How-To-Guides/Releasing/Releasing-a-Package>` into the Rolling distribution follows the same procedures as all other ROS 2 distributions.
+
+Cross-Distribution Communications
+---------------------------------
+
+Nodes are not guaranteed to be able to communicate across distributions.
+For example, a node built & running against Humble is not guaranteed to be able to communicate correctly with a node built & running against Iron.
+It may or may not work, but it is not supported and should not be relied upon.
+Note that :ref:`cross-vendor (single-distro) communications are also not guaranteed <different-middleware-vendors-cross-vendor-communication>`.


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Relates to #3288. #4736 (which closed #3288) added a section about cross-`rmw` vendor communications not being guaranteed. #3288 also mentioned cross-distro communications, but it was not documented.

This new Discourse post is asking about cross-distro (in)compatibility: https://discourse.ros.org/t/incompatability-between-distributions/43747. We've talked about it not being guaranteed many times before, but I don't think it's mentioned anywhere in the docs (but I could be wrong). Since it's about multiple distros and not a specific distro, it's hard to find a place to document this, but I think the main distributions/releases page works well. I'm open to other suggestions, though.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
