### PR TITLE
Update Raspberry Pi docs to ensure -backports and -updates suites are enabled

### DIFF
--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -18,7 +18,7 @@ Make sure to confirm that you have selected the correct version as described in 
 
 Ubuntu for Raspberry Pi doesn't include the *backports* and *updates* software suites by default, which are required for the ROS 2 binary install to work.
 
-So, please make check and edit the */etc/apt/sources.list.d/ubuntu.sources* file on your Raspberry Pi before installing ROS 2.
+So, please check and edit the ``/etc/apt/sources.list.d/ubuntu.sources`` file on your Raspberry Pi before installing ROS 2.
 
 For example, the Ubuntu 24.04 "Noble Numbat" release should have an entry that looks like this:
 

--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -16,6 +16,16 @@ Ubuntu for Raspberry Pi is available `here <https://ubuntu.com/download/raspberr
 
 Make sure to confirm that you have selected the correct version as described in `REP-2000 <https://reps.openrobotics.org/rep-2000/>`__.
 
+Ubuntu for Raspberry Pi doesn't include the *backports* and *updates* software suites by default. These are required for the ROS 2 binary install to work. So, please make check and edit the */etc/apt/sources.list.d/ubuntu.sources* file on your Raspberry Pi before istalling ROS 2. For example, the Ubuntu 24.04 "Noble Numbat" release should have an entry that looks like this:
+
+.. code-block:: console
+
+    Types: deb
+    URIs: http://ports.ubuntu.com/ubuntu-ports/
+    Suites: noble noble-updates noble-backports       # <-- IMPORTANT LINE
+    Components: main universe restricted multiverse
+    Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
 You can now install ROS 2 using the normal binary installation instructions for Ubuntu Linux.
 
 Raspberry Pi OS with ROS 2 in docker

--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -16,7 +16,7 @@ Ubuntu for Raspberry Pi is available `here <https://ubuntu.com/download/raspberr
 
 Make sure to confirm that you have selected the correct version as described in `REP-2000 <https://reps.openrobotics.org/rep-2000/>`__.
 
-Ubuntu for Raspberry Pi doesn't include the *backports* and *updates* software suites by default. These are required for the ROS 2 binary install to work. So, please make check and edit the */etc/apt/sources.list.d/ubuntu.sources* file on your Raspberry Pi before istalling ROS 2. For example, the Ubuntu 24.04 "Noble Numbat" release should have an entry that looks like this:
+Ubuntu for Raspberry Pi doesn't include the *backports* and *updates* software suites by default. These are required for the ROS 2 binary install to work. So, please make check and edit the */etc/apt/sources.list.d/ubuntu.sources* file on your Raspberry Pi before installing ROS 2. For example, the Ubuntu 24.04 "Noble Numbat" release should have an entry that looks like this:
 
 .. code-block:: console
 

--- a/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
+++ b/source/How-To-Guides/Installing-on-Raspberry-Pi.rst
@@ -16,7 +16,11 @@ Ubuntu for Raspberry Pi is available `here <https://ubuntu.com/download/raspberr
 
 Make sure to confirm that you have selected the correct version as described in `REP-2000 <https://reps.openrobotics.org/rep-2000/>`__.
 
-Ubuntu for Raspberry Pi doesn't include the *backports* and *updates* software suites by default. These are required for the ROS 2 binary install to work. So, please make check and edit the */etc/apt/sources.list.d/ubuntu.sources* file on your Raspberry Pi before installing ROS 2. For example, the Ubuntu 24.04 "Noble Numbat" release should have an entry that looks like this:
+Ubuntu for Raspberry Pi doesn't include the *backports* and *updates* software suites by default, which are required for the ROS 2 binary install to work.
+
+So, please make check and edit the */etc/apt/sources.list.d/ubuntu.sources* file on your Raspberry Pi before installing ROS 2.
+
+For example, the Ubuntu 24.04 "Noble Numbat" release should have an entry that looks like this:
 
 .. code-block:: console
 


### PR DESCRIPTION
## Description

By default the Ubuntu for Raspberry Pi doesn't include the `-updates` and `-backports` suites. Without these one encounters a problem with the `libzstd-dev` package. This PR updates the Rasperry Pi docs to encourage the user to verify that these software suites are enabled before attempting to install ROS 2.

Fixes: https://github.com/ros2/ros2/issues/1789

### Did you use Generative AI?

No

### Additional Information

Will backport to Jazzy after rolling merges.