### PR TITLE
Remove extra backticks in package release guides

### DIFF
--- a/source/How-To-Guides/Releasing/First-Time-Release.rst
+++ b/source/How-To-Guides/Releasing/First-Time-Release.rst
@@ -117,7 +117,7 @@ Bloom will automatically create a pull request for you against `rosdistro <https
 .. note::
 
   By default, bloom will release all packages in the source repository.
-  To selectively block the release of some packages for a particular ``{DISTRO}``, add ``{DISTRO}.ignored`` files to the ``master``` branch of the release repository.
+  To selectively block the release of some packages for a particular ``{DISTRO}``, add ``{DISTRO}.ignored`` files to the ``master`` branch of the release repository.
   In each file, list the name of the package, one per line, to block the release of the package.
   The `rosidl-release <https://github.com/ros2-gbp/rosidl-release>`_ repository may serve as a useful reference for this configuration.
 

--- a/source/How-To-Guides/Releasing/Subsequent-Releases.rst
+++ b/source/How-To-Guides/Releasing/Subsequent-Releases.rst
@@ -57,7 +57,7 @@ Bloom will automatically create a pull request for you against `rosdistro <https
 .. note::
 
   By default, bloom will release all packages in the source repository.
-  To selectively block the release of some packages for a particular ``{DISTRO}``, add ``{DISTRO}.ignored`` files to the ``master``` branch of the release repository.
+  To selectively block the release of some packages for a particular ``{DISTRO}``, add ``{DISTRO}.ignored`` files to the ``master`` branch of the release repository.
   In each file, list the name of the package, one per line, to block the release of the package.
   The `rosidl-release <https://github.com/ros2-gbp/rosidl-release>`_ repository may serve as a useful reference for this configuration.
 


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/99524341-55fa-4325-a847-fa02e40520ea)

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
