### PR TITLE
WARNING: html_static_path entry 'source/_static' is placed inside out…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
 	"build": {
 		"dockerfile": "../docker/image/Dockerfile"
 	},
-	"workspaceMount": "source=${localWorkspaceFolder},target=/tmp/doc_repository,type=bind",
-	"workspaceFolder": "/tmp/doc_repository",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/doc_repository,type=bind",
+	"workspaceFolder": "/workspaces/doc_repository",
 	"postCreateCommand": "pip3 install --no-warn-script-location --user --break-system-packages -r requirements.txt -c constraints.txt",
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {}

--- a/conf.py
+++ b/conf.py
@@ -173,7 +173,7 @@ html_favicon = 'favicon.ico'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [os.path.abspath('source/_static')]
+html_static_path = ['source/_static']
 
 # Drop any source link suffix
 html_sourcelink_suffix = ''


### PR DESCRIPTION
…dir.

## Description

the root cause was never about html_static_path resolution, it was the devcontainer workspace mount point.
with the workspace mounted at /tmp/doc_repository, the sphinx outdir (which defaults to something like /tmp/...) would end up encompassing the source tree. sphinx saw that /tmp/doc_repository/source/_static was inside its output directory and warned about it. by moving the workspace mount to /workspaces/doc_repository (the standard devcontainer convention), the source tree is no longer under /tmp/, so there's no path overlap with sphinx's outdir. and reverting html_static_path back to the simple relative 'source/_static' is the right cleanup since the os.path.abspath() wrapper was never helping.

i confirmed and verified this PR with devcontainer and venv, and there was no warning came up.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

fixes https://github.com/ros2/ros2_documentation/issues/6071
replaces https://github.com/ros2/ros2_documentation/pull/6341 and https://github.com/ros2/ros2_documentation/pull/6178

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

This problem only appears on dev container environment.
https://github.com/ros2/ros2_documentation/pull/6341 and https://github.com/ros2/ros2_documentation/pull/6178 tries to close it, but never worked AFAIK.

<!--
If applicable, provide any additional context or details about the changes.
-->
