### PR TITLE
Fix link to C++20 in Lyrical release page

### DIFF
--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -81,7 +81,7 @@ To use ROS Lyrical on any Tier 3 platform, you must build ROS Lyrical from sourc
 Minimum Language Requirements
 -----------------------------
 
-* [C++20](https://discourse.openrobotics.org/t/ros-2-lyrical-c-version/52551)
+* `C++20 <https://discourse.openrobotics.org/t/ros-2-lyrical-c-version/52551>`__
 * C17
 * Python 3.12 - 3.14
 


### PR DESCRIPTION
## Description

Make it a valid RST link.

Before:

<img width="1152" height="277" alt="Screenshot from 2026-04-12 10-36-59" src="https://github.com/user-attachments/assets/7e2e1612-c4d2-4f34-929a-fe99a14b6b93" />

After:

<img width="1152" height="277" alt="image" src="https://github.com/user-attachments/assets/07797a03-206c-4cbb-be8f-7fb0986b0bf0" />

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

only generative Christophe Intelligence

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
