### PR TITLE
Update Python.rst

### DIFF
--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -69,9 +69,19 @@ Beyond the :doc:`standard colcon testing commands <CLI>` you can also specify ar
 For example, you can specify the name of the function to run with
 
 
-.. code-block:: console
+.. tabs::
 
-  $ colcon test --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
+  .. group-tab:: Linux/macOS
+
+      .. code-block:: console
+
+         $ colcon test --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+         $ colcon test --merge-install --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
 
 To see the pytest output while running the tests, use these flags:
 


### PR DESCRIPTION
## Description

Updated the testing documentation to include platform-specific colcon test commands using tabs for Linux/macOS and Windows.

On Windows, `--merge-install` was added since ROS 2 workspaces are commonly built using the merged install layout. Without this option, the following error can occur during testing:

```
(pixi_ros2_rolling) C:\robotics\ros2_ws>colcon test --packages-select my_py_pkg --pytest-args -k test_math
[0.308s] colcon ERROR colcon test: The install directory 'install' was created with the layout 'merged'. Please remove the install directory, pick a different one or add the '--merge-install' option.
```
**Linux and macOS were not explicitly tested in this change**. However, the command used for Linux follows the existing ROS 2 documentation patterns used in distributions such as Jazzy and Rolling.

### Did you use Generative AI?
No

### Additional Information
This change only affects documentation.
