### PR TITLE
Switch from 'ROS Discourse' to 'Open Robotics Discourse'

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,8 +7,8 @@ contact_links:
     url: https://docs.ros.org/
     about: The ROS documentation is available at docs.ros.org
   - name: 🔗 Want to discuss a ROS feature or get the latest ROS news?
-    url: https://discourse.ros.org/
-    about: ROS Discourse is our community discussion forum.
+    url: https://discourse.openrobotics.org/c/ros/111
+    about: Open Robotics Discourse is our community discussion forum.
   - name: 🔗 Do you need real time support from other ROS users?
     url: https://openrobotics.zulipchat.com/
     about: Visit our community Zulip server. ROS questions belong in "ROS General" channel.

--- a/source/Concepts/Intermediate/About-RQt.rst
+++ b/source/Concepts/Intermediate/About-RQt.rst
@@ -78,6 +78,6 @@ From system architecture's perspective:
 Further Reading
 ---------------
 
-* ROS 2 Discourse `announcement of porting to ROS 2 <https://discourse.ros.org/t/rqt-in-ros2/6428>`__)
+* ROS 2 Discourse `announcement of porting to ROS 2 <https://discourse.openrobotics.org/t/rqt-in-ros2/6428>`__)
 * `RQt for ROS 1 documentation <https://wiki.ros.org/rqt>`__
 * Brief overview of RQt (from `a Willow Garage intern blog post <http://web.archive.org/web/20130518142837/http://www.willowgarage.com/blog/2012/10/21/ros-gui>`__)

--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -91,11 +91,11 @@ See the :doc:`Contributing <The-ROS2-Project/Contributing>` page for more detail
 Discussion
 ----------
 
-To start a discussion with other ROS 2 community members, visit the official `ROS Discourse <https://discourse.ros.org/>`__.
+To start a discussion with other ROS 2 community members, visit the official `Open Robotics Discourse <https://discourse.openrobotics.org/>`__.
 Content on the Discourse should be high-level;
 it's not a place to get *questions* about code answered, but it would be suitable to start a conversation about best practices or improving standards.
 
-Discussions about ROS 2 development and plans are happening on the `"Next Generation ROS" Discourse category <https://discourse.ros.org/c/ng-ros>`__.
+Discussions about ROS 2 development and plans are happening on the `Open Robotics Discourse' ROS category <https://discourse.openrobotics.org/c/ros/111>`__.
 Participating in these discussions is an important way to have a say on how different features of ROS 2 will work and be implemented.
 
 The diverse community behind the ROS ecosystem is one of its greatest assets.
@@ -129,10 +129,10 @@ Do not add unrelated content to posts.
 The content of posts should be focused on the topic at hand and not include unrelated content.
 Content, links, and images unrelated to the topic are considered spam.
 
-For commercial posts, see also `this discussion <https://discourse.ros.org/t/sponsorship-notation-in-posts-on-ros-org/2078>`_.
+For commercial posts, see also `this discussion <https://discourse.openrobotics.org/t/sponsorship-notation-in-posts-on-ros-org/2078>`_.
 
 Minimize references to content behind pay walls.
-The content posted on `ROS Discourse <https://discourse.ros.org/>`__ and `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ should "generally" be free and open to all users.
+The content posted on `Open Robotics Discourse <https://discourse.openrobotics.org/>`__ and `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ should "generally" be free and open to all users.
 Links to content behind pay walls such as private journal articles, text books, and paid news websites, while helpful and relevant, may not be accessible to all users.
 Where possible primary sources should be free and open with paid content playing a supporting role.
 

--- a/source/How-To-Guides/Releasing/_Next-Steps.rst
+++ b/source/How-To-Guides/Releasing/_Next-Steps.rst
@@ -3,4 +3,4 @@ If your package build is successful, in 24-48 hours your packages will become av
 
 Approximately every two to four weeks, the distribution's release manager manually synchronizes the contents of ros-testing into the main ROS repository.
 This is when your packages actually become available to the rest of the ROS community.
-To get updates on when the next synchronization (sync) is coming, subscribe to the `Packaging and Release Management Category on ROS Discourse <https://discourse.ros.org/c/release/16>`_.
+To get updates on when the next synchronization (sync) is coming, subscribe to the `Packaging and Release Management Category on Open Robotics Discourse <https://discourse.openrobotics.org/c/ros/release/16>`_.

