### PR TITLE
Exporting urdf document: removing inactive website link

### DIFF
--- a/source/Tutorials/Intermediate/URDF/Exporting-an-URDF-File.rst
+++ b/source/Tutorials/Intermediate/URDF/Exporting-an-URDF-File.rst
@@ -31,7 +31,6 @@ However, we figured it would be helpful to produce a list of available URDF expo
  * `OnShape URDF Exporter <https://github.com/Rhoban/onshape-to-robot>`_
  * `SolidWorks URDF Exporter <https://github.com/ros/solidworks_urdf_exporter>`_
  * `ExportURDF Library (Fusion360, OnShape, Solidworks) <https://github.com/daviddorf2023/ExportURDF>`_
- * `RoboForge Project (freemium / paid tooling) <https://robofor.ge/>`_
 
 **Other URDF Export and Conversion Tools**
 


### PR DESCRIPTION
Closes
https://github.com/ros2/lyrical_tutorial_party/issues/3204 
https://github.com/ros2/lyrical_tutorial_party/issues/3205
https://github.com/ros2/lyrical_tutorial_party/issues/3206
https://github.com/ros2/lyrical_tutorial_party/issues/3207

## Description

Removed RoboForge Project (freemium / paid tooling)  link from the exporting an urdf file document.


Fixes # (issue)

### Did you use Generative AI?

No

### Additional Information

Messaged the maintainer to send updated link. Once I get the new link I will update the documentation.
