### PR TITLE
Update testing installation docs to use ros-apt-source package

### DIFF
--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -66,7 +66,7 @@ RHEL testing repository
 
 For RHEL you can install binary packages from the **ros-testing** repository, by enabling the testing repository on the source configuration:
 
-1. Make sure you have a working ROS 2 installation for rpm packages (see :doc:`../RHEL-Install-RPMs`).
+1. Make sure you have a working ROS 2 installation for rpm packages (see the :doc:`RHEL installation instructions <RHEL-Install-RPMs>`).
 
 2. Enable testing and disable main repository:
 

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -62,7 +62,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 
 RHEL testing repository
-----------------------
+-----------------------
 
 For RHEL you can install binary packages from the **ros-testing** repository, by enabling the testing repository on the source configuration:
 

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -23,7 +23,8 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 1. Make sure you have a working ROS 2 installation from deb packages (see :doc:`../Installation`).
 
-2. Install the ros2-testing-apt-source package This will automatically uninstall the ros2-apt-source package since only one repository may be enabled at a time.
+2. Install the ros2-testing-apt-source package.
+   This will automatically uninstall the ros2-apt-source package since only one repository may be enabled at a time.
 
    .. code-block:: console
 

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -89,7 +89,7 @@ For RHEL you can install binary packages from the **ros-testing** repository, by
 
 5.  Once you are finished testing, you can switch back to the normal repository by re-enabling the main repository:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ sudo dnf config-manager setopt ros2-testing.enabled=0
       $ sudo dnf config-manager setopt ros2.enabled=1

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -49,7 +49,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 6. Once you are finished testing, you can switch back to the normal repository by re-installing the ros-apt-source package:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ sudo apt install -y ros2-apt-source
 

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -25,7 +25,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 
 2. Install the ros2-testing-apt-source package This will automatically uninstall the ros2-apt-source package since only one repository may be enabled at a time.
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ sudo apt install -y ros2-testing-apt-source
 

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -26,6 +26,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 2. Install the ros2-testing-apt-source package This will automatically uninstall the ros2-apt-source package since only one repository may be enabled at a time.
 
    .. code-block:: bash
+
       $ sudo apt install -y ros2-testing-apt-source
 
 3. Update the apt index:
@@ -49,6 +50,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 6. Once you are finished testing, you can switch back to the normal repository by re-installing the ros-apt-source package:
 
    .. code-block:: bash
+
       $ sudo apt install -y ros2-apt-source
 
    and doing an update and upgrade:
@@ -86,6 +88,7 @@ For RHEL you can install binary packages from the **ros-testing** repository, by
 5.  Once you are finished testing, you can switch back to the normal repository by re-enabling the main repository:
 
    .. code-block:: bash
+      
       $ sudo dnf config-manager setopt ros2-testing.enabled=0
       $ sudo dnf config-manager setopt ros2.enabled=1
 
@@ -95,7 +98,7 @@ For RHEL you can install binary packages from the **ros-testing** repository, by
 
       $ sudo dnf update
       $ sudo dnf system-upgrade
