### PR TITLE
Add Lyrical target platforms and release timeline

### DIFF
--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -10,26 +10,106 @@ Lyrical Luth (codename 'lyrical'; May, 2026)
    :local:
 
 *Lyrical Luth* is the twelfth release of ROS 2.
-What follows is highlights of the important changes and features in Lyrical Luth since the last release.
+
+Release Timeline
+----------------
+
+**As soon as possible** - Migrate ROS Rolling to ROS Lyrical's target platforms
+    * RHEL 10 + Ubuntu 26.04: Migrate as soon as core packages successfully build on both platforms.
+    * Windows 11: Migrate as soon as we have a green build
+
+**Mon. April 6, 2026** - Alpha + RMW freeze
+    * Preliminary testing of ROS Base packages
+    * API and feature freeze for RMW provider packages.
+
+**Mon. April 13, 2026** - Freeze
+    * API and feature freeze for ROS Base packages in Rolling Ridley.
+    * Only bug fix releases should be made after this point.
+    * New packages can be released.
+
+**Mon. April 20, 2026** - Branch
+    * Branch from Rolling Ridley
+    * ``rosdistro`` is reopened for Rolling PRs for ROS Base packages.
+    * Lyrical development shifts from ``ros-rolling-*`` packages to ``ros-lyrical-*`` packages.
+
+**Mon. April 27, 2026** - Beta
+    * Updated releases of ROS Desktop packages available.
+    * Call for general testing.
+
+**Thu, April 30, 2026** - Kick off Tutorial Party
+    * Open up tutorials for community testing.
+
+**Mon. May 11, 2026** - Release Candidate
+    * Build release candidate packages up to ROS Desktop
+
+**Mon. May 18, 2026** - Distro Freeze
+    * Freeze all Lyrical branches on all ROS desktop packages
+    * No pull requests for any Lyrical branch or targeting ``lyrical/distribution.yaml`` in ``rosdistro`` repo will be merged.
+
+**Friday May 22nd, 2026** - General Availability
+    * Release announcement.
+    * ROS desktop packages source freeze is lifted and ``rosdistro`` is reopened for Lyrical pull requests.
+
+For progress on the development of Lyrical Luth, see `this project board <https://github.com/orgs/ros2/projects/70>`__.
+For the broad process followed by Lyrical Luth, see the :doc:`process description page <Release-Process>`.
 
 Supported Platforms
 -------------------
 
-Lyrical Luth is primarily supported on the following platforms:
+ROS Lyrical supports the following platforms according to `the platform support tiers <../The-ROS2-Project/Platform-Support-Tiers>`:
 
-Tier 1 platforms:
++--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
+| Architecture | Ubuntu Resolute   | Ubuntu Noble      | Windows 11    | RHEL 10           | macOS     | Debian Trixie*  | OpenEmbedded / |
+|              | (26.04)           | (24.04)           | (VS2022)      |                   |           | (13)            | Yocto Project  |
++==============+===================+===================+===============+===================+===========+=================+================+
+| amd64        | Tier 1 [d][a]     | Tier 3            | Tier 1 [a]    | Tier 2 [d][a]     | Tier 3    | Tier 3          | Tier 3         |
++--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
+| arm64        | Tier 1 [d][a]     | Tier 3            |               |                   |           | Tier 3          | Tier 3         |
++--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
+| arm32        | Tier 3            | Tier 3            |               |                   |           | Tier 3          | Tier 3         |
++--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
 
-* TODO
+* ``*`` Debian Trixie is only supported until ``2028-08-09`` per `the platform EOL policy <../The-ROS2-Project/Platform-EOL-Policy>`
+* ``[d]`` You may install ROS Lyrical on this platform using Distribution-specific packaegs (Debian, RPM, etc.).
+* ``[a]`` You may install ROS Lyrical by downloading an archive containing pre-built packages for all packages in the `ROS Lyrical ros2.repos file <https://github.com/ros2/ros2/blob/lyrical/ros2.repos>`__
 
-Tier 2 platforms:
+To use ROS Lyrical on any Tier 3 platform, you must build ROS Lyrical from source.
 
-* TODO
+Minimum Language Requirements
+-----------------------------
 
