### PR TITLE
use FASTRTPS_DEFAULT_PROFILES_FILE.

### DIFF
--- a/source/Tutorials/Advanced/Creating-An-RMW-Implementation.rst
+++ b/source/Tutorials/Advanced/Creating-An-RMW-Implementation.rst
@@ -461,7 +461,7 @@ This is an advanced, non-portable feature that is not currently used by any (tie
 
 For a bit more flexibility, some implementations use environment variables: ``RMW_FASTRTPS_*``, ``RMW_CONNEXT_*``, etc.
 The underlying middleware may also be configurable through environment variables: ``FASTDDS_*``, ``ZENOH_*``, ``CYCLONEDDS_*``, ``EMAIL_*``, etc.
-For example, the ``CYCLONEDDS_URI``, ``FASTDDS_DEFAULT_PROFILES_FILE``, and ``ZENOH_SESSION_CONFIG_URI`` environment variables can be used to provide a path to a full configuration file if the relevant middleware is used.
+For example, the ``CYCLONEDDS_URI``, ``FASTRTPS_DEFAULT_PROFILES_FILE``, and ``ZENOH_SESSION_CONFIG_URI`` environment variables can be used to provide a path to a full configuration file if the relevant middleware is used.
 
 Footnotes
 ---------


### PR DESCRIPTION
## Description

related to https://github.com/ros2/rmw_fastrtps/issues/862

this `FASTDDS_DEFAULT_PROFILES_FILE` is not supported in jazzy or humble, it should then use FASTRTPS_DEFAULT_PROFILES_FILE.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
