### PR TITLE
Restore asterisk under interface field types tables

### DIFF
--- a/source/Concepts/Basic/About-Interfaces.rst
+++ b/source/Concepts/Basic/About-Interfaces.rst
@@ -159,7 +159,7 @@ Field types can be:
      - builtins.str*
      - string
 
-All types that are more permissive than their ROS definition enforce the ROS constraints in range and length by software.
+(*) All types that are more permissive than their ROS definition enforce the ROS constraints in range and length by software.
 
 *Example of message definition using arrays and bounded types:*
 


### PR DESCRIPTION
## Description

Relates to #5820.

I noticed that there are asterisks in the field types tables (especially for Python types), but there's no corresponding note: https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#field-types.

I dug through the git history, and found that the note is the sentence below the 2nd table:

> All types that are more permissive than their ROS definition enforce the ROS constraints in range and length by software

The asterisk was simply removed because it was not valid RST: 2aafc060692693a86c85f4191393ea9faa7d9fa2. Restore it while making sure it's valid RST.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
