### PR TITLE
RHEL 10 supported until 2035

### DIFF
--- a/source/Releases/Release-Lyrical-Luth.rst
+++ b/source/Releases/Release-Lyrical-Luth.rst
@@ -59,7 +59,7 @@ Supported Platforms
 ROS Lyrical supports the following platforms according to `the platform support tiers <../The-ROS2-Project/Platform-Support-Tiers>`:
 
 +--------------+-------------------+-------------------+---------------+-------------------+-----------+-----------------+----------------+
-| Architecture | Ubuntu Resolute   | Ubuntu Noble*     | Windows 11    | RHEL 10*          | macOS     | Debian Trixie*  | OpenEmbedded / |
+| Architecture | Ubuntu Resolute   | Ubuntu Noble*     | Windows 11    | RHEL 10           | macOS     | Debian Trixie*  | OpenEmbedded / |
 |              | (26.04)           | (24.04)           | (VS2022)      |                   |           | (13)            | Yocto Project  |
 +==============+===================+===================+===============+===================+===========+=================+================+
 | amd64        | Tier 1 [d][a]     | Tier 3            | Tier 1 [a]    | Tier 2 [d][a]     | Tier 3    | Tier 3          | Tier 3         |
@@ -71,7 +71,6 @@ ROS Lyrical supports the following platforms according to `the platform support 
 
 * ``*`` Early EOL per `the platform EOL policy <../The-ROS2-Project/Platform-EOL-Policy>`
     * Ubuntu Noble is supported until ``2029-06-01``
-    * RHEL 10 is supported until ``2030-05-31``
     * Debian Trixie is supported until ``2028-08-09``
 * ``[d]`` You may install ROS Lyrical on this platform using Distribution-specific packaegs (Debian, RPM, etc.).
 * ``[a]`` You may install ROS Lyrical by downloading an archive containing pre-built packages for all packages in the `ROS Lyrical ros2.repos file <https://github.com/ros2/ros2/blob/lyrical/ros2.repos>`__


### PR DESCRIPTION
## Description

@cottsay says

> The supported platforms list RHEL 10's EOL as 2030, which isn't entirely correct. The support model is different from Ubuntu, but 2030 will be the end of "full support" meaning no new FEATURES will land after that. Only bugfixes and security fixes, no RHEL minor releases. I think we should probably consider RHEL 10 as supported until 2035, which is when it enters "ELS" support which is more like Canonical's "ESM".

### Did you use Generative AI?

Is Scott AI?

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
