### PR TITLE
fix(launch_migration): Fixed order of exec-in-pkg parameters

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
@@ -422,7 +422,7 @@ There are, however, some changes w.r.t. ROS 1:
 * ``find`` has been replaced with ``find-pkg-share`` (substituting the share directory of an installed package).
   Alternatively ``find-pkg-prefix`` will return the root of an installed package.
 * There is a new ``exec-in-pkg`` substitution.
-  e.g.: ``$(exec-in-pkg <package_name> <exec_name>)``.
+  e.g.: ``$(exec-in-pkg <exec_name> <package_name>)``.
 * There is a new ``find-exec`` substitution.
 * ``arg`` has been replaced with ``var``.
   It looks at configurations defined either with ``arg`` or ``let`` tag.


### PR DESCRIPTION
## Description

Fixed the order of parameters for `exec-in-pkg` substitution.

### Did you use Generative AI?

No

### Additional Information

The order is given here: https://github.com/ros2/launch_ros/blob/35d83b0dda5c0a7e20e8aa8c2e10143eb6967784/launch_ros/launch_ros/substitutions/executable_in_package.py#L48 .