### PR TITLE
Bump asio version to 1.28.1 (jazzy)

### DIFF
--- a/source/Installation/_Windows-Install-Prerequisites.rst
+++ b/source/Installation/_Windows-Install-Prerequisites.rst
@@ -104,7 +104,7 @@ You will need to append the CMake bin folder ``C:\Program Files\CMake\bin`` to y
 
 Please download these packages from `this <https://github.com/ros2/choco-packages/releases/latest>`__ GitHub repository.
 
-* ``asio.1.12.1.nupkg``
+* ``asio.1.28.1.nupkg``
 * ``bullet.3.17.nupkg``
 * ``cunit.2.1.3.nupkg``
 * ``eigen.3.3.4.nupkg``


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This PR bumps the required `asio` version to `1.28.1` for the upcoming `Fast DDS v2.14.5` (jazzy)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Related to

* https://github.com/ros2/choco-packages/pull/21
