### PR TITLE
Fix green rows in distributions table

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -47,9 +47,8 @@ Rows in the table marked in green are the currently supported distributions.
      why it is like this.
    -->
    <style>
-     .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
-     .rst-content table.docutils:not(.field-list) tr:nth-child(3) td {background-color: #33cc66;}
-     .rst-content tr:nth-child(3) {background-color: #33cc66;}
+     .rst-content tr:nth-child(2) {background-color: #33cc66;}
+     .rst-content tr:nth-child(4) {background-color: #33cc66;}
    </style>
 
 .. |rolling| image:: Releases/rolling-small.png


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #5667

The indexes of the rows to be marked in green needed to be updated.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
