### PR TITLE
Fix Fibonacci action feedback field name

### DIFF
--- a/source/Concepts/Basic/About-Actions.rst
+++ b/source/Concepts/Basic/About-Actions.rst
@@ -38,7 +38,7 @@ For instance, consider an action to calculate the Fibonacci sequence with the fo
    ---
    int32[] sequence
    ---
-   int32[] sequence
+   int32[] partial_sequence
 
 The action server is the entity that receives this message, starts calculating the sequence up to ``order`` (providing feedback along the way), and finally returns a full result in ``sequence``.
 

--- a/source/Concepts/Basic/About-Interfaces.rst
+++ b/source/Concepts/Basic/About-Interfaces.rst
@@ -301,7 +301,7 @@ For instance, the ``Fibonacci`` action definition contains the following:
    ---
    int32[] sequence
    ---
-   int32[] sequence
+   int32[] partial_sequence
 
 This is an action definition where the action client is sending a single ``int32`` field representing the number of Fibonacci steps to take, and expecting the action server to produce an array of ``int32`` containing the complete steps.
 Along the way, the action server may also provide an intermediate array of ``int32`` containing the steps accomplished up until a certain point.


### PR DESCRIPTION
- Change feedback field from 'sequence' to 'partial_sequence'
- Updated in About-Interfaces.rst and About-Actions.rst
- Aligns with actual action definition used in tutorials

Fixes #4298

Fixed two files:
- `About-Interfaces.rst` 
- `About-Actions.rst`

Changed the feedback field from `sequence` → `partial_sequence` to match what the rest of the documentation and code use.

In ROS 2 actions:
- **Feedback** = `partial_sequence` (progress updates while running)
- **Result** = `sequence` (final answer when done)

Having both called `sequence` was misleading!

Small fix, but should help avoid confusion for people learning about actions!