### PR TITLE
docs: add note for wsl users about filesystem location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ To test building the multisite version deployed to the website use:
 `sensible-browser build/html/rolling/index.html`
 
 **NB:** This will ignore local workspace changes and build from the branches.
+
+### Note for windows (wsl) Users
+
+When building the documentation on windows using wsl, it is recommened to clone and work with this repository inside the Linux filesystem (for example, under `/home/<user>/`) rather than under `/mnt/c`.
+
+Woking under `/mnt/c` can lead to slower builds and filesystem-related issues with Sphinx and ROS tooling.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ To test building the multisite version deployed to the website use:
 
 **NB:** This will ignore local workspace changes and build from the branches.
 
-### Note for windows (wsl) Users
+### Note for Windows (WSL) Users
 
-When building the documentation on windows using wsl, it is recommened to clone and work with this repository inside the Linux filesystem (for example, under `/home/<user>/`) rather than under `/mnt/c`.
+When building the documentation on windows using WSL, it is recommened to clone and work with this repository inside the Linux filesystem (for example, under `/home/<user>/`) rather than under `/mnt/c`.
 
-Woking under `/mnt/c` can lead to slower builds and filesystem-related issues with Sphinx and ROS tooling.
+Working under `/mnt/c` can lead to slower builds and filesystem-related issues with Sphinx and ROS tooling.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ To test building the multisite version deployed to the website use:
 
 ### Note for Windows (WSL) Users
 
-When building the documentation on windows using WSL, it is recommened to clone and work with this repository inside the Linux filesystem (for example, under `/home/<user>/`) rather than under `/mnt/c`.
+When building the documentation on windows using WSL, it is recommended to clone and work with this repository inside the Linux filesystem (for example, under `/home/<user>/`) rather than under `/mnt/c`.
 
 Working under `/mnt/c` can lead to slower builds and filesystem-related issues with Sphinx and ROS tooling.


### PR DESCRIPTION
This PR adds a short note for Windows users building the  documentation with WSL, recommending working inside the Linux filesystem  instead  of /mnt/c to avoid common build issues.
