### PR TITLE
docs: Correct --dependencies description for ament_python packages

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -49,7 +49,7 @@ Navigate into ``ros2_ws/src`` and create a new package:
 
 Your terminal will return a message verifying the creation of your package ``python_parameters`` and all its necessary files and folders.
 
-The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml``. For ament_cmake packages, it would also update ``CMakeLists.txt``.
+The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml``.
 
 1.1 Update ``package.xml``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -54,7 +54,7 @@ The ``--dependencies`` argument will automatically add the necessary dependency 
 1.1 Update ``package.xml``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Because you used the ``--dependencies`` option during package creation, you don't have to manually add dependencies to ``package.xml`` or ``CMakeLists.txt``.
+Because you used the ``--dependencies`` option during package creation, you don't have to manually add dependencies to ``package.xml``.
 
 As always, though, make sure to add the description, maintainer email and name, and license information to ``package.xml``.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python.rst
@@ -49,7 +49,7 @@ Navigate into ``ros2_ws/src`` and create a new package:
 
 Your terminal will return a message verifying the creation of your package ``python_parameters`` and all its necessary files and folders.
 
-The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml`` and ``CMakeLists.txt``.
+The ``--dependencies`` argument will automatically add the necessary dependency lines to ``package.xml``. For ament_cmake packages, it would also update ``CMakeLists.txt``.
 
 1.1 Update ``package.xml``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

The description for the `--dependencies` argument incorrectly included CMakeLists.txt when creating an ament_python package. This change clarifies that for ament_python packages, only package.xml is modified, preventing confusion for new users.

### Did you use Generative AI?

No.

### Additional Information

N/A
