### PR TITLE
add ros2 service info -v to "Understanding services" (#6038)

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -153,6 +153,85 @@ For example, you can find the count of clients and servers for the ``/clear`` se
    Clients count: 0
    Services count: 1
 
+4.1 ros2 service info --verbose
+
+
+For more detailed information about a service, you can append the ``--verbose`` option to the ``info`` command:
+
+.. code-block:: console
+
+  $ ros2 service info --verbose <service_name>
+
+for example: you can get verbose information about the ``/clear`` service:
+
+.. code-block:: console
+
+  $ ros2 service info --verbose /clear
+
+This will return additional information including the node name and namespace of the service server, as well as the underlying middleware (RMW) implementation details.
+An important information for Developers that the ``Endpoint count`` will be 2 for DDS based RMW implementations (connextdds, cyclone, fastrtps) because DDS creates two endpoints (one for request and one for response) for each service server.
+
+.. code-block:: console
+
+    Type: std_srvs/srv/Empty
+    Clients count: 0
+    Services count: 1
+    Node name: turtlesim
+    Node namespace: /
+    Service type: std_srvs/srv/Empty
+    Service type hash: RIHS01_5888399dedec5ccc85ea6451949fd2c9f97bfdf963f9a588821639fcd31b5d19
+    Endpoint type: SERVER
+    Endpoint count: 2
+    GIDs:
+    - Request Reader : 01.0f.93.f0.07.92.53.47.00.00.00.00.00.00.13.04
+    - Response Writer : 01.0f.93.f0.07.92.53.47.00.00.00.00.00.00.14.03
+    QoS profiles:
+    - Request Reader :
+          Reliability: RELIABLE
+          History (Depth): KEEP_LAST (10)
+          Durability: VOLATILE
+          Lifespan: Infinite
+          Deadline: Infinite
+          Liveliness: AUTOMATIC
+          Liveliness lease duration: Infinite
+    - Response Writer :
+          Reliability: RELIABLE
+          History (Depth): KEEP_LAST (10)
+          Durability: VOLATILE
+          Lifespan: Infinite
+          Deadline: Infinite
+          Liveliness: AUTOMATIC
+          Liveliness lease duration: Infinite
+
+
+
+Where as for non-DDS based RMW implementations like zenoh, the Endpoint count will be 1 because they use a single endpoint for both request and response.
+
+.. code-block:: console
+
+    Type: std_srvs/srv/Empty
+    Clients count: 0
+    Services count: 1
+    Node name: turtlesim
+    Node namespace: /
+    Service type: std_srvs/srv/Empty
+    Service type hash: RIHS01_5888399dedec5ccc85ea6451949fd2c9f97bfdf963f9a588821639fcd31b5d19
+    Endpoint type: SERVER
+    Endpoint count: 1
+    GID: 59.b0.ea.78.57.3c.52.b4.c6.e9.af.44.22.3d.7c.f5
+    QoS profile:
+      Reliability: RELIABLE
+      History (Depth): KEEP_LAST (10)
+      Durability: VOLATILE
+      Lifespan: Infinite
+      Deadline: Infinite
+      Liveliness: AUTOMATIC
+      Liveliness lease duration: Infinite
+
+
+If you want to learn more about different RMW implementations, refer to the :doc:`About Different Middleware Vendors <../../../Concepts/Intermediate/About-Different-Middleware-Vendors>` concept.
+
+
 5 ros2 service find
 ^^^^^^^^^^^^^^^^^^^
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -155,7 +155,7 @@ For example, you can find the count of clients and servers for the ``/clear`` se
 
 4.1 ros2 service info --verbose  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
-For more detailed information about a service, you can append the ``--verbose`` (or ``-v``) option to the ``info`` command:  
+For more detailed information about a service, you can append the ``--verbose`` (or ``-v``) option to the ``info`` command:
 
 .. code-block:: console
 

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -153,8 +153,8 @@ For example, you can find the count of clients and servers for the ``/clear`` se
    Clients count: 0
    Services count: 1
 
-4.1 ros2 service info --verbose  
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+4.1 ros2 service info --verbose
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For more detailed information about a service, you can append the ``--verbose`` (or ``-v``) option to the ``info`` command:
 
 .. code-block:: console

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -153,16 +153,15 @@ For example, you can find the count of clients and servers for the ``/clear`` se
    Clients count: 0
    Services count: 1
 
-4.1 ros2 service info --verbose
-
-
-For more detailed information about a service, you can append the ``--verbose`` option to the ``info`` command:
+4.1 ros2 service info --verbose  
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+For more detailed information about a service, you can append the ``--verbose`` (or ``-v``) option to the ``info`` command:  
 
 .. code-block:: console
 
   $ ros2 service info --verbose <service_name>
 
-for example: you can get verbose information about the ``/clear`` service:
+For example: you can get verbose information about the ``/clear`` service:
 
 .. code-block:: console
 
@@ -203,9 +202,7 @@ An important information for Developers that the ``Endpoint count`` will be 2 fo
           Liveliness: AUTOMATIC
           Liveliness lease duration: Infinite
 
-
-
-Where as for non-DDS based RMW implementations like zenoh, the Endpoint count will be 1 because they use a single endpoint for both request and response.
+Where as for non-DDS based RMW implementations like ``rmw_zenoh_cpp``, the ``Endpoint count`` will be 1 because it uses a single endpoint for both request and response.  
 
 .. code-block:: console
 
@@ -228,9 +225,7 @@ Where as for non-DDS based RMW implementations like zenoh, the Endpoint count wi
       Liveliness: AUTOMATIC
       Liveliness lease duration: Infinite
 
-
 If you want to learn more about different RMW implementations, refer to the :doc:`About Different Middleware Vendors <../../../Concepts/Intermediate/About-Different-Middleware-Vendors>` concept.
-
 
 5 ros2 service find
 ^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.rst
@@ -202,7 +202,7 @@ An important information for Developers that the ``Endpoint count`` will be 2 fo
           Liveliness: AUTOMATIC
           Liveliness lease duration: Infinite
 
-Where as for non-DDS based RMW implementations like ``rmw_zenoh_cpp``, the ``Endpoint count`` will be 1 because it uses a single endpoint for both request and response.  
+Where as for non-DDS based RMW implementations like ``rmw_zenoh_cpp``, the ``Endpoint count`` will be 1 because it uses a single endpoint for both request and response.
 
 .. code-block:: console
 


### PR DESCRIPTION
## Description

- The PR adds the newly added --verbose functionality in rolling, for ROS services tutorials. (ros2 service info -v )
- The feature is currently only available if code is built from source of the rolling branch.
- Details of this new feature are mentioned in the thread (https://github.com/ros2/ros2cli/pull/916) in the ROS2 rolling documentation. 

Here is the link that shows details about the issue:
https://github.com/ros2/ros2_documentation/issues/6038

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*

Here is link to the issue : https://github.com/ros2/ros2_documentation/issues/6038

-->

Fixes #6038 

### Did you use Generative AI?
Partially, In some regions in the text. But not in code blocks, i tested the feature myself by building it from source.


<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
