### PR TITLE
Fix: Correct URDF path in demo_launch.py

### DIFF
--- a/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
+++ b/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
@@ -8,7 +8,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     urdf = FileContent(
-        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2', 'r2d2.urdf.xml')]))
+        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2'), 'urdf', 'r2d2.urdf.xml')]))
 
     return LaunchDescription([
         DeclareLaunchArgument(

--- a/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
+++ b/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
@@ -8,7 +8,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     urdf = FileContent(
-        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2'), 'urdf', 'r2d2.urdf.xml']))
+        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2'), 'r2d2.urdf.xml']))
 
     return LaunchDescription([
         DeclareLaunchArgument(

--- a/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
+++ b/source/Tutorials/Intermediate/URDF/launch/demo_launch.py
@@ -8,7 +8,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     urdf = FileContent(
-        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2'), 'urdf', 'r2d2.urdf.xml')]))
+        PathJoinSubstitution([FindPackageShare('urdf_tutorial_r2d2'), 'urdf', 'r2d2.urdf.xml']))
 
     return LaunchDescription([
         DeclareLaunchArgument(


### PR DESCRIPTION
This pull request resolves a launch file error by correcting the path used to find the robot's URDF file. The previous configuration was causing a TypeError because FindPackageShare was being called with too many arguments.

The correct implementation separates the package name from the file path, allowing PathJoinSubstitution to correctly combine them. This ensures the robot_state_publisher can successfully locate and load the r2d2.urdf.xml file.

## Description

This PR fixes a critical launch file error by correcting the path for the URDF file. The previous code was incorrectly passing multiple arguments to FindPackageShare, which only accepts a single package name. This change updates the PathJoinSubstitution to correctly join the package's share directory with the urdf subdirectory and the r2d2.urdf.xml file.

Fixes https://www.reddit.com/r/ROS/comments/1n5fhnx/ros2_jazzy_urdf_tutorial_error_in_launch_file/

### Did you use Generative AI?


### Additional Information
