### PR TITLE
Add policy for target platforms reaching EOL before a ROS distro

### DIFF
--- a/source/The-ROS2-Project.rst
+++ b/source/The-ROS2-Project.rst
@@ -12,5 +12,6 @@ Check out the resources below to learn more about the advancement of the ROS 2 p
    The-ROS2-Project/Roadmap
    The-ROS2-Project/ROSCon-Content
    The-ROS2-Project/Governance
+   The-ROS2-Project/Platform-EOL-Policy
    The-ROS2-Project/Marketing
    The-ROS2-Project/Metrics

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -7,39 +7,40 @@ Platform EOL Policy
    :depth: 1
    :local:
 
-Every :doc:`ROS distribution <Releases>` has **target platforms**, also known as operating systems, such as Windows 11 or Ubuntu 24.04.
-This page explains what happens when a target platform reaches its own end-of-life (EOL) before the ROS distribution reaches EOL.
+:doc:`ROS distributions <Releases>` do not support end-of-life (EOL) platforms, even if the ROS distribution is still active.
+This page explains:
 
-What to expect
---------------
+* What users of EOL platforms should expect
+* What ROS Bosses should do
 
-When a target platform reaches EOL:
+Policy
+------
 
-* All ROS distributions stop supporting that platform.
-* Existing ROS packages will remain available and functional, but they will no longer be updated.
+Every ROS distribution supports certain **platforms**, such as Windows 11 or Ubuntu 24.04.
+**Vendors**, such as Microsoft or Canonical, decide how long they will support one of their platforms.
+When a vendor decides a platform has reached EOL, they usually stop publishing critical bug and security fixes.
+To protect ourselves from potentially unpatched security vulnerabilities, we proactively remove all jobs on EOL platforms from the ROS build farm.
 
-When a target platform reaches EOL, it stops receiving critical bug and security fixes.
-To protect ourselves from potentially unpatched security vulnerabilities, we proactively drop all EOL platform job runners from the ROS build farm.
-
-If you're using a target platform that has reached EOL, you should expect to stop receiving updated ROS packages.
-However, ROS Bosses may choose to perform an update on a target platform after it reaches EOL in exceptional circumstances if the infrastructure is still available.
+If you are using a platform that is no longer supported by its vendor, you should expect to stop receiving updated ROS packages.
+Existing ROS packages will remain available and functional, but they will no longer be updated.
+However, ROS Bosses may choose to update packages on an EOL platform in exceptional circumstances.
 
 For ROS Bosses
 --------------
 
 Before a target platform reaches EOL:
 
-* Make sure the ROS distribution documentation includes an EOL date for any target platform that reaches EOL before the ROS distribution.
-* Post an announcement about the target platform reaching EOL at least 2 syncs beforehand so that package maintainers have time to update their packages.
+* Make sure the ROS distribution documentation includes EOL dates for any platform that reaches EOL before the ROS distribution.
+* Post an announcement about the platform reaching EOL at least 2 syncs beforehand so that package maintainers have time to update their packages.
 * Open a `pull request disabling buildfarm jobs for that platform <https://github.com/ros2/ros_buildfarm_config>`_ and seek review from the `Infrastructure PMC <https://osralliance.org/wp-content/uploads/2024/03/infrastructure_project_charter.pdf>`_.
-* Make one last release to that target platform.
+* Make one last sync to that platform.
 
 After a target platform reaches EOL:
 
-* Update ROS distribution to state the target platform will not receive updated ROS packages.
-* Announce that the ROS distribution has dropped support for that target platform on Discourse.
-* Consider making one last release to that target platform if:
+* Update the ROS distribution docs to state the platform will not receive updated ROS packages.
+* Announce that the ROS distribution has dropped support for that platform on Discourse.
+* Consider making one last release to that platform if:
     * You did not already do so prior to EOL, and
     * The updates seem unlikely to have regressions, and
-    * The ROS Buildfarm still has runners for that target platform.
-* Merge your pull request to disable buildfarm jobs.
+    * The ROS Buildfarm still has runners for that platform.
+* Merge your pull request to disable the buildfarm jobs.

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -16,7 +16,7 @@ What to expect
 When a target platform reaches EOL:
 
 * All ROS distributions immediately drop support for that platform.
-* Existing ROS packages will remain functional, but they will not be updated.
+* Existing ROS packages will remain available and functional, but they will no longer be updated.
 
 When a target platform reaches EOL, it stops receiving critical bug and security fixes.
 ROS distributions drop support immediately so that the ROS buildfarm may remove those runners to protect itself from potential unpatched security vulnerabilities.

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -36,10 +36,10 @@ Before a target platform reaches EOL:
 
 After a target platform reaches EOL:
 
