### PR TITLE
make uninstall command work in zsh

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -135,7 +135,7 @@ have already installed from binaries, run the following command:
 
 .. code-block:: console
 
-   $ sudo apt remove ~nros-{DISTRO}-* && sudo apt autoremove
+   $ sudo apt remove '~nros-{DISTRO}-*' && sudo apt autoremove
 
 You may also want to remove the repository:
 


### PR DESCRIPTION
## Description

The command:

```bash
sudo apt remove ~nros-jazzy-* && sudo apt autoremove
```

works in bash, but fails in zsh with the following error:

```bash
zsh: no matches found: ~nros-jazzy-*
```

Quoting the pattern prevents the shell from performing glob expansion and passes the pattern to `apt`  as-is

```bash
sudo apt remove '~nros-jazzy-*' && sudo apt autoremove
```

### Did you use Generative AI?

No

### Additional Information

A similar issue was discussed [here](https://askubuntu.com/a/335212).
