### PR TITLE
Enable Zenoh router to make the post-install example work

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -34,11 +34,11 @@ You will need to enable the EPEL repositories and the PowerTools repository:
 
 .. code-block:: console
 
-   $ sudo dnf install 'dnf-command(config-manager)' epel-release -y
-   $ sudo dnf config-manager --set-enabled crb
+   $ sudo dnf install -y 'dnf-command(config-manager)' https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
+   $ sudo dnf config-manager --set-enabled codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms
 
 .. note:: This step may be slightly different depending on the distribution you are using.
-          `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_
+          `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/getting-started/>`_
 
 Next, download the ``ros2-release`` package and install it:
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -125,7 +125,7 @@ Try some examples
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
-First, if you use `Zenoh` as the RMW implementation (default), you will require a router for node discovery and communication
+First, if you use ``Zenoh`` as the RMW implementation (default), you will require a router for node discovery and communication
 
 In one terminal start the Zenoh router daemon
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -34,11 +34,11 @@ You will need to enable the EPEL repositories and the PowerTools repository:
 
 .. code-block:: console
 
-   $ sudo dnf install -y 'dnf-command(config-manager)' https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
-   $ sudo dnf config-manager --set-enabled codeready-builder-for-rhel-$(rpm -E %rhel)-$(arch)-rpms
+   $ sudo dnf install 'dnf-command(config-manager)' epel-release -y
+   $ sudo dnf config-manager --set-enabled crb
 
 .. note:: This step may be slightly different depending on the distribution you are using.
-          `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/getting-started/>`_
+          `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_
 
 Next, download the ``ros2-release`` package and install it:
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -125,14 +125,23 @@ Try some examples
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
-In one terminal, source the setup file and then run a C++ ``talker``\ :
+First, if you use `Zenoh` as the RMW implementation (default), you will require a router for node discovery and communication
+
+In one terminal start the Zenoh router daemon
+
+.. code-block:: console
+
+   $ source /opt/ros/{DISTRO}/setup.bash
+   $ ros2 run rmw_zenoh_cpp rmw_zenohd
+
+In another terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: console
 
    $ source /opt/ros/{DISTRO}/setup.bash
    $ ros2 run demo_nodes_cpp talker
 
-In another terminal source the setup file and then run a Python ``listener``\ :
+In a third terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: console
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -127,7 +127,7 @@ If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
 First, if you use ``Zenoh`` as the RMW implementation, you will require a router for node discovery and communication.
 
-In one terminal start the Zenoh router daemon
+In one terminal, start the Zenoh router daemon:
 
 .. code-block:: console
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -125,7 +125,7 @@ Try some examples
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
-First, if you use ``Zenoh`` as the RMW implementation (default), you will require a router for node discovery and communication
+First, if you use ``Zenoh`` as the RMW implementation, you will require a router for node discovery and communication.
 
 In one terminal start the Zenoh router daemon
 


### PR DESCRIPTION
## Description

If you run the example as it appears in the DOC you won't get it working (listener do not receive anything).

Just by starting the Zenoh router it works:

`ros2 run rmw_zenoh_cpp rmw_zenohd`

I only updated the RHEL documentation since it is the system where I faced and solved the issue, but probably it will also happen in Ubuntu.

### Did you use Generative AI?

NO

### Additional Information

If you run without the router enabled you will get these warnings in both talker and listener:

```
[WARN] [1758031191.632663436] [rmw_zenoh_cpp]: Unable to connect to a Zenoh router. Have you started a router with `ros2 run rmw_zenoh_cpp rmw_zenohd`?
[WARN] [1758031191.633501357] [rmw_zenoh_cpp]: Unable to connect to a Zenoh router after 1 attempt(s). Please ensure that a Zenoh router is running and can be reached. You may increase the number of attempts to check for a router by setting the ZENOH_ROUTER_CHECK_ATTEMPTS environment variable. Proceeding with initialization but other peers will not discover or receive data from peers in this session until a router is started.
```
