### PR TITLE
Bump windows installation to Windows 11

### DIFF
--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -14,13 +14,11 @@ This page explains how to setup a development environment for ROS 2 on Windows.
 System requirements
 -------------------
 
-Only Windows 11 is supported.
-
 Language support
 ^^^^^^^^^^^^^^^^
 
 Make sure you have a locale which supports ``UTF-8``.
-For example, for a Chinese-language Windows 11 installation, you may need to install an `English language pack <https://support.microsoft.com/en-us/windows/language-packs-for-windows-a5094319-a92d-18de-5b53-1cfc697cfca8>`_.
+For example, for a Chinese-language Windows installation, you may need to install an `English language pack <https://support.microsoft.com/en-us/windows/language-packs-for-windows-a5094319-a92d-18de-5b53-1cfc697cfca8>`_.
 
 Create a location for the ROS 2 installation
 --------------------------------------------

--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -14,13 +14,13 @@ This page explains how to setup a development environment for ROS 2 on Windows.
 System requirements
 -------------------
 
-Only Windows 10 is supported.
+Only Windows 11 is supported.
 
 Language support
 ^^^^^^^^^^^^^^^^
 
 Make sure you have a locale which supports ``UTF-8``.
-For example, for a Chinese-language Windows 10 installation, you may need to install an `English language pack <https://support.microsoft.com/en-us/windows/language-packs-for-windows-a5094319-a92d-18de-5b53-1cfc697cfca8>`_.
+For example, for a Chinese-language Windows 11 installation, you may need to install an `English language pack <https://support.microsoft.com/en-us/windows/language-packs-for-windows-a5094319-a92d-18de-5b53-1cfc697cfca8>`_.
 
 Create a location for the ROS 2 installation
 --------------------------------------------

--- a/source/Installation/Alternatives/Windows-Development-Setup.rst
+++ b/source/Installation/Alternatives/Windows-Development-Setup.rst
@@ -58,19 +58,19 @@ Install MSVC
 ^^^^^^^^^^^^
 
 In order to compile the ROS 2 code, the MSVC compiler must be installed.
-Currently it is recommended to use MSVC 2019.
+Currently it is recommended to use MSVC 2022.
 
 Continue using the previous session, and run the following command to download it:
 
 .. code-block:: console
 
-   $ powershell irm https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile vs_buildtools_2019.exe
+   $ powershell irm https://aka.ms/vs/17/release/vs_buildtools.exe -OutFile vs_buildtools_2022.exe
 
-Now install MSVC 2019:
+Now install MSVC 2022:
 
 .. code-block:: console
 
-   $ .\vs_buildtools_2019.exe --quiet --wait --norestart --add Microsoft.Component.MSBuild --add Microsoft.Net.Component.4.6.1.TargetingPack --add Microsoft.Net.Component.4.8.SDK --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CLI.Support --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools
+   $ .\vs_buildtools_2022.exe --quiet --wait --norestart --add Microsoft.Component.MSBuild --add Microsoft.Net.Component.4.6.1.TargetingPack --add Microsoft.Net.Component.4.8.SDK --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CLI.Support --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools
 
 .. note::
 
@@ -118,7 +118,7 @@ This is required in the Command Prompt you'll use to compile ROS 2, but it is *n
 
 .. code-block:: console
 
-  $ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+  $ call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
 Source the pixi environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -13,11 +13,6 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
     All packages in the `ROS base variant <https://reps.openrobotics.org/rep-2001/#ros-base>`_ are included, and only a subset of packages in the `ROS desktop variant <https://reps.openrobotics.org/rep-2001/#desktop-variants>`_ are included.
     The exact list of packages are described by the repositories listed in `this ros2.repos file <https://github.com/ros2/ros2/blob/{REPOS_FILE_BRANCH}/ros2.repos>`_.
 
-System requirements
--------------------
-
-Only Windows 11 is supported.
-
 .. _windows-install-binary-installing-prerequisites:
 
 Create a location for the ROS 2 installation

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -16,7 +16,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-Only Windows 10 is supported.
+Only Windows 11 is supported.
 
 .. _windows-install-binary-installing-prerequisites:
 


### PR DESCRIPTION
As reported by @shahryar-mooraj during the Test and Tutorial party.  

We should be targeting Windows 11 rather than Windows 10 in documentation.

Per recommendation from @cottsay, I'm dropping the version suffix entirely.