### PR TITLE
The extra Python modules are available as RPMS via EPEL

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -63,6 +63,9 @@ If you are going to build ROS packages or otherwise do development, you can also
      make \
      patch \
      python3-colcon-common-extensions \
+     python3-flake8-blind-except \
+     python3-flake8-class-newline \
+     python3-flake8-deprecated \
      python3-mypy \
      python3-pip \
      python3-pydocstyle \
@@ -73,13 +76,6 @@ If you are going to build ROS packages or otherwise do development, you can also
      python3-setuptools \
      python3-vcstool \
      wget
-
-   ~ install some pip packages needed for testing and
-   ~ not available as RPMs
-   $ python3 -m pip install -U --user \
-     flake8-blind-except==0.1.1 \
-     flake8-class-newline \
-     flake8-deprecated
 
 Install ROS 2
 -------------


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Current instructions tell users to install the following Python module via `pip`:

```
     flake8-blind-except
     flake8-class-newline
     flake8-deprecated
```

However, they are available as RPMs:

https://rhel.pkgs.org/9/epel-x86_64/python3-flake8-blind-except-0.2.1-2.el9.noarch.rpm.html
https://rhel.pkgs.org/9/epel-x86_64/python3-flake8-class-newline-1.6.0-2.el9.noarch.rpm.html
https://rhel.pkgs.org/9/epel-x86_64/python3-flake8-deprecated-2.2.1-1.el9.noarch.rpm.html

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