-* Update ROS distribution to state the target platform is EOL, and will not receive any more updates.
+* Update ROS distribution to state the target platform will not receive updated ROS packages.
 * Announce that the ROS distribution has dropped support for that target platform on Discourse.
 * Consider making one last release to that target platform if:
-    * You did not already do so just prior to EOL, and
+    * You did not already do so prior to EOL, and
     * The updates seem unlikely to have regressions, and
     * The ROS Buildfarm still has runners for that target platform.
 * Merge your pull request to disable buildfarm jobs.

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -15,7 +15,7 @@ What to expect
 
 When a target platform reaches EOL:
 
-* All ROS distributions immediately drop support for that platform.
+* All ROS distributions stop supporting that platform.
 * Existing ROS packages will remain available and functional, but they will no longer be updated.
 
 When a target platform reaches EOL, it stops receiving critical bug and security fixes.

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -22,7 +22,7 @@ When a target platform reaches EOL, it stops receiving critical bug and security
 To protect ourselves from potentially unpatched security vulnerabilities, we proactively drop all EOL platform job runners from the ROS build farm.
 
 If you're using a target platform that has reached EOL, you should expect to stop receiving updated ROS packages.
-However, ROS Bosses may choose to perform one last update on a target platform after it reaches EOL.
+However, ROS Bosses may choose to perform an update on a target platform after it reaches EOL in exceptional circumstances if the infrastructure is still available.
 
 For ROS Bosses
 --------------

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -7,7 +7,7 @@ Platform EOL Policy
    :depth: 1
    :local:
 
-:doc:`ROS distributions <Releases>` do not support end-of-life (EOL) platforms, even if the ROS distribution is still active.
+:doc:`ROS distributions <../Releases>` do not support end-of-life (EOL) platforms, even if the ROS distribution is still active.
 This page explains:
 
 * What users of EOL platforms should expect

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -30,7 +30,7 @@ For ROS Bosses
 Before a target platform reaches EOL:
 
 * Make sure the ROS distribution documentation includes an EOL date for any target platform that reaches EOL before the ROS distribution.
-* When the EOL date for a target platform approaches, announce that ROS distribution will drop support for that target platform on Discourse.
+* Post an announcement about the target platform reaching EOL at least 2 syncs beforehand so that package maintainers have time to update their packages.
 * Open a `pull request disabling buildfarm jobs for that platform <https://github.com/ros2/ros_buildfarm_config>`_ and seek review from the `Infrastructure PMC <https://osralliance.org/wp-content/uploads/2024/03/infrastructure_project_charter.pdf>`_.
 * Make one last release to that target platform.
 

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -31,7 +31,7 @@ Before a target platform reaches EOL:
 
 * Make sure the ROS distribution documentation includes an EOL date for any target platform that reaches EOL before the ROS distribution.
 * When the EOL date for a target platform approaches, announce that ROS distribution will drop support for that target platform on Discourse.
-* Open a `pull request disabling buildfarm jobs for that platform <https://github.com/ros2/ros_buildfarm_config>`_ and seek review from the `Infrastructure PMC <https://osralliance.org/wp-content/uploads/2024/03/infrastructure_project_charter.pdf>`_. 
+* Open a `pull request disabling buildfarm jobs for that platform <https://github.com/ros2/ros_buildfarm_config>`_ and seek review from the `Infrastructure PMC <https://osralliance.org/wp-content/uploads/2024/03/infrastructure_project_charter.pdf>`_.
 * Make one last release to that target platform.
 
 After a target platform reaches EOL:

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -31,7 +31,7 @@ For ROS Bosses
 Before a target platform reaches EOL:
 
 * Make sure the ROS distribution documentation includes EOL dates for any platform that reaches EOL before the ROS distribution.
