### PR TITLE
Fix list in developer guide

### DIFF
--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -159,6 +159,7 @@ Guidelines for backporting PRs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When changing an older version of ROS:
+
 * Make sure the features or fixes are accepted and merged in the rolling branch before opening a PR to backport the changes to older versions.
 * When backporting to older versions, also consider backporting to any other :doc:`still supported versions <../../Releases>`, even non-LTS versions.
 * If you are backporting a single PR in its entirety, title the backport PR "[Distro] <name of original PR>".


### PR DESCRIPTION
## Description

I missed this change in #5872.

Before:

<img width="871" height="233" alt="Screenshot from 2025-10-11 15-30-01" src="https://github.com/user-attachments/assets/1003d791-ed32-4978-b221-dfc03ad48ab7" />

After:

<img width="871" height="306" alt="Screenshot from 2025-10-11 15-30-19" src="https://github.com/user-attachments/assets/1d9a920e-605a-46b6-a7f9-3c17c8a3b6e6" />

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
