### PR TITLE
Fix rst syntax

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -177,7 +177,8 @@ In the case that a package has both libraries and executables, make sure to comb
 Linking to dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Link to your dependencies using `target_link_libraries <https://cmake.org/cmake/help/latest/command/target_link_libraries.html>`__. It will give your target the necessary headers, libraries, and all their dependencies.
+Link to your dependencies using `target_link_libraries <https://cmake.org/cmake/help/latest/command/target_link_libraries.html>`__.
+It will give your target the necessary headers, libraries, and all their dependencies.
 
 As an example, suppose we want to link ``my_library`` against the linear algebra library Eigen3.
 ``Eigen3`` defines the target ``Eigen3::Eigen``.

--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -177,8 +177,7 @@ In the case that a package has both libraries and executables, make sure to comb
 Linking to dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Link to your dependencies using [target_link_libraries](https://cmake.org/cmake/help/latest/command/target_link_libraries.html)
-It will give your target the necessary headers, libraries, and all their dependencies.
+Link to your dependencies using `target_link_libraries <https://cmake.org/cmake/help/latest/command/target_link_libraries.html>`__. It will give your target the necessary headers, libraries, and all their dependencies.
 
 As an example, suppose we want to link ``my_library`` against the linear algebra library Eigen3.
 ``Eigen3`` defines the target ``Eigen3::Eigen``.


### PR DESCRIPTION
## Description

Fixes a link (had markdown instead of rst syntax).

See: 
![image](https://github.com/user-attachments/assets/a668d5e2-7ca5-4363-886d-04067187d1c7)
