### PR TITLE
Fix shell quoting in version detection command

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -45,7 +45,7 @@ Next, download the ``ros2-release`` package and install it:
 .. code-block:: console
 
    $ sudo dnf install curl
-   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
    $ sudo dnf install "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-release-${ROS_APT_SOURCE_VERSION}-1.noarch.rpm"
 
 The `ros2-release <https://github.com/ros-infrastructure/ros-apt-source/>`_ package provides keys and repo configuration for the various ROS repositories.

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -15,6 +15,6 @@ Updates to repository configuration will occur automatically when new versions o
 .. code-block:: console
 
    $ sudo apt update && sudo apt install curl -y
-   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+   $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
    $ curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
    $ sudo dpkg -i /tmp/ros2-apt-source.deb


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

The `awk -F\"` quoting in the install command causes a parse error in `zsh` when shell integration hooks (e.g., `iTerm2`, `oh-my-zsh`) are active:

```bash
preexec:4: unmatched "
preexec:4: parse error
```

This occurs because `\"` inside `$(...)` is ambiguous in some zsh configurations, even though it works in most bash environments.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
To fix, we replace `awk -F\"` with `awk -F'"'`, which is unambiguous across shells and hook configurations.

### Testing

Verified the fix works in:
- `bash`
- `zsh` (with and without `iTerm2` shell integration / `oh-my-zsh`)