### PR TITLE
Update Writing-a-Composable-Node.rst

### DIFF
--- a/source/Tutorials/Intermediate/Writing-a-Composable-Node.rst
+++ b/source/Tutorials/Intermediate/Writing-a-Composable-Node.rst
@@ -93,7 +93,7 @@ Second, we're going to replace our ``add_executable`` with a ``add_library`` wit
 
 .. code-block:: cmake
 
-    add_library(vincent_driver_component src/vincent_driver.cpp)
+    add_library(vincent_driver_component SHARED src/vincent_driver.cpp)
 
 Third, replace other build commands that used the old target to act on the new target.
 Don't forget to add ``rclcpp_components::component`` in ``target_link_libraries``.


### PR DESCRIPTION
Loading the node into the component container fails as it builds a static library.

## Description

Fixed documentation to build a shared library.

Fixes # (issue)

Failed to load component: Failed to load library: could not load library dlopen error: /home/mawais/repos/ros2_ws/install/ros_graph_viz/lib/libgraph_entities_component.a: invalid elf header, at ./src/shared_library.c:99

### Did you use Generative AI?

No

### Additional Information
