### PR TITLE
Rhel dependencies

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -40,6 +40,19 @@ You will need to enable the EPEL repositories and the PowerTools repository:
 .. note:: This step may be slightly different depending on the distribution you are using.
           `Check the EPEL documentation <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_
 
+Install some dependencies:
+
+.. code-block:: console
+
+   $ sudo dnf install -y \
+     spdlog-devel \
+     lttng-ust \
+     python3-typing-extensions \
+     python3-numpy \
+     python3-packaging \
+     python3-psutil \
+     python3-lark-parser
+
 Next, download the ``ros2-release`` package and install it:
 
 .. code-block:: console

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -51,7 +51,8 @@ Install some dependencies:
      python3-numpy \
      python3-packaging \
      python3-psutil \
-     python3-lark-parser
+     python3-lark-parser \
+     console-bridge-devel
 
 Next, download the ``ros2-release`` package and install it:
 


### PR DESCRIPTION
## Description
(Tested on RHEL 9.6)

You need these packages to be able to run `ros2` in RHEL.

### Additional Information

Without the packages you find errors such as:

```
[root@localhost ~]# ros2
Traceback (most recent call last):
  File "/usr/local/ros/kilted/bin/ros2", line 33, in <module>
    sys.exit(load_entry_point('ros2cli==0.38.0', 'console_scripts', 'ros2')())
  File "/usr/local/ros/kilted/bin/ros2", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib64/python3.9/importlib/metadata.py", line 86, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/ros/kilted/lib/python3.9/site-packages/ros2cli/cli.py", line 22, in <module>
    from rclpy.executors import ExternalShutdownException
  File "/usr/local/ros/kilted/lib/python3.9/site-packages/rclpy/__init__.py", line 51, in <module>
    from rclpy.context import Context as Context
  File "/usr/local/ros/kilted/lib/python3.9/site-packages/rclpy/context.py", line 29, in <module>
    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
  File "/usr/local/ros/kilted/lib/python3.9/site-packages/rclpy/impl/implementation_singleton.py", line 33, in <module>
    rclpy_implementation = import_c_library('._rclpy_pybind11', package)
  File "/usr/local/ros/kilted/lib/python3.9/site-packages/rpyutils/import_c_library.py", line 40, in import_c_library
    return importlib.import_module(name, package=package)
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: liblttng-ust.so.0: cannot open shared object file: No such file or directory
The C extension '/usr/local/ros/kilted/lib/python3.9/site-packages/rclpy/_rclpy_pybind11.cpython-39-x86_64-linux-gnu.so' failed to be imported while being present on the system. Please refer to 'https://docs.ros.org/en/kilted/How-To-Guides/Installation-Troubleshooting.html#import-failing-even-with-library-present-on-the-system' for possible solutions
```

You can run `ros2` without the `python3-psutil` and `python3-lark-parser` packages but you get this message on the top:

```
[root@localhost ~]# ros2
Failed to load entry point 'doctor': No module named 'psutil'
Failed to load entry point 'wtf': No module named 'psutil'
Failed to load entry point 'launch': No module named 'lark'
usage: ros2 [-h] [--use-python-default-buffering] Call `ros2 <command> -h` for more detailed usage. ...
```

