### PR TITLE
docs: demonstrate args vs ros_args in launch file tutorial

### DIFF
--- a/source/How-To-Guides/launch/different_formats_launch.py
+++ b/source/How-To-Guides/launch/different_formats_launch.py
@@ -51,21 +51,23 @@ def generate_launch_description():
             ]
         ),
 
-        # start a turtlesim_node in the turtlesim1 namespace
+        # start a turtlesim_node in the turtlesim1 namespace and use arguments to set the log level
         Node(
             package='turtlesim',
             namespace='turtlesim1',
             executable='turtlesim_node',
-            name='sim'
+            name='sim',
+            arguments=['--ros-args', '--log-level', 'info']
         ),
 
-        # start another turtlesim_node in the turtlesim2 namespace
-        # and use args to set parameters
+        # start another turtlesim_node in the turtlesim2 namespace,
+        # use ros_arguments to set the log level, and parameters to set the parameters
         Node(
             package='turtlesim',
             namespace='turtlesim2',
             executable='turtlesim_node',
             name='sim',
+            ros_arguments=['--log-level', 'warn'],
             parameters=[{
                 'background_r': LaunchConfiguration('background_r'),
                 'background_g': LaunchConfiguration('background_g'),

--- a/source/How-To-Guides/launch/different_formats_launch.xml
+++ b/source/How-To-Guides/launch/different_formats_launch.xml
@@ -32,11 +32,11 @@
     <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.yaml" />
   </group>
 
-  <!-- start a turtlesim_node in the turtlesim1 namespace -->
-  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1" />
+  <!-- start a turtlesim_node in the turtlesim1 namespace and use args to set the log level -->
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1" args="--ros-args --log-level info" />
 
-  <!-- start another turtlesim_node in the turtlesim2 namespace and use args to set parameters -->
-  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2">
+  <!-- start another turtlesim_node in the turtlesim2 namespace, use ros_args to set the log level, and child elements to set the parameters -->
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2" ros_args="--log-level warn">
     <param name="background_r" value="$(var background_r)" />
     <param name="background_g" value="$(var background_g)" />
     <param name="background_b" value="$(var background_b)" />

--- a/source/How-To-Guides/launch/different_formats_launch.yaml
+++ b/source/How-To-Guides/launch/different_formats_launch.yaml
@@ -46,19 +46,21 @@ launch:
     - include:
         file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.yaml"
 
-# start a turtlesim_node in the turtlesim1 namespace
+# start a turtlesim_node in the turtlesim1 namespace and use args to set the log level
 - node:
     pkg: "turtlesim"
     exec: "turtlesim_node"
     name: "sim"
     namespace: "turtlesim1"
+    args: "--ros-args --log-level info"
 
-# start another turtlesim_node in the turtlesim2 namespace and use args to set parameters
+# start another turtlesim_node in the turtlesim2 namespace, use ros_args to set the log level, and param to set the parameters
 - node:
     pkg: "turtlesim"
     exec: "turtlesim_node"
     name: "sim"
     namespace: "turtlesim2"
+    ros_args: "--log-level warn"
     param:
     - name: "background_r"
       value: "$(var background_r)"

--- a/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
+++ b/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
@@ -86,10 +86,14 @@ As mentioned above, this can either be in XML, YAML, or Python.
 All of the launch files above are launching a system of three nodes, all from the ``turtlesim`` package.
 The goal of the system is to launch two turtlesim windows, and have one turtle mimic the movements of the other.
 
-When launching the two turtlesim nodes, the only difference between them is their namespace values.
+When launching the two turtlesim nodes, the primary difference between them is their namespace values.
 Unique namespaces allow the system to start two nodes without node name or topic name conflicts.
 Both turtles in this system receive commands over the same topic and publish their pose over the same topic.
 With unique namespaces, messages meant for different turtles can be distinguished.
+
+The two turtlesim nodes also demonstrate different ways to pass ROS arguments.
+The first node uses ``args`` with ``--ros-args --log-level info`` which sets the log level to ``info``.
+The second node uses ``ros_args`` (``ros_arguments`` in Python) with ``--log-level warn`` (more concise syntax) which sets the log level to ``warn``. 
 
 The final node is also from the ``turtlesim`` package, but a different executable: ``mimic``.
 This node has added configuration details in the form of remappings.
@@ -101,7 +105,7 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 
   .. group-tab:: XML
 
-    The first two actions launch the two turtlesim windows:
+    The first two actions launch the two turtlesim windows with different argument passing approaches:
 
     .. literalinclude:: launch/turtlesim_mimic_launch.xml
       :language: xml
@@ -115,17 +119,17 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 
   .. group-tab:: YAML
 
-    The first two actions launch the two turtlesim windows:
+    The first two actions launch the two turtlesim windows with different argument passing approaches:
 
     .. literalinclude:: launch/turtlesim_mimic_launch.yaml
       :language: yaml
-      :lines: 4-14
+      :lines: 4-16
 
     The final action launches the mimic node with the remaps:
 
     .. literalinclude:: launch/turtlesim_mimic_launch.yaml
       :language: yaml
-      :lines: 16-24
+      :lines: 18-26
 
   .. group-tab:: Python
 
@@ -139,19 +143,19 @@ In other words, ``turtlesim2`` will mimic ``turtlesim1``'s movements.
 
     .. literalinclude:: launch/turtlesim_mimic_launch.py
       :language: python
-      :lines: 5-7,28
+      :lines: 5-6,30
 
-    The first two actions in the launch description launch the two turtlesim windows:
+    The first two actions in the launch description launch the two turtlesim windows with different argument passing approaches:
 
     .. literalinclude:: launch/turtlesim_mimic_launch.py
       :language: python
-      :lines: 7-18
+      :lines: 7-20
 
     The final action launches the mimic node with the remaps:
 
     .. literalinclude:: launch/turtlesim_mimic_launch.py
       :language: python
-      :lines: 19-27
+      :lines: 21-29
 
 
 3 ros2 launch

--- a/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
+++ b/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
@@ -92,8 +92,8 @@ Both turtles in this system receive commands over the same topic and publish the
 With unique namespaces, messages meant for different turtles can be distinguished.
 
 The two turtlesim nodes also demonstrate different ways to pass ROS arguments.
-The first node uses ``args`` with ``--ros-args --log-level info`` which sets the log level to ``info``.
-The second node uses ``ros_args`` (``ros_arguments`` in Python) with ``--log-level warn`` (more concise syntax) which sets the log level to ``warn``. 
+The first node uses ``args`` with ``--ros-args --log-level info``.
+The second node uses ``ros_args`` (``ros_arguments`` in Python) with ``--log-level warn``, which is designed specifically for ROS arguments.
 
 The final node is also from the ``turtlesim`` package, but a different executable: ``mimic``.
 This node has added configuration details in the form of remappings.

--- a/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
+++ b/source/Tutorials/Intermediate/Launch/Creating-Launch-Files.rst
@@ -91,9 +91,10 @@ Unique namespaces allow the system to start two nodes without node name or topic
 Both turtles in this system receive commands over the same topic and publish their pose over the same topic.
 With unique namespaces, messages meant for different turtles can be distinguished.
 
-The two turtlesim nodes also demonstrate different ways to pass ROS arguments.
-The first node uses ``args`` with ``--ros-args --log-level info``.
-The second node uses ``ros_args`` (``ros_arguments`` in Python) with ``--log-level warn``, which is designed specifically for ROS arguments.
+The two turtlesim nodes also demonstrate different ways to pass arguments to nodes.
+The first node uses ``args`` to pass arguments directly to the executable, requiring the ``--ros-args`` flag for ROS-specific arguments.
+The second node uses ``ros_args`` (``ros_arguments`` in Python), designed specifically for ROS arguments.
+Use ``args`` when mixing ROS and non-ROS arguments (e.g., ``my_custom_arg --ros-args --log-level info``), or ``ros_args`` for cleaner syntax with only ROS arguments like remappings, parameters, or log levels.
 
 The final node is also from the ``turtlesim`` package, but a different executable: ``mimic``.
 This node has added configuration details in the form of remappings.

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_mimic_launch.py
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_mimic_launch.py
@@ -8,13 +8,15 @@ def generate_launch_description():
             package='turtlesim',
             namespace='turtlesim1',
             executable='turtlesim_node',
-            name='sim'
+            name='sim',
+            arguments=['--ros-args', '--log-level', 'info']
         ),
         Node(
             package='turtlesim',
             namespace='turtlesim2',
             executable='turtlesim_node',
-            name='sim'
+            name='sim',
+            ros_arguments=['--log-level', 'warn']
         ),
         Node(
             package='turtlesim',

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_mimic_launch.xml
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_mimic_launch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1" />
-  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2" />
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1" args="--ros-args --log-level info" />
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2" ros_args="--log-level warn" />
   <node pkg="turtlesim" exec="mimic" name="mimic">
     <remap from="/input/pose" to="/turtlesim1/turtle1/pose" />
     <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel" />

--- a/source/Tutorials/Intermediate/Launch/launch/turtlesim_mimic_launch.yaml
+++ b/source/Tutorials/Intermediate/Launch/launch/turtlesim_mimic_launch.yaml
@@ -6,12 +6,14 @@ launch:
       exec: "turtlesim_node"
       name: "sim"
       namespace: "turtlesim1"
+      args: "--ros-args --log-level info"
 
   - node:
       pkg: "turtlesim"
       exec: "turtlesim_node"
       name: "sim"
       namespace: "turtlesim2"
+      ros_args: "--log-level warn"
 
   - node:
       pkg: "turtlesim"


### PR DESCRIPTION
## Description

Demonstrates two ways to pass ROS arguments to nodes in the "Creating a launch file" tutorial:

- `turtlesim1` uses `args` parameter with `--ros-args --log-level info`
- `turtlesim2` uses `ros_args` parameter with `--log-level warn` (no `--ros-args` prefix needed)

Updated all three launch file formats (XML, YAML, Python) and the tutorial text to explain both approaches.

Fixes #4188

### Did you use Generative AI?

Yes, Claude Sonnet 4.5 (Anthropic) was used to assist with:
- Writing the commit and PR messages
- Refining the documentation text

### Additional Information

Uses log level examples to show the practical difference between `args` and `ros_args` parameters.