-* Post an announcement about the platform reaching EOL at least 2 syncs beforehand so that package maintainers have time to update their packages.
+* Post an announcement about the platform reaching EOL at least 2 syncs (roughly 60-90 days) beforehand so that package maintainers have time to update their packages.
 * Open a `pull request disabling buildfarm jobs for that platform <https://github.com/ros2/ros_buildfarm_config>`_ and seek review from the `Infrastructure PMC <https://osralliance.org/wp-content/uploads/2024/03/infrastructure_project_charter.pdf>`_.
 * Make one last sync to that platform.
 

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -1,0 +1,45 @@
+.. _PlatformEOLPolicy:
+
+Platform EOL Policy
+===================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+Every :doc:`ROS distribution <Releases>` has **target platforms**, such as Windows 11 or Ubuntu 24.04.
+This page explains what happens when a target platform reaches its own end-of-life (EOL) before the ROS distribution reaches EOL.
+
+What to expect
+--------------
+
+When a target platform reaches EOL:
+
+* All ROS distributions immediately drop support for that platform.
+* Existing ROS packages will remain functional, but they will not be updated.
+
+When a target platform reaches EOL, it stops receiving critical bug and security fixes.
+ROS distributions drop support immediately so that the ROS buildfarm may remove those runners to protect itself from potential unpatched security vulnerabilities.
+
+If you're using a target platform that has reached EOL, you should expect to stop receiving updated ROS packages.
+However, ROS Bosses may choose to perform one last update on a target platform after it reaches EOL.
+
+For ROS Bosses
+--------------
+
+Before a target platform reaches EOL:
+
+* Make sure the ROS distribution documentation includes an EOL date for any target platform that reaches EOL before the ROS distribution.
+* When the EOL date for a target platform approaches, announce that ROS distribution will drop support for that target platform on Discourse.
+* Open a `pull request disabling buildfarm jobs for that platform <https://github.com/ros2/ros_buildfarm_config>`_ and seek review from the `Infrastructure PMC <https://osralliance.org/wp-content/uploads/2024/03/infrastructure_project_charter.pdf>`_. 
+* Make one last release to that target platform.
+
+After a target platform reaches EOL:
+
+* Update ROS distribution to state the target platform is EOL, and will not receive any more updates.
+* Announce that the ROS distribution has dropped support for that target platform on Discourse.
+* Consider making one last release to that target platform if:
+    * You did not already do so just prior to EOL, and
+    * The updates seem unlikely to have regressions, and
+    * The ROS Buildfarm still has runners for that target platform.
+* Merge your pull request to disable buildfarm jobs.

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -17,7 +17,7 @@ Policy
 ------
 
 Every ROS distribution supports certain **platforms**, such as Windows 11 or Ubuntu 24.04.
-**Vendors**, such as Microsoft or Canonical, decide how long they will support one of their platforms.
+**Vendors** of these platforms, such as Microsoft or Canonical, decide how long they will support one of their platforms.
 When a vendor decides a platform has reached EOL, they usually stop publishing critical bug and security fixes.
 To protect ourselves from potentially unpatched security vulnerabilities, we proactively remove all jobs on EOL platforms from the ROS build farm.
 

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -7,7 +7,7 @@ Platform EOL Policy
    :depth: 1
    :local:
 
-Every :doc:`ROS distribution <Releases>` has **target platforms**, such as Windows 11 or Ubuntu 24.04.
+Every :doc:`ROS distribution <Releases>` has **target platforms**, also known as operating systems, such as Windows 11 or Ubuntu 24.04.
 This page explains what happens when a target platform reaches its own end-of-life (EOL) before the ROS distribution reaches EOL.
 
 What to expect

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -19,7 +19,7 @@ When a target platform reaches EOL:
 * Existing ROS packages will remain available and functional, but they will no longer be updated.
 
 When a target platform reaches EOL, it stops receiving critical bug and security fixes.
-To protect ourselves from potentially unpatched security vulnerabilities, we proactively drop all EOL platform job runners from the ROS build farm . 
+To protect ourselves from potentially unpatched security vulnerabilities, we proactively drop all EOL platform job runners from the ROS build farm.
 
 If you're using a target platform that has reached EOL, you should expect to stop receiving updated ROS packages.
 However, ROS Bosses may choose to perform one last update on a target platform after it reaches EOL.

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -19,7 +19,7 @@ When a target platform reaches EOL:
 * Existing ROS packages will remain available and functional, but they will no longer be updated.
 
 When a target platform reaches EOL, it stops receiving critical bug and security fixes.
-ROS distributions drop support immediately so that the ROS buildfarm may remove those runners to protect itself from potential unpatched security vulnerabilities.
+To protect ourselves from potentially unpatched security vulnerabilities, we proactively drop all EOL platform job runners from the ROS build farm . 
 
 If you're using a target platform that has reached EOL, you should expect to stop receiving updated ROS packages.
 However, ROS Bosses may choose to perform one last update on a target platform after it reaches EOL.


### PR DESCRIPTION
## Description

Per some ROS PMC meeting, we decided we needed a documented policy on how to handle a target platform going EOL before the ROS distribution. I checked with @gbiggs, and he said projects should put this kind of policy in their own documentation rather than a REP

### Did you use Generative AI?

I used Gemini to draft it, then rewrote it all by hand, so ... maybe?

### Additional Information

