### PR TITLE
Fix html_static_path warning by anchoring path to conf.py location (#…

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -173,7 +173,7 @@ html_favicon = 'favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [os.path.abspath('source/_static')]
+html_static_path = [os.path.join(os.path.dirname(os.path.abspath(__file__)), 'source', '_static')]
 
 # Drop any source link suffix
 html_sourcelink_suffix = ''


### PR DESCRIPTION
## Summary
Fixes #6071

## Root Cause

`html_static_path` was set using `os.path.abspath('source/_static')`, which resolves relative to the **current working directory** at runtime.

When `make lint` runs `sphinx-lint-with-ros source`, Sphinx sets its outdir dynamically. In environments like the devcontainer, the cwd causes source/_static` to resolve inside outdir — triggering the warning.

## Fix

**Before (`conf.py` line 176):**
```python
html_static_path = [os.path.abspath('source/_static')]
```

**After:**
```python
html_static_path = [os.path.join(os.path.dirname(os.path.abspath(__file__)), 'source', '_static')]
```

`__file__` always refers to `conf.py`'s own location on disk.  
This makes the path stable regardless of where sphinx-build is invoked from.

## Testing
- `make lint` → `No problems found.` (no html_static_path warning)
- Only `conf.py` modified — no content changes

<img width="514" height="62" alt="image" src="https://github.com/user-attachments/assets/553cd667-0872-4206-80bb-5e845f0eee6f" />


## Checklist
- [x] Only `conf.py` modified
- [x] `make lint` passes — `No problems found.`
- [x] No documentation content changed


**Note:** The warning could not be reproduced in my Docker environment, but this fix addresses the structural root cause confirmed by @fujitatomoya in the devcontainer. Requesting maintainer verification.