### PR TITLE
Add small clarification to cpp service and client tutorial

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Writing-A-Simple-Cpp-Service-And-Client.rst
@@ -166,7 +166,7 @@ The ``main`` function accomplishes the following, line by line:
 ~~~~~~~~~~~~~~~~~~
 
 The ``add_executable`` macro generates an executable you can run using ``ros2 run``.
-Add the following code block to ``CMakeLists.txt`` to create an executable named ``server``:
+Add the following code block to ``CMakeLists.txt`` just below the dependencies to create an executable named ``server``:
 
 .. code-block:: cmake
 


### PR DESCRIPTION
## Description

Changed line on Begginer Client Libraries Tutorial: Writing a simple service and client (C++).
Following the tutorial, I mistakenly added the code block after ament_package(), noticing my mistake later when the full CMakeLists.txt file text is provided.

I added "just below the dependencies" as a way to clarify its position, having called them "dependencies" since that's what it is called on "Writing a simple publisher and subscriber (C++)". What that's referring to are the find_package(...) calls.
I also note that right after my change, the tutorial says to add a different code block "right before" ament_package(), so I chose to use "just below" instead of "right below" on my addition.

### Did you use Generative AI?
This pull request did not use Generative AI.

### Additional Information