### PR TITLE
Remove mention of `wtf`

### DIFF
--- a/source/Concepts/Basic/About-Command-Line-Tools.rst
+++ b/source/Concepts/Basic/About-Command-Line-Tools.rst
@@ -43,7 +43,6 @@ Examples of sub-commands that are available include:
 * ``test``: Run a ROS launch test
 * ``topic``: Introspect/publish ROS topics
 * ``trace``: Tracing tools to get information on ROS nodes execution (only available on Linux)
-* ``wtf``: An alias for ``doctor``
 
 Example
 -------


### PR DESCRIPTION
## Description

Removes the documentation of the `wtf` alias. The result of the conversation of the PMC meeting on 7/26/25.

Fixes https://github.com/ros2/ros2cli/issues/1078

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
