### PR TITLE
Update python-rosdep to python3-rosdep in setup

### DIFF
--- a/source/Installation/Ubuntu-Development-Setup.rst
+++ b/source/Installation/Ubuntu-Development-Setup.rst
@@ -47,7 +47,7 @@ Install development tools and ROS tools
      git \
      python3-colcon-common-extensions \
      python3-pip \
-     python-rosdep \
+     python3-rosdep \
      python3-vcstool \
      wget
    # install some pip packages needed for testing


### PR DESCRIPTION
This PR updates the installation command/dependency list to use python3-rosdep instead of the obsolete python-rosdep.

In modern Ubuntu distributions (20.04+) and ROS 2 environments, the Python 2 version of this package is no longer available in the standard repositories, which previously caused the setup process to fail with a "package not found" error.

Fixes # (issue)

Did you use Generative AI?

No

Additional Information

This change ensures compatibility with current ROS 2 installation guides and prevents build failures in CI/CD pipelines or clean environment setups.
