### PR TITLE
use credential settings for release repo access

### DIFF
--- a/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
+++ b/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
@@ -27,3 +27,19 @@ Save your GitHub username and PAT to a new file called ``~/.config/bloom``, with
       "github_user": "<your-github-username>",
       "oauth_token": "<token-you-created-for-bloom>"
    }
+
+Configure in your ``~/.gitconfig`` that your GitHub account and PAT are used for all release repositories under https://github.com/ros2-gbp:
+
+.. code-block:: ini
+
+    [credential "https://github.com/ros2-gbp"]
+        username = x-access-token
+        helper = "!f() { test \"$1\" = get && echo \"password=<token-you-created-for-bloom>\"; }; f"
+
+You can additionally use different GitHub accounts and PATs for different release repos:
+
+.. code-block:: ini
+
+    [credential "https://github.com/ros2-gbp/my_package-release.git"]
+        username = x-access-token
+        helper = "!f() { test \"$1\" = get && echo \"password=<other-token-you-created-for-bloom>\"; }; f"

--- a/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
+++ b/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
@@ -28,7 +28,7 @@ Save your GitHub username and PAT to a new file called ``~/.config/bloom``, with
       "oauth_token": "<token-you-created-for-bloom>"
    }
 
-Configure in your ``~/.gitconfig`` that your GitHub account and PAT are used for all release repositories under https://github.com/ros2-gbp:
+Configure in your ``~/.gitconfig`` that your GitHub account and PAT are used for all release repositories under `ros2-gbp <https://github.com/ros2-gbp>`_:
 
 .. code-block:: ini
 

--- a/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
+++ b/source/How-To-Guides/Releasing/_Personal-Access-Token.rst
@@ -36,7 +36,7 @@ Configure in your ``~/.gitconfig`` that your GitHub account and PAT are used for
         username = x-access-token
         helper = "!f() { test \"$1\" = get && echo \"password=<token-you-created-for-bloom>\"; }; f"
 
-You can additionally use different GitHub accounts and PATs for different release repos:
+You can additionally use different GitHub accounts and PATs for individual release repositories:
 
 .. code-block:: ini
 


### PR DESCRIPTION
## Description

Use the credential settings in '~/.gitconfig' instead of the custom bloom configuration file in order to avoid maintaining an additional file with tokens and to avoid mapping https to ssh.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

See https://github.com/ros-infrastructure/bloom/issues/752.

### Did you use Generative AI?

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
