### PR TITLE
Force canonical URLs to include ROS distro

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -305,7 +305,9 @@ def smv_rewrite_configs(app, config):
     # conf.py).  Instead, hook into the 'config-inited' event which is late enough
     # to rewrite the various configuration items with the current version.
     if app.config.smv_current_version != '':
-        app.config.html_baseurl = app.config.html_baseurl + '/' + app.config.smv_current_version
+        app.config.html_baseurl = (
+            f"https://docs.ros.org/en/{app.config.smv_current_version}"
+        )
         app.config.project = 'ROS 2 Documentation: ' + app.config.smv_current_version.title()
 
         app.config.html_logo = 'source/Releases/' + app.config.smv_current_version + '-small.png'


### PR DESCRIPTION
## Description

This PR fixes canonical URL generation for sphinx-multiversion builds by
explicitly setting `html_baseurl` to include the ROS distribution
(e.g. `https://docs.ros.org/en/rolling`).

This prevents mirrors or alternate build environments from generating
incorrect canonical URLs that omit the ROS distribution or use
non-official domains.

Fixes #6112.

### Did you use Generative AI?

Yes — ChatGPT (for guidance and explanation only).

### Additional Information

- Implemented as a clean commit on top of `rolling`
- No unrelated documentation history included
