### PR TITLE
Clarify ros2-gbp org requirement for Rolling release repos

### DIFF
--- a/source/How-To-Guides/Releasing/Release-Team-Repository.rst
+++ b/source/How-To-Guides/Releasing/Release-Team-Repository.rst
@@ -75,7 +75,8 @@ If you have previously released your packages for ROS 2, when raising the `Add N
 
 .. note::
 
+   **When releasing your packages into the Rolling distribution, you must use a release repository hosted in the ros2-gbp organization**.
    Release repositories hosted elsewhere are still supported for stable distributions if you are not planning to release the repository into Rolling.
    Since stable distributions created from Rolling will start with release repositories in the ros2-gbp organization it is recommend that you use the ros2-gbp release repositories for all ROS 2 distributions to avoid fragmenting the release information.
 
-   A ros2-gbp release repository may become a hard requirement in the future and maintaining a single release repository for all ROS 2 distributions simplifies the maintenance of releases for both the Rolling distribution maintainers and package maintainers.
+   A ros2-gbp release repository may become a hard requirement for all distros in the future and maintaining a single release repository for all ROS 2 distributions simplifies the maintenance of releases for both the Rolling distribution maintainers and package maintainers.


### PR DESCRIPTION
## Description

We've been requiring release repos hosted under the ros2-gbp Github org for Rolling. However, the language here wasn't very clear. Make it clearer.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
