### PR TITLE
Add documents for rosidl::Buffer features

### DIFF
--- a/source/Concepts/Intermediate.rst
+++ b/source/Concepts/Intermediate.rst
@@ -17,3 +17,4 @@ These are the concepts that further your understanding of a basic ROS 2 system.
    Intermediate/About-Cross-Compilation
    Intermediate/About-Security
    Intermediate/About-Tf2
+   Intermediate/About-Buffer-Backends

--- a/source/Concepts/Intermediate/About-Buffer-Backends.rst
+++ b/source/Concepts/Intermediate/About-Buffer-Backends.rst
@@ -79,8 +79,8 @@ User-facing containers and implementation pimpls
    │  ┌────────────────────────┐  │
    │  │ BufferImplBase<T>  ◄──-┼──┼── CpuBufferImpl<T>      (default)
    │  │ (pimpl)                │  │── CudaBufferImpl<T>     (vendor)
-   │  └────────────────────────┘  │── TorchBufferImpl<T>    (vendor)
-   └──────────────────────────────┘── ...
+   │  └────────────────────────┘  │── OtherBufferImpl<T>    (vendor)
+   └──────────────────────────────┘
 
 A freshly-constructed ``rosidl::Buffer<T>`` uses ``CpuBufferImpl<T>``, which
 simply wraps a ``std::vector<T, Allocator>``.
@@ -141,34 +141,28 @@ The current ``rmw_fastrtps_cpp`` integration resolves this aggregate to
 ``rosidl_typesupport_fastrtps_cpp``, but nothing in the backend API ties
 it to a specific RMW.
 
-Base backends and composed backends
+Backends and higher-level libraries
 -----------------------------------
 
-The backend interface is narrow enough that vendors typically ship
-backends in two layers:
+A backend should represent a memory substrate or transport technology.
+Examples include a CUDA backend built on CUDA VMM and CUDA IPC, a ROCm
+backend, or a shared-memory backend.
+The backend knows how to allocate memory, package that memory into a
+descriptor, and re-import it on another endpoint.
 
-* **Base backends** are tied to a memory substrate or a transport
-  technology.
-  Examples: a CUDA backend built on CUDA VMM and CUDA IPC; a ROCm backend;
-  a shared-memory backend.
-  A base backend knows how to allocate its memory, how to package it into a
-  descriptor, and how to re-import it on another endpoint.
-
-* **Composed backends** add a higher-level programming model on top of a
-  base backend while staying agnostic to *which* base they run on.
-  The canonical example is a PyTorch backend whose buffers are tensors with
-  shape/strides/dtype; the tensor storage is delegated to whatever base
-  backend is appropriate for the current device (CUDA today, CPU as a
-  portable fallback, other device backends in principle).
-
-Descriptors for composed backends typically embed a ``uint8[]`` field that
-the RMW serializes using the *inner* buffer's backend, so the composition
-does not require the composed backend to know the wire format of each base.
-
-This is the expected shape of the backend ecosystem: one or two
-vendor-specific base backends, plus a handful of well-known user-facing
-composed backends (tensor libraries, point-cloud libraries, etc.) that can
-be layered on top.
+Higher-level data models can live above this layer as ordinary messages and
+libraries.
+For example, ``tensor_msgs/msg/ExperimentalTensor`` carries DLPack-aligned
+tensor metadata (dtype, shape, strides, byte offset) plus a ``uint8[] data``
+field.
+That ``data`` field is a ``rosidl::Buffer<uint8_t>`` in generated C++ code, so
+it can be transported by whichever backend is negotiated for the connection.
+The ``torch_conversions`` helper library converts between
+``ExperimentalTensor`` and ``at::Tensor``; it is not itself a buffer backend.
+When the message's data buffer uses the ``cuda`` backend, tensor bytes can
+move through CUDA IPC.
+When it uses the CPU backend, the same message and helper APIs still work with
+ordinary host memory.
 
 Relationship to other ROS 2 mechanisms
 --------------------------------------

--- a/source/Concepts/Intermediate/About-Buffer-Backends.rst
+++ b/source/Concepts/Intermediate/About-Buffer-Backends.rst
@@ -1,0 +1,199 @@
+About ``rosidl::Buffer`` backends
+=================================
+
+.. contents:: Table of Contents
+   :local:
+
+Overview
+--------
+
+``rosidl::Buffer<T>`` is a container type used as the in-memory representation
+of variable-length primitive array fields in generated C++ messages
+(``uint8[]``, ``float32[]``, etc.).
+It is a drop-in replacement for ``std::vector<T>`` that also supports
+pluggable memory backends, so the bytes of a ``uint8[]`` field can live in
+CPU memory, GPU memory, or any other memory domain a vendor provides -- all
+without changing the ``.msg`` file or the rest of the ROS 2 message pipeline.
+
+The feature was introduced to let vendors transport large binary payloads
+(camera images, point clouds, tensors, ...) through the existing ROS 2
+pub/sub API with as few copies as the underlying memory technology allows,
+while keeping every piece of existing code that treats a ``uint8[]`` field as
+a ``std::vector<uint8_t>`` working unchanged.
+
+Why a new type is needed
+------------------------
+
+ROS 2 messages already have two complementary mechanisms for reducing copies:
+
+* :doc:`Intra-process communication <../../Tutorials/Demos/Intra-Process-Communication>`
+  avoids copies between publishers and subscriptions in the same process by
+  passing ``std::unique_ptr`` ownership.
+* :doc:`Loaned messages <../../How-To-Guides/Configure-ZeroCopy-loaned-messages>`
+  let the RMW manage message memory to enable shared-memory transport between
+  processes, for message types the underlying middleware can lay out.
+
+Neither of these helps when the *source* of the data is a non-CPU memory
+region, such as a GPU-rendered image or a tensor produced by an accelerator
+runtime.
+Copying such data into a ``std::vector<uint8_t>`` purely to satisfy the
+generated C++ message type defeats the point of producing it on the
+accelerator in the first place.
+
+``rosidl::Buffer`` solves this at the container level: a message field that
+is declared as ``uint8[]`` in the ``.msg`` file is still a byte array on the
+wire and still behaves like a ``std::vector<uint8_t>`` by default, but its
+implementation is a pluggable pimpl that backends can replace with
+their own memory-domain-specific storage.
+
+Architecture
+------------
+
+The feature is split across three core packages and a pluggable set of
+vendor-provided backend packages.
+
+Core packages
+^^^^^^^^^^^^^
+
+* ``rosidl_buffer`` -- defines the user-facing ``rosidl::Buffer<T>`` container
+  and the ``rosidl::BufferImplBase<T>`` abstract base class that backends
+  subclass.
+  ``rosidl::Buffer<T>`` forwards every operation to the implementation it
+  holds and provides implicit conversion to ``std::vector<T>&`` when the
+  active backend is CPU, which is what preserves backward compatibility.
+* ``rosidl_buffer_backend`` -- defines the ``rosidl::BufferBackend`` plugin
+  interface that vendors implement.
+  The interface is intentionally small: it advertises the backend's name and
+  descriptor message type, creates and consumes descriptor messages on the
+  publishing and receiving sides, and participates in endpoint discovery.
+* ``rosidl_buffer_backend_registry`` -- discovers installed backend plugins
+  via ``pluginlib`` and exposes them to the rest of the stack.
+
+User-facing containers and implementation pimpls
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   ┌──────────────────────────────┐
+   │     rosidl::Buffer<T>        │  (what generated messages hold)
+   │  ┌────────────────────────┐  │
+   │  │ BufferImplBase<T>  ◄──-┼──┼── CpuBufferImpl<T>      (default)
+   │  │ (pimpl)                │  │── CudaBufferImpl<T>     (vendor)
+   │  └────────────────────────┘  │── TorchBufferImpl<T>    (vendor)
+   └──────────────────────────────┘── ...
+
+A freshly-constructed ``rosidl::Buffer<T>`` uses ``CpuBufferImpl<T>``, which
+simply wraps a ``std::vector<T, Allocator>``.
+A backend swaps this out for its own ``BufferImplBase<T>`` subclass when it
+allocates a buffer (on the publisher side) or reconstructs one from a
+received descriptor (on the subscriber side).
+
+The backend plugin
+^^^^^^^^^^^^^^^^^^
+
+The ``rosidl::BufferBackend`` plugin is what the RMW layer talks to.
+Its job is essentially to translate between an in-memory
+``BufferImplBase<T>`` and a **descriptor message** -- a normal ROS 2 ``.msg``
+that describes how to locate or reconstruct the payload on the receiving
+side.
+For a CPU-only backend the descriptor would just carry the bytes;
+for a GPU backend it typically carries an IPC handle plus metadata.
+
+Descriptor messages are bounded (``rosidl::kMaxBufferDescriptorSize``, 4096
+bytes) so that the RMW can plan serialization buffer sizes up front.
+
+Descriptor round-trip and RMW integration
+-----------------------------------------
+
+When a publisher sends a message that contains a ``rosidl::Buffer<T>`` field
+with a non-CPU backend, the RMW:
+
+#. asks the backend to build a descriptor for the current peer
+   (``create_descriptor_with_endpoint``);
+#. serializes the descriptor in place of the raw ``uint8[]`` bytes;
+#. on the subscriber side, deserializes the descriptor and asks the backend
+   to rebuild a ``BufferImplBase<T>`` from it
+   (``from_descriptor_with_endpoint``).
+
+Discovery hooks
+^^^^^^^^^^^^^^^
+
+Backends are told about every matched endpoint via
+``on_creating_endpoint`` (local) and ``on_discovering_endpoint`` (remote).
+They use these hooks to decide whether a given pub/sub pair is actually
+compatible with the backend's transport -- for instance, a GPU IPC backend
+might only accept peers on the same host and the same physical device.
+If a backend cannot serve a particular peer, it returns ``nullptr`` from
+``create_descriptor_with_endpoint`` and the RMW falls back to normal CPU
+serialization of the field.
+
+RMW-agnostic plugin contract
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The plugin interface itself is RMW-agnostic.
+``BufferBackend::get_descriptor_type_support()`` returns the generic
+``rosidl_message_type_support_t *`` aggregate handle (the same handle
+``rosidl_typesupport_cpp::get_message_type_support_handle<T>()`` produces)
+for the backend's descriptor message type.
+The consuming RMW resolves that aggregate to the concrete per-typesupport
+library it needs at runtime.
+The current ``rmw_fastrtps_cpp`` integration resolves this aggregate to
+``rosidl_typesupport_fastrtps_cpp``, but nothing in the backend API ties
+it to a specific RMW.
+
+Base backends and composed backends
+-----------------------------------
+
+The backend interface is narrow enough that vendors typically ship
+backends in two layers:
+
+* **Base backends** are tied to a memory substrate or a transport
+  technology.
+  Examples: a CUDA backend built on CUDA VMM and CUDA IPC; a ROCm backend;
+  a shared-memory backend.
+  A base backend knows how to allocate its memory, how to package it into a
+  descriptor, and how to re-import it on another endpoint.
+
+* **Composed backends** add a higher-level programming model on top of a
+  base backend while staying agnostic to *which* base they run on.
+  The canonical example is a PyTorch backend whose buffers are tensors with
+  shape/strides/dtype; the tensor storage is delegated to whatever base
+  backend is appropriate for the current device (CUDA today, CPU as a
+  portable fallback, other device backends in principle).
+
+Descriptors for composed backends typically embed a ``uint8[]`` field that
+the RMW serializes using the *inner* buffer's backend, so the composition
+does not require the composed backend to know the wire format of each base.
+
+This is the expected shape of the backend ecosystem: one or two
+vendor-specific base backends, plus a handful of well-known user-facing
+composed backends (tensor libraries, point-cloud libraries, etc.) that can
+be layered on top.
+
+Relationship to other ROS 2 mechanisms
+--------------------------------------
+
+* ``rosidl::Buffer`` is orthogonal to :doc:`intra-process communication
+  <../../Tutorials/Demos/Intra-Process-Communication>` and to
+  :doc:`loaned messages <../../How-To-Guides/Configure-ZeroCopy-loaned-messages>`.
+  A backend may implement either, both, or neither for a given pub/sub pair;
+  the decision lives entirely inside the backend.
+* Whether a given publisher/subscriber pair can actually use a non-CPU
+  transport (intra-process, inter-process same-host, inter-host, ...) is a
+  property of the backend implementation, not of ``rosidl::Buffer``.
+  Consult each backend's own documentation for its support matrix.
+* The ``.msg`` IDL does not change: a field that was ``uint8[]`` before is
+  still ``uint8[]``; only its generated C++ type changed from
+  ``std::vector<uint8_t>`` to ``rosidl::Buffer<uint8_t>``, and implicit
+  conversion keeps most existing code working.
+
+Where to go next
+----------------
+
+* :doc:`../../How-To-Guides/Using-Buffer-Backends` -- user-facing guide on
+  enabling a buffer backend for a subscription and reading/writing the
+  backend-native data.
+* :doc:`../../Tutorials/Advanced/Writing-a-Buffer-Backend` -- vendor-facing
+  guide on implementing and packaging a new ``BufferBackend`` plugin.
+* :doc:`../../Tutorials/Demos/GPU-Buffer-Transport` -- end-to-end demo that
+  exercises a GPU-backed publish/subscribe pipeline.

--- a/source/Concepts/Intermediate/About-Buffer-Backends.rst
+++ b/source/Concepts/Intermediate/About-Buffer-Backends.rst
@@ -96,8 +96,8 @@ Its job is essentially to translate between an in-memory
 ``BufferImplBase<T>`` and a **descriptor message** -- a normal ROS 2 ``.msg``
 that describes how to locate or reconstruct the payload on the receiving
 side.
-For a CPU-only backend the descriptor would just carry the bytes;
-for a GPU backend it typically carries an IPC handle plus metadata.
+For a CPU-only backend the descriptor can carry the bytes directly.
+For a non-CPU backend the descriptor is usually a small reference that the receiving side uses to re-attach to the payload; the exact mechanism is backend-specific.
 
 Descriptor messages are bounded (``rosidl::kMaxBufferDescriptorSize``, 4096
 bytes) so that the RMW can plan serialization buffer sizes up front.
@@ -120,9 +120,8 @@ Discovery hooks
 
 Backends are told about every matched endpoint via
 ``on_creating_endpoint`` (local) and ``on_discovering_endpoint`` (remote).
