### PR TITLE
Update Windows colcon build instructions --symlink-install

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -187,7 +187,8 @@ This allows the installed files to be changed by changing the files in the ``sou
       $ colcon build --merge-install
 
     Windows doesn't allow long paths, so ``merge-install`` will combine all the paths into the ``install`` directory.
-    On Windows, you need special permissions to create symbolic links, so ``--symlink-install`` is not used by default. To use it, you need to run the command as administrator or enable developer mode in system settings.
+    On Windows, you need special permissions to create symbolic links, so ``--symlink-install`` is not used by default.
+    To use it, you need to run the command as administrator or enable developer mode in system settings.
 
 .. tip::
 

--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -184,9 +184,10 @@ This allows the installed files to be changed by changing the files in the ``sou
 
     .. code-block:: console
 
-      $ colcon build --symlink-install --merge-install
+      $ colcon build --merge-install
 
     Windows doesn't allow long paths, so ``merge-install`` will combine all the paths into the ``install`` directory.
+    On Windows, you need special permissions to create symbolic links, so `--symlink-install` is not used by default. To use it, you need to run the command as administrator or enable developer mode in system settings.
 
 .. tip::
 

--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -187,7 +187,7 @@ This allows the installed files to be changed by changing the files in the ``sou
       $ colcon build --merge-install
 
     Windows doesn't allow long paths, so ``merge-install`` will combine all the paths into the ``install`` directory.
-    On Windows, you need special permissions to create symbolic links, so `--symlink-install` is not used by default. To use it, you need to run the command as administrator or enable developer mode in system settings.
+    On Windows, you need special permissions to create symbolic links, so ``--symlink-install`` is not used by default. To use it, you need to run the command as administrator or enable developer mode in system settings.
 
 .. tip::
 


### PR DESCRIPTION
Clarify Windows build command and permissions for symbolic links.

## Description

Remove `--symlink-install` and add some instructions how to enable it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #5120 

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
