### PR TITLE
Mention client library support for runtime parameter manipulation

### DIFF
--- a/source/Concepts/Basic/About-Parameters.rst
+++ b/source/Concepts/Basic/About-Parameters.rst
@@ -117,6 +117,13 @@ The ``ros2 param`` command is the general way to interact with parameters for no
 ``ros2 param`` uses the parameter service API as described above to perform the various operations.
 See :doc:`this how-to guide <../../How-To-Guides/Using-ros2-param>` for details on how to use ``ros2 param``.
 
+In addition to the command-line interface, parameters can also be manipulated programmatically at runtime using the ROS 2 client libraries.
+All client libraries provide APIs to get, set, and react to parameter changes while a node is running.
+
+Client library support includes:
+ * **C++ (rclcpp)**: see :doc:`../../Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP` and :doc:`../../Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP`.
+ * **Python (rclpy)**: see :doc:`../../Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python`.
+
 Migrating from ROS 1
 --------------------
 

--- a/source/Concepts/Basic/About-Parameters.rst
+++ b/source/Concepts/Basic/About-Parameters.rst
@@ -122,7 +122,7 @@ All client libraries provide APIs to get, set, and react to parameter changes wh
 
 Client library support includes:
  * **C++ (rclcpp)**: see :doc:`../../Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-CPP` and :doc:`../../Tutorials/Intermediate/Monitoring-For-Parameter-Changes-CPP`.
- * **Python (rclpy)**: see :doc:`../../Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python`.
+ * **Python (rclpy)**: see :doc:`../../Tutorials/Beginner-Client-Libraries/Using-Parameters-In-A-Class-Python` and :doc:`../../Tutorials/Intermediate/Monitoring-For-Parameter-Changes-Python`.
 
 Migrating from ROS 1
 --------------------


### PR DESCRIPTION
# Docs fix

Fixes #5761

## Summary
This PR extends the "Manipulating parameter values at runtime" section of the
_**About Parameters**_ documentation to explicitly mention that parameters can also
be manipulated programmatically at runtime using the ROS 2 client libraries.

It adds pointers to the relevant C++ (rclcpp) and Python (rclpy) tutorials,
improving discoverability and aligning the section with the documented
capabilities of the parameter system.

## Checklist
- [x] Updated documentation (as needed)
