### PR TITLE
Update Using-Parameters-In-A-Class-CPP.rst

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP.rst
@@ -343,7 +343,7 @@ By adding the two lines below, we ensure our output is printed in our console.
 Now open the ``CMakeLists.txt`` file.
 Below the lines you added earlier, add the following lines of code.
 
-.. code-block:: console
+.. code-block:: cmake
 
     install(
       DIRECTORY launch


### PR DESCRIPTION
# Updated Code Block Type From "console" To "cmake"

## Description
This pull request updates the `Using-Parameters-In-A-Class-CPP.rst` tutorial to ensure the correct syntax highlighting is applied to the code block. The change replaces the `console` directive with the `cmake` directive for improved clarity and accuracy.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
Unknown model. I manually made the change however, I use GitHub Copilot when typing this PR up to summarize the changes. Current date is 06/26/2025 (MM-DD-YYYY)