### PR TITLE
Update support channel link from Discord to Zulip

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -106,7 +106,7 @@ ROS community resources
 
 If you need help, have an idea, or would like to contribute to the project, please visit our ROS community resources.
 
-* `Official ROS Discord Channel for discussion and support <https://discord.com/servers/open-robotics-1077825543698927656>`__ (ROS 1, ROS 2)
+* `Official ROS Zulip Channel for discussion and support <https://openrobotics.zulipchat.com/>`__ (ROS 1, ROS 2)
 
 * `Robotics Stack Exchange - community Q&A website <https://robotics.stackexchange.com/>`__ (ROS 1, ROS 2)
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Changes the link of the chat channel from Discord to [Zulip](https://openrobotics.zulipchat.com/).

This needs to be backported to:
* Humble
* Jazzy
* Kilted
* Perhaps also the EOLs?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
