### PR TITLE
Color active releases dark blue

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -37,19 +37,19 @@ Rows in the table marked in green are the currently supported distributions.
      This CSS overrides the styles of certain rows to mark them green, indicating they are supported releases.
      For the odd number rows, a line like the following must be used:
 
-       .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
+       .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {...}
 
      For the even number rows, a line like the following must be used:
 
-       .rst-content tr:nth-child(2) {background-color: #33cc66;}
+       .rst-content tr:nth-child(2) {...}
 
      No other combination I've found has worked.  Yes, this is extremely fragile.  No, I don't understand
      why it is like this.
    -->
    <style>
-     .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #33cc66;}
-     .rst-content tr:nth-child(2) {background-color: #33cc66;}
-     .rst-content tr:nth-child(4) {background-color: #33cc66;}
+     .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #22314E; color: white}
+     .rst-content tr:nth-child(2) {background-color: #22314E; color: white}
+     .rst-content tr:nth-child(4) {background-color: #22314E; color: white}
    </style>
 
 .. |rolling| image:: Releases/rolling-small.png

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -47,9 +47,20 @@ Rows in the table marked in green are the currently supported distributions.
      why it is like this.
    -->
    <style>
-     .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {background-color: #22314E; color: white}
-     .rst-content tr:nth-child(2) {background-color: #22314E; color: white}
-     .rst-content tr:nth-child(4) {background-color: #22314E; color: white}
+     /* Targeting the cells and rows for the background and plain text */
+    .rst-content table.docutils:not(.field-list) tr:nth-child(1) td,
+    .rst-content tr:nth-child(2),
+    .rst-content tr:nth-child(4) {
+      background-color: #22314E;
+      color: white;
+    }
+
+    /* Targeting the links inside those specific rows to force them to be not-blue */
+    .rst-content table.docutils:not(.field-list) tr:nth-child(1) td a,
+    .rst-content tr:nth-child(2) a,
+    .rst-content tr:nth-child(4) a {
+      color: #B0B0B0;
+    }
    </style>
 
 .. |rolling| image:: Releases/rolling-small.png

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -18,7 +18,7 @@ List of Distributions
 ---------------------
 
 Below is a list of current and historic ROS 2 distributions.
-Rows in the table marked in green are the currently supported distributions.
+Rows in the table marked in blue are the currently supported distributions.
 
 .. toctree::
    :hidden:
@@ -34,7 +34,7 @@ Rows in the table marked in green are the currently supported distributions.
 .. raw:: html
 
    <!--
-     This CSS overrides the styles of certain rows to mark them green, indicating they are supported releases.
+     This CSS overrides the styles of certain rows to mark them blue, indicating they are supported releases.
      For the odd number rows, a line like the following must be used:
 
        .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {...}

--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -37,7 +37,7 @@ Rows in the table marked in blue are the currently supported distributions.
      This CSS overrides the styles of certain rows to mark them blue, indicating they are supported releases.
      For the odd number rows, a line like the following must be used:
 
-       .rst-content table.docutils:not(.field-list) tr:nth-child(1) td {...}
+       .rst-content table.distros:not(.field-list) tr:nth-child(1) td {...}
 
      For the even number rows, a line like the following must be used:
 
@@ -48,18 +48,18 @@ Rows in the table marked in blue are the currently supported distributions.
    -->
    <style>
      /* Targeting the cells and rows for the background and plain text */
-    .rst-content table.docutils:not(.field-list) tr:nth-child(1) td,
-    .rst-content tr:nth-child(2),
-    .rst-content tr:nth-child(4) {
+    .rst-content table.distros:not(.field-list) tr:nth-child(1) td,
+    .rst-content table.distros tr:nth-child(2),
+    .rst-content table.distros tr:nth-child(4) {
       background-color: #22314E;
       color: white;
     }
 
     /* Targeting the links inside those specific rows to force them to be not-blue */
-    .rst-content table.docutils:not(.field-list) tr:nth-child(1) td a,
-    .rst-content tr:nth-child(2) a,
-    .rst-content tr:nth-child(4) a {
-      color: #B0B0B0;
+    .rst-content table.distros:not(.field-list) tr:nth-child(1) td a,
+    .rst-content table.distros tr:nth-child(2) a,
+    .rst-content table.distros tr:nth-child(4) a {
+      color: #B0B0B0 !important;
     }
    </style>
 


### PR DESCRIPTION
Addressing https://github.com/ros2/ros2_documentation/pull/6249#issuecomment-3975715024

Trying out the logo colors from slide 16 https://www.ros.org/imgs/ROSBrandGuide.pdf instead of bright green.

<img width="976" height="874" alt="Screenshot 2026-03-06 at 1 50 52 PM" src="https://github.com/user-attachments/assets/8ed3ec3e-922c-43a8-859b-2184d8c0618b" />
