### PR TITLE
Set launch file migration guide ToC depth to 2 to ease navigation

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
@@ -10,7 +10,7 @@ Migrating Launch Files
 ======================
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 While launch files in ROS 1 are always specified using `XML <https://wiki.ros.org/roslaunch/XML>`__ files, ROS 2 supports both XML and YAML files.


### PR DESCRIPTION
## Description

Since this is kind of a reference guide with multiple sections and subsections, it helps to quickly find (and navigate to) the right (sub)section.

Before:

<img width="361" height="263" alt="image" src="https://github.com/user-attachments/assets/f7891bb4-9bba-4c2f-8bfe-3f818be2585f" />

After:

<img width="361" height="609" alt="image" src="https://github.com/user-attachments/assets/204a65a2-1a72-4ab5-a549-d22f1ccd9c98" />


### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
