### PR TITLE
Update example_substitutions_launch.py

### DIFF
--- a/source/Tutorials/Intermediate/Launch/launch/example_substitutions_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/example_substitutions_launch.py
@@ -34,7 +34,7 @@ def generate_launch_description():
                 'ros2 service call ',
                 turtlesim_ns,
                 '/spawn ',
-                'turtlesim_msgs/srv/Spawn ',
+                'turtlesim/srv/Spawn ',
                 '"{x: 2, y: 2, theta: 0.2}"'
             ]],
             shell=True


### PR DESCRIPTION
Fixed a typo on Line 37. 

'turtlesim_msgs/srv/spawn' -> 'turtlesim/srv/spawn'

The original was using an incorrect interface name

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
