### PR TITLE
Fix namespace in handle_turtle_pose lambda

### DIFF
--- a/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
+++ b/source/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Broadcaster-Cpp.rst
@@ -101,7 +101,7 @@ Open the file using your preferred text editor.
         stream << "/" << turtlename_.c_str() << "/pose";
         std::string topic_name = stream.str();
 
-        auto handle_turtle_pose = [this](const std::shared_ptr<const turtlesim_msgs::msg::Pose> msg){
+        auto handle_turtle_pose = [this](const std::shared_ptr<const turtlesim::msg::Pose> msg){
             geometry_msgs::msg::TransformStamped t;
 
             // Read message content and assign it to


### PR DESCRIPTION
## Description

The actual package name is `turtlesim`, not `turtlesim_msgs`. This typo in the tutorial caused a compilation failure when building the C++ listener node. 

I updated `turtlesim_msgs::msg::Pose` to `turtlesim::msg::Pose` to match the actual ROS 2 message definition, which resolves the build error for beginners following the guide.

### Did you use Generative AI?

No.  :D