### PR TITLE
rtisetenv_x64Linux4gcc8.5.0.bash should be used.

### DIFF
--- a/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
+++ b/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
@@ -97,7 +97,7 @@ For example, for version 7.7.0, you can run the following code to execute the he
 
 .. code-block:: console
 
-   $ source /opt/rti.com/rti_connext_dds-7.7.0/resource/scripts/rtisetenv_x64Linux4gcc7.7.0.bash
+   $ source /opt/rti.com/rti_connext_dds-7.7.0/resource/scripts/rtisetenv_x64Linux4gcc8.5.0.bash
 
 If the previous command failed, and you can't find the location of the RTI Connext installation, run this to find all Connext installations (and their corresponding helper scripts) in your system:
 


### PR DESCRIPTION
## Description

follow-up of https://github.com/ros2/ros2_documentation/pull/6359#discussion_r3071584752

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

no

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
