### PR TITLE
Update project URL for Czech Technical University

### DIFF
--- a/source/The-ROS2-Project/Adopters/adopters.yaml
+++ b/source/The-ROS2-Project/Adopters/adopters.yaml
@@ -121,7 +121,7 @@ adopters:
   - organization: "Czech Technical University in Prague"
     organization_url: "https://cvut.cz"
     project: "Vision for Robotics and Autonomous Systems"
-    project_url: "https://cyber.felk.cvut.cz/vras/"
+    project_url: "https://cyber.felk.cvut.cz/research/groups-teams/vras/"
     domain:
       - Defense/Government
       - Education


### PR DESCRIPTION
I think this should fix this error:

```
  File "/home/runner/work/ros2_documentation/ros2_documentation/plugins/sphinx_adopters.py", line 79, in run
    raise ExtensionError(
sphinx.errors.ExtensionError: Adopters YAML validation failed:
  - Entry 8 (Czech Technical University in Prague/Vision for Robotics and Autonomous Systems): "project_url" URL is not reachable: https://cyber.felk.cvut.cz/vras/ (The read operation timed out)
multiprocessing.pool.RemoteTraceback: 
"""
```

https://github.com/ros2/ros2_documentation/actions/runs/25147132841/job/73709342605?pr=6484
