### PR TITLE
Add Power Stow to adopters.yaml

### DIFF
--- a/plugins/adopters_schema.py
+++ b/plugins/adopters_schema.py
@@ -25,6 +25,7 @@ import re
 
 VALID_DOMAINS = [
     'Agriculture',         # Farming, harvesting, crop monitoring, and precision agriculture
+    'Aviation',            # Aircraft systems, avionics, luggage handling, passenger service, and airport operations
     'Aerial/Drone',        # UAVs, drones, aerial inspection, and survey systems
     'Automotive',          # Self-driving cars, ADAS, and ground vehicle autonomy
     'Components',          # Robot parts and peripherals (cameras, LIDAR, RADAR, SONAR, etc)

--- a/source/The-ROS2-Project/Adopters/adopters.yaml
+++ b/source/The-ROS2-Project/Adopters/adopters.yaml
@@ -15,7 +15,7 @@
 #   description (required): Brief explanation of how they use ROS
 #
 # Domain values:
-#   Agriculture, Aerial/Drone, Automotive, Components, Construction, Consumer Robot,
+#   Agriculture, Aerial/Drone, Automotive, Aviation, Components, Construction, Consumer Robot,
 #   Defense/Government, Education, Energy, Healthcare/Medical, Humanoid,
 #   Logistics/Warehouse, Manufacturing, Marine, Research, Space, Service Robot
 

--- a/source/The-ROS2-Project/Adopters/adopters.yaml
+++ b/source/The-ROS2-Project/Adopters/adopters.yaml
@@ -219,3 +219,12 @@ adopters:
       - IT
     description: "The RObotic SEnsors Technologies for Environment and Agriculture (ROSETEA) laboratory at Politecnico di Milano studies innovative methodologies and technologies to support the development of sustainable food production systems, and of resilient agricultural practices, increasing productivity and production while reducing the environmental footprint."
     
+  - organization: "Power Stow"
+    project: "Autonomous Luggage Handling"
+    project_url: "https://www.powerstow.com"
+    domain:
+      - Airport
+    date_added: "2026-04-16"
+    country:
+      - DK
+    description: "Autonomous luggage handling with a custom manipulator and tool using ROS 2, ros2_control and MoveIt"

--- a/source/The-ROS2-Project/Adopters/adopters.yaml
+++ b/source/The-ROS2-Project/Adopters/adopters.yaml
@@ -223,7 +223,7 @@ adopters:
     project: "Autonomous Luggage Handling"
     project_url: "https://www.powerstow.com"
     domain:
-      - Airport
+      - Aviation
     date_added: "2026-04-16"
     country:
       - DK


### PR DESCRIPTION
## Description

This PR adds the Autonomous Luggage Handling project from Power Stow to the `adopters.yaml` file.

### Remark

I was missing additional domain categories so I am suggesting to add `Airport` or `Aviation` as another domain.
