### PR TITLE
Fix dead link to launch architecture documentation

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -458,7 +458,7 @@ Now you can pass the desired arguments to the launch file as follows:
 Documentation
 -------------
 
-`The launch documentation <https://docs.ros.org/en/rolling/p/launch/doc/source/architecture.html>`_ provides detailed information about available substitutions.
+`The launch documentation <https://docs.ros.org/en/{DISTRO}/p/launch/doc/source/architecture.html>`_ provides detailed information about available substitutions.
 
 Summary
 -------

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -458,7 +458,7 @@ Now you can pass the desired arguments to the launch file as follows:
 Documentation
 -------------
 
-`The launch documentation <https://docs.ros.org/en/{DISTRO}/p/launch/architecture.html>`_ provides detailed information about available substitutions.
+`The launch documentation <https://docs.ros.org/en/rolling/p/launch/doc/source/architecture.html>`_ provides detailed information about available substitutions.
 
 Summary
 -------


### PR DESCRIPTION
This PR fixes a broken link in the "Using Substitutions" tutorial.

The previous link pointed to:
https://docs.ros.org/en/kilted/p/launch/architecture.html
which returned a 404.

Updated to:
https://docs.ros.org/en/rolling/p/launch/doc/source/architecture.html

Closes #6042.
