### PR TITLE
Fix name of test-tools target in PHONY list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ linkcheck:
 	@echo
 	@echo "Check finished. Report is in $(LINKCHECKDIR)."
 
-.PHONY: help Makefile multiversion test test-unit linkcheck lint spellcheck check-dictionaries sort-dictionaries
+.PHONY: help Makefile multiversion test test-tools linkcheck lint spellcheck check-dictionaries sort-dictionaries


### PR DESCRIPTION
## Description

There is no `test-unit` target. It was initially named `test-unit` in #5050 but was changed to `test-tools` during review.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
