### PR TITLE
replace "partial_sequence" into "sequence".

### DIFF
--- a/source/Tutorials/Intermediate/Creating-an-Action.rst
+++ b/source/Tutorials/Intermediate/Creating-an-Action.rst
@@ -134,9 +134,9 @@ Within the ``action`` directory, create a file called ``Fibonacci.action`` with 
   ---
   int32[] sequence
   ---
-  int32[] partial_sequence
+  int32[] sequence
 
-The goal request is the ``order`` of the Fibonacci sequence we want to compute, the result is the final ``sequence``, and the feedback is the ``partial_sequence`` computed so far.
+The goal request is the ``order`` of the Fibonacci sequence we want to compute, the result is the final ``sequence``, and the feedback is the ``sequence`` computed so far.
 
 3 Building an action
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
@@ -347,7 +347,7 @@ Here's the callback function for feedback messages:
     :language: python
     :lines: 41-43
 
-In the callback we get the feedback portion of the message and print the ``partial_sequence`` field to the screen.
+In the callback we get the feedback portion of the message and print the ``sequence`` field to the screen.
 
 We need to register the callback with the action client.
 This is achieved by additionally passing the callback to the action client when we send a goal:

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client.cpp
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client.cpp
@@ -63,7 +63,7 @@ public:
     {
       std::stringstream ss;
       ss << "Next number in sequence received: ";
-      for (auto number : feedback->partial_sequence) {
+      for (auto number : feedback->sequence) {
         ss << number << " ";
       }
       RCLCPP_INFO(this->get_logger(), ss.str().c_str());

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_2.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/client_2.py
@@ -40,7 +40,7 @@ class FibonacciActionClient(Node):
 
     def feedback_callback(self, feedback_msg):
         feedback = feedback_msg.feedback
-        self.get_logger().info('Received feedback: {0}'.format(feedback.partial_sequence))
+        self.get_logger().info('Received feedback: {0}'.format(feedback.sequence))
 
 
 def main(args=None):

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server.cpp
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server.cpp
@@ -65,7 +65,7 @@ private:
     rclcpp::Rate loop_rate(1);
     const auto goal = goal_handle->get_goal();
     auto feedback = std::make_shared<Fibonacci::Feedback>();
-    auto & sequence = feedback->partial_sequence;
+    auto & sequence = feedback->sequence;
     sequence.push_back(0);
     sequence.push_back(1);
     auto result = std::make_shared<Fibonacci::Result>();

--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_3.py
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/scripts/server_3.py
@@ -22,19 +22,19 @@ class FibonacciActionServer(Node):
         self.get_logger().info('Executing goal...')
 
         feedback_msg = Fibonacci.Feedback()
-        feedback_msg.partial_sequence = [0, 1]
+        feedback_msg.sequence = [0, 1]
 
         for i in range(1, goal_handle.request.order):
-            feedback_msg.partial_sequence.append(
-                feedback_msg.partial_sequence[i] + feedback_msg.partial_sequence[i-1])
-            self.get_logger().info('Feedback: {0}'.format(feedback_msg.partial_sequence))
+            feedback_msg.sequence.append(
+                feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
+            self.get_logger().info('Feedback: {0}'.format(feedback_msg.sequence))
             goal_handle.publish_feedback(feedback_msg)
             time.sleep(1)
 
         goal_handle.succeed()
 
         result = Fibonacci.Result()
-        result.sequence = feedback_msg.partial_sequence
+        result.sequence = feedback_msg.sequence
         return result
 
 


### PR DESCRIPTION
## Description

- action_tutorials_interfaces: has been removed with https://github.com/ros2/demos/pull/701, including all downstream packages.
- https://github.com/ros2/test_interface_files/blob/rolling/action/Fibonacci.action and https://github.com/ros2/example_interfaces/blob/rolling/action/Fibonacci.action are identical. this could be considered as duplication, but test_interface_files are used for test purpose and used in many places. besides that, test_interface_files would change the action file in the future for the speicic test cases. with that, i think that is okay to keep both packages. (in addition, removing public packages would break the user space without deprecation.)

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #4298 

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