-They use these hooks to decide whether a given pub/sub pair is actually
-compatible with the backend's transport -- for instance, a GPU IPC backend
-might only accept peers on the same host and the same physical device.
+They use these hooks to decide whether a given pub/sub pair is actually compatible with the backend's transport.
+For instance, the CUDA backend currently accepts peers only when it can share CUDA VMM allocations safely.
 If a backend cannot serve a particular peer, it returns ``nullptr`` from
 ``create_descriptor_with_endpoint`` and the RMW falls back to normal CPU
 serialization of the field.
@@ -180,6 +179,21 @@ Relationship to other ROS 2 mechanisms
   still ``uint8[]``; only its generated C++ type changed from
   ``std::vector<uint8_t>`` to ``rosidl::Buffer<uint8_t>``, and implicit
   conversion keeps most existing code working.
+* The current RMW integration applies to topic publish/subscribe.
+  Services and actions continue to use their normal serialization paths and do not negotiate non-CPU buffer backends.
+
+Relationship to type adaptation
+------------------------------------------
+
+``rosidl::Buffer`` backends operate at the generated-message container layer.
+The ROS message definition remains the topic type, while selected variable-length primitive array fields can use backend-specific storage and descriptor-based transport.
+
+Type adaptation and systems such as Isaac ROS NITROS solve a different problem: they let application code work with framework-native types and negotiate adapted representations above the ROS message type, using mechanisms such as `REP 2007 <https://reps.openrobotics.org/rep-2007/>`__ and `REP 2009 <https://reps.openrobotics.org/rep-2009/>`__.
+The two approaches are not part of the same abstraction and are not intended to depend on each other; their scopes are different.
+They can coexist in an application when both are useful.
+For example, an adapted application type can still contain or produce a ROS message whose ``uint8[]`` field is backed by ``rosidl::Buffer``.
+
+One practical difference is that buffer backends are visible to the RMW publish/subscribe path, so a backend can provide cross-process transport support while type adaptation can only work within a single process.
 
 Where to go next
 ----------------

--- a/source/Glossary.rst
+++ b/source/Glossary.rst
@@ -36,3 +36,27 @@ Glossary of terms used throughout this documentation:
    repository
        A collection of packages usually managed using a :term:`VCS` like git or mercurial and usually hosted on a site like GitHub or BitBucket.
        In the context of this document, repositories usually contain one or more |packages| of one type or another.
+
+   Buffer
+       ``rosidl::Buffer<T>``, the in-memory container used by generated C++ messages for variable-length primitive array fields (``uint8[]``, ``float32[]``, ...).
+       It behaves like a ``std::vector<T>`` by default and supports pluggable memory backends so that vendors can back those fields with non-CPU memory.
+       See :doc:`Concepts/Intermediate/About-Buffer-Backends`.
+
+   Buffer backend
+       A ``pluginlib`` plugin, implementing the ``rosidl::BufferBackend`` interface, that teaches the RMW how to transport a ``rosidl::Buffer`` whose storage lives in a vendor-specific memory domain (for example, GPU memory).
+
+   Base backend
+       A ``rosidl::Buffer`` backend tied to a specific memory substrate or transport technology (for example a CUDA backend over CUDA IPC).
+       Base backends know how to allocate their memory, serialize it into a descriptor, and re-import it on another endpoint.
+
+   Composed backend
+       A ``rosidl::Buffer`` backend that layers a higher-level programming model (tensor metadata, point-cloud metadata, ...) on top of one or more base backends while remaining agnostic to which base backend actually holds the bytes.
+
+   Buffer descriptor
+       A normal ROS 2 ``.msg`` produced by a ``BufferBackend`` that travels on the wire in place of the raw ``uint8[]`` contents of a buffer-backed field.
+       Serialized descriptors must not exceed ``rosidl::kMaxBufferDescriptorSize`` (4096 bytes).
+
+   Acceptable backend list
+       The value of ``rclcpp::SubscriptionOptions::acceptable_buffer_backends`` (or ``acceptable_buffer_backends`` in ``rclpy``).
+       A comma-separated list of backend names the subscription is willing to receive; ``"cpu"`` (or empty) means CPU-only, ``"any"`` means any installed backend, and CPU is always implicitly acceptable.
+       See :doc:`How-To-Guides/Using-Buffer-Backends`.

--- a/source/Glossary.rst
+++ b/source/Glossary.rst
@@ -45,12 +45,9 @@ Glossary of terms used throughout this documentation:
    Buffer backend
        A ``pluginlib`` plugin, implementing the ``rosidl::BufferBackend`` interface, that teaches the RMW how to transport a ``rosidl::Buffer`` whose storage lives in a vendor-specific memory domain (for example, GPU memory).
 
-   Base backend
-       A ``rosidl::Buffer`` backend tied to a specific memory substrate or transport technology (for example a CUDA backend over CUDA IPC).
-       Base backends know how to allocate their memory, serialize it into a descriptor, and re-import it on another endpoint.
-
-   Composed backend
-       A ``rosidl::Buffer`` backend that layers a higher-level programming model (tensor metadata, point-cloud metadata, ...) on top of one or more base backends while remaining agnostic to which base backend actually holds the bytes.
+   Tensor message
+       A normal ROS 2 message, such as ``tensor_msgs/msg/ExperimentalTensor``, that carries tensor metadata and stores the raw tensor bytes in a ``uint8[]`` field backed by ``rosidl::Buffer``.
+       Libraries such as ``torch_conversions`` can map these messages to framework-native tensor types while the underlying bytes use a regular buffer backend such as ``cpu`` or ``cuda``.
 
    Buffer descriptor
        A normal ROS 2 ``.msg`` produced by a ``BufferBackend`` that travels on the wire in place of the raw ``uint8[]`` contents of a buffer-backed field.

