### PR TITLE
Skip test_tracetools with 'rosdep install' in ros2_tracing tutorial

### DIFF
--- a/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
+++ b/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
@@ -62,7 +62,7 @@ Install dependencies with rosdep.
 .. code-block:: console
 
   $ rosdep update
-  $ rosdep install --from-paths src --ignore-src -y
+  $ rosdep install --from-paths src --ignore-src -y --skip-keys test_tracetools
 
 Then build and configure ``performance_test`` for ROS 2.
 See its `documentation <https://gitlab.com/ApexAI/performance_test/-/tree/master/performance_test#performance_test>`_.


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Relates to https://github.com/ros2/kilted_tutorial_party/issues/383, see https://github.com/ros2/kilted_tutorial_party/issues/383#issuecomment-2892516389

This can be backported to Kilted and Jazzy, but not Humble, since we build everything in Humble (since the tracing instrumentation is not included by default before Iron).

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
