### PR TITLE
Fix: subset naming convention in rosbag cli tutorial

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
@@ -212,7 +212,7 @@ Run the following for at least 15 seconds, allowing for three 5-second bag files
     [INFO] [rosbag2_cpp]: Writing remaining messages from cache to the bag. It may take a while
 
 Press :kbd:`Ctrl-C` when you're finished.
-You should find a ``subset_split`` directory with these files inside: ``subset_split_0.mcap``, ``subset_split_1.mcap``, and so on.
+You should find a ``subset_split`` directory with these files inside: ``0_subset_split_YYYY_MM_DD-HH_MM_SS.mcap``, ``1_subset_split_YYYY_MM_DD-HH_MM_SS.mcap``, and so on.
 
 4 Inspect topic data
 ^^^^^^^^^^^^^^^^^^^^
@@ -231,6 +231,7 @@ Running this command on the ``subset`` bag recording will return a list of infor
     Files:             subset_0.mcap
     Bag size:          228.5 KiB
     Storage id:        mcap
+    ROS Distro:        lyrical
     Duration:          48.47s
     Start:             Oct 11 2019 06:09:09.12 (1570799349.12)
     End                Oct 11 2019 06:09:57.60 (1570799397.60)
@@ -242,7 +243,7 @@ Running this command on the ``subset`` bag recording will return a list of infor
     Actions:           0
     Action information:
 
-Alternatively, you can also call ``ros2 bag info`` on an individual file, such as ``subset_split/subset_split_0.mcap``, and it will only show information for that portion of the recording; in this case, the first 5 seconds.
+Alternatively, you can also call ``ros2 bag info`` on an individual file, such as ``subset_split/0_subset_split_YYYY_MM_DD-HH_MM_SS.mcap``, and it will only show information for that portion of the recording; in this case, the first 5 seconds.
 
 5 Play topic data
 ^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.rst
@@ -231,7 +231,7 @@ Running this command on the ``subset`` bag recording will return a list of infor
     Files:             subset_0.mcap
     Bag size:          228.5 KiB
     Storage id:        mcap
-    ROS Distro:        lyrical
+    ROS Distro:        rolling
     Duration:          48.47s
     Start:             Oct 11 2019 06:09:09.12 (1570799349.12)
     End                Oct 11 2019 06:09:57.60 (1570799397.60)


### PR DESCRIPTION
## Description

### Part of Lyrical Luth Testing Party Fixes

In [Section 3.3](https://docs.ros.org/en/lyrical/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.html#split-recording-into-multiple-files) under "Managing Topic Data" of [ "Recording and playing back data"](https://docs.ros.org/en/lyrical/Tutorials/Beginner-CLI-Tools/Recording-And-Playing-Back-Data/Recording-And-Playing-Back-Data.html#recording-and-playing-back-data), the tutorial shows the subset bag files following the convention: `name_count.mcap`

<img width="557" height="343" alt="Screenshot 2026-05-02 133433" src="https://github.com/user-attachments/assets/86ebf6cd-c338-4fa4-9d9b-5bffcbcf1483" />

<br>
The actual files saved have a different naming convention being followed as count_name_YYYY_MM_DD-HH_MM_SS.mcap
<br>

<img width="510" height="282" alt="Screenshot 2026-05-02 133232" src="https://github.com/user-attachments/assets/ba0f5d01-35c2-4ce9-b47a-12a5ccad960e" />

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes issues raised while testing: ros2/lyrical_tutorial_party#1987

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
NO

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
NA
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

