### PR TITLE
Fix ros_gz_bridge parameter_bridge command syntax

### DIFF
--- a/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
+++ b/source/Tutorials/Advanced/Simulators/Gazebo/Gazebo.rst
@@ -197,7 +197,7 @@ This topic will be available under the topic ``/lidar_scan``:
       .. code-block:: console
 
         $ source /opt/ros/{DISTRO}/setup.bash
-        $ ros2 run ros_gz_bridge parameter_bridge /lidar2@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan --ros-args -r /lidar2:=/laser_scan
+        $ ros2 run ros_gz_bridge parameter_bridge /lidar2@sensor_msgs/msg/LaserScan@ignition.msgs.LaserScan --ros-args -r /lidar2:=/laser_scan
 
 To visualize the data from the lidar in ROS 2 you can use Rviz2:
 


### PR DESCRIPTION
## Summary

Fixes the `ros_gz_bridge parameter_bridge` command in the Gazebo tutorial.

The command was using `[` instead of `@` as the separator between ROS and Gazebo message types:

```diff
- ros2 run ros_gz_bridge parameter_bridge /lidar2@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan
+ ros2 run ros_gz_bridge parameter_bridge /lidar2@sensor_msgs/msg/LaserScan@ignition.msgs.LaserScan
```

The incorrect syntax causes a "bad pattern" error.

Fixes #3761