### PR TITLE
DOC: Add note on naming convention inconsistencies

### DIFF
--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -101,7 +101,6 @@ Variable Naming
   * For new projects, developers should follow the existing conventions in related ROS 2 packages
   * When in doubt, prefer consistency with surrounding code over strict adherence to Google style
 
-
 Function and Method Naming
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -93,6 +93,15 @@ Variable Naming
   * rationale: easy to tell the scope of a variable at a glance
   * consistency across languages
 
+* **Note on naming conventions**: ROS 2 deviates from the Google C++ Style Guide in several naming areas:
+
+  * The Google style guide recommends ``kPascalCase`` for constants (e.g., ``kDaysInAWeek``)
+  * ROS 2 projects currently use a mix of ``snake_case``, ``PascalCase``, and ``UPPER_CASE`` naming conventions
+  * This deviation is for historical reasons and consistency with existing ROS codebases
+  * For new projects, developers should follow the existing conventions in related ROS 2 packages
+  * When in doubt, prefer consistency with surrounding code over strict adherence to Google style
+
+
 Function and Method Naming
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request: Clarify Naming Convention Deviations in ROS 2 C++ Style Guide

### What was fixed?

- **Added a clear notice** in the C++ "Variable Naming" section of the documentation.
- The notice explains that ROS 2 projects use a mix of `snake_case`, `PascalCase`, and `UPPER_CASE` for constants and variables, which **deviates from the Google C++ Style Guide** (which recommends `kPascalCase` for constants).
- **Rationale and guidance** were provided for contributors:
  - This deviation is due to historical reasons and consistency with existing ROS codebases.
  - New projects should follow the conventions used in related ROS 2 packages.
  - When in doubt, contributors should prefer consistency with surrounding code over strict adherence to Google style.

### Why was this needed?

- There was confusion among contributors about the naming conventions, since the documentation referenced the Google C++ Style Guide but did not explain the deviations.
- This update makes the documentation more transparent and helps maintain consistency across the codebase.

### Where was it fixed?

- The change was made in  
  `source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst`  
  under the **C++ > Variable Naming** section.

---

**Example of the new notice:**

> **Note on naming conventions:**  
> ROS 2 deviates from the Google C++ Style Guide in several naming areas:
>
> - The Google style guide recommends `kPascalCase` for constants (e.g., `kDaysInAWeek`)
> - ROS 2 projects currently use a mix of `snake_case`, `PascalCase`, and `UPPER_CASE` naming conventions
> - This deviation is for historical reasons and consistency with existing ROS codebases
> - For new projects, developers should follow the existing conventions in related ROS 2 packages
> - When in doubt, prefer consistency with surrounding code over strict adherence to Google style

---

**This change improves clarity for all contributors and reviewers working on ROS 2 C++ code.**