### PR TITLE
docs: add fusion2URDF to URDF exporters list

### DIFF
--- a/source/Tutorials/Intermediate/URDF/Exporting-an-URDF-File.rst
+++ b/source/Tutorials/Intermediate/URDF/Exporting-an-URDF-File.rst
@@ -27,6 +27,7 @@ However, we figured it would be helpful to produce a list of available URDF expo
  * `RobotCAD (FreeCAD OVERCROSS) <https://github.com/drfenixion/freecad.overcross>`_
  * `Freecad to Gazebo Exporter <https://github.com/Dave-Elec/freecad_to_gazebo>`_
  * `Fusion 360 URDF Exporter <https://github.com/dheena2k2/fusion2urdf-ros2>`_
+ * `fusion2URDF (Fusion 360, ros2_control, closed loops) <https://github.com/Adriaeik/fusion2URDF>`_
  * `FusionSDF: Fusion 360 to SDF exporter <https://github.com/andreasBihlmaier/FusionSDF>`_
  * `OnShape URDF Exporter <https://github.com/Rhoban/onshape-to-robot>`_
  * `SolidWorks URDF Exporter <https://github.com/ros/solidworks_urdf_exporter>`_


### PR DESCRIPTION
Adds [fusion2URDF](https://github.com/Adriaeik/fusion2URDF) to the CAD Exporters section under URDF Tutorials.

`fusion2URDF` is a Fusion 360 add-in that exports a complete ROS 2 `robot_description` package on every run:

- Hierarchical xacro with modular per-assembly macros, plus a flat URDF for validation
- Generated `<ros2_control>` block with `mock_components/GenericSystem` by default, swappable for real hardware drivers
- Six-strategy collision pipeline with per-link overrides (`!acc_*` / `!cxh_*` / `!pri_*`)
- Closed-loop joint sidecar in `robot_data.yaml` for kinematic chains URDF cannot represent (parallel grippers, four-bar linkages)
- Frame helpers (`!frame_*`), inertia preserved straight from Fusion, KaTeX symbolic transform matrices, JSON snapshot for offline tooling

Tested against ROS 2 Jazzy. Two ready-to-launch packages bundled under `examples/` (Husarion Panther mobile robot and a 6-DoF arm with a parallel-jaw gripper that exercises the closed-loop sidecar in NVIDIA Isaac Sim).

Repo: https://github.com/Adriaeik/fusion2URDF