### PR TITLE
Update notes in Ubuntu installation instructions

### DIFF
--- a/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
+++ b/source/Installation/Alternatives/Ubuntu-Install-Binary.rst
@@ -62,6 +62,7 @@ Install ROS 2
 * Download the latest package for Ubuntu; let's assume that it ends up at ``~/Downloads/ros2-package-linux-x86_64.tar.bz2``.
 
   * Note: there may be more than one binary download option which might cause the file name to differ.
+  * Note: the binaries for the linux-noble-amd64 and linux-noble-arm64 assets are switched
 
 *
   Unpack it:


### PR DESCRIPTION
Clarify note about binary download options and asset names. 

Please change the assets in https://github.com/ros2/ros2/releases instead

## Description

Added a note detailing that the amd64 and arm64 binary assets for the linux noble ros2 jazzy are switched

Fixes ([issue #1779 in the ros2/ros2 repo](https://github.com/ros2/ros2/releases))

### Did you use Generative AI?

No

### Additional Information

Please change the assets in https://github.com/ros2/ros2/releases instead