### PR TITLE
Added link to Phantom Bridge docs / Kilted

### DIFF
--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -36,4 +36,5 @@ Company-driven Projects
 
    Related-Projects/Intel-ROS2-Projects
    Related-Projects/Nvidia-ROS2-Projects
+   Related-Projects/Visualizing-Data-And-Teleoperating-With-Phantom-Bridge
    Related-Projects/Visualizing-ROS-2-Data-With-Foxglove

--- a/source/Related-Projects/Visualizing-Data-And-Teleoperating-With-Phantom-Bridge.rst
+++ b/source/Related-Projects/Visualizing-Data-And-Teleoperating-With-Phantom-Bridge.rst
@@ -1,0 +1,10 @@
+Visualizing Data and Teleoperating with Phantom Bridge
+======================================================
+
+Redirecting to `https://docs.phntm.io/bridge <https://docs.phntm.io/bridge>`_...
+
+.. raw:: html
+
+   <script type="text/javascript">
+        window.location.href = 'https://docs.phntm.io/bridge'
+   </script>


### PR DESCRIPTION
## Description

Adding a link to https://docs.phntm.io/bridge to Related Projects

[Announcement](https://discourse.openrobotics.org/t/announcement-phantom-bridge-a-new-take-on-ros-real-time-data-visualization-teleoperation-observability-remote-and-local-debugging/51471)