### PR TITLE
Update Learning-About-Tf2-And-Time-Cpp.rst

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Cpp.rst
@@ -38,7 +38,7 @@ Open ``turtle_tf2_listener.cpp`` and take a look at the ``lookupTransform()`` ca
 
 .. code-block:: C++
 
-   transformStamped = tf_buffer_->lookupTransform(
+   t = tf_buffer_->lookupTransform(
       toFrameRel,
       fromFrameRel,
       tf2::TimePointZero);
@@ -58,7 +58,7 @@ Now, change this line to get the transform at the current time, ``this->get_cloc
 .. code-block:: C++
 
    rclcpp::Time now = this->get_clock()->now();
-   transformStamped = tf_buffer_->lookupTransform(
+   t = tf_buffer_->lookupTransform(
       toFrameRel,
       fromFrameRel,
       now);
@@ -89,7 +89,7 @@ To fix this, edit your code as shown below (add the last timeout parameter):
 .. code-block:: C++
 
    rclcpp::Time now = this->get_clock()->now();
-   transformStamped = tf_buffer_->lookupTransform(
+   t = tf_buffer_->lookupTransform(
       toFrameRel,
       fromFrameRel,
       now,


### PR DESCRIPTION
In the tutorial code of the previous listener at https://raw.githubusercontent.com/ros/geometry_tutorials/humble/turtle_tf2_cpp/src/turtle_tf2_listener.cpp, the variable that stores the return value of the lookupTransform function is t instead of transformStamped. There is no need to waste the mental energy of every learner on such a minor issue.

## Description

- **Documentation Accuracy**: The original documentation used `transformStamped` (a common convention for TF2 transforms), but the code uses the abbreviated variable `t`. Aligning the documentation with the code eliminates confusion for learners following along with the tutorial.  

## Issue Fixed  
Fixes [insert issue number or link if available] (e.g., "Fixes #5678 - Documentation-code mismatch in TF2 listener variable naming").  

## Additional Information  
No generative AI was used in this change. The modification strictly aligns documentation with existing code to maintain accuracy, without altering the code's functionality or style. This ensures consistency between written explanations and executable examples in the ROS tutorial suite.  
