### PR TITLE
Fixing misleading Zenoh usage in try-some-example #5954

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -136,6 +136,8 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
+If you want to use other RMW implementations, you can check the :doc:`guide <./RMW-Implementations>`.
+
 Next steps
 ----------
 

--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -118,23 +118,14 @@ Try some examples
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
-First, if you use ``Zenoh`` as the RMW implementation, you will require a router for node discovery and communication.
-
-In one terminal, start the Zenoh router daemon:
-
-.. code-block:: console
-
-   $ source /opt/ros/{DISTRO}/setup.bash
-   $ ros2 run rmw_zenoh_cpp rmw_zenohd
-
-In another terminal, source the setup file and then run a C++ ``talker``\ :
+In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: console
 
    $ source /opt/ros/{DISTRO}/setup.bash
    $ ros2 run demo_nodes_cpp talker
 
-In a third terminal source the setup file and then run a Python ``listener``\ :
+In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: console
 

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -97,23 +97,14 @@ Try some examples
 
 If you installed ``ros-{DISTRO}-desktop`` above you can try some examples.
 
-First, if you use ``Zenoh`` as the RMW implementation, you will require a router for node discovery and communication.
-
-In one terminal, start the Zenoh router daemon:
-
-.. code-block:: console
-
-   $ source /opt/ros/{DISTRO}/setup.bash
-   $ ros2 run rmw_zenoh_cpp rmw_zenohd
-
-In another terminal, source the setup file and then run a C++ ``talker``\ :
+In one terminal, source the setup file and then run a C++ ``talker``\ :
 
 .. code-block:: console
 
    $ source /opt/ros/{DISTRO}/setup.bash
    $ ros2 run demo_nodes_cpp talker
 
-In a third terminal source the setup file and then run a Python ``listener``\ :
+In another terminal source the setup file and then run a Python ``listener``\ :
 
 .. code-block:: console
 

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -115,6 +115,8 @@ You should see the ``talker`` saying that it's ``Publishing`` messages and the `
 This verifies both the C++ and Python APIs are working properly.
 Hooray!
 
+If you want to use other RMW implementations, you can check the :doc:`guide <./RMW-Implementations>`.
+
 Next steps
 ----------
 


### PR DESCRIPTION
…nal commands

## Description

On the following documentation page:
📄 **[Installation Ubuntu (deb packages)](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debs.html#try-some-examples)**
the **“try-some-example”** section contains the following instruction:

> If you installed ros-kilted-desktop above you can try some examples.
>
> First, if you use Zenoh as the RMW implementation, you will require a router for node discovery and communication.
>
> In one terminal, start the Zenoh router daemon:
>
> ```bash
> source /opt/ros/kilted/setup.bash  
> ros2 run rmw_zenoh_cpp rmw_zenohd  
> ```

This step asks users to run rmw_zenohd, but the section neither switches the RMW implementation to Zenoh nor installs ros-jazzy-rmw-zenoh-cpp beforehand.
As a result, the command will likely fail or have no effect — and more importantly, it may mislead newcomers into thinking that running rmw_zenohd is always required for ROS 2, even though the example itself does not use Zenoh.

[This issue](https://github.com/ros2/ros2_documentation/issues/5954) related this PR


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (5954)

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