--- a/source/How-To-Guides.rst
+++ b/source/How-To-Guides.rst
@@ -45,6 +45,7 @@ If you are new and looking to learn the ropes, start with the :doc:`Tutorials <T
    How-To-Guides/Using-ros2-param
    How-To-Guides/Using-ros1_bridge-Jammy-upstream
    How-To-Guides/Configure-ZeroCopy-loaned-messages
+   How-To-Guides/Using-Buffer-Backends
    How-To-Guides/Installing-on-Raspberry-Pi
    How-To-Guides/Using-callback-groups
    How-To-Guides/Getting-Backtraces-in-ROS-2

--- a/source/How-To-Guides/Using-Buffer-Backends.rst
+++ b/source/How-To-Guides/Using-Buffer-Backends.rst
@@ -1,0 +1,342 @@
+Using ``rosidl::Buffer`` backends
+=================================
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+Overview
+--------
+
+``rosidl::Buffer<T>`` is the generated C++ representation of variable-length
+primitive array fields in ROS 2 messages (``uint8[]``, ``float32[]``, ...).
+It behaves like a ``std::vector<T>`` by default, but its storage is pluggable
+so that vendors can back those fields with non-CPU memory (for example, GPU
+memory) and transport them with as few copies as the RMW and the backend
+allow.
+
+See :doc:`../Concepts/Intermediate/About-Buffer-Backends` for a conceptual
+overview.
+
+This guide covers:
+
+* how to keep existing publishers and subscribers working without changes;
+* how to opt a subscription in to a specific set of backends;
+* how to use a backend's user-facing API to read and write its native data
+  type;
+* how to make sure publisher and subscriber are configured compatibly.
+
+Default behavior (no changes required)
+--------------------------------------
+
+If no backend is explicitly configured, ``rosidl::Buffer<T>`` still behaves
+like ``std::vector<T>``.
+Existing code such as
+
+.. code-block:: c++
+
+    auto msg = std::make_unique<sensor_msgs::msg::Image>();
+    msg->data.resize(width * height * 3);
+    std::memcpy(msg->data.data(), source_ptr, msg->data.size());
+    publisher_->publish(std::move(msg));
+
+continues to compile and run unchanged because ``rosidl::Buffer<uint8_t>``
+implicitly converts to ``std::vector<uint8_t> &`` when its active backend is
+CPU.
+
+On the subscription side, if a subscription does not opt in to any
+non-CPU backend (see below), the RMW delivers the data with the CPU backend
+just like it did before the feature was introduced, so
+``msg->data.size()``, ``msg->data[i]``, ``msg->data.data()`` and so on keep
+working.
+
+RMW support
+-----------
+
+Buffer backends require support from the RMW implementation to negotiate
+and serialize descriptors on the wire.
+
+.. list-table:: Buffer backend support status
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - RMW implementation
+     - Support status
+     - Notes
+   * - ``rmw_fastrtps_cpp``
+     - supported
+     - First and currently only supported RMW implementation.
+   * - ``rmw_cyclonedds_cpp``
+     - not supported
+     - Subscriptions fall back to CPU even when a non-CPU backend is
+       requested.
+   * - ``rmw_connextdds``
+     - not supported
+     - Subscriptions fall back to CPU even when a non-CPU backend is
+       requested.
+
+On an unsupported RMW, a subscription that requests a non-CPU backend still
+functions -- it simply receives CPU-backed data, exactly as if
+``acceptable_buffer_backends`` had not been set.
+
+Discovering installed backends
+------------------------------
+
+Backend plugins are discovered through ``pluginlib`` and live in packages
+whose ``package.xml`` exports the ``rosidl_buffer_backend`` plugin
+description file.
+To see which backends are installed in the current environment:
+
+.. code-block:: console
+
+    $ ros2 pkg list | grep _buffer_backend
+
+Each backend package usually installs two things:
+
+* the backend plugin itself (a shared library), registered under a short
+  name such as ``cuda`` or ``torch`` in the plugin XML;
+* a descriptor-message package (``*_msgs``) containing the backend's
+  descriptor ``.msg`` type.
+
+Both must be installed on every node that participates in the topic --
+publishers, subscribers, and (for composed backends) the underlying base
+backends as well.
+
+Enabling a backend on a subscription
+------------------------------------
+
+Publishers do **not** advertise a list of backends; they simply publish
+whatever backend their buffer currently uses.
+Subscriptions, on the other hand, opt in to non-CPU backends via the
+``acceptable_buffer_backends`` option on ``rclcpp::SubscriptionOptions``
+(or the ``acceptable_buffer_backends`` keyword argument in ``rclpy``).
+
+The option is a comma-separated string of backend names.
+It accepts the following forms:
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Value
+     - Meaning
+   * - empty or ``"cpu"``
+     - CPU only. This is the default and preserves backward compatibility.
+   * - ``"any"``
+     - Accept any backend that is installed in this process.
+   * - ``"cuda,torch"``
+     - Accept only the listed backends, in addition to CPU. Names match the
+       plugin ``name`` attribute in the backend's plugin XML.
+
+CPU is always implicitly acceptable, so no matter what is specified, a
+subscription can always receive CPU-backed messages (for example, when the
+publisher's backend cannot serve this particular peer).
+
+C++ example
+^^^^^^^^^^^
+
+.. code-block:: c++
+
+    #include <cuda_runtime.h>
+
+    #include "rclcpp/rclcpp.hpp"
+    #include "sensor_msgs/msg/image.hpp"
+    #include "cuda_buffer/cuda_buffer_api.hpp"
+
+    class GpuImageSubscriber : public rclcpp::Node
+    {
+    public:
+      GpuImageSubscriber()
+      : Node("gpu_image_subscriber")
+      {
+        cudaStreamCreate(&stream_);
+
+        rclcpp::SubscriptionOptions sub_opts;
+        sub_opts.acceptable_buffer_backends = "cuda";
+
+        subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
+          "image", 10,
+          [this](sensor_msgs::msg::Image::SharedPtr msg) {
+            if (msg->data.get_backend_type() == "cuda") {
+              // Zero-copy GPU path: read the device pointer directly.
+              auto rh = cuda_buffer_backend::from_buffer(msg->data, stream_);
+              process_on_gpu(rh.get_ptr(), msg->data.size(), stream_);
+            } else {
+              // CPU fallback: msg->data behaves like std::vector<uint8_t>.
+              process_on_cpu(msg->data.data(), msg->data.size());
+            }
+          },
+          sub_opts);
+      }
+
+    private:
+      rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr subscription_;
+      cudaStream_t stream_{nullptr};
+    };
+
+Two things to note:
+
+* The subscription only declares which backends are *acceptable*; the actual
+  backend of a received message is whatever the publisher sent, subject to
+  negotiation.
+  Always branch on ``msg->data.get_backend_type()`` before using a
+  backend-specific API.
+* Backend APIs (``cuda_buffer_backend::from_buffer``,
+  ``torch_buffer_backend::from_buffer``, ...) are provided by the backend
+  package, not by ``rclcpp``.
+  Consult each backend's own documentation for its full API surface.
+
+Python
+^^^^^^
+
+``rclpy`` exposes the same option as a keyword argument on
+``Node.create_subscription``:
+
+.. code-block:: python
+
+    self.create_subscription(
+        Image,
+        'image',
+        self.image_callback,
+        10,
+        acceptable_buffer_backends='cuda')
+
+On the Python side the ``data`` field still surfaces as a byte sequence;
+backend user-facing APIs are currently C++-only, so Python subscribers that
+accept non-CPU backends typically rely on the backend's own CPU-fallback
+path (the RMW serializes the buffer to CPU if the backend cannot serve the
+Python endpoint directly).
+
+Publisher side
+--------------
+
+Publishers use the backend's allocation API to produce a message whose
+``uint8[]`` field is already backed by that backend's memory.
+For example, with the CUDA backend:
+
+.. code-block:: c++
+
+    #include "cuda_buffer/cuda_buffer_api.hpp"
+
+    auto msg = cuda_buffer_backend::allocate_msg<sensor_msgs::msg::Image>(
+      width * height * 3);
+    msg.header.stamp = this->now();
+    msg.width = width;
+    msg.height = height;
+    msg.encoding = "rgb8";
+    msg.step = width * 3;
+
+    {
+      auto wh = cuda_buffer_backend::from_buffer(msg.data, stream_);
+      my_kernel<<<grid, block, 0, stream_>>>(wh.get_ptr(), ...);
+    }
+
+    publisher_->publish(msg);
+
+A publisher does not need any ``rclcpp`` option changes; the backend of the
+buffer inside the message is what the RMW sees at publish time.
+If a given subscriber has not opted in to that backend, the RMW falls back
+to CPU serialization for that peer transparently -- the publisher writes the
+same message either way.
+
+Ensuring a compatible pub/sub pair
+----------------------------------
+
+Aside from matching backend names (``"cuda"`` on both sides, and so on),
+there are three practical rules for making a non-CPU path actually work
+end-to-end.
+
+1. Install the same backend on both sides
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Both the backend plugin package **and** its descriptor-message package
+(``*_backend_msgs``) must be installed and available to the process.
+If the subscriber is missing either, it will silently fall back to CPU and
+log a warning from the RMW buffer-backend loader.
+
+Check with:
+
+.. code-block:: console
+
+    $ ros2 pkg list | grep -E 'cuda_buffer|torch_buffer'
+
+For composed backends (see :doc:`../Concepts/Intermediate/About-Buffer-Backends`)
+the base backend must be installed too: e.g. ``torch_buffer_backend``
+generally requires ``cuda_buffer_backend`` to run its CUDA path.
+
+2. Use the same RMW on both sides
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the same RMW implementation for publisher and subscriber.
+Buffer descriptors are serialized through the RMW's normal type-support
+pipeline, so the ordinary advice for
+:doc:`multiple RMW implementations <Working-with-multiple-RMW-implementations>`
+applies: set ``RMW_IMPLEMENTATION`` consistently.
+
+3. Keep backend versions aligned with ROS 2 core
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Backend plugins are ABI-coupled to ``rosidl_buffer_backend`` and to the
+RMW's type-support library.
+Rebuild installed backends after upgrading ROS 2 core, the same way you
+would rebuild any other plugin package.
+
+Transport scope depends on the backend
+--------------------------------------
+
+``rosidl::Buffer`` only guarantees that the descriptor round-trips through
+the RMW.
+Whether a given ``backend`` can actually carry data intra-process,
+inter-process on the same host, or inter-host is entirely a property of the
+backend implementation.
+Consult each backend's own documentation for its support matrix.
+
+For reference, the CUDA backend currently supports:
+
+* intra-process (same Python/C++ process);
+* inter-process on the same host, same GPU, same user (via CUDA VMM IPC);
+* inter-host is not supported; the RMW falls back to CPU serialization.
+
+Other backends have their own constraints, documented in their own
+repositories.
+
+Diagnostics
+-----------
+
+Inspecting negotiated transport
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Inside a subscription callback, ``msg->data.get_backend_type()`` returns the
+backend of the just-received message (``"cpu"``, ``"cuda"``, ``"torch"``,
+...).
+Comparing it to what you expected is the quickest way to tell whether the
+zero-copy path actually engaged or the RMW fell back to CPU.
+
+Listing loaded backends at runtime
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+From C++, the registry exposes a list of discovered plugins:
+
+.. code-block:: c++
+
+    #include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+
+    rosidl_buffer_backend_registry::BufferBackendRegistry registry;
+    for (const auto & name : registry.get_backend_names()) {
+      RCLCPP_INFO(rclcpp::get_logger("app"), "Loaded buffer backend: %s", name.c_str());
+    }
+
+Most backends also log a warning when they fall back to CPU
+serialization, which is visible at the default log level.
+
+Interaction with other transport features
+-----------------------------------------
+
+* :doc:`Loaned messages <Configure-ZeroCopy-loaned-messages>` operate at a
+  different layer: they let the RMW own the *message* memory, while
+  ``rosidl::Buffer`` backends control the storage of individual variable-length
+  array fields. The two features can be combined when both the RMW and the
+  backend support it.
+* :doc:`Intra-process communication <../Tutorials/Demos/Intra-Process-Communication>`
+  is orthogonal: a backend may implement its own intra-process fast path
+  (the CUDA backend does), but the decision is up to the backend.

--- a/source/How-To-Guides/Using-Buffer-Backends.rst
+++ b/source/How-To-Guides/Using-Buffer-Backends.rst
@@ -121,12 +121,13 @@ It accepts the following forms:
    * - Value
      - Meaning
    * - empty or ``"cpu"``
-     - CPU only. This is the default and preserves backward compatibility.
+     - CPU only.
+       This is the default and preserves backward compatibility.
    * - ``"any"``
      - Accept any backend that is installed in this process.
    * - ``"cuda,torch"``
-     - Accept only the listed backends, in addition to CPU. Names match the
-       plugin ``name`` attribute in the backend's plugin XML.
+     - Accept only the listed backends, in addition to CPU.
+       Names match the plugin ``name`` attribute in the backend's plugin XML.
 
 CPU is always implicitly acceptable, so no matter what is specified, a
 subscription can always receive CPU-backed messages (for example, when the
@@ -335,8 +336,9 @@ Interaction with other transport features
 * :doc:`Loaned messages <Configure-ZeroCopy-loaned-messages>` operate at a
   different layer: they let the RMW own the *message* memory, while
   ``rosidl::Buffer`` backends control the storage of individual variable-length
-  array fields. The two features can be combined when both the RMW and the
-  backend support it.
+  array fields.
+  The two features can be combined when both the RMW and the backend support
+  it.
 * :doc:`Intra-process communication <../Tutorials/Demos/Intra-Process-Communication>`
   is orthogonal: a backend may implement its own intra-process fast path
   (the CUDA backend does), but the decision is up to the backend.

--- a/source/How-To-Guides/Using-Buffer-Backends.rst
+++ b/source/How-To-Guides/Using-Buffer-Backends.rst
@@ -24,6 +24,8 @@ This guide covers:
 * how to opt a subscription in to a specific set of backends;
 * how to use a backend's user-facing API to read and write its native data
   type;
+* how ``tensor_msgs/msg/ExperimentalTensor`` and ``torch_conversions`` use the
+  same backend mechanism for tensor data;
 * how to make sure publisher and subscriber are configured compatibly.
 
 Default behavior (no changes required)
@@ -56,27 +58,9 @@ RMW support
 Buffer backends require support from the RMW implementation to negotiate
 and serialize descriptors on the wire.
 
-.. list-table:: Buffer backend support status
-   :widths: 25 25 50
-   :header-rows: 1
-
-   * - RMW implementation
-     - Support status
-     - Notes
-   * - ``rmw_fastrtps_cpp``
-     - supported
-     - First and currently only supported RMW implementation.
-   * - ``rmw_cyclonedds_cpp``
-     - not supported
-     - Subscriptions fall back to CPU even when a non-CPU backend is
-       requested.
-   * - ``rmw_connextdds``
-     - not supported
-     - Subscriptions fall back to CPU even when a non-CPU backend is
-       requested.
-
-On an unsupported RMW, a subscription that requests a non-CPU backend still
-functions -- it simply receives CPU-backed data, exactly as if
+The first supported RMW integration is ``rmw_fastrtps_cpp``.
+With other RMW implementations, a subscription that requests a non-CPU
+backend still functions -- it simply receives CPU-backed data, exactly as if
 ``acceptable_buffer_backends`` had not been set.
 
 Discovering installed backends
@@ -94,13 +78,12 @@ To see which backends are installed in the current environment:
 Each backend package usually installs two things:
 
 * the backend plugin itself (a shared library), registered under a short
-  name such as ``cuda`` or ``torch`` in the plugin XML;
+  name such as ``cuda`` in the plugin XML;
 * a descriptor-message package (``*_msgs``) containing the backend's
   descriptor ``.msg`` type.
 
 Both must be installed on every node that participates in the topic --
-publishers, subscribers, and (for composed backends) the underlying base
-backends as well.
+publishers and subscribers.
 
 Enabling a backend on a subscription
 ------------------------------------
@@ -125,7 +108,7 @@ It accepts the following forms:
        This is the default and preserves backward compatibility.
    * - ``"any"``
      - Accept any backend that is installed in this process.
-   * - ``"cuda,torch"``
+   * - ``"cuda,mydev"``
      - Accept only the listed backends, in addition to CPU.
        Names match the plugin ``name`` attribute in the backend's plugin XML.
 
@@ -160,7 +143,7 @@ C++ example
           [this](sensor_msgs::msg::Image::SharedPtr msg) {
             if (msg->data.get_backend_type() == "cuda") {
               // Zero-copy GPU path: read the device pointer directly.
-              auto rh = cuda_buffer_backend::from_buffer(msg->data, stream_);
+              auto rh = cuda_buffer_backend::from_input_buffer(msg->data, stream_);
               process_on_gpu(rh.get_ptr(), msg->data.size(), stream_);
             } else {
               // CPU fallback: msg->data behaves like std::vector<uint8_t>.
@@ -182,8 +165,8 @@ Two things to note:
   negotiation.
   Always branch on ``msg->data.get_backend_type()`` before using a
   backend-specific API.
-* Backend APIs (``cuda_buffer_backend::from_buffer``,
-  ``torch_buffer_backend::from_buffer``, ...) are provided by the backend
+* Backend APIs (``cuda_buffer_backend::from_input_buffer``,
+  ``cuda_buffer_backend::from_output_buffer``, ...) are provided by the backend
   package, not by ``rclcpp``.
   Consult each backend's own documentation for its full API surface.
 
@@ -219,8 +202,8 @@ For example, with the CUDA backend:
 
     #include "cuda_buffer/cuda_buffer_api.hpp"
 
-    auto msg = cuda_buffer_backend::allocate_msg<sensor_msgs::msg::Image>(
-      width * height * 3);
+    sensor_msgs::msg::Image msg;
+    msg.data = cuda_buffer_backend::allocate_buffer(width * height * 3);
     msg.header.stamp = this->now();
     msg.width = width;
     msg.height = height;
@@ -228,7 +211,7 @@ For example, with the CUDA backend:
     msg.step = width * 3;
 
     {
-      auto wh = cuda_buffer_backend::from_buffer(msg.data, stream_);
+      auto wh = cuda_buffer_backend::from_output_buffer(msg.data, stream_);
       my_kernel<<<grid, block, 0, stream_>>>(wh.get_ptr(), ...);
     }
 
@@ -239,6 +222,49 @@ buffer inside the message is what the RMW sees at publish time.
 If a given subscriber has not opted in to that backend, the RMW falls back
 to CPU serialization for that peer transparently -- the publisher writes the
 same message either way.
+
+Tensor messages with ``torch_conversions``
+------------------------------------------
+
+The experimental tensor path uses a normal ROS 2 message,
+``tensor_msgs/msg/ExperimentalTensor``.
+Its ``data`` field is a ``rosidl::Buffer<uint8_t>``, while the other fields
+carry DLPack-aligned tensor metadata such as dtype, shape, strides, and byte
+offset.
+The ``torch_conversions`` package is a header-only helper library that fills
+that message and converts it to or from ``at::Tensor``; it does not register a
+separate buffer backend.
+
+On the publisher side:
+
+.. code-block:: c++
+
+    #include "torch_conversions/torch_conversions.hpp"
+    #include "tensor_msgs/msg/experimental_tensor.hpp"
+
+    auto guard = torch_conversions::set_stream();
+    auto msg = torch_conversions::allocate_tensor_msg(
+      {height, width, 4}, torch::kByte, c10::kCUDA);
+    torch_conversions::to_tensor_msg(msg, rendered_frame);
+    publisher_->publish(msg);
+
+On the subscriber side, opt in to the storage backend you want to accept and
+then convert the received tensor message:
+
+.. code-block:: c++
+
+    rclcpp::SubscriptionOptions sub_opts;
+    sub_opts.acceptable_buffer_backends = "cuda";
+
+    subscription_ = this->create_subscription<tensor_msgs::msg::ExperimentalTensor>(
+      "image", 10,
+      [](const tensor_msgs::msg::ExperimentalTensor::SharedPtr msg) {
+        auto guard = torch_conversions::set_stream();
+        at::Tensor frame =
+          torch_conversions::from_input_tensor_msg(*msg, /*clone=*/false);
+        consume(frame);
+      },
+      sub_opts);
 
 Ensuring a compatible pub/sub pair
 ----------------------------------
@@ -259,11 +285,12 @@ Check with:
 
 .. code-block:: console
 
-    $ ros2 pkg list | grep -E 'cuda_buffer|torch_buffer'
+    $ ros2 pkg list | grep cuda_buffer
 
-For composed backends (see :doc:`../Concepts/Intermediate/About-Buffer-Backends`)
-the base backend must be installed too: e.g. ``torch_buffer_backend``
-generally requires ``cuda_buffer_backend`` to run its CUDA path.
+Libraries built on top of ``rosidl::Buffer`` may have their own dependencies.
+For example, ``torch_conversions`` uses the ``cuda`` backend for CUDA tensor
+storage when the CUDA packages are available, but it does not register a
+separate buffer backend name.
 
 2. Use the same RMW on both sides
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -308,8 +335,7 @@ Inspecting negotiated transport
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Inside a subscription callback, ``msg->data.get_backend_type()`` returns the
-backend of the just-received message (``"cpu"``, ``"cuda"``, ``"torch"``,
-...).
+backend of the just-received message (``"cpu"``, ``"cuda"``, ...).
 Comparing it to what you expected is the quickest way to tell whether the
 zero-copy path actually engaged or the RMW fell back to CPU.
 

--- a/source/How-To-Guides/Using-Buffer-Backends.rst
+++ b/source/How-To-Guides/Using-Buffer-Backends.rst
@@ -63,6 +63,9 @@ With other RMW implementations, a subscription that requests a non-CPU
 backend still functions -- it simply receives CPU-backed data, exactly as if
 ``acceptable_buffer_backends`` had not been set.
 
+The non-CPU backend path currently applies to topic publish/subscribe only.
+Services and actions do not expose an ``acceptable_buffer_backends`` option and continue to use their normal request, response, feedback, status, and result serialization paths.
+
 Discovering installed backends
 ------------------------------
 
@@ -140,7 +143,7 @@ C++ example
 
         subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
           "image", 10,
-          [this](sensor_msgs::msg::Image::SharedPtr msg) {
+          [this](sensor_msgs::msg::Image::ConstSharedPtr msg) {
             if (msg->data.get_backend_type() == "cuda") {
               // Zero-copy GPU path: read the device pointer directly.
               auto rh = cuda_buffer_backend::from_input_buffer(msg->data, stream_);
@@ -222,6 +225,16 @@ buffer inside the message is what the RMW sees at publish time.
 If a given subscriber has not opted in to that backend, the RMW falls back
 to CPU serialization for that peer transparently -- the publisher writes the
 same message either way.
+
+QoS considerations
+------------------
+
+QoS compatibility is still checked by the RMW implementation in the usual way.
+The backend selection controls how eligible buffer fields are represented once a sample is being delivered; it does not replace DDS reliability, history, deadline, lifespan, or liveliness behavior.
+
+The CUDA backend's zero-copy path is intended for live topic samples.
+Use volatile durability for CUDA-backed topics.
+Transient-local durability for late-joining subscribers is not a supported zero-copy CUDA use case, because the descriptor refers to publisher-owned live memory that may be recycled by the backend.
 
 Tensor messages with ``torch_conversions``
 ------------------------------------------
@@ -323,7 +336,7 @@ For reference, the CUDA backend currently supports:
 
 * intra-process (same Python/C++ process);
 * inter-process on the same host, same GPU, same user (via CUDA VMM IPC);
-* inter-host is not supported; the RMW falls back to CPU serialization.
+* inter-host CUDA transport is not currently supported by this backend, so it declines that peer and the publish/subscribe path uses CPU serialization for the field.
 
 Other backends have their own constraints, documented in their own
 repositories.

--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -23,7 +23,7 @@ Community ``rosidl::Buffer`` backends
 Out-of-tree :doc:`buffer backend <Concepts/Intermediate/About-Buffer-Backends>` plugins let ``rosidl::Buffer`` fields (``uint8[]``, etc.) use vendor-specific memory domains such as GPU memory.
 For background, see :doc:`How-To-Guides/Using-Buffer-Backends` and :doc:`Tutorials/Advanced/Writing-a-Buffer-Backend`.
 
-* **rosidl_buffer_backends** `(github.com/ros2/rosidl_buffer_backends) <https://github.com/ros2/rosidl_buffer_backends>`_: CUDA and PyTorch buffer backend implementations for ``rosidl::Buffer``, enabling zero-copy GPU memory sharing between ROS 2 publishers and subscribers.
+* **rosidl_buffer_backends** `(github.com/ros2/rosidl_buffer_backends) <https://github.com/ros2/rosidl_buffer_backends>`_: CUDA buffer backend implementation for ``rosidl::Buffer`` plus ``tensor_msgs/msg/ExperimentalTensor`` and ``torch_conversions`` helpers, enabling zero-copy GPU memory sharing between ROS 2 publishers and subscribers.
 * **rosidl_buffer_backends_tutorials** `(github.com/ros2/rosidl_buffer_backends_tutorials) <https://github.com/ros2/rosidl_buffer_backends_tutorials>`_: End-to-end demos exercising ``rosidl_buffer_backends``, including the ``robot_arm_demo`` featured in :doc:`Tutorials/Demos/GPU-Buffer-Transport`.
 
 Further Community Projects

