### PR TITLE
Additional comment on callback group references

### DIFF
--- a/source/How-To-Guides/Using-callback-groups.rst
+++ b/source/How-To-Guides/Using-callback-groups.rst
@@ -43,6 +43,8 @@ all callbacks created by the client will be assigned to that callback group.
 Callback groups can be created by a node's ``create_callback_group``
 function in rclcpp and by calling the constructor of the group in rclpy.
 The callback group can then be passed as argument/option when creating a subscription, timer, etc.
+A reference to the callback group should be retained, otherwise the callback
+associated with the callback group will not be called by the executor.
 
 .. tabs::
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
I have found that without keeping the shared pointer to a callback group, the callbacks in the group will never be called, leading to deadlocks.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
