### PR TITLE
add namespace argument to node_container in composition_launch.xml

### DIFF
--- a/source/How-To-Guides/launch/composition_launch.xml
+++ b/source/How-To-Guides/launch/composition_launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <node_container pkg="rclcpp_components" exec="component_container" name="image_container">
+  <node_container pkg="rclcpp_components" exec="component_container" name="image_container" namespace="">
     <composable_node pkg="image_tools" plugin="image_tools::Cam2Image" name="cam2image">
       <remap from="/image" to="/burgerimage" />
       <param name="width" value="320" />


### PR DESCRIPTION
## Description

This adds a `namespace` argument to `node_container` in the [Using ROS 2 launch to launch composable nodes](https://docs.ros.org/en/jazzy/How-To-Guides/Launching-composable-nodes.html#using-ros-2-launch-to-launch-composable-nodes) how-to guide.

In the current form, executing the example launchfile results in
```
[INFO] [launch]: All log files can be found below /home/ott/.ros/log/2025-11-18-14-24-35-136782-ade-863871
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [xml]:
 - TypeError: ComposableNodeContainer.__init__() missing 1 required keyword-only argument: 'namespace'
 - SyntaxError: invalid syntax (test.launch.xml, line 1)
 ```

This seems to have been mandatory since 2020: https://github.com/ros2/launch_ros/pull/189

### Did you use Generative AI?
No.

### Additional Information
Tested on jazzy, probably applicable to everything >Foxy
