### PR TITLE
docs(turtlesim): fix incomplete remapping in section 6 for turtle2 teleop

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.rst
@@ -231,13 +231,13 @@ That's because there is no teleop node for ``turtle2``.
 
 You need a second teleop node in order to control ``turtle2``.
 However, if you try to run the same command as before, you will notice that this one also controls ``turtle1``.
-The way to change this behavior is by remapping the ``cmd_vel`` topic.
+The way to change this behavior is by remapping the ``cmd_vel`` topic and the ``rotate_absolute`` action.
 
 In a new terminal, source ROS 2, and run:
 
 .. code-block:: console
 
-  $ ros2 run turtlesim turtle_teleop_key --ros-args --remap turtle1/cmd_vel:=turtle2/cmd_vel
+  $ ros2 run turtlesim turtle_teleop_key --ros-args --remap turtle1/cmd_vel:=turtle2/cmd_vel --remap turtle1/rotate_absolute:=turtle2/rotate_absolute
 
 
 Now, you can move ``turtle2`` when this terminal is active, and ``turtle1`` when the other terminal running ``turtle_teleop_key`` is active.


### PR DESCRIPTION
## Description
The remapping command in the "6 Remapping" section of the turtlesim tutorial
only remaps the `cmd_vel` topic, which means arrow key movement works for
`turtle2` but the absolute orientation keys (F, G, B, V, C) silently continue
to control `turtle1` because the `rotate_absolute` action is not remapped.

Two changes are made:
- Updated the prose description to mention both `cmd_vel` and `rotate_absolute`
- Added `--remap turtle1/rotate_absolute:=turtle2/rotate_absolute` to the shell command

### Did you use Generative AI?
Claude (Sonnet 4.6) was used to assist with drafting the commit message and PR description.

### Additional Information
The fix applies to the jazzy branch. The same issue may be present in other
supported distributions (humble, rolling) and may warrant separate PRs.