### PR TITLE
Install bokeh in venv in ros2_tracing analysis tutorial

### DIFF
--- a/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
+++ b/source/Tutorials/Advanced/ROS2-Tracing-Trace-and-Analyze.rst
@@ -158,10 +158,15 @@ Install Jupyter notebook and bokeh, and then open the sample notebook.
 
 .. code-block:: console
 
-  $ pip3 install bokeh
+  $ source install/setup.bash
+  $ python3 -m venv venv --system-site-packages
+  $ source venv/bin/activate
+  $ pip3 install bokeh ipykernel
+  $ python3 -m ipykernel install --user --name=venv
   $ jupyter notebook ~/tracing_ws/src/tracetools_analysis/tracetools_analysis/analysis/callback_duration.ipynb
 
 This will open the notebook in the browser.
+Click ``Kernel``, then ``Change kernel``, and select ``venv``.
 
 Replace the value for the ``path`` variable in the second cell to the path to the trace directory:
 


### PR DESCRIPTION
## Description

`pip3 install ...` doesn't just work like it used to. The proper way is now to use a venv. We just have to add another layer (`ipykernel`) to be able to use the venv inside the notebook. This worked for me.

* https://github.com/ros2/lyrical_tutorial_party/issues/1566#issuecomment-4450692904
* https://github.com/ros2/lyrical_tutorial_party/issues/1573#issuecomment-4449982737

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
