### PR TITLE
add ROS_APT_SOURCE_VERSION env variable to fetch release version.

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,6 +15,6 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://raw.githubusercontent.com/ros-infrastructure/ros-apt-source/main/release.txt)
+   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
    $ curl -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
    $ sudo apt install /tmp/ros2-apt-source.deb

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,5 +15,6 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ curl -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
+   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://raw.githubusercontent.com/ros-infrastructure/ros-apt-source/main/release.txt)
+   $ curl -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}~$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
    $ sudo apt install /tmp/ros2-apt-source.deb


### PR DESCRIPTION
## Description

Use `ROS_APT_SOURCE_VERSION` environmental variable to install ros2-apt-source.deb.

Fixes # (issue)

Follow up of https://github.com/ros2/ros2_documentation/pull/5675

### Did you use Generative AI?

No

### Additional Information

N.A