### PR TITLE
Fix link to project board.

### DIFF
--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -42,6 +42,6 @@ New features in this ROS 2 release
 Development progress
 --------------------
 
-For progress on the development of Lyrical Luth, see `this project board <https://github.com/orgs/ros2/projects/63>`__.
+For progress on the development of Lyrical Luth, see `this project board <https://github.com/orgs/ros2/projects/70>`__.
 
 For the broad process followed by Lyrical Luth, see the :doc:`process description page <Release-Process>`.


### PR DESCRIPTION
## Description

Update the link to the Lyrical Luth github project board.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
