### PR TITLE
Replace all moveit.ros.org to moveit.ai

### DIFF
--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -14,7 +14,7 @@ Large community projects involve multiple developers from all over the globe and
 
 * **ros2_control** `(control.ros.org) <https://control.ros.org/>`_: Flexible framework for real-time control of robots implemented with ROS 2.
 * **Navigation2** `(navigation.ros.org) <https://navigation.ros.org/>`_: Comprehensive and flexible navigation stack for mobile robots using ROS 2.
-* **MoveIt** `(moveit.ros.org) <https://moveit.ros.org/>`_: A rich platform for building manipulation applications featuring advanced kinematics, motion planning, control, collision checking, and much more.
+* **MoveIt** `(moveit.ai) <https://moveit.ai/>`_: A rich platform for building manipulation applications featuring advanced kinematics, motion planning, control, collision checking, and much more.
 * **micro-ROS** `(micro.ros.org) <https://micro.ros.org/>`_: A platform for putting ROS 2 onto microcontrollers, starting at less than 100 kB of RAM.
 
 Further Community Projects

--- a/source/The-ROS2-Project/Roadmap.rst
+++ b/source/The-ROS2-Project/Roadmap.rst
@@ -106,7 +106,7 @@ If you'd like to take on one of these tasks, please :doc:`get in touch with us <
 
 Additional project-specific roadmaps can be found in the links below:
 
-- MoveIt2: https://moveit.ros.org/documentation/contributing/roadmap/
+- MoveIt2: https://moveit.ai/documentation/contributing/roadmap/
 - Nav2: https://navigation.ros.org/roadmap/roadmap.html
 
 


### PR DESCRIPTION
The ROS.org team is turning of moveit.ros.org, which redirects to moveit.ai currently. We need to find all instances of moveit.ros.org and make PRs to replace them.

@gbiggs is pushing to turn off moveit.ros.rog per this post from a year ago

https://discourse.openrobotics.org/t/move-of-nav2-and-moveit-repositories-at-github/37450