--- a/source/Related-Projects.rst
+++ b/source/Related-Projects.rst
@@ -17,6 +17,15 @@ Large community projects involve multiple developers from all over the globe and
 * **MoveIt** `(moveit.ai) <https://moveit.ai/>`_: A rich platform for building manipulation applications featuring advanced kinematics, motion planning, control, collision checking, and much more.
 * **micro-ROS** `(micro.ros.org) <https://micro.ros.org/>`_: A platform for putting ROS 2 onto microcontrollers, starting at less than 100 kB of RAM.
 
+Community ``rosidl::Buffer`` backends
+-------------------------------------
+
+Out-of-tree :doc:`buffer backend <Concepts/Intermediate/About-Buffer-Backends>` plugins let ``rosidl::Buffer`` fields (``uint8[]``, etc.) use vendor-specific memory domains such as GPU memory.
+For background, see :doc:`How-To-Guides/Using-Buffer-Backends` and :doc:`Tutorials/Advanced/Writing-a-Buffer-Backend`.
+
+* **rosidl_buffer_backends** `(github.com/ros2/rosidl_buffer_backends) <https://github.com/ros2/rosidl_buffer_backends>`_: CUDA and PyTorch buffer backend implementations for ``rosidl::Buffer``, enabling zero-copy GPU memory sharing between ROS 2 publishers and subscribers.
+* **rosidl_buffer_backends_tutorials** `(github.com/ros2/rosidl_buffer_backends_tutorials) <https://github.com/ros2/rosidl_buffer_backends_tutorials>`_: End-to-end demos exercising ``rosidl_buffer_backends``, including the ``robot_arm_demo`` featured in :doc:`Tutorials/Demos/GPU-Buffer-Transport`.
+
 Further Community Projects
 --------------------------
 

--- a/source/The-ROS2-Project/Features.rst
+++ b/source/The-ROS2-Project/Features.rst
@@ -87,6 +87,11 @@ For planned future development, see the :doc:`Roadmap <Roadmap>`.
    * - Action Introspection
      - :doc:`Demo <../Tutorials/Demos/Action-Introspection>`
      -
+   * - :doc:`Pluggable buffer backends <../Concepts/Intermediate/About-Buffer-Backends>` for ``uint8[]`` fields (e.g. GPU memory transport)
+     - :doc:`Concept <../Concepts/Intermediate/About-Buffer-Backends>`, :doc:`How-to Guide <../How-To-Guides/Using-Buffer-Backends>`, :doc:`Demo <../Tutorials/Demos/GPU-Buffer-Transport>`
+     - Experimental.
+       Currently supported in ``rmw_fastrtps_cpp``.
+       User-facing backend APIs are C++-only today.
 
 Besides core features of the platform, the biggest impact of ROS comes from its available packages.
 The following are a few high-profile packages which are available in the latest release:

--- a/source/Tutorials/Advanced.rst
+++ b/source/Tutorials/Advanced.rst
@@ -20,5 +20,6 @@ Advanced
    Advanced/Create-An-Rqtbag-Plugin
    Advanced/ROS2-Tracing-Trace-and-Analyze
    Advanced/Creating-An-RMW-Implementation
+   Advanced/Writing-a-Buffer-Backend
    Advanced/Simulators/Simulation-Main
    Advanced/Security/Security-Main

--- a/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
+++ b/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
@@ -52,14 +52,16 @@ All three are small enough to read in full:
 
 * ``cuda_buffer_backend``: a realistic **base backend** built on CUDA VMM
   and CUDA IPC, with intra-process, inter-process same-host, and CPU-fallback
-  paths. See `ros2/rosidl_buffer_backends <https://github.com/ros2/rosidl_buffer_backends>`__.
+  paths.
+  See `ros2/rosidl_buffer_backends <https://github.com/ros2/rosidl_buffer_backends>`__.
 * ``torch_buffer_backend``: a **composed backend** that wraps a device
   backend (CUDA today, CPU as a fallback) and adds tensor semantics.
   Same repository.
 * ``demo_buffer_backend``: a minimal CPU-to-CPU backend used by the
-  ``rosidl::Buffer`` system tests. Useful as a pedagogical example with no
-  device dependencies. See ``rcl_buffer/demo_buffer_backend`` in the
-  workspace used by this tutorial.
+  ``rosidl::Buffer`` system tests.
+  Useful as a pedagogical example with no device dependencies.
+  See ``rcl_buffer/demo_buffer_backend`` in the workspace used by this
+  tutorial.
 
 The ``BufferBackend`` interface
 -------------------------------
@@ -140,8 +142,8 @@ buffer whose size and contents match the publisher's buffer.
 Two important constraints:
 
 * The serialized descriptor must be no larger than
-  ``rosidl::kMaxBufferDescriptorSize`` bytes (4096). The RMW plans its
-  serialization buffers around this bound.
+  ``rosidl::kMaxBufferDescriptorSize`` bytes (4096).
+  The RMW plans its serialization buffers around this bound.
 * The descriptor package must be a plain ``rosidl_default_generators``
   message package so that the generic
   ``rosidl_typesupport_cpp::get_message_type_support_handle<T>()`` returns an
@@ -174,7 +176,8 @@ and Torch backend (``torch_buffer_backend_msgs/TorchBufferDescriptor.msg``)
 illustrate two different descriptor shapes: the CUDA descriptor carries IPC
 handles directly, while the Torch descriptor carries a ``uint8[]``
 ``device_data`` field that the RMW re-serializes using the *inner* buffer's
-backend. The second pattern is what makes a composed backend base-agnostic.
+backend.
+The second pattern is what makes a composed backend base-agnostic.
 
 Step 2: Implement ``BufferImplBase<T>``
 ---------------------------------------
@@ -244,13 +247,15 @@ Current RMW integrations resolve the aggregate to
 These are the two hot-path methods.
 
 ``create_descriptor_with_endpoint`` is called on the publisher side once per
-matched remote endpoint. It receives a type-erased non-owning pointer to a
+matched remote endpoint.
+It receives a type-erased non-owning pointer to a
 ``BufferImplBase<uint8_t>`` and the peer's ``rmw_topic_endpoint_info_t``.
 Return a filled-in descriptor for that peer, or ``nullptr`` to tell the RMW
 *"I cannot serve this peer with my backend; please fall back to CPU
 serialization."*
 
-Returning ``nullptr`` is a first-class signal. Use it whenever:
+Returning ``nullptr`` is a first-class signal.
+Use it whenever:
 
 * the peer does not support your backend (check
   ``endpoint_supported_backends`` during discovery and cache the answer);
@@ -259,11 +264,12 @@ Returning ``nullptr`` is a first-class signal. Use it whenever:
 * any other reason a non-CPU path is not available for *this* peer.
 
 ``from_descriptor_with_endpoint`` is the inverse, invoked on the subscriber
-side. It must produce a ``std::unique_ptr<void, void (*)(void *)>`` owning a
-freshly-constructed ``BufferImplBase<T>``. The custom deleter is
-**required** because the plugin may be unloaded independently of the rest
-of the process; the deleter ensures destruction happens inside the correct
-shared library.
+side.
+It must produce a ``std::unique_ptr<void, void (*)(void *)>`` owning a
+freshly-constructed ``BufferImplBase<T>``.
+The custom deleter is **required** because the plugin may be unloaded
+independently of the rest of the process; the deleter ensures destruction
+happens inside the correct shared library.
 
 A typical deleter looks like:
 
@@ -285,17 +291,18 @@ register themselves.
 It returns a ``std::pair<bool, std::vector<std::set<uint32_t>>>``:
 
 * The ``bool`` tells the RMW whether this peer is served by the backend at
-  all. Returning ``false`` permanently routes this peer to CPU
-  serialization.
+  all.
+  Returning ``false`` permanently routes this peer to CPU serialization.
 * The ``std::vector<std::set<uint32_t>>`` is for backends that need to
   group endpoints (e.g. which subscribers share the same device and can use
-  the same IPC handle). Most backends leave this empty.
+  the same IPC handle).
+  Most backends leave this empty.
 
 The ``endpoint_supported_backends`` argument is a map from the peer's
-advertised backend names to their metadata strings. A correct backend
-**must** check that its own name is in this map before declaring the peer
-compatible; otherwise a publisher will waste descriptor work on a
-subscription that cannot consume it.
+advertised backend names to their metadata strings.
+A correct backend **must** check that its own name is in this map before
+declaring the peer compatible; otherwise a publisher will waste descriptor
+work on a subscription that cannot consume it.
 
 Example from the Torch backend:
 
@@ -487,12 +494,12 @@ Typical auxiliary considerations:
   to live in some other backend (CPU, another device backend, ...), a
   helpful pattern is to allocate a new buffer in *your* domain and copy
   into it transparently, keeping ownership via a ``get_promoted_buffer()``
-  getter on the returned handle. The CUDA backend does this for CPU-to-CUDA
-  inputs.
+  getter on the returned handle.
+  The CUDA backend does this for CPU-to-CUDA inputs.
 * **Synchronisation**: if your backend is asynchronous (streams, events,
   queues), encode the synchronisation policy into your handle types rather
-  than on the free functions. RAII on destruction makes correct use the
-  default.
+  than on the free functions.
+  RAII on destruction makes correct use the default.
 * **Reading is safe by default**: for read handles, a ``clone=true`` default
   that returns an independent copy is a useful safety net; offer a
   ``clone=false`` zero-copy overload for callers that explicitly want it.
@@ -507,12 +514,13 @@ metadata, ...).
 The recommended pattern is:
 
 * Your ``BufferImplBase<T>`` subclass *contains* a ``rosidl::Buffer<T>``
-  member for the device bytes. The inner buffer's backend is whichever base
-  is appropriate for the current device (``"cuda"``, ``"cpu"``, and so on).
+  member for the device bytes.
+  The inner buffer's backend is whichever base is appropriate for the
+  current device (``"cuda"``, ``"cpu"``, and so on).
 * Your descriptor ``.msg`` carries the high-level metadata plus a
-  ``uint8[]`` field holding the inner buffer. The RMW serializes that inner
-  field using the *inner* backend's logic, so your composed backend never
-  has to know each base's wire format.
+  ``uint8[]`` field holding the inner buffer.
+  The RMW serializes that inner field using the *inner* backend's logic, so
+  your composed backend never has to know each base's wire format.
 * In discovery, accept the peer if and only if it also supports your
   composed backend name (not the base name): two endpoints that both happen
   to support ``"cuda"`` do not automatically understand each other's
@@ -538,7 +546,8 @@ Testing
 -------
 
 The most useful tests for a backend are launch tests that exercise real
-pub/sub topologies. The reference CUDA backend ships a representative set:
+pub/sub topologies.
+The reference CUDA backend ships a representative set:
 
 * intra-process (publisher and subscriber in the same process);
 * inter-process on the same host;

