### PR TITLE
docs: add community contribution guides

### DIFF
--- a/source/Contact.rst
+++ b/source/Contact.rst
@@ -86,6 +86,14 @@ When you feel comfortable enough to suggest a specific change directly to the co
 Pull requests are welcome for any of `the ros2 repositories <https://github.com/ros2>`__.
 See the :doc:`Contributing <The-ROS2-Project/Contributing>` page for more details and etiquette on how to contribute.
 
+Step-by-step guides:
+
+* :doc:`Making a Pull Request <The-ROS2-Project/Contributing/Making-A-Pull-Request>`
+* :doc:`Reviewing a Pull Request <The-ROS2-Project/Contributing/Reviewing-A-Pull-Request>`
+* :doc:`Reporting an Issue <The-ROS2-Project/Contributing/Reporting-An-Issue>`
+* :doc:`Triaging an Issue <The-ROS2-Project/Contributing/Triaging-An-Issue>`
+* :doc:`Community Contributing <The-ROS2-Project/Contributing/Community-Contributing>`
+
 .. _Using ROS Discourse:
 
 Discussion

--- a/source/The-ROS2-Project/Contributing.rst
+++ b/source/The-ROS2-Project/Contributing.rst
@@ -114,3 +114,16 @@ Becoming a maintainer of one or more of those repositories is an invitation-only
 Approximately every 3 months, the ROS 2 team will review the contributions in all of the repositories and send out invitations to new maintainers.
 Once the invitation is accepted, the new maintainer will be asked to go through a short training process on the mechanisms and policies of the ROS 2 repositories.
 After that training process is completed, the new maintainer will be given write access to the appropriate repositories.
+
+Community contributions
+-----------------------
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   Contributing/Community-Contributing
+   Contributing/Reporting-An-Issue
+   Contributing/Making-A-Pull-Request
+   Contributing/Reviewing-A-Pull-Request
+   Contributing/Triaging-An-Issue

