### PR TITLE
Update metrics page, add this years report.

### DIFF
--- a/source/The-ROS2-Project/Metrics.rst
+++ b/source/The-ROS2-Project/Metrics.rst
@@ -16,7 +16,8 @@ Live Project Metrics
 
 - `metrics.ros.org <https://metrics.ros.org>`_ is a website that hosts relatively up to day visualizations of metrics about the ROS community.
 - `The Linux Foundation's LFX dashboard on ROS <https://insights.linuxfoundation.org/project/ros?>`_ contains an up-to-date contributor, development, popularity, and project health metrics.
-- `Our OSU OSL AWStats dashboard <https://awstats.osuosl.org/reports/packages.ros.org/2026/01/awstats.packages.ros.org.html>`_ provides real time data on ROS package downloads. *Note that you will need to specify the current month and year in the AWStats URL to get the latest information.*
+- `Our OSU OSL AWStats dashboard <https://awstats.osuosl.org/reports/packages.ros.org/2026/01/awstats.packages.ros.org.html>`_ provides real time data on ROS package downloads.
+*Note that you will need to specify the current month and year in the AWStats URL to get the latest information.*
 - Github mains a complete list of packages and projects tagged with `#ROS <https://github.com/topics/ros>`_ and `#ROS2 <https://github.com/topics/ros2>`_.
 - An up to date list of citations for the original `ROS paper <https://scholar.google.com/scholar?cites=1227661396257612398&as_sdt=2005&sciodt=0,5&hl=en>`_ (`Quigley et al., 2009 <http://lars.mec.ua.pt/public/LAR%20Projects/BinPicking/2016_RodrigoSalgueiro/LIB/ROS/icraoss09-ROS.pdf>`_), and the canonical `ROS 2 paper <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1227661396257612398&as_sdt=5>`_ (`Macenski et al., 2022 <https://www.science.org/doi/abs/10.1126/scirobotics.abm6074>`_) are both available on Google Scholar. 
 

--- a/source/The-ROS2-Project/Metrics.rst
+++ b/source/The-ROS2-Project/Metrics.rst
@@ -19,7 +19,7 @@ Live Project Metrics
 - `Our OSU OSL AWStats dashboard <https://awstats.osuosl.org/reports/packages.ros.org/2026/01/awstats.packages.ros.org.html>`_ provides real time data on ROS package downloads.
 *Note that you will need to specify the current month and year in the AWStats URL to get the latest information.*
 - Github mains a complete list of packages and projects tagged with `#ROS <https://github.com/topics/ros>`_ and `#ROS2 <https://github.com/topics/ros2>`_.
-- An up to date list of citations for the original `ROS paper <https://scholar.google.com/scholar?cites=1227661396257612398&as_sdt=2005&sciodt=0,5&hl=en>`_ (`Quigley et al., 2009 <http://lars.mec.ua.pt/public/LAR%20Projects/BinPicking/2016_RodrigoSalgueiro/LIB/ROS/icraoss09-ROS.pdf>`_), and the canonical `ROS 2 paper <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1227661396257612398&as_sdt=5>`_ (`Macenski et al., 2022 <https://www.science.org/doi/abs/10.1126/scirobotics.abm6074>`_) are both available on Google Scholar. 
+- An up to date list of citations for the original `ROS paper <https://scholar.google.com/scholar?cites=1227661396257612398&as_sdt=2005&sciodt=0,5&hl=en>`_ (`Quigley et al., 2009 <http://lars.mec.ua.pt/public/LAR%20Projects/BinPicking/2016_RodrigoSalgueiro/LIB/ROS/icraoss09-ROS.pdf>`_), and the canonical `ROS 2 paper <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1227661396257612398&as_sdt=5>`_ (`Macenski et al., 2022 <https://www.science.org/doi/abs/10.1126/scirobotics.abm6074>`_) are both available on Google Scholar.
 
 Periodic Metrics Report
 -----------------------

--- a/source/The-ROS2-Project/Metrics.rst
+++ b/source/The-ROS2-Project/Metrics.rst
@@ -8,25 +8,31 @@ Metrics
    :local:
 
 
-We measure aspects of the ROS community to understand and track the impact of our work and identify areas for improvement.
-We take inspiration from the MeeGo Project's metrics.
+While we do not track ROS users, we do measure various aspects of the ROS community to understand and track the impact of our work and identify areas for improvement.
 
-Metrics.ros.org
----------------
 
