### PR TITLE
add missing '$' in humble ubuntu install instruction section

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -70,7 +70,7 @@ No GUI tools.
 
 Development tools: Compilers and other tools to build ROS packages
 
-.. code-block:: bash
+.. code-block:: console
 
    $ sudo apt install ros-dev-tools
 

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -72,7 +72,7 @@ Development tools: Compilers and other tools to build ROS packages
 
 .. code-block:: bash
 
-   sudo apt install ros-dev-tools
+   $ sudo apt install ros-dev-tools
 
 Environment setup
 -----------------


### PR DESCRIPTION
## Description
While reading through the ROS 2 Humble installation guide, i noticed that one of the command examples was missing the `$`. So, i added it. 
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
