### PR TITLE
Ubuntu derivatives support

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,5 +15,5 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ curl -o /tmp/ros2-apt-source.deb "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb"
+   $ curl -o /tmp/ros2-apt-source.deb "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.1.0~$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb"
    $ sudo apt install /tmp/ros2-apt-source.deb

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,5 +15,5 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ curl -o /tmp/ros2-apt-source.deb "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
+   $ curl -o /tmp/ros2-apt-source.deb "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.0.0~$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb"
    $ sudo apt install /tmp/ros2-apt-source.deb

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,5 +15,5 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ curl -o /tmp/ros2-apt-source.deb "https://ftp.osuosl.org/pub/ros/packages.ros.org/ros2/ubuntu/pool/main/r/ros-apt-source/ros2-apt-source_1.1.0~$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb"
+   $ curl -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
    $ sudo apt install /tmp/ros2-apt-source.deb


### PR DESCRIPTION
Like linux Mint for example

## Description

Ubuntu derivatives still provide UBUNTU_CODENAME. Just like ubuntu itself.
This was also part of the previous instructions such as humble.


### Did you use Generative AI?

No

### Additional Information


