### PR TITLE
Fix doc install RHEL from RPM - crb repo do not exist in RHEL

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -35,7 +35,7 @@ You will need to enable the EPEL repositories and the PowerTools repository:
 .. code-block:: console
 
    $ sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
-   $ sudo crb enable
+   $ sudo env FORCE_DNF=1 crb enable
 
 .. note:: This step may be slightly different depending on the distribution you are using.
           `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/getting-started/>`_

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -34,11 +34,11 @@ You will need to enable the EPEL repositories and the PowerTools repository:
 
 .. code-block:: console
 
-   $ sudo dnf install 'dnf-command(config-manager)' epel-release -y
-   $ sudo dnf config-manager --set-enabled crb
+   $ sudo dnf install -y 'dnf-command(config-manager)' https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
+   $ sudo dnf config-manager --set-enabled codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms
 
 .. note:: This step may be slightly different depending on the distribution you are using.
-          `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_
+          `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/getting-started/>`_
 
 Next, download the ``ros2-release`` package and install it:
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -34,8 +34,8 @@ You will need to enable the EPEL repositories and the PowerTools repository:
 
 .. code-block:: console
 
-   $ sudo dnf install -y 'dnf-command(config-manager)' https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
-   $ sudo dnf config-manager --set-enabled codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms
+   $ sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
+   $ sudo crb enable
 
 .. note:: This step may be slightly different depending on the distribution you are using.
           `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/getting-started/>`_


### PR DESCRIPTION
## Description

"dnf config-manager --set-enabled crb" do not work since the crb repo do not exist in any RHEL reelase, that is valid for CentOS Stream only.

### Did you use Generative AI?

No

### Additional Information

https://docs.fedoraproject.org/en-US/epel/getting-started/