--- a/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
+++ b/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
@@ -1,0 +1,591 @@
+Writing a ``rosidl::Buffer`` backend
+====================================
+
+**Goal:** Learn how to implement and package a new ``rosidl::Buffer``
+backend plugin so that a vendor-specific memory domain (GPU, shared memory,
+tensor library, ...) can back ``uint8[]`` fields of ROS 2 messages.
+
+**Tutorial level:** Advanced
+
+**Time:** 60+ minutes
+
+.. contents:: Table of Contents
+   :local:
+
+Introduction
+------------
+
+:doc:`rosidl::Buffer backends <../../Concepts/Intermediate/About-Buffer-Backends>`
+let vendors transport the bytes of a ``uint8[]`` message field through ROS 2
+pub/sub with as few copies as their memory technology permits.
+A backend is a ``pluginlib`` plugin that implements the
+``rosidl::BufferBackend`` interface from the ``rosidl_buffer_backend``
+package.
+
+This guide shows how to build such a plugin, end to end.
+It uses a hypothetical ``mydev`` backend in the prose (for a vendor device
+memory domain) and refers to the real CUDA, Torch, and demo backends in the
+reference links for concrete code.
+
+This guide is intended as a starting point; the existing reference backends
+go into much more detail than is practical to reproduce here.
+The core contract, however, is small: once your plugin can answer the six
+``BufferBackend`` virtuals correctly for a single message type, everything
+else is polish.
+
+When **not** to write a backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A backend is the right tool when you want to change the *memory domain* of
+variable-length primitive array fields.
+If your goal is to reduce copies within CPU memory, you are almost
+certainly looking for :doc:`intra-process communication
+<../Demos/Intra-Process-Communication>` or
+:doc:`loaned messages <../../How-To-Guides/Configure-ZeroCopy-loaned-messages>`
+instead.
+
+Reference implementations
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Three open-source backends are good reading.
+All three are small enough to read in full:
+
+* ``cuda_buffer_backend``: a realistic **base backend** built on CUDA VMM
+  and CUDA IPC, with intra-process, inter-process same-host, and CPU-fallback
+  paths. See `ros2/rosidl_buffer_backends <https://github.com/ros2/rosidl_buffer_backends>`__.
+* ``torch_buffer_backend``: a **composed backend** that wraps a device
+  backend (CUDA today, CPU as a fallback) and adds tensor semantics.
+  Same repository.
+* ``demo_buffer_backend``: a minimal CPU-to-CPU backend used by the
+  ``rosidl::Buffer`` system tests. Useful as a pedagogical example with no
+  device dependencies. See ``rcl_buffer/demo_buffer_backend`` in the
+  workspace used by this tutorial.
+
+The ``BufferBackend`` interface
+-------------------------------
+
+The plugin interface is declared in
+`rosidl_buffer_backend/buffer_backend.hpp
+<https://github.com/ros2/rosidl/blob/{DISTRO}/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp>`__.
+It has six methods you will commonly override, plus a descriptor-size
+constant.
+
+.. code-block:: c++
+
+    namespace rosidl
+    {
+
+    inline constexpr size_t kMaxBufferDescriptorSize = 4096;
+
+    class BufferBackend
+    {
+    public:
+      virtual ~BufferBackend() = default;
+
+      // Identity
+      virtual std::string get_backend_type() const = 0;
+      virtual std::string get_backend_metadata() const { return ""; }
+
+      // Descriptor type support and construction
+      virtual const rosidl_message_type_support_t *
+      get_descriptor_type_support() const = 0;
+      virtual std::shared_ptr<void> create_empty_descriptor() const = 0;
+      virtual std::shared_ptr<void> create_descriptor_with_endpoint(
+        const void * impl,
+        const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
+      virtual std::unique_ptr<void, void (*)(void *)>
+      from_descriptor_with_endpoint(
+        const void * descriptor,
+        const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
+
+      // Discovery hooks (optional to override)
+      virtual void on_creating_endpoint(
+        const rmw_topic_endpoint_info_t & endpoint_info) const;
+      virtual std::pair<bool, std::vector<std::set<uint32_t>>>
+      on_discovering_endpoint(
+        const rmw_topic_endpoint_info_t & endpoint_info,
+        const std::vector<rmw_topic_endpoint_info_t> & existing_endpoints,
+        const std::unordered_map<std::string, std::string> & endpoint_supported_backends);
+    };
+
+    }  // namespace rosidl
+
+Anatomy of a backend package
+----------------------------
+
+A complete backend is usually split across three or four ROS 2 packages:
+
+#. **Core memory-domain library** (e.g. ``mydev_buffer``): the non-plugin
+   code -- custom allocator, ``BufferImplBase<T>`` subclass, IPC manager,
+   RAII handles.
+   This is where most of the vendor's engineering lives.
+#. **Descriptor message package** (e.g. ``mydev_buffer_backend_msgs``): a
+   normal ROS 2 ``.msg`` that describes how to reconstruct the buffer on
+   the receiving side.
+#. **Backend plugin package** (e.g. ``mydev_buffer_backend``): a thin
+   shared library that implements ``rosidl::BufferBackend`` and is
+   registered via ``pluginlib``.
+#. **User-facing API header** (optional, usually shipped inside the core
+   library): helpers like ``allocate_msg``, ``from_buffer``, and
+   ``to_buffer`` that application authors use to produce and consume
+   backend-native data.
+
+Step 1: Design the descriptor message
+-------------------------------------
+
+The descriptor is the only thing that actually travels over the wire.
+It must contain everything the receiving endpoint needs to reconstruct a
+buffer whose size and contents match the publisher's buffer.
+
+Two important constraints:
+
+* The serialized descriptor must be no larger than
+  ``rosidl::kMaxBufferDescriptorSize`` bytes (4096). The RMW plans its
+  serialization buffers around this bound.
+* The descriptor package must be a plain ``rosidl_default_generators``
+  message package so that the generic
+  ``rosidl_typesupport_cpp::get_message_type_support_handle<T>()`` returns an
+  aggregate handle that contains the FastRTPS C++ sub-handle.
+  (Today that sub-handle is the one the RMW layer extracts; see
+  :ref:`writing-buffer-backend_type-support`.)
+
+A descriptor typically carries either enough information to open an IPC
+handle on the receiving side, or a serialized copy of the payload for the
+CPU-fallback case, or both.
+For example, a simplified device-IPC descriptor might look like:
+
+.. code-block:: text
+
+    # mydev_buffer_backend_msgs/msg/MyDevBufferDescriptor.msg
+    uint64 size                       # allocation size in bytes
+    int32  device_id                  # producing device
+
+    # IPC path (preferred)
+    bool   use_ipc
+    string ipc_socket_path
+    uint32 ipc_block_id
+    uint64 ipc_uid                    # unique id for staleness detection
+
+    # CPU fallback (empty when IPC is used)
+    uint8[] serialized_data
+
+The real CUDA backend (``cuda_buffer_backend_msgs/CudaBufferDescriptor.msg``)
+and Torch backend (``torch_buffer_backend_msgs/TorchBufferDescriptor.msg``)
+illustrate two different descriptor shapes: the CUDA descriptor carries IPC
+handles directly, while the Torch descriptor carries a ``uint8[]``
+``device_data`` field that the RMW re-serializes using the *inner* buffer's
+backend. The second pattern is what makes a composed backend base-agnostic.
+
+Step 2: Implement ``BufferImplBase<T>``
+---------------------------------------
+
+``BufferImplBase<T>`` is the pimpl that lives inside ``rosidl::Buffer<T>``.
+Its interface is intentionally minimal:
+
+.. code-block:: c++
+
+    template<typename T>
+    class BufferImplBase
+    {
+    public:
+      virtual ~BufferImplBase() = default;
+      virtual std::string get_backend_type() const = 0;
+      virtual size_t size() const = 0;
+      virtual std::unique_ptr<BufferImplBase<T>> to_cpu() const = 0;
+      virtual std::unique_ptr<BufferImplBase<T>> clone() const = 0;
+    };
+
+* ``get_backend_type()`` must return the same short name your plugin's XML
+  declares (``"cuda"``, ``"torch"``, ``"mydev"``, ...).
+* ``size()`` returns the element count (not byte count, unless ``T`` is
+  ``uint8_t``).
+* ``to_cpu()`` is the escape hatch used by ``Buffer<T>::to_vector()`` when a
+  consumer explicitly wants CPU memory; it must return a populated
+  ``CpuBufferImpl<T>``.
+* ``clone()`` produces a deep copy of ``*this``; it is used by
+  ``Buffer<T>``'s copy constructor.
+
+Beyond those four required methods, your implementation will usually hold
+all of your backend's state: device pointers, IPC handles, cached streams,
+staleness counters, and so on.
+The plugin side of the interface then talks to this state through
+``dynamic_cast`` to your concrete type.
+
+Step 3: Implement ``BufferBackend``
+-----------------------------------
+
+.. _writing-buffer-backend_type-support:
+
+Identity and descriptor type support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``get_backend_type()`` returns the short name.
+``get_descriptor_type_support()`` should return the **generic** aggregate
+type support handle for your descriptor, not a specific typesupport
+library's handle:
+
+.. code-block:: c++
+
+    const rosidl_message_type_support_t *
+    MyDevBufferBackend::get_descriptor_type_support() const
+    {
+      return rosidl_typesupport_cpp::get_message_type_support_handle<
+        mydev_buffer_backend_msgs::msg::MyDevBufferDescriptor>();
+    }
+
+This keeps the plugin RMW-agnostic.
+Current RMW integrations resolve the aggregate to
+``rosidl_typesupport_fastrtps_cpp`` at runtime, so any standard
+``rosidl_default_generators`` message package will work out of the box.
+
+``create_descriptor_with_endpoint`` / ``from_descriptor_with_endpoint``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These are the two hot-path methods.
+
+``create_descriptor_with_endpoint`` is called on the publisher side once per
+matched remote endpoint. It receives a type-erased non-owning pointer to a
+``BufferImplBase<uint8_t>`` and the peer's ``rmw_topic_endpoint_info_t``.
+Return a filled-in descriptor for that peer, or ``nullptr`` to tell the RMW
+*"I cannot serve this peer with my backend; please fall back to CPU
+serialization."*
+
+Returning ``nullptr`` is a first-class signal. Use it whenever:
+
+* the peer does not support your backend (check
+  ``endpoint_supported_backends`` during discovery and cache the answer);
+* the hardware or environment cannot serve this pair (different device,
+  different host, IPC disabled, ...);
+* any other reason a non-CPU path is not available for *this* peer.
+
+``from_descriptor_with_endpoint`` is the inverse, invoked on the subscriber
+side. It must produce a ``std::unique_ptr<void, void (*)(void *)>`` owning a
+freshly-constructed ``BufferImplBase<T>``. The custom deleter is
+**required** because the plugin may be unloaded independently of the rest
+of the process; the deleter ensures destruction happens inside the correct
+shared library.
+
+A typical deleter looks like:
+
+.. code-block:: c++
+
+    auto impl = std::make_unique<MyDevBufferImpl<uint8_t>>(...);
+    return {impl.release(), [](void * p) {
+        delete static_cast<rosidl::BufferImplBase<uint8_t> *>(p);
+      }};
+
+Discovery hooks
+^^^^^^^^^^^^^^^
+
+``on_creating_endpoint`` lets your backend learn about local publishers and
+subscriptions as they are created; this is usually where IPC managers
+register themselves.
+
+``on_discovering_endpoint`` is the compatibility negotiation step.
+It returns a ``std::pair<bool, std::vector<std::set<uint32_t>>>``:
+
+* The ``bool`` tells the RMW whether this peer is served by the backend at
+  all. Returning ``false`` permanently routes this peer to CPU
+  serialization.
+* The ``std::vector<std::set<uint32_t>>`` is for backends that need to
+  group endpoints (e.g. which subscribers share the same device and can use
+  the same IPC handle). Most backends leave this empty.
+
+The ``endpoint_supported_backends`` argument is a map from the peer's
+advertised backend names to their metadata strings. A correct backend
+**must** check that its own name is in this map before declaring the peer
+compatible; otherwise a publisher will waste descriptor work on a
+subscription that cannot consume it.
+
+Example from the Torch backend:
+
+.. code-block:: c++
+
+    std::pair<bool, std::vector<std::set<uint32_t>>>
+    TorchBufferBackend::on_discovering_endpoint(
+      const rmw_topic_endpoint_info_t & /*endpoint_info*/,
+      const std::vector<rmw_topic_endpoint_info_t> & /*existing_endpoints*/,
+      const std::unordered_map<std::string, std::string> & endpoint_supported_backends)
+    {
+      return {
+        endpoint_supported_backends.find("torch") != endpoint_supported_backends.end(),
+        {}};
+    }
+
+Step 4: Register the plugin
+---------------------------
+
+Add a ``pluginlib`` XML file that declares your backend class:
+
+.. code-block:: xml
+
+    <!-- mydev_buffer_backend/mydev_buffer_plugin.xml -->
+    <library path="mydev_buffer_backend">
+      <class name="mydev"
+             type="mydev_buffer_backend::MyDevBufferBackend"
+             base_class_type="rosidl::BufferBackend">
+        <description>Example backend for the mydev memory domain.</description>
+      </class>
+    </library>
+
+The ``name`` attribute is the short name that users put into
+``acceptable_buffer_backends`` (see
+:doc:`../../How-To-Guides/Using-Buffer-Backends`) and that your
+``get_backend_type()`` must return.
+
+Export it from ``CMakeLists.txt``:
+
+.. code-block:: cmake
+
+    pluginlib_export_plugin_description_file(
+      rosidl_buffer_backend mydev_buffer_plugin.xml)
+
+and install it:
+
+.. code-block:: cmake
+
+    install(
+      FILES mydev_buffer_plugin.xml
+      DESTINATION share/${PROJECT_NAME}
+    )
+
+And register the class in your plugin source file:
+
+.. code-block:: c++
+
+    #include <pluginlib/class_list_macros.hpp>
+    #include "mydev_buffer_backend/mydev_buffer_backend.hpp"
+
+    PLUGINLIB_EXPORT_CLASS(
+      mydev_buffer_backend::MyDevBufferBackend,
+      rosidl::BufferBackend)
+
+Step 5: Package and build system
+--------------------------------
+
+``package.xml`` for the plugin package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: xml
+
+    <package format="3">
+      <name>mydev_buffer_backend</name>
+      <version>0.0.1</version>
+      <description>mydev backend for rosidl::Buffer</description>
+      <maintainer email="you@example.com">You</maintainer>
+      <license>Apache License 2.0</license>
+
+      <buildtool_depend>ament_cmake</buildtool_depend>
+
+      <depend>rosidl_buffer_backend</depend>
+      <depend>rosidl_buffer_backend_registry</depend>
+      <depend>rosidl_runtime_cpp</depend>
+      <depend>pluginlib</depend>
+      <depend>mydev_buffer</depend>
+      <depend>mydev_buffer_backend_msgs</depend>
+
+      <export>
+        <build_type>ament_cmake</build_type>
+      </export>
+    </package>
+
+``CMakeLists.txt`` for the plugin package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The minimum shape is:
+
+.. code-block:: cmake
+
+    cmake_minimum_required(VERSION 3.8)
+    project(mydev_buffer_backend)
+
+    find_package(ament_cmake REQUIRED)
+    find_package(rosidl_buffer_backend REQUIRED)
+    find_package(rosidl_buffer_backend_registry REQUIRED)
+    find_package(rosidl_runtime_cpp REQUIRED)
+    find_package(pluginlib REQUIRED)
+    find_package(mydev_buffer REQUIRED)
+    find_package(mydev_buffer_backend_msgs REQUIRED)
+
+    add_library(${PROJECT_NAME} SHARED
+      src/mydev_buffer_backend_plugin.cpp)
+
+    target_include_directories(${PROJECT_NAME} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+
+    target_link_libraries(${PROJECT_NAME} PUBLIC
+      rosidl_buffer_backend::rosidl_buffer_backend
+      rosidl_buffer_backend_registry::rosidl_buffer_backend_registry
+      rosidl_runtime_cpp::rosidl_runtime_cpp
+      pluginlib::pluginlib
+      mydev_buffer::mydev_buffer
+      mydev_buffer_backend_msgs::mydev_buffer_backend_msgs__rosidl_typesupport_cpp)
+
+    install(
+      TARGETS ${PROJECT_NAME}
+      EXPORT ${PROJECT_NAME}
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+      RUNTIME DESTINATION bin
+      INCLUDES DESTINATION include/${PROJECT_NAME})
+
+    install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+    install(FILES mydev_buffer_plugin.xml DESTINATION share/${PROJECT_NAME})
+
+    pluginlib_export_plugin_description_file(
+      rosidl_buffer_backend mydev_buffer_plugin.xml)
+
+    ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+    ament_export_dependencies(
+      rosidl_buffer_backend
+      rosidl_buffer_backend_registry
+      rosidl_runtime_cpp
+      pluginlib
+      mydev_buffer
+      mydev_buffer_backend_msgs)
+
+    ament_package()
+
+See ``cuda_buffer_backend/CMakeLists.txt`` for a production-quality
+version that also defines the test targets used by the reference launch
+tests.
+
+Step 6: Design a user-facing API
+--------------------------------
+
+Application authors do not typically construct ``BufferImplBase`` subclasses
+by hand; they go through a user-facing API header shipped by the backend.
+A minimal API usually provides three operations:
+
+#. **Allocate a message** whose ``uint8[]`` field is already backed by your
+   backend's memory:
+
+   .. code-block:: c++
+
+       template<typename MsgT>
+       MsgT allocate_msg(std::size_t byte_count);
+
+#. **Obtain a writable handle** to a backend-backed buffer so the caller can
+   produce data in place (e.g. launch a kernel writing into the device
+   pointer):
+
+   .. code-block:: c++
+
+       WriteHandle from_buffer(rosidl::Buffer<uint8_t> & buffer, ...);
+
+#. **Obtain a readable handle** on the subscriber side, synchronised with
+   whatever the publisher's write did (e.g. waiting on a shared event):
+
+   .. code-block:: c++
+
+       ReadHandle from_buffer(const rosidl::Buffer<uint8_t> & buffer, ...);
+
+Typical auxiliary considerations:
+
+* **Auto-promotion**: if a caller hands your backend a buffer that happens
+  to live in some other backend (CPU, another device backend, ...), a
+  helpful pattern is to allocate a new buffer in *your* domain and copy
+  into it transparently, keeping ownership via a ``get_promoted_buffer()``
+  getter on the returned handle. The CUDA backend does this for CPU-to-CUDA
+  inputs.
+* **Synchronisation**: if your backend is asynchronous (streams, events,
+  queues), encode the synchronisation policy into your handle types rather
+  than on the free functions. RAII on destruction makes correct use the
+  default.
+* **Reading is safe by default**: for read handles, a ``clone=true`` default
+  that returns an independent copy is a useful safety net; offer a
+  ``clone=false`` zero-copy overload for callers that explicitly want it.
+  See the Torch backend's ``from_buffer`` for an example.
+
+Composed backends (layering on a base backend)
+----------------------------------------------
+
+A **composed backend** reuses an existing base backend for the actual bytes
+and only adds a higher-level data model (tensor metadata, point-cloud
+metadata, ...).
+The recommended pattern is:
+
+* Your ``BufferImplBase<T>`` subclass *contains* a ``rosidl::Buffer<T>``
+  member for the device bytes. The inner buffer's backend is whichever base
+  is appropriate for the current device (``"cuda"``, ``"cpu"``, and so on).
+* Your descriptor ``.msg`` carries the high-level metadata plus a
+  ``uint8[]`` field holding the inner buffer. The RMW serializes that inner
+  field using the *inner* backend's logic, so your composed backend never
+  has to know each base's wire format.
+* In discovery, accept the peer if and only if it also supports your
+  composed backend name (not the base name): two endpoints that both happen
+  to support ``"cuda"`` do not automatically understand each other's
+  composed semantics.
+
+The Torch backend demonstrates all three points in fewer than 100 lines:
+``torch_buffer_backend/torch_buffer_backend/include/torch_buffer_backend/torch_buffer_backend.hpp``.
+
+Consequences for the ecosystem
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This layering is the recommended shape for the backend ecosystem:
+
+* Vendors ship one or two **base backends** close to the memory substrate.
+* A handful of well-known, cross-vendor **composed backends** (tensor
+  libraries, point-cloud libraries, ...) layer on top.
+
+For the layering to stay clean, composed backends should treat the set of
+acceptable bases as a configuration choice (compile-time or runtime), never
+hard-coded, and their descriptors should stay base-agnostic.
+
+Testing
+-------
+
+The most useful tests for a backend are launch tests that exercise real
+pub/sub topologies. The reference CUDA backend ships a representative set:
+
+* intra-process (publisher and subscriber in the same process);
+* inter-process on the same host;
+* mixed intra/inter-process (one publisher, multiple subscribers);
+* multi-publisher (several producers into one topic);
+* CPU fallback (subscriber that does not advertise the backend must still
+  receive correct bytes);
+* "mixed / no duplicate" (a subscription that accepts both the backend and
+  CPU must not observe duplicated messages).
+
+See ``cuda_buffer_backend/test/`` for the full set.
+
+For finer-grained unit tests on the plugin interface itself (descriptor
+round-trip without an RMW), the ``rosidl_buffer_backend_registry``
+package's own tests and the ``test_rosidl_buffer`` system tests are good
+starting points.
+
+Ship checklist
+--------------
+
+Before releasing a backend, verify that:
+
+* the plugin is discoverable, i.e. ``rosidl_buffer_backend_registry``'s
+  ``get_backend_names()`` lists your short name;
+* your descriptor serializes to ``<= 4096`` bytes for every shape you
+  support;
+* ``get_descriptor_type_support()`` returns the generic aggregate handle,
+  not an RMW-specific one;
+* ``create_descriptor_with_endpoint`` returns ``nullptr`` on every
+  unsupported peer (cross-host, wrong device, IPC disabled, ...), and
+  launch tests confirm CPU fallback works;
+* ``from_descriptor_with_endpoint``'s returned ``unique_ptr`` uses a custom
+  deleter bound inside your shared library;
+* ``on_discovering_endpoint`` consults ``endpoint_supported_backends`` and
+  refuses peers that do not advertise your backend;
+* your package README includes a **transport-support matrix**
+  (intra-process / inter-process same-host / inter-host / ...) so users
+  know what to expect.
+
+Where to go next
+----------------
+
+* :doc:`../../Concepts/Intermediate/About-Buffer-Backends` -- conceptual
+  overview of the feature.
+* :doc:`../../How-To-Guides/Using-Buffer-Backends` -- the user-facing side
+  of the same feature; useful for understanding what your plugin is
+  expected to look like from a subscription's point of view.
+* :doc:`../Demos/GPU-Buffer-Transport` -- end-to-end demo of a
+  GPU-backed pub/sub pipeline that exercises both a base and a composed
+  backend.

--- a/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
+++ b/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
@@ -148,9 +148,8 @@ Two important constraints:
   (Today that sub-handle is the one the RMW layer extracts; see
   :ref:`writing-buffer-backend_type-support`.)
 
-A descriptor typically carries either enough information to open an IPC
-handle on the receiving side, or a serialized copy of the payload for the
-CPU-fallback case, or both.
+A descriptor typically carries either a small reference that the receiving side uses to re-attach to the payload, a serialized copy of the payload for the CPU-fallback case, or both.
+The exact re-attachment mechanism is backend-specific.
 For example, a simplified device-IPC descriptor might look like:
 
 .. code-block:: text
@@ -170,9 +169,12 @@ For example, a simplified device-IPC descriptor might look like:
 
 The real CUDA backend
 (``cuda_buffer_backend_msgs/CudaBufferDescriptor.msg``) illustrates the
-device-IPC shape: the descriptor carries CUDA IPC metadata when the peer can
-use CUDA IPC, and the backend returns ``nullptr`` when that peer should receive
-the field through CPU fallback instead.
+device-IPC shape: the descriptor carries the publisher process id, block id,
+socket path, and synchronization metadata needed to import a CUDA VMM block.
+The exported file descriptor itself is passed out-of-band over the Unix-domain
+socket named by the descriptor.
+If the backend cannot serve a peer through CUDA IPC, it returns ``nullptr`` so
+that peer receives the field through CPU fallback instead.
 
 Step 2: Implement ``BufferImplBase<T>``
 ---------------------------------------
@@ -194,7 +196,7 @@ Its interface is intentionally minimal:
     };
 
 * ``get_backend_type()`` must return the same short name your plugin's XML
-  declares (``"cuda"``, ``"torch"``, ``"mydev"``, ...).
+  declares (``"cuda"``, ``"mydev"``, ...).
 * ``size()`` returns the element count (not byte count, unless ``T`` is
   ``uint8_t``).
 * ``to_cpu()`` is the escape hatch used by ``Buffer<T>::to_vector()`` when a

--- a/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
+++ b/source/Tutorials/Advanced/Writing-a-Buffer-Backend.rst
@@ -3,7 +3,7 @@ Writing a ``rosidl::Buffer`` backend
 
 **Goal:** Learn how to implement and package a new ``rosidl::Buffer``
 backend plugin so that a vendor-specific memory domain (GPU, shared memory,
-tensor library, ...) can back ``uint8[]`` fields of ROS 2 messages.
+accelerator memory, ...) can back ``uint8[]`` fields of ROS 2 messages.
 
 **Tutorial level:** Advanced
 