-Tier 3 platforms:
+* [C++20](https://discourse.openrobotics.org/t/ros-2-lyrical-c-version/52551)
+* C17
+* Python 3.12 - 3.14
 
-* TODO
+Dependency Requirements
+-----------------------
 
-For more information about RMW implementations, compiler / interpreter versions, and system dependency versions see `REP 2000 <https://reps.openrobotics.org/rep-2000/>`__.
+TODO - this section will show a table of important system package versions across supported platforms.
+
+Middleware Implementation support
+---------------------------------
+
+The default middleware in ROS Lyrical is `rmw_fastrtps_cpp`.
+
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+| Middleware Library        | Middleware Provider     | Support Level | Platforms                  | Architectures                 |
++===========================+=========================+===============+============================+===============================+
+| rmw_fastrtps_cpp          | eProsima Fast-DDS       | Tier 1        | All Platforms              | All Architectures             |
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+| rmw_connextdds            | RTI Connext             | Tier 1        | Ubuntu, Windows, and macOS | All Architectures except arm64|
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+| rmw_cyclonedds_cpp        | Eclipse Cyclone DDS     | Tier 1        | All Platforms              | All Architectures             |
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+| rmw_zenoh_cpp             | Eclipse Zenoh           | Tier 1        | All Platforms              | All Architectures             |
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+| rmw_fastrtps_dynamic_cpp  | eProsima Fast-DDS       | Tier 2        | All Platforms              | All Architectures             |
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+| rmw_gurumdds_cpp          | GurumNetworks GurumDDS  | Tier 3        | Ubuntu and Windows         | All Architectures except arm32|
++---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
+
+Middleware implementation support is dependent upon the platform support tier.
+For example, a Tier 1 middleware implementation on a Tier 2 platform will only receive Tier 2 support.
 
 Installation
 ------------
@@ -73,10 +153,3 @@ See https://github.com/ros-perception/point_cloud_transport/pull/109 for more de
 
 Passing in Python ``set`` objects into array or sequence fields is now deprecated.
 Instead pass in something that implements ``collections.abc.Sequence`` most commonly a ``list``, ``tuple``, or a ``numpy.ndarray``. To be removed in ROS M.
-
-Development progress
---------------------
-
-For progress on the development of Lyrical Luth, see `this project board <https://github.com/orgs/ros2/projects/70>`__.
-
-For the broad process followed by Lyrical Luth, see the :doc:`process description page <Release-Process>`.

--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -93,7 +93,7 @@ TODO - this section will show a table of important system package versions acros
 Middleware Implementation support
 ---------------------------------
 
-The default middleware in ROS Lyrical is `rmw_fastrtps_cpp`.
+The default middleware in ROS Lyrical is **rmw_fastrtps_cpp**.
 
 +---------------------------+-------------------------+---------------+----------------------------+-------------------------------+
 | Middleware Library        | Middleware Provider     | Support Level | Platforms                  | Architectures                 |

--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -59,7 +59,7 @@ Supported Platforms
 ROS Lyrical supports the following platforms according to `the platform support tiers <../The-ROS2-Project/Platform-Support-Tiers>`:
 
 +--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
-| Architecture | Ubuntu Resolute   | Ubuntu Noble      | Windows 11    | RHEL 10           | macOS     | Debian Trixie*  | OpenEmbedded / |
+| Architecture | Ubuntu Resolute   | Ubuntu Noble*     | Windows 11    | RHEL 10*          | macOS     | Debian Trixie*  | OpenEmbedded / |
 |              | (26.04)           | (24.04)           | (VS2022)      |                   |           | (13)            | Yocto Project  |
 +==============+===================+===================+===============+===================+===========+=================+================+
 | amd64        | Tier 1 [d][a]     | Tier 3            | Tier 1 [a]    | Tier 2 [d][a]     | Tier 3    | Tier 3          | Tier 3         |
@@ -69,7 +69,10 @@ ROS Lyrical supports the following platforms according to `the platform support 
 | arm32        | Tier 3            | Tier 3            |               |                   |           | Tier 3          | Tier 3         |
 +--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
 
-* ``*`` Debian Trixie is only supported until ``2028-08-09`` per `the platform EOL policy <../The-ROS2-Project/Platform-EOL-Policy>`
+* ``*`` Early EOL per `the platform EOL policy <../The-ROS2-Project/Platform-EOL-Policy>`
+    * Ubuntu Noble is supported until ``2029-06-01``
+    * RHEL 10 is supported until ``2030-05-31``
+    * Debian Trixie is supported until ``2028-08-09``
 * ``[d]`` You may install ROS Lyrical on this platform using Distribution-specific packaegs (Debian, RPM, etc.).
 * ``[a]`` You may install ROS Lyrical by downloading an archive containing pre-built packages for all packages in the `ROS Lyrical ros2.repos file <https://github.com/ros2/ros2/blob/lyrical/ros2.repos>`__
 


### PR DESCRIPTION
## Description

Requires https://github.com/ros2/ros2_documentation/pull/6249

Add ROS Lyrical target platforms and release timeline. I put the release timeline at the top, because that's what matters most before the release. I'll move it to the bottom to match existing release pages when the release is out.

### Did you use Generative AI?

I had Gemini format some stuff as RST

### Additional Information

PR should match the discussion from the Feb 27th ROS Lyrical Release Working Group meeting: https://docs.google.com/document/d/1lkilmVulAUF1qVRsmimMa1cJtO2jOLoGy75itOCwc78/edit?tab=t.jwc3m8s1ivun
