### PR TITLE
Mark kilted in green/supported

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -47,6 +47,7 @@ Rows in the table marked in green are the currently supported distributions.
      why it is like this.
    -->
    <style>
+     .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
      .rst-content tr:nth-child(2) {background-color: #33cc66;}
      .rst-content tr:nth-child(4) {background-color: #33cc66;}
    </style>


### PR DESCRIPTION
Kilted is a currently supported release and should be marked in green.

## Description

Marks Kilted Kaiju in green.

Fixes # (issue)

### Did you use Generative AI?

no

### Additional Information

This should be backported (if it works)