### PR TITLE
Fix dnf config-manager syntax for RHEL testing repo

### DIFF
--- a/source/Installation/Testing.rst
+++ b/source/Installation/Testing.rst
@@ -73,8 +73,8 @@ For RHEL you can install binary packages from the **ros-testing** repository, by
 
    .. code-block:: console
 
-      $ sudo dnf config-manager setopt ros2-testing.enabled=1
-      $ sudo dnf config-manager setopt ros2.enabled=0
+      $ sudo dnf config-manager --set-enabled ros2-testing
+      $ sudo dnf config-manager --set-disabled ros2
 
 3. Update the dnf index:
 
@@ -92,8 +92,8 @@ For RHEL you can install binary packages from the **ros-testing** repository, by
 
    .. code-block:: console
 
-      $ sudo dnf config-manager setopt ros2-testing.enabled=0
-      $ sudo dnf config-manager setopt ros2.enabled=1
+      $ sudo dnf config-manager --set-disabled ros2-testing
+      $ sudo dnf config-manager --set-enabled ros2
 
    and doing an update and upgrade:
 


### PR DESCRIPTION
## Description

At least on rhel10, `setopt ros2-testing.enabled=1` did not work:
```
#13 [ 7/15] RUN   dnf config-manager setopt ros2-testing.enabled=1 &&   dnf config-manager setopt ros2.enabled=0 &&   dnf update &&   dnf clean all
#13 0.223 Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --set-enabled --enable --set-disabled --disable
#13 0.230 usage: dnf config-manager [-c [config file]] [-q] [-v] [--version]
#13 0.230                           [--installroot [path]] [--nodocs] [--noplugins]
#13 0.230                           [--enableplugin [plugin]] [--disableplugin [plugin]]
#13 0.230                           [--releasever RELEASEVER]
#13 0.230                           [--releasever-major RELEASEVER_MAJOR]
#13 0.230                           [--releasever-minor RELEASEVER_MINOR]
#13 0.230                           [--setopt SETOPTS] [--skip-broken] [-h]
#13 0.230                           [--allowerasing] [-b | --nobest] [-C] [-R [minutes]]
#13 0.230                           [-d [debug level]] [--debugsolver]
#13 0.230                           [--showduplicates] [-e ERRORLEVEL] [--obsoletes]
#13 0.230                           [--rpmverbosity [debug level name]] [-y]
#13 0.230                           [--assumeno] [--enablerepo [repo]]
#13 0.230                           [--disablerepo [repo] | --repo [repo]]
#13 0.230                           [--enable | --disable] [-x [package]]
#13 0.230                           [--disableexcludes [repo]]
#13 0.230                           [--repofrompath [repo,path]] [--noautoremove]
#13 0.230                           [--nogpgcheck] [--color COLOR] [--refresh] [-4] [-6]
#13 0.230                           [--destdir DESTDIR] [--downloadonly] [--transient]
#13 0.230                           [--comment COMMENT] [--bugfix] [--enhancement]
#13 0.230                           [--newpackage] [--security] [--advisory ADVISORY]
#13 0.230                           [--bz BUGZILLA] [--cve CVES]
#13 0.230                           [--sec-severity {Critical,Important,Moderate,Low}]
#13 0.230                           [--forcearch ARCH] [--save] [--add-repo URL]
#13 0.230                           [--dump] [--dump-variables]
#13 0.230                           [--set-enabled | --set-disabled]
#13 0.230                           [section ...]
```

`--setopt` could also work?

### Did you use Generative AI?

no

### Additional Information

should be backported to lyrical, which also uses rhel10