@@ -24,8 +24,8 @@ package.
 
 This guide shows how to build such a plugin, end to end.
 It uses a hypothetical ``mydev`` backend in the prose (for a vendor device
-memory domain) and refers to the real CUDA, Torch, and demo backends in the
-reference links for concrete code.
+memory domain) and refers to the real CUDA backend, the ``torch_conversions``
+helper library, and the demo backend in the reference links for concrete code.
 
 This guide is intended as a starting point; the existing reference backends
 go into much more detail than is practical to reproduce here.
@@ -47,21 +47,18 @@ instead.
 Reference implementations
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Three open-source backends are good reading.
-All three are small enough to read in full:
+Two open-source backends and one user-level tensor library are good reading.
+All are small enough to read in full:
 
-* ``cuda_buffer_backend``: a realistic **base backend** built on CUDA VMM
+* ``cuda_buffer_backend``: a realistic CUDA backend built on CUDA VMM
   and CUDA IPC, with intra-process, inter-process same-host, and CPU-fallback
   paths.
   See `ros2/rosidl_buffer_backends <https://github.com/ros2/rosidl_buffer_backends>`__.
-* ``torch_buffer_backend``: a **composed backend** that wraps a device
-  backend (CUDA today, CPU as a fallback) and adds tensor semantics.
+* ``torch_conversions``: a header-only user library, not a backend plugin.
+  It converts between ``tensor_msgs/msg/ExperimentalTensor`` and ``at::Tensor``.
+  The tensor message's ``uint8[] data`` field is transported by an ordinary
+  buffer backend such as ``cuda`` or ``cpu``.
   Same repository.
-* ``demo_buffer_backend``: a minimal CPU-to-CPU backend used by the
-  ``rosidl::Buffer`` system tests.
-  Useful as a pedagogical example with no device dependencies.
-  See ``rcl_buffer/demo_buffer_backend`` in the workspace used by this
-  tutorial.
 
 The ``BufferBackend`` interface
 -------------------------------
@@ -128,9 +125,9 @@ A complete backend is usually split across three or four ROS 2 packages:
    shared library that implements ``rosidl::BufferBackend`` and is
    registered via ``pluginlib``.
 #. **User-facing API header** (optional, usually shipped inside the core
-   library): helpers like ``allocate_msg``, ``from_buffer``, and
-   ``to_buffer`` that application authors use to produce and consume
-   backend-native data.
+   library): helpers like ``allocate_buffer``, ``from_output_buffer``,
+   ``from_input_buffer``, and ``to_buffer`` that application authors use to
+   produce and consume backend-native data.
 
 Step 1: Design the descriptor message
 -------------------------------------
@@ -171,13 +168,11 @@ For example, a simplified device-IPC descriptor might look like:
     # CPU fallback (empty when IPC is used)
     uint8[] serialized_data
 
-The real CUDA backend (``cuda_buffer_backend_msgs/CudaBufferDescriptor.msg``)
-and Torch backend (``torch_buffer_backend_msgs/TorchBufferDescriptor.msg``)
-illustrate two different descriptor shapes: the CUDA descriptor carries IPC
-handles directly, while the Torch descriptor carries a ``uint8[]``
-``device_data`` field that the RMW re-serializes using the *inner* buffer's
-backend.
-The second pattern is what makes a composed backend base-agnostic.
+The real CUDA backend
+(``cuda_buffer_backend_msgs/CudaBufferDescriptor.msg``) illustrates the
+device-IPC shape: the descriptor carries CUDA IPC metadata when the peer can
+use CUDA IPC, and the backend returns ``nullptr`` when that peer should receive
+the field through CPU fallback instead.
 
 Step 2: Implement ``BufferImplBase<T>``
 ---------------------------------------
@@ -304,19 +299,25 @@ A correct backend **must** check that its own name is in this map before
 declaring the peer compatible; otherwise a publisher will waste descriptor
 work on a subscription that cannot consume it.
 