--- a/source/The-ROS2-Project/Contributing.rst
+++ b/source/The-ROS2-Project/Contributing.rst
@@ -82,7 +82,7 @@ If you are interested in contributing to the ROS 2 project, we encourage you to 
 If you'd like to cast a wider net, we welcome contributions on any open issue (or others that you might propose), particularly tasks that have a milestone signifying they're targeted for the next ROS 2 release (the milestone will be the next release's e.g. 'crystal').
 
 If you have some code to contribute that fixes a bug or improves documentation, please submit it as a pull request to the relevant repository.
-For larger changes, it is a good idea to discuss the proposal `on the ROS 2 forum <https://discourse.ros.org/c/ng-ros>`__ before you start to work on it so that you can identify if someone else is already working on something similar.
+For larger changes, it is a good idea to discuss the proposal `on the ROS 2 forum <https://discourse.openrobotics.org/c/ros/111>`__ before you start to work on it so that you can identify if someone else is already working on something similar.
 If your proposal involves changes to the APIs, it is especially recommended that you discuss the approach before starting work.
 
 Submitting your code changes

--- a/source/The-ROS2-Project/Contributing/Build-Farms.rst
+++ b/source/The-ROS2-Project/Contributing/Build-Farms.rst
@@ -21,7 +21,7 @@ There are two hosted instance for open source packages:
 #. https://build.ros2.org/ for ROS 2 packages
 
 If you are going to use any of the provided infrastructure please consider signing up for the
-`build farm discussion forum <http://discourse.ros.org/c/buildfarm>`__ in order to receive notifications,
+`build farm discussion forum <https://discourse.openrobotics.org/c/infrastructure-project/infra-buildfarm/20>`__ in order to receive notifications,
 e.g., about any upcoming changes.
 
 

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -219,7 +219,7 @@ The next step for migrating a ROS Wiki page is to determine the correct location
 Only ROS Wiki pages that cover core ROS concepts belong in the ROS Documentation, these pages should be migrated to a logical location within the ROS documentation.
 Package specific documentation should be migrated to the package-level documentation generated in the package's source repository.
 Once the package level documentation has been updated it will be visible `as part of the package-level documentation <https://docs.ros.org/en/rolling/p/>`__.
-If you are unsure whether and where to migrate a page, please get in touch via an issue on https://github.com/ros2/ros2_documentation or on https://discourse.ros.org.
+If you are unsure whether and where to migrate a page, please get in touch via an issue on https://github.com/ros2/ros2_documentation or on https://discourse.openrobotics.org/.
 
 Once you've determined that a ROS Wiki page is worth migrating, and found an appropriate landing spot in the ROS documentation, the next step in the migration process is to set up the conversion tools necessary to migrate the page.
 In most cases the only tools necessary to migrate a single ROS Wiki page to the ROS Docs are the `PanDoc <https://pandoc.org/>`_ command line tool and a text editor.

--- a/source/The-ROS2-Project/Metrics.rst
+++ b/source/The-ROS2-Project/Metrics.rst
@@ -29,7 +29,7 @@ Periodic Metrics Report
 We periodically publish a metrics report that provides a quantitative view of the ROS community.
 We're collectively learning what to measure and how and evolving as systems change.
 Please provide feedback!
-Add your suggestions on how to improve these reports by posting them to `ROS Discourse Site Feedback Category <http://discourse.ros.org/c/site-feedback>`_.
+Add your suggestions on how to improve these reports by posting them to `Open Robotics Discourse Site Feedback Category <https://discourse.openrobotics.org/c/site-feedback/3>`_.
 
 Historical Metrics Reports
 ..........................

--- a/source/The-ROS2-Project/Roadmap.rst
+++ b/source/The-ROS2-Project/Roadmap.rst
@@ -46,5 +46,5 @@ Here are a few resources to get you going.
 2. Check out the list of :doc:`Feature Ideas <Feature-Ideas>` for inspiration.
 3. For more information on the design of ROS 2 please see `design.ros2.org <https://design.ros2.org>`__.
 4. The core code for ROS 2 is in the `ros2 GitHub organization <https://github.com/ros2>`__.
-5. The Discourse forum/mailing list for discussing ROS 2 design is `ng-ros <https://discourse.ros.org/c/ng-ros>`__.
+5. The forum discussing ROS 2 design is `Open Robotics Discourse's ROS category <https://discourse.openrobotics.org/c/ros/111>`__.
 6. Questions should be asked on `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__\ , make sure to include at least the ``ros2`` tag and the rosdistro version you are running, e.g. ``{DISTRO}``.

--- a/source/Tutorials/Intermediate/Composition.rst
+++ b/source/Tutorials/Intermediate/Composition.rst
@@ -410,7 +410,7 @@ If you want to export a composable node as a shared library from a package and u
 
 Then install the generated file and export the generated file.
 
-A practical example can be seen here: `ROS Discourse - Ament best practice for sharing libraries <https://discourse.ros.org/t/ament-best-practice-for-sharing-libraries/3602>`__
+A practical example can be seen here: `ROS Discourse - Ament best practice for sharing libraries <https://discourse.openrobotics.org/t/ament-best-practice-for-sharing-libraries/3602>`__
 
 Composing Non-Node Derived Components
 -------------------------------------

--- a/source/Tutorials/Miscellaneous/Deploying-ROS-2-on-IBM-Cloud.rst
+++ b/source/Tutorials/Miscellaneous/Deploying-ROS-2-on-IBM-Cloud.rst
@@ -87,7 +87,7 @@ b) ROS 2 Image
 ^^^^^^^^^^^^^^
 
 ROS
-`announced <https://discourse.ros.org/t/announcing-official-docker-images-for-ros2/7381/2>`__
+`announced <https://discourse.openrobotics.org/t/announcing-official-docker-images-for-ros2/7381/2>`__
 image containers for several ROS distributions in January 2019.
 More detailed instructions on the use of ROS 2 docker images can be found
 `here <https://hub.docker.com/_/ros/>`__.

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -7,7 +7,7 @@
       <tr>
         <td valign="middle">
           ROS Resources:
-            <a href="http://discourse.ros.org/">Discussion Forum</a>
+            <a href="https://discourse.openrobotics.org/">Discussion Forum</a>
             |
             <a href="http://status.ros.org/">Service Status</a>
             |

--- a/source/index.rst
+++ b/source/index.rst
@@ -119,7 +119,7 @@ If you need help, have an idea, or would like to contribute to the project, plea
 
   - See :ref:`Contact Page <Using Robotics Stack Exchange>` for more information
 
-* `ROS Discourse <https://discourse.ros.org/>`__ (ROS 1, ROS 2)
+* `Open Robotics Discourse <https://discourse.openrobotics.org/>`__ (ROS 1, ROS 2)
 
   - Forum for general discussions and announcements for the ROS community
   - See the :ref:`Contact Page <Using ROS Discourse>` for more information


### PR DESCRIPTION
## Description

Update links (most links redirect to the correct category or post, but not all) and update references to "Open Robotics Discourse."

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

We can try backporting this.