### PR TITLE
Fix variable name inconsistency in custom interface tutorial

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.rst
@@ -429,7 +429,7 @@ We won't create a subscriber in this tutorial, but you can try to write one your
          contact.first_name = "John";
          contact.last_name = "Doe";
          contact.phone_number = "1234567890";
-         contact.phone_type = message.PHONE_TYPE_MOBILE;
+         contact.phone_type = contact.PHONE_TYPE_MOBILE;
          msg->address_book.push_back(contact);
        }
        {
@@ -437,7 +437,7 @@ We won't create a subscriber in this tutorial, but you can try to write one your
          contact.first_name = "Jane";
          contact.last_name = "Doe";
          contact.phone_number = "4254242424";
-         contact.phone_type = message.PHONE_TYPE_HOME;
+         contact.phone_type = contact.PHONE_TYPE_HOME;
          msg->address_book.push_back(contact);
        }
 


### PR DESCRIPTION
## Description

This PR fixes a variable naming inconsistency in the "Implementing custom interfaces" tutorial.

In the original version, a new type `Contact` is created via the `Contact.msg` file, and `Contact.msg` is identical to `AddressBook.msg`. However, in the updated callback example, the message variable is named `contact`, while the code still uses `message.PHONE_TYPE_MOBILE`, which is inconsistent and incorrect.

This PR updates the callback code to consistently use the `contact` variable when assigning `phone_type`.

Fixes # (issue)

### Did you use Generative AI?

I did not.


