### PR TITLE
Fix group-tab indentation in python.rst

### DIFF
--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -69,9 +69,19 @@ Beyond the :doc:`standard colcon testing commands <CLI>` you can also specify ar
 For example, you can specify the name of the function to run with
 
 
-.. code-block:: console
+.. tabs::
 
-  $ colcon test --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
+  .. group-tab:: Linux/macOS
+
+      .. code-block:: console
+
+         $ colcon test --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+         $ colcon test --merge-install --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
 
 To see the pytest output while running the tests, use these flags:
 

--- a/source/Tutorials/Intermediate/Testing/Python.rst
+++ b/source/Tutorials/Intermediate/Testing/Python.rst
@@ -77,7 +77,7 @@ For example, you can specify the name of the function to run with
 
          $ colcon test --packages-select <name-of-pkg> --pytest-args -k name_of_the_test_function
 
-   .. group-tab:: Windows
+  .. group-tab:: Windows
 
       .. code-block:: console
 


### PR DESCRIPTION
## Description

Fix incorrect group-tab rendering in python.rst caused by inconsistent indentation/whitespace inside the tabs directive. A previous [PR ](https://github.com/ros2/ros2_documentation/pull/6638) had an indentation problem. This PR fixes the formatting/rendering issue.

This change only updates RST formatting and does not modify functionality

### Did you use Generative AI?
No

### Additional Information

Linux and macOS were not explicitly tested in this change. However, the command used for Linux follows the existing ROS 2 documentation patterns used in distributions such as Jazzy and Rolling. Should it be tested before merging for mac or shall I add only 2 tab groups Linux and Windows instead of Linux/Mac and windows