-At `metrics.ros.org <https://metrics.ros.org>`_ you can find many visualizations of metrics about ROS.
+Live Project Metrics
+--------------------
+
+- `metrics.ros.org <https://metrics.ros.org>`_ is a website that hosts relatively up to day visualizations of metrics about the ROS community.
+- `The Linux Foundation's LFX dashboard on ROS <https://insights.linuxfoundation.org/project/ros?>`_ contains an up-to-date contributor, development, popularity, and project health metrics.
+- `Our OSU OSL AWStats dashboard <https://awstats.osuosl.org/reports/packages.ros.org/2026/01/awstats.packages.ros.org.html>`_ provides real time data on ROS package downloads. *Note that you will need to specify the current month and year in the AWStats URL to get the latest information.*
+- Github mains a complete list of packages and projects tagged with `#ROS <https://github.com/topics/ros>`_ and `#ROS2 <https://github.com/topics/ros2>`_.
+- An up to date list of citations for the original `ROS paper <https://scholar.google.com/scholar?cites=1227661396257612398&as_sdt=2005&sciodt=0,5&hl=en>`_ (`Quigley et al., 2009 <http://lars.mec.ua.pt/public/LAR%20Projects/BinPicking/2016_RodrigoSalgueiro/LIB/ROS/icraoss09-ROS.pdf>`_), and the canonical `ROS 2 paper <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1227661396257612398&as_sdt=5>`_ (`Macenski et al., 2022 <https://www.science.org/doi/abs/10.1126/scirobotics.abm6074>`_) are both available on Google Scholar. 
 
 Periodic Metrics Report
 -----------------------
 
 We periodically publish a metrics report that provides a quantitative view of the ROS community.
-We're collectively learning what to measure and how and evoloving as systems change.
+We're collectively learning what to measure and how and evolving as systems change.
 Please provide feedback!
 Add your suggestions on how to improve these reports by posting them to `ROS Discourse Site Feedback Category <http://discourse.ros.org/c/site-feedback>`_.
 
 Historical Metrics Reports
 ..........................
 
+* `2025 <https://discourse.openrobotics.org/t/2025-ros-metrics-report/52575>`_
+* `2024 <https://discourse.openrobotics.org/t/2024-ros-metrics-report/42354>`_
 * `2023 <http://download.ros.org/downloads/metrics/metrics-report-2024-01.pdf>`_
 * `2022 <http://download.ros.org/downloads/metrics/metrics-report-2022-07.pdf>`_
 * `2021 <http://download.ros.org/downloads/metrics/metrics-report-2021-07.pdf>`_

--- a/source/The-ROS2-Project/Metrics.rst
+++ b/source/The-ROS2-Project/Metrics.rst
@@ -17,7 +17,9 @@ Live Project Metrics
 - `metrics.ros.org <https://metrics.ros.org>`_ is a website that hosts relatively up to day visualizations of metrics about the ROS community.
 - `The Linux Foundation's LFX dashboard on ROS <https://insights.linuxfoundation.org/project/ros?>`_ contains an up-to-date contributor, development, popularity, and project health metrics.
 - `Our OSU OSL AWStats dashboard <https://awstats.osuosl.org/reports/packages.ros.org/2026/01/awstats.packages.ros.org.html>`_ provides real time data on ROS package downloads.
+
 *Note that you will need to specify the current month and year in the AWStats URL to get the latest information.*
+
 - Github mains a complete list of packages and projects tagged with `#ROS <https://github.com/topics/ros>`_ and `#ROS2 <https://github.com/topics/ros2>`_.
 - An up to date list of citations for the original `ROS paper <https://scholar.google.com/scholar?cites=1227661396257612398&as_sdt=2005&sciodt=0,5&hl=en>`_ (`Quigley et al., 2009 <http://lars.mec.ua.pt/public/LAR%20Projects/BinPicking/2016_RodrigoSalgueiro/LIB/ROS/icraoss09-ROS.pdf>`_), and the canonical `ROS 2 paper <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1227661396257612398&as_sdt=5>`_ (`Macenski et al., 2022 <https://www.science.org/doi/abs/10.1126/scirobotics.abm6074>`_) are both available on Google Scholar.
 


### PR DESCRIPTION
This pull request adds the following. 

- A link to our AWStats page
- A link to our LFX Insights page
- Links to metrics on Github and Google Scholar (for the canonical ROS 1 and ROS 2 papers)
- Our 2024 and 2025 metrics reports. 

I also cleaned up a few things in the document. 
  
### Did you use Generative AI?

Heck no. 

### Additional Information

Previous metrics link to downloads.ros.org. I can't seem to ssh/scp into downloads.ros.org to upload the PDF. Honestly, I think it is better to link to the metrics report on Discourse to keep the context and discussion intact.  
