### PR TITLE
Update URDF model link to new repository path

### DIFF
--- a/source/Tutorials/Intermediate/URDF/Adding-Physical-and-Collision-Properties-to-a-URDF-Model.rst
+++ b/source/Tutorials/Intermediate/URDF/Adding-Physical-and-Collision-Properties-to-a-URDF-Model.rst
@@ -24,7 +24,7 @@ Collision
 
 So far, we've only specified our links with a single sub-element, ``visual``, which defines (not surprisingly) what the robot looks like.
 However, in order to get collision detection to work or to simulate the robot, we need to define a ``collision`` element as well.
-`Here is the new urdf <https://raw.githubusercontent.com/ros/urdf_tutorial/master/urdf/07-physics.urdf>`_ with collision and physical properties.
+`Here is the new urdf <https://raw.githubusercontent.com/ros/urdf_tutorial/ros2/urdf/07-physics.urdf>`_ with collision and physical properties.
 
 Here is the code for our new base link.
 


### PR DESCRIPTION
## Description

The documentation currently links to the `master` branch of the `urdf_tutorial` 
repository for the `07-physics.urdf` example file. The `master` branch contains 
incorrect inertia values (`ixx="1.0"`, `iyy="1.0"`, `izz="1.0"`) which is the 
identity matrix. The documentation itself warns against using the identity matrix:

> "The identity matrix is a particularly bad choice, since it is often much too 
> high (it corresponds to a box of 0.1 m side length with a mass of 600 kg!)"

The `ros2` branch of `urdf_tutorial` already has the correct values 
(`ixx="1e-3"`, `iyy="1e-3"`, `izz="1e-3"`) which is consistent with the 
documentation recommendation:

> "a matrix with ixx/iyy/izz=1e-3 or smaller is often a reasonable default 
> for a mid-sized link"

This PR updates the link to point to the `ros2` branch instead of `master` 
so that users following the tutorial see the correct example file that is 
consistent with the documentation text.

Related: ros2/lyrical_tutorial_party#3157

### Did you use Generative AI?
No

### Additional Information
This is a minimal one-line change. The fix in the `ros2` branch of 
`urdf_tutorial` was already present — this PR simply updates the 
documentation to link to the correct branch.

cc - @kscottz 