### PR TITLE
Revert "Switch to ros2-testing repo for Lyrical pre-release testing"

### DIFF
--- a/source/Installation/RHEL-Install-RPMs.rst
+++ b/source/Installation/RHEL-Install-RPMs.rst
@@ -47,8 +47,6 @@ Next, download the ``ros2-release`` package and install it:
    $ sudo dnf install curl
    $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
    $ sudo dnf install "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-release-${ROS_APT_SOURCE_VERSION}-1.noarch.rpm"
-   $ sudo dnf config-manager --set-enabled ros2-testing
-   $ sudo dnf config-manager --set-disabled ros2
 
 The `ros2-release <https://github.com/ros-infrastructure/ros-apt-source/>`_ package provides keys and repo configuration for the various ROS repositories.
 Updates to repository configuration will occur automatically when new versions of this package are released to the ROS repositories.

--- a/source/Installation/_Apt-Repositories.rst
+++ b/source/Installation/_Apt-Repositories.rst
@@ -16,5 +16,5 @@ Updates to repository configuration will occur automatically when new versions o
 
    $ sudo apt update && sudo apt install curl -y
    $ export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
-   $ curl -L -o /tmp/ros2-testing-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-testing-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
-   $ sudo dpkg -i /tmp/ros2-testing-apt-source.deb
+   $ curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+   $ sudo dpkg -i /tmp/ros2-apt-source.deb


### PR DESCRIPTION
## Description

This reverts commit c8e2a0e0318877c30c4724af3b2db330d683fdb2 from https://github.com/ros2/ros2_documentation/pull/6626 which was merged only to the `lyrical` branch

Fixes #6627

### Did you use Generative AI?

No

### Additional Information

Reverting now so docs.ros.org updates before the release on May 22nd.