### PR TITLE
Fix html_static_path warning by using absolute path

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -172,7 +172,7 @@ html_favicon = 'favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['source/_static']
+html_static_path = [os.path.abspath('source/_static')]
 
 # Drop any source link suffix
 html_sourcelink_suffix = ''


### PR DESCRIPTION
## Summary

Fixes the Sphinx warning that appears during `make lint` and `make html`:

```
WARNING: html_static_path entry 'source/_static' is placed inside outdir
```

## Changes

Use `os.path.abspath()` to convert the relative path to an absolute path:

```diff
- html_static_path = ['source/_static']
+ html_static_path = [os.path.abspath('source/_static')]
```

## Testing

- [x] `make html` builds without warnings
- [x] Static files (custom.css) still work correctly

Fixes #6071