### PR TITLE
Updating console->cmake for CMakeLists.txt codeblock in Topic-Statist…

### DIFF
--- a/source/Tutorials/Advanced/Topic-Statistics-Tutorial/Topic-Statistics-Tutorial.rst
+++ b/source/Tutorials/Advanced/Topic-Statistics-Tutorial/Topic-Statistics-Tutorial.rst
@@ -161,7 +161,7 @@ Now open the ``CMakeLists.txt`` file.
 
 Add the executable and name it ``listener_with_topic_statistics`` so you can run your node using ``ros2 run``:
 
-.. code-block:: console
+.. code-block:: cmake
 
     add_executable(listener_with_topic_statistics src/member_function_with_topic_statistics.cpp)
     target_link_libraries(listener_with_topic_statistics rclcpp::rclcpp std_msgs::std_msgs)


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Minor documentation fix of code-block from `console` to `cmake` a minor fix for [1.2 CMakeLists.txt](https://docs.ros.org/en/lyrical/Tutorials/Advanced/Topic-Statistics-Tutorial/Topic-Statistics-Tutorial.html#id6)[](https://docs.ros.org/en/lyrical/Tutorials/Advanced/Topic-Statistics-Tutorial/Topic-Statistics-Tutorial.html#cmakelists-txt) section for `copy` to work as intended.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/lyrical_tutorial_party/issues/1891

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information
NA
<!--
If applicable, provide any additional context or details about the changes.
-->
