### PR TITLE
Add CQU Mirror for ROS 2 installation

### DIFF
--- a/source/Installation/ROS-2-Mirrors.rst
+++ b/source/Installation/ROS-2-Mirrors.rst
@@ -33,6 +33,9 @@ Asia
    * - Qilu University of Technology (QLU)
      - China
      - `https://mirrors.qlu.edu.cn/ros2/ubuntu/ <https://mirrors.qlu.edu.cn/ros2/ubuntu/>`_
+   * - Chongqing University (CQU)
+     - China
+     - `https://mirrors.cqu.edu.cn/ros2/ubuntu/ <https://mirrors.cqu.edu.cn/ros2/ubuntu/>`_
 
 Europe
 ^^^^^^


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Add CQU Mirror for ROS 2 installation
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Did you use Generative AI?
<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->
NO

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Chongqing University Open Source Mirror has added ROS2 into mirror lists. This mirror is hosted by Chongqing University(CQU) and provides stable and fast mirror service for locals in the southwest of China. We are pleased to be included in the official wiki.