### PR TITLE
Fix outdated http links to https (#4209)

### DIFF
--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -65,7 +65,7 @@ If following a tutorial or online instructions provide a link to the specific in
 * Any warnings or errors.
   Cut and paste them directly from the terminal window to which they were printed.
   Please do not re-type or include a screenshot.
-* In case of a bug consider providing a `short, self contained, correct (compilable), example <http://sscce.org/>`__.
+* In case of a bug consider providing a `short, self contained, correct (compilable), example <https://sscce.org/>`__.
 * When discussing any compiling/linking/installation issues, also provide the compiler version
 
 As appropriate, also include your:

--- a/source/Glossary.rst
+++ b/source/Glossary.rst
@@ -24,7 +24,7 @@ Glossary of terms used throughout this documentation:
         ROS Enhancement Proposal.
         A document that describes an enhancement, standardization, or convention for the ROS community.
         The associated REP approval process allows the community to iterate on a proposal until some consensus has been made, at which point it can be ratified and implemented, which then becomes documentation.
-        All REPs are viewable from the `REP index <http://www.ros.org/reps/rep-0000.html>`_.
+        All REPs are viewable from the `REP index <https://www.ros.org/reps/rep-0000.html>`_.
 
    VCS
        Version Control System, such as CVS, SVN, git, mercurial, etc...

--- a/source/Package-Docs.rst
+++ b/source/Package-Docs.rst
@@ -28,9 +28,9 @@ API Documentation
 You can find the API level documentation for the ROS client libraries in the {DISTRO_TITLE} distribution using the links below:
 
 * `rclcpp - C++ client library <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html>`_
-* `rclcpp_lifecycle - C++ lifecycle library <http://docs.ros.org/en/{DISTRO}/p/rclcpp_lifecycle/generated/index.html>`_
-* `rclcpp_components - C++ components library <http://docs.ros.org/en/{DISTRO}/p/rclcpp_components/generated/index.html>`_
-* `rclcpp_action - C++ actions library <http://docs.ros.org/en/{DISTRO}/p/rclcpp_action/generated/index.html>`_
+* `rclcpp_lifecycle - C++ lifecycle library <https://docs.ros.org/en/{DISTRO}/p/rclcpp_lifecycle/generated/index.html>`_
+* `rclcpp_components - C++ components library <https://docs.ros.org/en/{DISTRO}/p/rclcpp_components/generated/index.html>`_
+* `rclcpp_action - C++ actions library <https://docs.ros.org/en/{DISTRO}/p/rclcpp_action/generated/index.html>`_
 
 Adding Your Package to docs.ros.org
 -----------------------------------

--- a/source/Package-Docs.rst
+++ b/source/Package-Docs.rst
@@ -27,7 +27,7 @@ API Documentation
 
 You can find the API level documentation for the ROS client libraries in the {DISTRO_TITLE} distribution using the links below:
 
-* `rclcpp - C++ client library <http://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html>`_
+* `rclcpp - C++ client library <https://docs.ros.org/en/{DISTRO}/p/rclcpp/generated/index.html>`_
 * `rclcpp_lifecycle - C++ lifecycle library <http://docs.ros.org/en/{DISTRO}/p/rclcpp_lifecycle/generated/index.html>`_
 * `rclcpp_components - C++ components library <http://docs.ros.org/en/{DISTRO}/p/rclcpp_components/generated/index.html>`_
 * `rclcpp_action - C++ actions library <http://docs.ros.org/en/{DISTRO}/p/rclcpp_action/generated/index.html>`_

--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -5,7 +5,7 @@ Related Projects
 Gazebo
 ------
 
-**Gazebo** `(gazebosim.org) <http://gazebosim.org/>`_ and its predecessor Gazebo Classic are the first open source choice for 3D physics simulation of ROS-based robots.
+**Gazebo** `(gazebosim.org) <https://gazebosim.org/>`_ and its predecessor Gazebo Classic are the first open source choice for 3D physics simulation of ROS-based robots.
 
 Large Community Projects
 ------------------------

--- a/source/index.rst
+++ b/source/index.rst
@@ -141,7 +141,7 @@ General ROS project resources
   - Showcases robots projects from the community
   - Instructions on how to contribute a robot
 
-* `ROS Wiki <http://wiki.ros.org/>`__ (ROS 1)
+* `ROS Wiki <https://wiki.ros.org/>`__ (ROS 1)
 
   - ROS 1 documentation and user modifiable content
   - Active until at least the last ROS 1 distribution is EOL


### PR DESCRIPTION
This PR addresses issue #4209 by updating several outdated links 
from http:// to https:// to avoid redirects and potential breakages.

Files updated:
- Contact.rst
- Glossary.rst
- index.rst
- Package-Docs.rst
- Related-Projects.rst