-Example from the Torch backend:
+Simplified example from the CUDA backend:
 
 .. code-block:: c++
 
     std::pair<bool, std::vector<std::set<uint32_t>>>
-    TorchBufferBackend::on_discovering_endpoint(
+    CudaBufferBackend::on_discovering_endpoint(
       const rmw_topic_endpoint_info_t & /*endpoint_info*/,
       const std::vector<rmw_topic_endpoint_info_t> & /*existing_endpoints*/,
       const std::unordered_map<std::string, std::string> & endpoint_supported_backends)
     {
-      return {
-        endpoint_supported_backends.find("torch") != endpoint_supported_backends.end(),
-        {}};
+      if (endpoint_supported_backends.find("cuda") ==
+          endpoint_supported_backends.end())
+      {
+        return {false, {}};
+      }
+
+      // The full implementation also checks VMM IPC support, endpoint
+      // locality, device id, and user id before returning true.
+      return {true, {}};
     }
 
 Step 4: Register the plugin
@@ -465,13 +466,12 @@ Application authors do not typically construct ``BufferImplBase`` subclasses
 by hand; they go through a user-facing API header shipped by the backend.
 A minimal API usually provides three operations:
 
-#. **Allocate a message** whose ``uint8[]`` field is already backed by your
-   backend's memory:
+#. **Allocate a buffer** whose storage is already backed by your backend's
+   memory:
 
    .. code-block:: c++
 
-       template<typename MsgT>
-       MsgT allocate_msg(std::size_t byte_count);
+       rosidl::Buffer<uint8_t> allocate_buffer(std::size_t byte_count);
 
 #. **Obtain a writable handle** to a backend-backed buffer so the caller can
    produce data in place (e.g. launch a kernel writing into the device
@@ -479,14 +479,14 @@ A minimal API usually provides three operations:
 
    .. code-block:: c++
 
-       WriteHandle from_buffer(rosidl::Buffer<uint8_t> & buffer, ...);
+       WriteHandle from_output_buffer(rosidl::Buffer<uint8_t> & buffer, ...);
 
 #. **Obtain a readable handle** on the subscriber side, synchronised with
    whatever the publisher's write did (e.g. waiting on a shared event):
 
    .. code-block:: c++
 
-       ReadHandle from_buffer(const rosidl::Buffer<uint8_t> & buffer, ...);
+       ReadHandle from_input_buffer(const rosidl::Buffer<uint8_t> & buffer, ...);
 
 Typical auxiliary considerations:
 
@@ -500,47 +500,30 @@ Typical auxiliary considerations:
   queues), encode the synchronisation policy into your handle types rather
   than on the free functions.
   RAII on destruction makes correct use the default.
-* **Reading is safe by default**: for read handles, a ``clone=true`` default
-  that returns an independent copy is a useful safety net; offer a
-  ``clone=false`` zero-copy overload for callers that explicitly want it.
-  See the Torch backend's ``from_buffer`` for an example.
 
-Composed backends (layering on a base backend)
-----------------------------------------------
+Higher-level libraries on top of backends
+-----------------------------------------
 
-A **composed backend** reuses an existing base backend for the actual bytes
-and only adds a higher-level data model (tensor metadata, point-cloud
-metadata, ...).
-The recommended pattern is:
+Do not write a new backend just to add application-level metadata such as
+tensor shape, point-cloud fields, or image color-space information.
+Those semantics fit better in a normal ROS 2 message whose payload field is a
+``uint8[]`` and therefore a ``rosidl::Buffer<uint8_t>`` in generated C++ code.
+The message can then ride on whichever storage backend is negotiated for that
+field.
 
-* Your ``BufferImplBase<T>`` subclass *contains* a ``rosidl::Buffer<T>``
-  member for the device bytes.
-  The inner buffer's backend is whichever base is appropriate for the
-  current device (``"cuda"``, ``"cpu"``, and so on).
-* Your descriptor ``.msg`` carries the high-level metadata plus a
-  ``uint8[]`` field holding the inner buffer.
-  The RMW serializes that inner field using the *inner* backend's logic, so
-  your composed backend never has to know each base's wire format.
-* In discovery, accept the peer if and only if it also supports your
-  composed backend name (not the base name): two endpoints that both happen
-  to support ``"cuda"`` do not automatically understand each other's
-  composed semantics.
+The tensor packages in ``rosidl_buffer_backends`` follow this model:
 
-The Torch backend demonstrates all three points in fewer than 100 lines:
-``torch_buffer_backend/torch_buffer_backend/include/torch_buffer_backend/torch_buffer_backend.hpp``.
+* ``tensor_msgs/msg/ExperimentalTensor`` stores DLPack-aligned dtype, shape,
+  stride, and byte-offset metadata plus a ``uint8[] data`` field.
+* ``torch_conversions`` converts between that message and ``at::Tensor``.
+  It allocates CUDA-backed ``data`` when requested and available, otherwise it
+  uses CPU storage.
+* Subscribers opt in to the underlying storage backend (for example
+  ``acceptable_buffer_backends = "cuda"`` or ``"any"``), not to a separate
+  tensor backend name.
 
-Consequences for the ecosystem
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This layering is the recommended shape for the backend ecosystem:
-
-* Vendors ship one or two **base backends** close to the memory substrate.
-* A handful of well-known, cross-vendor **composed backends** (tensor
-  libraries, point-cloud libraries, ...) layer on top.
-
-For the layering to stay clean, composed backends should treat the set of
-acceptable bases as a configuration choice (compile-time or runtime), never
-hard-coded, and their descriptors should stay base-agnostic.
+This keeps the backend ecosystem focused on memory transport while allowing
+ordinary user libraries to add richer programming models above it.
 
 Testing
 -------
@@ -596,5 +579,5 @@ Where to go next
   of the same feature; useful for understanding what your plugin is
   expected to look like from a subscription's point of view.
 * :doc:`../Demos/GPU-Buffer-Transport` -- end-to-end demo of a
-  GPU-backed pub/sub pipeline that exercises both a base and a composed
-  backend.
+  GPU-backed tensor pub/sub pipeline using the CUDA backend and
+  ``torch_conversions``.

--- a/source/Tutorials/Demos.rst
+++ b/source/Tutorials/Demos.rst
@@ -7,6 +7,7 @@ Demos
    Demos/Quality-of-Service
    Demos/Managed-Nodes
    Demos/Intra-Process-Communication
+   Demos/GPU-Buffer-Transport
    Demos/Real-Time-Programming
    Demos/dummy-robot-demo
    Demos/Logging-and-logger-configuration

--- a/source/Tutorials/Demos/GPU-Buffer-Transport.rst
+++ b/source/Tutorials/Demos/GPU-Buffer-Transport.rst
@@ -14,9 +14,10 @@ vendor-specific memory domains such as GPU memory, with the descriptor
 round-trip handled transparently by the RMW.
 
 This demo exercises the full pipeline using the community-maintained CUDA
-and PyTorch backends, publishing ``sensor_msgs/msg/Image`` frames between
-two processes either over a zero-copy CUDA path or over the traditional
-CPU-serialised path, and comparing throughput at several resolutions.
+backend and the ``torch_conversions`` helper library.
+It publishes ``tensor_msgs/msg/ExperimentalTensor`` frames between two
+processes either over a zero-copy CUDA path or over the traditional
+CPU-serialised path, and compares throughput at several resolutions.
 
 The underlying demo is maintained in
 `ros2/rosidl_buffer_backends_tutorials
@@ -28,25 +29,27 @@ What the demo does
 
 ``robot_arm_demo`` renders an SDF-based pencil-sketch robot arm animation
 entirely on the GPU via LibTorch tensor operations, publishes BGRA frames
-as ``sensor_msgs/msg/Image``, and displays them in an SDL2/OpenGL window
-with CUDA-GL interop.
+as ``tensor_msgs/msg/ExperimentalTensor``, and displays them in an
+SDL2/OpenGL window with CUDA-GL interop.
 Two processes are involved:
 
 #. ``renderer_node`` -- renders BGRA frames on the GPU using LibTorch
-   operations and publishes them as ``sensor_msgs/msg/Image``.
-#. ``display_node`` -- subscribes to the image topic, displays frames, and
-   reports FPS.
+   operations, copies them into an ``ExperimentalTensor`` message with
+   ``torch_conversions``, and publishes that message.
+#. ``display_node`` -- subscribes to the tensor topic, wraps the received
+   message as an ``at::Tensor`` with ``torch_conversions``, displays frames,
+   and reports FPS.
 
 Two transport modes are compared:
 
-* **CUDA** -- the ``Image.data`` field is backed by the ``torch`` buffer
-  backend which in turn sits on top of the ``cuda`` base backend.
+* **CUDA** -- the ``ExperimentalTensor.data`` field is backed by the ``cuda``
+  buffer backend.
   The bytes never leave GPU memory: the descriptor on the wire only
   carries a CUDA IPC handle.
 * **CPU** -- the frame is rendered on the GPU, copied back to host memory
   with ``cudaMemcpy``, and then serialised through the RMW as a regular
   ``uint8[]``.
-  No buffer backend is involved.
+  No non-CPU buffer backend is involved.
 
 Both modes render on the GPU; the only difference is the transport path,
 making this a clean comparison of zero-copy CUDA IPC versus traditional
@@ -64,6 +67,7 @@ You need:
 * A ROS 2 Rolling source workspace.
   See the :doc:`Installation instructions <../../Installation>` for the
   canonical source-build flow.
+* ``rmw_fastrtps_cpp`` for the non-CPU buffer path.
 
 The demo's ``libtorch_vendor`` package will download and install a
 pre-built LibTorch distribution automatically at build time if one is not
@@ -88,34 +92,38 @@ Install the system dependencies:
     $ rosdep install --from-paths src --ignore-src -y \
         --skip-keys "fastcdr rti-connext-dds-7.7.0 urdfdom_headers qt6-svg-dev"
 
-Build the CUDA backend first, source it, then build the demo:
+Build ``torch_conversions`` and its CUDA transport dependency first, source
+the workspace, then build the demo:
 
 .. code-block:: console
 
-    $ colcon build --symlink-install --packages-up-to cuda_buffer_backend
+    $ colcon build --symlink-install --packages-up-to torch_conversions
     $ source install/setup.sh
     $ colcon build --symlink-install --packages-up-to robot_arm_demo
     $ source install/setup.sh
 
-The intermediate ``source install/setup.sh`` is required so that the Torch
-backend can discover the CUDA backend at CMake configure time and compile
-its CUDA path.
+The intermediate ``source install/setup.sh`` is required so that
+``torch_conversions`` can discover ``cuda_buffer`` at CMake configure time and
+compile its CUDA path.
 
 Running
 -------
 
 The demo ships three launch files.
+Run them with ``RMW_IMPLEMENTATION=rmw_fastrtps_cpp`` when exercising the
+CUDA path.
 
 CUDA zero-copy (default)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
+    $ export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
     $ ros2 launch robot_arm_demo robot_arm_demo.launch.py
 
-The renderer and display processes negotiate the ``torch`` backend on top
-of ``cuda``; the image payload never leaves GPU memory between the two
-processes.
+The renderer and display processes negotiate the ``cuda`` backend for the
+tensor message's data field; the payload never leaves GPU memory between the
+two processes.
 
 CPU transport
 ^^^^^^^^^^^^^
@@ -148,7 +156,7 @@ When the CUDA path is active, the display node logs the negotiated backend:
 
 .. code-block:: console
 
-    [display_node]: Received frame: backend=torch, size=31457280
+    [display_node]: Received frame: backend=cuda, size=31457280
 
 When the path falls back to CPU, the same log line shows ``backend=cpu``
 and the FPS drops accordingly as image size grows.
@@ -218,14 +226,14 @@ What to look at in the source
 Two files are worth reading to see exactly what an application does
 differently on each side:
 
-* The renderer's publisher code shows how ``torch_buffer_backend::allocate_msg``
-  is used to produce a GPU-backed ``sensor_msgs::msg::Image`` and how the
-  tensor is written in place via ``torch_buffer_backend::to_buffer``.
+* The renderer's publisher code shows how
+  ``torch_conversions::allocate_tensor_msg`` and
+  ``torch_conversions::to_tensor_msg`` produce an
+  ``ExperimentalTensor`` whose ``data`` field is CUDA-backed.
 * The display's subscriber sets
-  ``SubscriptionOptions::acceptable_buffer_backends = "torch"`` and branches
-  on ``msg->data.get_backend_type()`` to either consume the data as a
-  PyTorch tensor (zero-copy) or fall back to a host-side copy when the CPU
-  path is in use.
+  ``SubscriptionOptions::acceptable_buffer_backends = "any"`` for the CUDA
+  path and uses ``torch_conversions::from_input_tensor_msg`` to consume the
+  message as a PyTorch tensor.
 
 Both files are reasonably short and make good reading after
 :doc:`../../How-To-Guides/Using-Buffer-Backends`.

--- a/source/Tutorials/Demos/GPU-Buffer-Transport.rst
+++ b/source/Tutorials/Demos/GPU-Buffer-Transport.rst
@@ -29,7 +29,8 @@ What the demo does
 ``robot_arm_demo`` renders an SDF-based pencil-sketch robot arm animation
 entirely on the GPU via LibTorch tensor operations, publishes BGRA frames
 as ``sensor_msgs/msg/Image``, and displays them in an SDL2/OpenGL window
-with CUDA-GL interop. Two processes are involved:
+with CUDA-GL interop.
+Two processes are involved:
 
 #. ``renderer_node`` -- renders BGRA frames on the GPU using LibTorch
    operations and publishes them as ``sensor_msgs/msg/Image``.
@@ -44,7 +45,8 @@ Two transport modes are compared:
   carries a CUDA IPC handle.
 * **CPU** -- the frame is rendered on the GPU, copied back to host memory
   with ``cudaMemcpy``, and then serialised through the RMW as a regular
-  ``uint8[]``. No buffer backend is involved.
+  ``uint8[]``.
+  No buffer backend is involved.
 
 Both modes render on the GPU; the only difference is the transport path,
 making this a clean comparison of zero-copy CUDA IPC versus traditional
@@ -54,12 +56,14 @@ Prerequisites
 -------------
 
 This demo is not part of the ROS 2 binary distribution; it lives in its own
-repository and has GPU-specific dependencies. You need:
+repository and has GPU-specific dependencies.
+You need:
 
 * A CUDA-capable GPU and the CUDA Toolkit (>= 11.8).
 * SDL2, GLEW, OpenGL, X11 development packages.
-* A ROS 2 Rolling source workspace. See the :doc:`Installation
-  instructions <../../Installation>` for the canonical source-build flow.
+* A ROS 2 Rolling source workspace.
+  See the :doc:`Installation instructions <../../Installation>` for the
+  canonical source-build flow.
 
 The demo's ``libtorch_vendor`` package will download and install a
 pre-built LibTorch distribution automatically at build time if one is not
@@ -153,8 +157,8 @@ Benchmark results
 -----------------
 
 The demo's README includes reference numbers measured on a single machine
-(inter-process, headless mode, RTX 3090, ``rmw_fastrtps_cpp``). You can
-reproduce them with:
+(inter-process, headless mode, RTX 3090, ``rmw_fastrtps_cpp``).
+You can reproduce them with:
 
 .. code-block:: console
 
@@ -202,10 +206,11 @@ reproduce them with:
      - --
 
 The CUDA path maintains high throughput across resolutions because the
-zero-copy IPC transfer only carries a handle, not the pixel data. The CPU
-path must copy frames from GPU to host and serialise them through the
-middleware, so throughput drops as image size grows. At 4K (31.6 MB per
-frame) the CUDA backend is roughly 6x faster than the raw CPU path.
+zero-copy IPC transfer only carries a handle, not the pixel data.
+The CPU path must copy frames from GPU to host and serialise them through
+the middleware, so throughput drops as image size grows.
+At 4K (31.6 MB per frame) the CUDA backend is roughly 6x faster than the
+raw CPU path.
 
 What to look at in the source
 -----------------------------

--- a/source/Tutorials/Demos/GPU-Buffer-Transport.rst
+++ b/source/Tutorials/Demos/GPU-Buffer-Transport.rst
@@ -1,0 +1,236 @@
+GPU buffer transport with ``rosidl::Buffer``
+============================================
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Background
+----------
+
+:doc:`rosidl::Buffer backends <../../Concepts/Intermediate/About-Buffer-Backends>`
+let ROS 2 messages carry large payloads (images, tensors, ...) in
+vendor-specific memory domains such as GPU memory, with the descriptor
+round-trip handled transparently by the RMW.
+
+This demo exercises the full pipeline using the community-maintained CUDA
+and PyTorch backends, publishing ``sensor_msgs/msg/Image`` frames between
+two processes either over a zero-copy CUDA path or over the traditional
+CPU-serialised path, and comparing throughput at several resolutions.
+
+The underlying demo is maintained in
+`ros2/rosidl_buffer_backends_tutorials
+<https://github.com/ros2/rosidl_buffer_backends_tutorials>`__; the package
+name is ``robot_arm_demo``.
+
+What the demo does
+------------------
+
+``robot_arm_demo`` renders an SDF-based pencil-sketch robot arm animation
+entirely on the GPU via LibTorch tensor operations, publishes BGRA frames
+as ``sensor_msgs/msg/Image``, and displays them in an SDL2/OpenGL window
+with CUDA-GL interop. Two processes are involved:
+
+#. ``renderer_node`` -- renders BGRA frames on the GPU using LibTorch
+   operations and publishes them as ``sensor_msgs/msg/Image``.
+#. ``display_node`` -- subscribes to the image topic, displays frames, and
+   reports FPS.
+
+Two transport modes are compared:
+
+* **CUDA** -- the ``Image.data`` field is backed by the ``torch`` buffer
+  backend which in turn sits on top of the ``cuda`` base backend.
+  The bytes never leave GPU memory: the descriptor on the wire only
+  carries a CUDA IPC handle.
+* **CPU** -- the frame is rendered on the GPU, copied back to host memory
+  with ``cudaMemcpy``, and then serialised through the RMW as a regular
+  ``uint8[]``. No buffer backend is involved.
+
+Both modes render on the GPU; the only difference is the transport path,
+making this a clean comparison of zero-copy CUDA IPC versus traditional
+CPU-serialised image transport.
+
+Prerequisites
+-------------
+
+This demo is not part of the ROS 2 binary distribution; it lives in its own
+repository and has GPU-specific dependencies. You need:
+
+* A CUDA-capable GPU and the CUDA Toolkit (>= 11.8).
+* SDL2, GLEW, OpenGL, X11 development packages.
+* A ROS 2 Rolling source workspace. See the :doc:`Installation
+  instructions <../../Installation>` for the canonical source-build flow.
+
+The demo's ``libtorch_vendor`` package will download and install a
+pre-built LibTorch distribution automatically at build time if one is not
+already visible on the system.
+
+Building
+--------
+
+Clone both repositories into your ROS 2 workspace's ``src/`` directory:
+
+.. code-block:: console
+
+    $ cd ~/ros2_ws/src
+    $ git clone https://github.com/ros2/rosidl_buffer_backends.git
+    $ git clone https://github.com/ros2/rosidl_buffer_backends_tutorials.git
+
+Install the system dependencies:
+
+.. code-block:: console
+
+    $ cd ~/ros2_ws
+    $ rosdep install --from-paths src --ignore-src -y \
+        --skip-keys "fastcdr rti-connext-dds-7.7.0 urdfdom_headers qt6-svg-dev"
+
+Build the CUDA backend first, source it, then build the demo:
+
+.. code-block:: console
+
+    $ colcon build --symlink-install --packages-up-to cuda_buffer_backend
+    $ source install/setup.sh
+    $ colcon build --symlink-install --packages-up-to robot_arm_demo
+    $ source install/setup.sh
+
+The intermediate ``source install/setup.sh`` is required so that the Torch
+backend can discover the CUDA backend at CMake configure time and compile
+its CUDA path.
+
+Running
+-------
+
+The demo ships three launch files.
+
+CUDA zero-copy (default)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    $ ros2 launch robot_arm_demo robot_arm_demo.launch.py
+
+The renderer and display processes negotiate the ``torch`` backend on top
+of ``cuda``; the image payload never leaves GPU memory between the two
+processes.
+
+CPU transport
+^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    $ ros2 launch robot_arm_demo robot_arm_demo.launch.py use_cuda:=false
+
+The subscription is not opted into any non-CPU backend, so the RMW falls
+back to CPU serialisation and the publisher copies the frame back to host
+memory before publishing.
+
+Side-by-side comparison
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    $ ros2 launch robot_arm_demo robot_arm_compare.launch.py
+
+This starts both pipelines at once so you can compare their throughput
+visually.
+
+All three launch files accept ``headless:=true`` to run without a display
+window (useful for benchmarking on a headless box).
+
+Expected output
+---------------
+
+When the CUDA path is active, the display node logs the negotiated backend:
+
+.. code-block:: console
+
+    [display_node]: Received frame: backend=torch, size=31457280
+
+When the path falls back to CPU, the same log line shows ``backend=cpu``
+and the FPS drops accordingly as image size grows.
+
+Benchmark results
+-----------------
+
+The demo's README includes reference numbers measured on a single machine
+(inter-process, headless mode, RTX 3090, ``rmw_fastrtps_cpp``). You can
+reproduce them with:
+
+.. code-block:: console
+
+    $ ros2 launch robot_arm_demo robot_arm_demo.launch.py \
+        headless:=true width:=W height:=H use_cuda:=<true|false>
+
+.. list-table::
+   :widths: 20 20 20 20 20
+   :header-rows: 1
+
+   * - Resolution
+     - Image size
+     - Transport
+     - FPS
+     - Speedup
+   * - 1920x1080
+     - 7.9 MB
+     - CUDA
+     - 116.6
+     - 3.3x
+   * - 1920x1080
+     - 7.9 MB
+     - CPU
+     - 35.5
+     - --
+   * - 2560x1440
+     - 14.1 MB
+     - CUDA
+     - 90.6
+     - 4.3x
+   * - 2560x1440
+     - 14.1 MB
+     - CPU
+     - 21.3
+     - --
+   * - 3840x2160
+     - 31.6 MB
+     - CUDA
+     - 59.5
+     - 5.8x
+   * - 3840x2160
+     - 31.6 MB
+     - CPU
+     - 10.3
+     - --
+
+The CUDA path maintains high throughput across resolutions because the
+zero-copy IPC transfer only carries a handle, not the pixel data. The CPU
+path must copy frames from GPU to host and serialise them through the
+middleware, so throughput drops as image size grows. At 4K (31.6 MB per
+frame) the CUDA backend is roughly 6x faster than the raw CPU path.
+
+What to look at in the source
+-----------------------------
+
+Two files are worth reading to see exactly what an application does
+differently on each side:
+
+* The renderer's publisher code shows how ``torch_buffer_backend::allocate_msg``
+  is used to produce a GPU-backed ``sensor_msgs::msg::Image`` and how the
+  tensor is written in place via ``torch_buffer_backend::to_buffer``.
+* The display's subscriber sets
+  ``SubscriptionOptions::acceptable_buffer_backends = "torch"`` and branches
+  on ``msg->data.get_backend_type()`` to either consume the data as a
+  PyTorch tensor (zero-copy) or fall back to a host-side copy when the CPU
+  path is in use.
+
+Both files are reasonably short and make good reading after
+:doc:`../../How-To-Guides/Using-Buffer-Backends`.
+
+Where to go next
+----------------
+
+* :doc:`../../Concepts/Intermediate/About-Buffer-Backends` for the
+  conceptual background.
+* :doc:`../../How-To-Guides/Using-Buffer-Backends` for the user-facing
+  guide applied to your own nodes.
+* :doc:`../Advanced/Writing-a-Buffer-Backend` if you want to implement a
+  backend for a different memory domain.

--- a/source/Tutorials/Demos/GPU-Buffer-Transport.rst
+++ b/source/Tutorials/Demos/GPU-Buffer-Transport.rst
@@ -44,12 +44,11 @@ Two transport modes are compared:
 
 * **CUDA** -- the ``ExperimentalTensor.data`` field is backed by the ``cuda``
   buffer backend.
-  The bytes never leave GPU memory: the descriptor on the wire only
-  carries a CUDA IPC handle.
+  The bytes never leave GPU memory: the descriptor on the wire carries a small reference that lets the subscriber re-attach to the publisher-owned CUDA allocation.
 * **CPU** -- the frame is rendered on the GPU, copied back to host memory
   with ``cudaMemcpy``, and then serialised through the RMW as a regular
   ``uint8[]``.
-  No non-CPU buffer backend is involved.
+  The default CPU buffer backend is used.
 
 Both modes render on the GPU; the only difference is the transport path,
 making this a clean comparison of zero-copy CUDA IPC versus traditional
@@ -64,7 +63,7 @@ You need:
 
 * A CUDA-capable GPU and the CUDA Toolkit (>= 11.8).
 * SDL2, GLEW, OpenGL, X11 development packages.
-* A ROS 2 Rolling source workspace.
+* A ROS 2 Lyrical Luth or later source workspace.
   See the :doc:`Installation instructions <../../Installation>` for the
   canonical source-build flow.
 * ``rmw_fastrtps_cpp`` for the non-CPU buffer path.


### PR DESCRIPTION
## Description

Introduces documentation for the new `rosidl::Buffer` feature and its pluggable backend architecture. 

Pages created in this pull request to cover the features are::

- `Concepts/Intermediate/About-Buffer-Backends.rst` — conceptual overview:
  the `Buffer<T>` / `BufferImplBase<T>` / `BufferBackend` split, the
  descriptor round-trip, discovery hooks, and the "base backend vs
  composed backend" pattern (CUDA as a base; PyTorch as a composed
  backend that can layer on top of multiple bases). Also clarifies that
  the plugin interface is RMW-agnostic — `get_descriptor_type_support()`
  returns a generic aggregate handle, and the RMW (currently
  `rmw_fastrtps_cpp`) resolves it internally.

