### PR TITLE
Change link for free trial license

### DIFF
--- a/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
+++ b/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
@@ -49,7 +49,7 @@ RTI Connext Pro is available through a variety of channels:
 
 **Other Installation Options**
 RTI Connext DDS is a proprietary DDS implementation with a number of advanced features and commercial support options.
-RTI provides both a `non-commercial / research license <https://www.rti.com/free-trial/university-program>`__ for students and researchers and a `time-limited free trial license <https://www.rti.com/free-trial>`__ for commercial users.
+RTI provides both a `non-commercial / research license <https://www.rti.com/free-trial/university-program>`__ for students and researchers and a `time-limited free trial license <https://content.rti.com/l/983311/2025-06-26/q5tyw3>`__ for commercial users.
 Detailed instructions for building and tuning the RMW and ROS 2 applications for a variety of platforms, and enabling DDS Security and safety-cert options are available on the `RTI ROS Community <https://community.rti.com/ros>`__ pages.
 
 


### PR DESCRIPTION
## Description

While testing Kilted before its release, several users encountered issues downloading Connext 7.3.0 — the latest LTS version of RTI Connext DDS officially supported in ROS 2 (see for example: https://github.com/ros2/kilted_tutorial_party/issues/461).

To address this and improve the developer experience, RTI has published a dedicated download page with a direct link to the appropriate version. This change helps reduce friction during setup and avoids future issues related to compatibility or installation.

With this update, ROS 2 users can reliably access the correct middleware version without confusion.

### Did you use Generative AI?

No
