### PR TITLE
use FASTDDS_DEFAULT_PROFILES_FILE.

### DIFF
--- a/source/How-To-Guides/Ament-CMake-Documentation.rst
+++ b/source/How-To-Guides/Ament-CMake-Documentation.rst
@@ -634,7 +634,7 @@ Inside your created ``hooks`` folder, create a ``my_package.sh.in`` as follows:
 
     export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
     export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-    export FASTRTPS_DEFAULT_PROFILES_FILE="$COLCON_CURRENT_PREFIX/my_dds_profile.xml"
+    export FASTDDS_DEFAULT_PROFILES_FILE="$COLCON_CURRENT_PREFIX/my_dds_profile.xml"
 
 In the same folder, create a ``my_package.dsv.in`` file as follows:
 
@@ -642,7 +642,7 @@ In the same folder, create a ``my_package.dsv.in`` file as follows:
 
     set;RMW_IMPLEMENTATION;rmw_fastrtps_cpp
     set;RMW_FASTRTPS_USE_QOS_FROM_XML;1
-    set;FASTRTPS_DEFAULT_PROFILES_FILE;my_dds_profile.xml
+    set;FASTDDS_DEFAULT_PROFILES_FILE;my_dds_profile.xml
 
 Once added, you can register them using the ament_environment_hooks function in your ``CMakeLists.txt`` file:
 

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -272,7 +272,7 @@ You will need to export the following environment variables for the XML to be lo
 
       $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ export FASTRTPS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
+      $ export FASTDDS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
 
   .. group-tab:: macOS
 
@@ -280,7 +280,7 @@ You will need to export the following environment variables for the XML to be lo
 
       $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ export FASTRTPS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
+      $ export FASTDDS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
 
   .. group-tab:: Windows
 
@@ -288,7 +288,7 @@ You will need to export the following environment variables for the XML to be lo
 
       $ SET RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ SET RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ SET FASTRTPS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
+      $ SET FASTDDS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
 
 Finally, ensure you have sourced your setup files and run the node:
 
@@ -385,7 +385,7 @@ With the publisher node running in one terminal, open another one and export the
 
       $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ export FASTRTPS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
+      $ export FASTDDS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
 
   .. group-tab:: macOS
 
@@ -393,7 +393,7 @@ With the publisher node running in one terminal, open another one and export the
 
       $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ export FASTRTPS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
+      $ export FASTDDS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
 
   .. group-tab:: Windows
 
@@ -401,7 +401,7 @@ With the publisher node running in one terminal, open another one and export the
 
       $ SET RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ SET RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ SET FASTRTPS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
+      $ SET FASTDDS_DEFAULT_PROFILES_FILE=path/to/SyncAsync.xml
 
 Finally, ensure you have sourced your setup files and run the node:
 
@@ -432,7 +432,7 @@ In order to define a configuration for a specific topic, just name the profile a
 and ``rmw_fastrtps`` will apply this profile to all publishers and subscribers for that topic.
 The default configuration profile is identified by the attribute ``is_default_profile`` set to ``true``, and acts as a fallback profile when there is no other one with a name matching the topic name.
 
-The environment variable ``FASTRTPS_DEFAULT_PROFILES_FILE`` is used to inform *Fast DDS* the path to the XML file with the configuration profiles to load.
+The environment variable ``FASTDDS_DEFAULT_PROFILES_FILE`` is used to inform *Fast DDS* the path to the XML file with the configuration profiles to load.
 
 RMW_FASTRTPS_USE_QOS_FROM_XML
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -756,7 +756,7 @@ Then set the required environment variables for the XML to be loaded:
 
       $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ export FASTRTPS_DEFAULT_PROFILES_FILE=path/to/ping.xml
+      $ export FASTDDS_DEFAULT_PROFILES_FILE=path/to/ping.xml
 
   .. group-tab:: macOS
 
@@ -764,7 +764,7 @@ Then set the required environment variables for the XML to be loaded:
 
       $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ export RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ export FASTRTPS_DEFAULT_PROFILES_FILE=path/to/ping.xml
+      $ export FASTDDS_DEFAULT_PROFILES_FILE=path/to/ping.xml
 
   .. group-tab:: Windows
 
@@ -772,7 +772,7 @@ Then set the required environment variables for the XML to be loaded:
 
       $ SET RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       $ SET RMW_FASTRTPS_USE_QOS_FROM_XML=1
-      $ SET FASTRTPS_DEFAULT_PROFILES_FILE=path/to/ping.xml
+      $ SET FASTDDS_DEFAULT_PROFILES_FILE=path/to/ping.xml
 
 
 On the first terminal run the service node.


### PR DESCRIPTION
## Description

related to https://github.com/ros2/rmw_fastrtps/issues/862

FASTRTPS_DEFAULT_PROFILES_FILE has been deprecated, instead we should use FASTDDS_DEFAULT_PROFILES_FILE

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
