### PR TITLE
Fix incorrect ros2 plugin CLI reference in pluginlib tutorial

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Pluginlib.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Pluginlib.rst
@@ -330,15 +330,7 @@ From ``ros2_ws``, be sure to source the setup files:
 
       $ call install/setup.bat
 
-You can verify that your plugins were successfully registered by listing them:
-
-.. code-block:: console
-
-     $ ros2 plugin list
-     polygon_plugins:
-        Plugin(name='polygon_plugins::Square', type='polygon_plugins::Square', base='polygon_base::RegularPolygon')
-        Plugin(name='polygon_plugins::Triangle', type='polygon_plugins::Triangle', base='polygon_base::RegularPolygon')
-
+In ROS 2, there is no CLI command to list plugins. Plugins are discovered at runtime using the plugin description XML file registered in the ament index. To verify available plugins, inspect the plugin XML file and ensure it is correctly exported in ``CMakeLists.txt``.
 Now run the node:
 
 .. code-block:: console


### PR DESCRIPTION
This PR removes an incorrect reference to ros2 plugin list in the Pluginlib beginner tutorial.
ROS 2 does not provide a CLI command to list plugins; plugins are discovered via plugin XML descriptors registered with the ament index.
This change prevents confusion for new ROS 2 users following the Jazzy documentation.