### PR TITLE
Fixed typo error in lyrcial docs (ubuntu,windows) #6516

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -20,7 +20,7 @@ Resources
 
 * Status Page:
 
-  * ROS 2 {DISTRO_TITLE} (Ubuntu Noble 24.04): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_unv8.html>`__
+  * ROS 2 {DISTRO_TITLE} (Ubuntu Noble 26.04): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_unv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 

--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -20,7 +20,7 @@ Resources
 
 * Status Page:
 
-  * ROS 2 {DISTRO_TITLE} (Ubuntu Noble 26.04): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_unv8.html>`__
+  * ROS 2 {DISTRO_TITLE} (Ubuntu Resolute Raccoon 26.04): `amd64 <http://repo.ros2.org/status_page/ros_{DISTRO}_default.html>`__\ , `arm64 <http://repo.ros2.org/status_page/ros_{DISTRO}_unv8.html>`__
 * `Jenkins Instance <http://build.ros2.org/>`__
 * `Repositories <http://repo.ros2.org>`__
 

--- a/source/Installation/Windows-Install-Binary.rst
+++ b/source/Installation/Windows-Install-Binary.rst
@@ -16,7 +16,7 @@ This page explains how to install ROS 2 on Windows from a pre-built binary packa
 System requirements
 -------------------
 
-Only Windows 10 is supported.
+Only Windows 11 is supported.
 
 .. _windows-install-binary-installing-prerequisites:
 


### PR DESCRIPTION
## Description

Updated the typo error in the docs for lyrical  fixed it to windows 11 and Ubuntu 26.04 the actual supported os 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #6516

### Did you use Generative AI?
no

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->