### PR TITLE
fix: add instruction for RHEL in Introducing-Turtlesim

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
@@ -51,18 +51,24 @@ Install the turtlesim package for your ROS 2 distro:
 
 .. tabs::
 
-   .. group-tab:: Linux
+  .. group-tab:: Ubuntu
 
       .. code-block:: console
 
         $ sudo apt update
         $ sudo apt install ros-{DISTRO}-turtlesim
 
-   .. group-tab:: macOS
+  .. group-tab:: RHEL
+
+      .. code-block:: console
+
+        $ sudo dnf install ros-{DISTRO}-turtlesim
+
+  .. group-tab:: macOS
 
       As long as the archive you installed ROS 2 from contains the ``ros_tutorials`` repository, you should already have turtlesim installed.
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
       As long as the archive you installed ROS 2 from contains the ``ros_tutorials`` repository, you should already have turtlesim installed.
 


### PR DESCRIPTION
## Description

https://docs.ros.org/en/lyrical/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.html 
missing instruction for RHEL when installing turtlesim

Result preview screenshot:
<img width="901" height="389" alt="image" src="https://github.com/user-attachments/assets/880889af-2978-48b0-bcb8-8db2a70ac9f0" />

Fixes https://github.com/ros2/lyrical_tutorial_party/issues/3631

### Did you use Generative AI?

NO

### Additional Information

NO
