### PR TITLE
Correct URL for Power Stow in adopters.yaml

### DIFF
--- a/source/The-ROS2-Project/Adopters/adopters.yaml
+++ b/source/The-ROS2-Project/Adopters/adopters.yaml
@@ -220,8 +220,8 @@ adopters:
     description: "The RObotic SEnsors Technologies for Environment and Agriculture (ROSETEA) laboratory at Politecnico di Milano studies innovative methodologies and technologies to support the development of sustainable food production systems, and of resilient agricultural practices, increasing productivity and production while reducing the environmental footprint."
     
   - organization: "Power Stow"
+    organization_url: "https://www.powerstow.com"
     project: "Autonomous Luggage Handling"
-    project_url: "https://www.powerstow.com"
     domain:
       - Aviation
     date_added: "2026-04-16"


### PR DESCRIPTION
## Description
A follow-up PR to #6402 to use `organization_url` instead of `project_url`.