### PR TITLE
Fix obsolete advice and code samples, clarify use of colcon test argument

### DIFF
--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -17,7 +17,7 @@ To compile and run the tests, simply run the `test <https://colcon.readthedocs.i
 
   $ colcon test --ctest-args tests [package_selection_args]
 
-Where ``package_selection_args`` are optional package selection arguments for ``colcon`` to limit which packages are built and run.
+Where ``package_selection_args`` are optional package selection arguments for ``colcon`` to limit which packages are built and run, *e.g.* ``--packages-select my_ros_package```.
 Find more info in the `colcon documentation on Package selection arguments <https://colcon.readthedocs.io/en/released/reference/package-selection-arguments.html>`__
 
 :ref:`Sourcing the workspace <colcon-tutorial-source-the-environment>` before testing **IS** necessary. If you don’t, you risk running into the following issue:

--- a/source/Tutorials/Intermediate/Testing/CLI.rst
+++ b/source/Tutorials/Intermediate/Testing/CLI.rst
@@ -20,8 +20,15 @@ To compile and run the tests, simply run the `test <https://colcon.readthedocs.i
 Where ``package_selection_args`` are optional package selection arguments for ``colcon`` to limit which packages are built and run.
 Find more info in the `colcon documentation on Package selection arguments <https://colcon.readthedocs.io/en/released/reference/package-selection-arguments.html>`__
 
-:ref:`Sourcing the workspace <colcon-tutorial-source-the-environment>` before testing should not be necessary.
-``colcon test`` makes sure that the tests run with the right environment, have access to their dependencies, etc.
+:ref:`Sourcing the workspace <colcon-tutorial-source-the-environment>` before testing **IS** necessary. If you don’t, you risk running into the following issue:
+
+.. code-block::console
+  $ colcon test-result --verbose
+  ...
+  <<< error message
+    collection failure
+  >>>
+  ...
 
 Examine Test Results
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -18,7 +18,11 @@ Your ``setup.py`` must have a test dependency on ``pytest`` within the call to `
 
 .. code-block:: python
 
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
 
 Test Files and Folders
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

- Advise the use of the newer syntax to indicate pytest dependency in ``setup.py``
- Correct invalid statement claiming it is not necessary to source workspace ROS installation
- Clarify the use of ``colcon test`` pytest arguments.

### Did you use Generative AI?

Nope.

### Additional Information

Very minor corrections. I read the Contributing to ROS 2 Documentation page, hopefully I did not miss anything. Also apparently I have to make a pull request before being able to test the generated documentation.