### PR TITLE
Updating Qt version in RViz-Custom-Display tutorial

### DIFF
--- a/source/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.rst
+++ b/source/Tutorials/Intermediate/RViz/RViz-Custom-Display/RViz-Custom-Display.rst
@@ -137,7 +137,7 @@ Add the following lines to the top of the standard boilerplate.
    find_package(rviz_plugin_tutorial_msgs REQUIRED)
 
    set(CMAKE_AUTOMOC ON)
-   qt5_wrap_cpp(MOC_FILES
+   qt6_wrap_cpp(MOC_FILES
      include/rviz_plugin_tutorial/point_display.hpp
    )
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

For `ros-lyrical`, when building a custom RViz display as per documentation, it leads to CMake error
                                            
```
Finished <<< rviz_plugin_tutorial_msgs [4.18s]                    
Starting >>> rviz_plugin_tutorial
--- stderr: rviz_plugin_tutorial                         
CMake Error at CMakeLists.txt:25 (qt5_wrap_cpp):
  Unknown CMake command "qt5_wrap_cpp".


---
Failed   <<< rviz_plugin_tutorial [1.68s, exited with code 1]
```

As Qt6 is the default for `ros-lyrical`, `"qt5_wrap_cpp"` is changed to `"qt6_wrap_cpp"` after which it builds successfully.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/lyrical_tutorial_party/issues/2737

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information
NA
<!--
If applicable, provide any additional context or details about the changes.
-->