--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -15,6 +15,29 @@ In order to achieve a consistent looking product we will all follow externally (
 For other things like package layout or documentation layout we will need to come up with our own guidelines, drawing on current, popular styles in use now.
 
 Additionally, wherever possible, developers should use integrated tools to allow them to check that these guidelines are followed in their editors.
+
+Summary
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Language
+     - Standard
+     - Style Guide
+   * - C
+     - C17
+     - `PEP7 <https://www.python.org/dev/peps/pep-0007/>`__ with modifications
+   * - C++
+     - C++20
+     - `Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html>`__ with modifications
+   * - Python
+     - Python 3
+     - `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__ with modifications
+   * - CMake
+     - 3.14.4 minimum
+     - ROS 2 internal style guide
 For example, everyone should have a PEP8 checker built into their editor to cut down on review iterations related to style.
 
 Also where possible, packages should check style as part of their unit tests to help with the automated detection of style issues (see `ament_lint_auto <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_lint_auto/doc/index.rst>`__).

--- a/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
+++ b/source/The-ROS2-Project/Contributing/Code-Style-Language-Versions.rst
@@ -38,6 +38,7 @@ Summary
    * - CMake
      - 3.14.4 minimum
      - ROS 2 internal style guide
+
 For example, everyone should have a PEP8 checker built into their editor to cut down on review iterations related to style.
 
 Also where possible, packages should check style as part of their unit tests to help with the automated detection of style issues (see `ament_lint_auto <https://github.com/ament/ament_lint/blob/{REPOS_FILE_BRANCH}/ament_lint_auto/doc/index.rst>`__).

--- a/source/The-ROS2-Project/Contributing/Community-Contributing.rst
+++ b/source/The-ROS2-Project/Contributing/Community-Contributing.rst
@@ -1,0 +1,41 @@
+.. _community-contributing:
+
+Community Contributing
+======================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+You do not need to write code to contribute to ROS 2.
+There are many ways to help depending on your time and experience.
+
+Ways to contribute
+------------------
+
+* Report bugs and file issues
+* Triage existing issues
+* Review pull requests
+* Improve documentation
+* Answer questions on `ROS Discourse <https://discourse.ros.org>`__ and `ROS Answers <https://robotics.stackexchange.com>`__
+* Host or attend community events
+
+First-time contributors
+-----------------------
+
+* Browse issues labeled `"good first issue" <https://github.com/search?q=user%3Aament+user%3Aros2+is%3Aopen+label%3A%22good+first+issue%22&type=Issues>`__.
+* Try :doc:`Reporting an Issue <Reporting-An-Issue>`.
+* Read :doc:`Contributing To ROS 2 Documentation <Contributing-To-ROS-2-Documentation>` if you want to help with docs.
+
+Community participation
+-----------------------
+
+* Attend `ROS 2 TSC meetings <https://github.com/ros2/ros2/wiki/ROS-2-TSC-Meetings>`__ which are open to everyone.
+* Join `ROS Discourse <https://discourse.ros.org>`__ for async discussions.
+* Host a local meetup or online event.
+* Apply to run a local ROSCon event in your region.
+
+Getting help
+------------
+
+If you are unsure where to start, ask on `ROS Discourse <https://discourse.ros.org>`__ or check the :doc:`Contact <../../Contact>` page.

--- a/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Contributing-To-ROS-2-Documentation.rst
@@ -15,6 +15,18 @@ Please be sure to read the below sections carefully before contributing.
 
 The site is built using `Sphinx <https://www.sphinx-doc.org/en/master/>`_, and more particularly using `Sphinx multiversion <https://sphinx-contrib.github.io/multiversion/main/index.html>`_.
 
+Quick start
+-----------
+
+For small fixes, you do not need a local build:
+
+1. Fork `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`__ on GitHub.
+2. Edit the relevant ``.rst`` file in the ``source/`` directory.
+3. Open a pull request against the ``rolling`` branch.
+4. GitHub Actions will build and lint your changes automatically.
+
+For larger changes, follow the steps in `Building the site locally`_.
+
 Branch structure
 ----------------
 

--- a/source/The-ROS2-Project/Contributing/Making-A-Pull-Request.rst
+++ b/source/The-ROS2-Project/Contributing/Making-A-Pull-Request.rst
@@ -1,0 +1,70 @@
+.. _making-a-pull-request:
+
+Making a Pull Request
+=====================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+Before you start
+----------------
+
+* For large changes, open an issue or post on `ROS Discourse <https://discourse.ros.org>`__ first.
+* Check there is no open PR for the same change.
+* Read the :doc:`Developer Guide <Developer-Guide>`.
+
+Setup
+-----
+
+1. Fork the repository and clone it:
+
+   .. code-block:: bash
+
+      git clone https://github.com/YOUR_USERNAME/REPO_NAME.git
+      cd REPO_NAME
+
+2. Add upstream:
+
+   .. code-block:: bash
+
+      git remote add upstream https://github.com/ros2/REPO_NAME.git
+
+3. Create a branch:
+
+   .. code-block:: bash
+
+      git checkout -b my-fix-branch
+
+Making changes
+--------------
+
+* One fix or feature per PR.
+* Follow :doc:`Code Style and Language Versions <Code-Style-Language-Versions>`.
+* Add or update tests.
+* Update docs if user-facing behavior changes.
+
+Submitting
+----------
+
+1. Commit your changes:
+
+   .. code-block:: bash
+
+      git commit -m "fix: description of change"
+
+2. Push to your fork:
+
+   .. code-block:: bash
+
+      git push origin my-fix-branch
+
+3. Open a PR against the ``rolling`` branch.
+4. Fill in the PR template.
+5. Reference related issues with ``Closes #ISSUE_NUMBER``.
+
+After submitting
+----------------
+
+* Address review comments promptly.
+* Do not force-push after a review has started unless asked.

--- a/source/The-ROS2-Project/Contributing/Reporting-An-Issue.rst
+++ b/source/The-ROS2-Project/Contributing/Reporting-An-Issue.rst
@@ -1,0 +1,49 @@
+.. _reporting-an-issue:
+
+Reporting an Issue
+==================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+Before filing an issue
+----------------------
+
+* Search existing issues in the repository to avoid duplicates.
+* Check if the problem is fixed in the latest release or rolling branch.
+* Try to reproduce it with a minimal example.
+
+Where to file
+-------------
+
+File your issue in the repository closest to the problem:
+
+* `ros2/rclpy <https://github.com/ros2/rclpy>`__ for Python client library issues
+* `ros2/rclcpp <https://github.com/ros2/rclcpp>`__ for C++ client library issues
+* `ros2/ros2_documentation <https://github.com/ros2/ros2_documentation>`__ for documentation issues
+* `ros2/ros2 <https://github.com/ros2/ros2/issues>`__ for general issues
+
+What to include
+---------------
+
+* ROS 2 distribution (e.g. Rolling, Jazzy)
+* OS and version (e.g. Ubuntu 24.04)
+* Steps to reproduce
+* Expected behavior
+* Actual behavior and full error output
+
+How to file
+-----------
+
+1. Go to the repository on GitHub.
+2. Click the **Issues** tab.
+3. Click **New Issue**.
+4. Fill in the template.
+5. Click **Submit new issue**.
+
+After filing
+------------
+
+* Watch for follow-up questions from maintainers.
+* If you fix it yourself, reference the issue number in your pull request.

--- a/source/The-ROS2-Project/Contributing/Reviewing-A-Pull-Request.rst
+++ b/source/The-ROS2-Project/Contributing/Reviewing-A-Pull-Request.rst
@@ -1,0 +1,41 @@
+.. _reviewing-a-pull-request:
+
+Reviewing a Pull Request
+========================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+Anyone can review a PR. You do not need to be a maintainer.
+
+Finding PRs to review
+---------------------
+
+* Browse open PRs in any `ros2 <https://github.com/ros2>`__ or `ament <https://github.com/ament>`__ repository.
+* Look for PRs labeled ``needs-review``.
+
+What to check
+-------------
+
+* Does the change do what the description says?
+* Are edge cases handled?
+* Do tests cover the new behavior?
+* Does the code follow the :doc:`style guidelines <Code-Style-Language-Versions>`?
+* Is documentation updated if behavior changed?
+
+How to review
+-------------
+
+1. Open the PR on GitHub.
+2. Click **Files changed**.
+3. Click the ``+`` icon on a line to leave a comment.
+4. Click **Review changes** when done.
+5. Choose **Comment**, **Approve**, or **Request changes**.
+
+Review etiquette
+----------------
+
+* Be specific about what needs to change and why.
+* Separate blocking issues from minor suggestions.
+* Do not nitpick things that automated tools already catch.

--- a/source/The-ROS2-Project/Contributing/Reviewing-A-Pull-Request.rst
+++ b/source/The-ROS2-Project/Contributing/Reviewing-A-Pull-Request.rst
@@ -7,7 +7,8 @@ Reviewing a Pull Request
    :depth: 1
    :local:
 
-Anyone can review a PR. You do not need to be a maintainer.
+Anyone can review a PR.
+You do not need to be a maintainer.
 
 Finding PRs to review
 ---------------------

--- a/source/The-ROS2-Project/Contributing/Triaging-An-Issue.rst
+++ b/source/The-ROS2-Project/Contributing/Triaging-An-Issue.rst
@@ -1,0 +1,42 @@
+.. _triaging-an-issue:
+
+Triaging an Issue
+=================
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
+Triage means reviewing issues to keep the tracker organized.
+No special permissions are needed.
+
+What triage involves
+--------------------
+
+* Checking if a bug is reproducible
+* Asking for missing information
+* Labeling issues
+* Closing duplicates
+* Linking related issues or PRs
+
+Finding issues to triage
+------------------------
+
+* Look for issues with no labels or responses in any `ros2 <https://github.com/ros2>`__ repository.
+* Filter with ``is:issue is:open no:label`` on GitHub.
+
+Steps
+-----
+
+1. Read the issue.
+2. Search for duplicates and link them if found.
+3. Try to reproduce the issue.
+4. Ask for missing details if needed.
+5. Add labels if you have permission.
+6. Tag a maintainer if the issue is critical or stale.
+
+Tips
+----
+
+* Be welcoming, reporters may be new to open source.
+* If closing an issue as invalid, explain why.

--- a/source/index.rst
+++ b/source/index.rst
@@ -74,6 +74,7 @@ If you're interested in the advancement of the ROS 2 project:
 * :doc:`Contributing <The-ROS2-Project/Contributing>`
 
   - Best practices and methodology for contributing to ROS 2, as well as instructions for migrating existing ROS 1 content to ROS 2
+  - Includes guides on filing issues, making and reviewing pull requests, triaging, and community participation
 
 * :doc:`Distributions <Releases>`
 


### PR DESCRIPTION
Fixes #6828

- Add Community-Contributing overview
- Add Reporting-An-Issue how-to
- Add Making-A-Pull-Request how-to
- Add Reviewing-A-Pull-Request how-to
- Add Triaging-An-Issue how-to
- Link all new guides in Contributing.rst toctree
- Update Contact.rst to link new guides
- Update index.rst to mention community guides
- Add quick start section to Contributing-To-ROS-2-Documentation.rst
- Add language summary table to Code-Style-Language-Versions.rst

### Did you use Generative AI?
Gemini used to help write the new RST files with better wording.

### Additional Information
No new dependencies. Build passes with no warnings or errors.