### PR TITLE
Replace apt install with dpkg -i to install ros2-apt-source package

### DIFF
--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -17,4 +17,4 @@ Updates to repository configuration will occur automatically when new versions o
    $ sudo apt update && sudo apt install curl -y
    $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
    $ curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
-   $ sudo apt install /tmp/ros2-apt-source.deb
+   $ sudo dpkg -i /tmp/ros2-apt-source.deb


### PR DESCRIPTION
## Description

When migrating to the updated installation method, `apt install` may ignore the installed deb file and pull from an old version of the ros repos, causing both ros2.list and ros2.source to be installed and `apt update` to return an error. `dpkg -i` will correctly install the curled deb file.

Fixes #5751 

### Did you use Generative AI?

No

### Additional Information

Mainly applies to systems where ROS2 has been installed in the past, and keys/sources are being updated to the new method.
