### PR TITLE
Add short section on generative AI policy

### DIFF
--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -38,6 +38,14 @@ We recommend all ROS developers strive to adhere to the following policies to en
 
 For more specific code recommendations please see :doc:`the Quality Guide <Quality-Guide>`.
 
+Use of generative AI
+^^^^^^^^^^^^^^^^^^^^
+
+When making contributions of any kind to ROS code or documentation, you must follow the `OSRF Policy <https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf>`__ on the use of generative AI.
+
+This includes tools which automatically create any part of your contribution using models trained on existing human-created content.
+It does not include tools which generate content through standard algorithms, or appropriately licensed content libraries.
+
 .. _semver:
 
 Versioning


### PR DESCRIPTION
## Description

Small section added to ROS Developer Guide article, linking to OSRF policy document on gen AI.

Please note that this is a deliberately small update for getting a reference to the gen AI policy included in the docs, as it has been cited as a priority. More work on this article is planned for the coming months.

Related to: ros2/ros2#1725

### Did you use Generative AI?

No

### Additional Information

Documentation updates from 3di Information Solutions, agreed with Geoff and Tully.