- `How-To-Guides/Using-Buffer-Backends.rst` — user guide for enabling a
  backend on a subscription via
  `SubscriptionOptions::acceptable_buffer_backends`
  (`""`/`"cpu"` / `"any"` / comma-separated list), C++ and Python
  examples, a per-RMW support matrix, and the three practical rules for a
  compatible pub/sub pair (same backend installed on both sides, same RMW,
  aligned package versions). Also emphasises that intra-process /
  inter-process / inter-host transport scope is a property of each
  backend, not of `rosidl::Buffer`.

- `Tutorials/Advanced/Writing-a-Buffer-Backend.rst` — vendor-facing
  step-by-step guide for implementing and packaging a new `BufferBackend`
  plugin: interface walkthrough, descriptor design (including the 4096-byte
  `kMaxBufferDescriptorSize` limit), `BufferImplBase<T>` and
  `BufferBackend` implementation, `pluginlib` registration, CMake/`package.xml`
  scaffolding, user-facing API patterns (`allocate_msg`, `from_buffer`,
  `to_buffer`), the composed-backend pattern, and a ship checklist. Uses a
  generic `mydev` backend in prose and cross-links the real CUDA, Torch,
  and demo backends for concrete reference.

- `Tutorials/Demos/GPU-Buffer-Transport.rst` — runnable end-to-end demo
  based on `robot_arm_demo` from `ros2/rosidl_buffer_backends_tutorials`,
  comparing CUDA zero-copy vs CPU-serialised transport at several
  resolutions, with the benchmark table reproduced from the demo README.

Other registration / discoverability page updates:

- `Concepts/Intermediate.rst`, `How-To-Guides.rst`,
  `Tutorials/Advanced.rst`, `Tutorials/Demos.rst` — new pages added to the
  respective `toctree`s.
- `Glossary.rst` — new entries for "Buffer", "Buffer backend", "Base
  backend", "Composed backend", "Buffer descriptor", and "Acceptable
  backend list".
- `The-ROS2-Project/Features.rst` — added a "Pluggable buffer backends"
  row (marked experimental, currently supported in `rmw_fastrtps_cpp` and, C++ user-facing APIs only).
- `Related-Projects.rst` — added a "Community `rosidl::Buffer` backends"
  section linking to `ros2/rosidl_buffer_backends` and
  `ros2/rosidl_buffer_backends_tutorials`.

### Did you use Generative AI?

Yes. Cursor with Claude Opus 4.7 was used to assist with the draft version of the docs included in this pull request.
