### PR TITLE
docs: warn about missing noble-updates/backports on Ubuntu 24 installs

### DIFF
--- a/source/Installation/Ubuntu-Install-Debs.rst
+++ b/source/Installation/Ubuntu-Install-Debs.rst
@@ -44,6 +44,29 @@ Install development tools (optional)
 
 If you are going to build ROS packages or otherwise do development, you can also install the development tools:
 
+.. warning::
+
+   On Ubuntu 24.04 installs your apt sources may only include the base ``noble`` suite.
+   This can cause dependency conflicts when installing ``ros-dev-tools``.
+
+   Check ``/etc/apt/sources.list.d/ubuntu.sources`` and ensure the ``Suites:`` line includes ``noble-updates`` and ``noble-backports``:
+
+   .. code-block:: console
+
+      $ grep Suites /etc/apt/sources.list.d/ubuntu.sources
+
+   If ``noble-updates`` or ``noble-backports`` are missing then edit the file and update the line to:
+
+   .. code-block:: text
+
+      Suites: noble noble-updates noble-backports
+
+   Then run:
+
+   .. code-block:: console
+
+      $ sudo apt clean && sudo apt update && sudo apt full-upgrade -y
+
 .. code-block:: console
 
    $ sudo apt update && sudo apt install ros-dev-tools


### PR DESCRIPTION
Closes #6853

On Ubuntu 24.04 installs, the apt sources may only include the base `noble` suite which causes this error when installing `ros-dev-tools`:

    bzip2 : Depends: libbz2-1.0 (= 1.0.8-5.1) but 1.0.8-5.1build0.1 is to be installed
    E: Unable to correct problems, you have held broken packages.

Added a warning block with steps to check and fix the apt sources before proceeding with the installation.

### Did you use Generative AI?
No