### PR TITLE
Fix action tutorial code block mixing command and output

### DIFF
--- a/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
+++ b/source/Tutorials/Intermediate/Writing-an-Action-Server-Client/Py.rst
@@ -218,7 +218,6 @@ Let's test our action client by first running the action server built earlier:
       $ python fibonacci_action_server.py
 
 In another terminal, run the action client.
-You should see messages printed by the action server as it successfully executes the goal:
 
 .. tabs::
 
@@ -227,12 +226,6 @@ You should see messages printed by the action server as it successfully executes
     .. code-block:: console
 
       $ python3 fibonacci_action_client.py
-      [INFO] [fibonacci_action_server]: Executing goal...
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3, 5])
-      ~ etc.
 
 
   .. group-tab:: macOS
@@ -240,12 +233,6 @@ You should see messages printed by the action server as it successfully executes
     .. code-block:: console
 
       $ python3 fibonacci_action_client.py
-      [INFO] [fibonacci_action_server]: Executing goal...
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3, 5])
-      ~ etc.
 
 
   .. group-tab:: Windows
@@ -253,12 +240,17 @@ You should see messages printed by the action server as it successfully executes
     .. code-block:: console
 
       $ python fibonacci_action_client.py
-      [INFO] [fibonacci_action_server]: Executing goal...
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3])
-      [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3, 5])
-      # etc.
+
+You should see messages printed by the action server as it successfully executes the goal:
+
+.. code-block:: console
+
+    [INFO] [fibonacci_action_server]: Executing goal...
+    [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1])
+    [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2])
+    [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3])
+    [INFO] [fibonacci_action_server]: Feedback: array('i', [0, 1, 1, 2, 3, 5])
+    ~ etc.
 
 The action client should start up, and then quickly finish.
 At this point, we have a functioning action client, but we don't see any results or get any feedback.


### PR DESCRIPTION
## Description

### Part of Lyrical Luth Testing Party Fixes
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
In Section 2 of "Writing an action server and client (Python)", the instructions state:

“In another terminal, run the action client. You should see messages printed by the action server as it successfully executes the goal:”

However, the accompanying code block included both:  the action client command, and the action server’s output

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes issues raised while testing: ros2/lyrical_tutorial_party#3320

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
NO

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
NA