### PR TITLE
Replace tests_require with extras_require

### DIFF
--- a/source/Tutorials/Advanced/Simulators/Webots/Code/setup.py
+++ b/source/Tutorials/Advanced/Simulators/Webots/Code/setup.py
@@ -19,7 +19,9 @@ setup(
     maintainer_email='user.name@mail.com',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
+    extras_require={
+        'test': ['pytest'],
+    },
     entry_points={
         'console_scripts': [
             'my_robot_driver = my_package.my_robot_driver:main',

--- a/source/Tutorials/Advanced/Simulators/Webots/Code/setup_sensor.py
+++ b/source/Tutorials/Advanced/Simulators/Webots/Code/setup_sensor.py
@@ -19,7 +19,9 @@ setup(
     maintainer_email='user.name@mail.com',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
+    extras_require={
+        'test': ['pytest'],
+    },
     entry_points={
         'console_scripts': [
             'my_robot_driver = my_package.my_robot_driver:main',

--- a/source/Tutorials/Advanced/Simulators/Webots/Setting-Up-Simulation-Webots-Advanced.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Setting-Up-Simulation-Webots-Advanced.rst
@@ -139,7 +139,7 @@ You have to modify these two other files to launch your new node.
         .. literalinclude:: Code/setup_sensor.py
             :language: python
             :dedent: 8
-            :lines: 24-27
+            :lines: 26-29
 
         This will add an entry point for the ``obstacle_avoider`` node.
 

--- a/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.rst
@@ -508,7 +508,9 @@ This is where your ``package.xml`` would list its dependencies on other packages
         maintainer_email='TODO',
         description='TODO: Package description',
         license='TODO: License declaration',
-        tests_require=['pytest'],
+        extras_require={
+            'test': ['pytest'],
+        },
         entry_points={
             'console_scripts': [
                     'my_node = my_py_pkg.my_node:main'

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -18,7 +18,9 @@ Your ``setup.py`` must have a test dependency on ``pytest`` within the call to `
 
 .. code-block:: python
 
-    tests_require=['pytest'],
+    extras_require={
+        'test': ['pytest'],
+    },
 
 Test Files and Folders
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

When testing Nav2 in Lyrical, I noticed that:

```
/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'tests_require'
  warnings.warn(msg)
```

This should probably be replaced with extras_require

### Did you use Generative AI?

No

### Additional Information

I think this should be backported to Lyrical
