### PR TITLE
Releases notes Lyrical Luth: Class loader and plugin lib allow to pass arguments to constructors

### DIFF
--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -39,6 +39,19 @@ TODO
 New features in this ROS 2 release
 ----------------------------------
 
+``class_loader``
+
+Add support for passing arguments to constructors.
+As a result, users can now create plugins that are not default constructible, removing the need for initialize method.
+
+See https://github.com/ros/class_loader/pull/223 for more details.
+
+``plugin_lib``
+
+Add support for passing arguments to constructors.
+
+See https://github.com/ros/pluginlib/pull/291 for more details.
+
 ``rosidl_python``
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Releases notes Lyrical Luth: Class loader and plugin lib allow to pass arguments to constructors