### PR TITLE
Humble: removed const rclcpp::SerilizedMessage from subscription callback in advanced tutorial

### DIFF
--- a/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
+++ b/source/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.rst
@@ -101,7 +101,7 @@ Inside the ``ros2_ws/src/bag_recorder_nodes/src`` directory, create a new file c
       }
 
     private:
-      void topic_callback(std::shared_ptr<const rclcpp::SerializedMessage> msg) const
+      void topic_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) const
       {
         rclcpp::Time time_stamp = this->now();
 
@@ -158,7 +158,7 @@ We do this for two reasons.
 
 .. code-block:: C++
 
-      void topic_callback(std::shared_ptr<const rclcpp::SerializedMessage> msg) const
+      void topic_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) const
       {
 
 Within the subscription callback, the first thing to do is determine the time stamp to use for the stored message.


### PR DESCRIPTION

## Description
This fixes the problem in advance tutorial for [Recording a Bag From Your Own Node](https://docs.ros.org/en/humble/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.html) where we cannot pass a `std::shared_ptr<const rclcpp::SerializedMessage> ` to the write method in an instance of `ros2_cpp::Writer class`. This is because the humble branch does not have an overloaded method for the parameter, it only has one for `std::shared_ptr<rclcpp::SerializedMessage> `. 

This contribution just removes the const in relevant sections so that individuals can complete the tutorial and build the package successfully. 

Fixes #6277 

### Did you use Generative AI?
No AI was used

### Additional Information
