### PR TITLE
Update Ubuntu-Development-Setup.rst

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Alternatives/Ubuntu-Development-Setup.rst
@@ -89,7 +89,8 @@ Install packages according to your Ubuntu version.
             flake8-quotes \
             "pytest>=5.3" \
             pytest-repeat \
-            pytest-rerunfailures
+            pytest-rerunfailures \
+            empy==3.3.4
 
 
 .. _linux-dev-get-ros2-code:


### PR DESCRIPTION


## Description
Update install instructions. Specify exact version of empy when pip installing.

Compile fails when system has empy 4.2 installed. Related to https://github.com/ros2/ros2_documentation/pull/5141
Related to https://github.com/ros2/ros2_documentation/pull/5141 


Fixes #5141 but on Ubuntu

### Additional Information

Some systems have Python package empy version 4.2 installed, which introduces breaking changes.
