### PR TITLE
Increase the depth of some ToCs to 2 for easier navigation

### DIFF
--- a/source/How-To-Guides/Configure-ZeroCopy-loaned-messages.rst
+++ b/source/How-To-Guides/Configure-ZeroCopy-loaned-messages.rst
@@ -6,7 +6,7 @@ Configure Zero Copy Loaned Messages
 ===================================
 
 .. contents:: Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 Overview

--- a/source/How-To-Guides/Installation-Troubleshooting.rst
+++ b/source/How-To-Guides/Installation-Troubleshooting.rst
@@ -9,7 +9,7 @@ Installation troubleshooting
 Troubleshooting techniques for installation are sorted by the platforms they apply to.
 
 .. contents:: Platforms
-   :depth: 1
+   :depth: 2
    :local:
 
 General

--- a/source/How-To-Guides/Launch-file-different-formats.rst
+++ b/source/How-To-Guides/Launch-file-different-formats.rst
@@ -6,7 +6,7 @@ Using XML, YAML, and Python for ROS 2 Launch Files
 ==================================================
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 ROS 2 launch files can be written in XML, YAML, and Python.

--- a/source/How-To-Guides/Node-arguments.rst
+++ b/source/How-To-Guides/Node-arguments.rst
@@ -8,7 +8,7 @@ Passing ROS arguments to nodes via the command-line
 ===================================================
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 

--- a/source/Tutorials/Demos/Action-Introspection.rst
+++ b/source/Tutorials/Demos/Action-Introspection.rst
@@ -8,7 +8,7 @@ Configure action introspection
 **Time:** 15 minutes
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 Overview

--- a/source/Tutorials/Demos/Intra-Process-Communication.rst
+++ b/source/Tutorials/Demos/Intra-Process-Communication.rst
@@ -7,7 +7,7 @@ Setting up efficient intra-process communication
 ================================================
 
 .. contents:: Table of Contents
-   :depth: 1
+   :depth: 2
    :local:
 
 Background


### PR DESCRIPTION
## Description

This is a minor user experience improvement.

I was reading the [intra-process tutorial](https://docs.ros.org/en/rolling/Tutorials/Demos/Intra-Process-Communication.html) and saw that the table of contents isn't very useful:

<img width="681" height="186" alt="image" src="https://github.com/user-attachments/assets/50304940-6b0d-4033-9028-6b1da46391a6" />

In most cases, increasing the depth from 1 to 2 doesn't really "cost" anything and is pretty helpful IMO. Therefore, I looked for pages that aren't too short, have more than 1 level of sections, and use a ToC with a depth of 1, and increased their depth to 2.

<img width="681" height="247" alt="image" src="https://github.com/user-attachments/assets/fb9bc267-0d08-40ff-83b1-505986796223" />

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

There's no reason not to try backporting this.