-      
+
 .. _Prerelease_binaries:
 
 Binary archives

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -10,31 +10,28 @@ Usually, you will get the released version of binaries when following :doc:`../I
 There are also pre-released versions of binaries that are useful for testing before making an official release.
 This article describes several options if you would like to try out pre-released versions of ROS binaries.
 
-deb testing repository
-----------------------
-
 When packages are released into a ROS distribution (using bloom), the buildfarm builds them into deb packages which are stored temporarily in the **building** apt repository.
 As dependent packages are rebuilt, an automatic process periodically synchronizes the packages in **building** to a secondary repository called **ros-testing**.
 **ros-testing** is intended as a soaking area where developers and bleeding-edge users may give the packages extra testing, before they are manually synced into the public ros repository from which users typically install packages.
 
 Approximately every two weeks, the rosdistro's release manager manually synchronizes the contents of **ros-testing** into the **main** ROS repository.
 
+deb testing repository
+----------------------
+
 For Debian-based operating systems, you can install binary packages from the **ros-testing** repository.
 
 1. Make sure you have a working ROS 2 installation from deb packages (see :doc:`../Installation`).
 
-2. Edit (with sudo) the file ``/etc/apt/sources.list.d/ros2.list`` and change ``ros2`` with ``ros2-testing``.
-   For example, on Ubuntu Noble the contents should look like the following:
+2. Install the ros2-testing-apt-source package This will automatically uninstall the ros2-apt-source package since only one repository may be enabled at a time.
 
    .. code-block:: bash
+      $ sudo apt install -y ros2-testing-apt-source
 
-      # deb http://packages.ros.org/ros2/ubuntu noble main
-      deb http://packages.ros.org/ros2-testing/ubuntu noble main
-
-3. Update the ``apt`` index:
+3. Update the apt index:
 
    .. code-block:: console
-
+      
       $ sudo apt update
 
 4. You can now install individual packages from the testing repository, for example:
@@ -49,12 +46,10 @@ For Debian-based operating systems, you can install binary packages from the **r
 
       $ sudo apt dist-upgrade
 
-6. Once you are finished testing, you can switch back to the normal repository by changing back the contents of ``/etc/apt/sources.list.d/ros2.list``:
+6. Once you are finished testing, you can switch back to the normal repository by re-installing the ros-apt-source package:
 
    .. code-block:: bash
-
-      deb http://packages.ros.org/ros2/ubuntu noble main
-      # deb http://packages.ros.org/ros2-testing/ubuntu noble main
+      $ sudo apt install -y ros2-apt-source
 
    and doing an update and upgrade:
 
@@ -63,6 +58,44 @@ For Debian-based operating systems, you can install binary packages from the **r
       $ sudo apt update
       $ sudo apt dist-upgrade
 
+
+RHEL testing repository
+----------------------
+
+For RHEL you can install binary packages from the **ros-testing** repository, by enabling the testing repository on the source configuration: 
+
+1. Make sure you have a working ROS 2 installation for rpm packages (see :doc:`../RHEL-Install-RPMs`).
+
+2. Enable testing and disable main repository:
+   .. code-block:: console
+
+      $ sudo dnf config-manager setopt ros2-testing.enabled=1
+      $ sudo dnf config-manager setopt ros2.enabled=0
+
+3. Update the dnf index: 
+   .. code-block:: console
+
+      $ sudo dnf update
+
+4.  You can now install individual packages from the testing repository, for example:
+
+   .. code-block:: console
+
+      $ sudo dnf install ros-{DISTRO}-my-just-released-package
+
+5.  Once you are finished testing, you can switch back to the normal repository by re-enabling the main repository:
+
+   .. code-block:: bash
+      $ sudo dnf config-manager setopt ros2-testing.enabled=0
+      $ sudo dnf config-manager setopt ros2.enabled=1
+
+   and doing an update and upgrade:
+
+   .. code-block:: console
+
+      $ sudo dnf update
+      $ sudo dnf system-upgrade
+      
 .. _Prerelease_binaries:
 
 Binary archives

--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -32,7 +32,7 @@ For Debian-based operating systems, you can install binary packages from the **r
 3. Update the apt index:
 
    .. code-block:: console
-      
+
       $ sudo apt update
 
 4. You can now install individual packages from the testing repository, for example:
@@ -64,17 +64,19 @@ For Debian-based operating systems, you can install binary packages from the **r
 RHEL testing repository
 ----------------------
 
-For RHEL you can install binary packages from the **ros-testing** repository, by enabling the testing repository on the source configuration: 
+For RHEL you can install binary packages from the **ros-testing** repository, by enabling the testing repository on the source configuration:
 
 1. Make sure you have a working ROS 2 installation for rpm packages (see :doc:`../RHEL-Install-RPMs`).
 
 2. Enable testing and disable main repository:
+
    .. code-block:: console
 
       $ sudo dnf config-manager setopt ros2-testing.enabled=1
       $ sudo dnf config-manager setopt ros2.enabled=0
 
-3. Update the dnf index: 
+3. Update the dnf index:
+
    .. code-block:: console
 
       $ sudo dnf update
@@ -88,7 +90,7 @@ For RHEL you can install binary packages from the **ros-testing** repository, by
 5.  Once you are finished testing, you can switch back to the normal repository by re-enabling the main repository:
 
    .. code-block:: bash
-      
+
       $ sudo dnf config-manager setopt ros2-testing.enabled=0
       $ sudo dnf config-manager setopt ros2.enabled=1
 


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR unifies the deb testing repository instruction to those on the [Kilted docs](https://docs.ros.org/en/kilted/Installation/Testing.html).

Additionally a NEW section with the RPM instructions is added to indicate how to do the switch between testing and main on rpm. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #5773 

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
I did not use any generative AI.

### Additional Information
These changes should be ported over to jazzy, humble and kilted.
<!--
If applicable, provide any additional context or details about the changes.
-->
