### PR TITLE
Clarify that discovery server does not need mutation tries configuration

### DIFF
--- a/source/Tutorials/Advanced/Discovery-Server/Discovery-Server.rst
+++ b/source/Tutorials/Advanced/Discovery-Server/Discovery-Server.rst
@@ -472,7 +472,7 @@ Save this file (e.g. as ``large_scale_configuration.xml``) and set the environme
 
     The ``mutation_tries`` value should be set to at least the number of participants you intend to run on a single host.
     Increasing it beyond what is needed has no negative side effects.
-    This configuration must be applied to **all** participants in the system, including the discovery server itself.
+    This configuration must be applied to **all** participants in the system, except the discovery server, for which a specific unicast port is already configured at launch.
 
 For more details, see the `Fast DDS documentation on participant configuration <https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/xml_configuration.html>`__.
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This is a follow up of #6636, clarifying that `mutation_tries` configuration is not necessary for the discovery server itself.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Did you use Generative AI?

No
<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
