### PR TITLE
Add section on boolean substitutions

### DIFF
--- a/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
+++ b/source/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.rst
@@ -428,6 +428,9 @@ There are, however, some changes w.r.t. ROS 1:
   It looks at configurations defined either with ``arg`` or ``let`` tag.
 * ``eval`` and ``dirname`` substitutions require escape characters for string values, e.g. ``if="$(eval '\'$(var variable)\' == \'val1\'')"``.
   You can also use HTML escapes like ``&quot;`` .
+* Boolean predicates can also be expressed directly with the ``equals``, ``not-equals``, ``and``, ``or``, ``any``, and ``all`` substitutions.
+  For example, ``if="$(equals $(var variable) val1)"`` is equivalent to ``if="$(eval '\'$(var variable)\' == \'val1\'')"``.
+  See :ref:`Boolean substitutions <BooleanSubstitutions>` for details.
 * ``eval`` does not pass configurations ( ``arg`` ) as local Python variables.
   They have to be accessed via ``$(var name)``.
 * The argument of ``eval`` has to be a quoted string in ROS 2.

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -455,6 +455,79 @@ Now you can pass the desired arguments to the launch file as follows:
 
         $ ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
+Boolean substitutions
+---------------------
+
+In addition to ``$(eval <python-expression>)``, a set of dedicated boolean substitutions is available for comparing values and combining the results.
+They can be used anywhere a substitution is allowed, including the ``if`` and ``unless`` attributes of any action.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 30 45
+
+   * - XML / YAML name
+     - Python class
+     - Description
+   * - ``$(equals A B)``
+     - ``EqualsSubstitution``
+     - Resolves to ``'true'`` if ``A`` equals ``B``, otherwise ``'false'``.
+   * - ``$(not-equals A B)``
+     - ``NotEqualsSubstitution``
+     - Resolves to ``'true'`` if ``A`` does not equal ``B``, otherwise ``'false'``.
+   * - ``$(and A B)``
+     - ``AndSubstitution``
+     - Logical AND of two boolean substitutions.
+   * - ``$(or A B)``
+     - ``OrSubstitution``
+     - Logical OR of two boolean substitutions.
+   * - ``$(any A B ...)``
+     - ``AnySubstitution``
+     - Resolves to ``'true'`` if any argument is truthy.
+   * - ``$(all A B ...)``
+     - ``AllSubstitution``
+     - Resolves to ``'true'`` only if every argument is truthy.
+
+The ``if`` predicate from the previous section can also be expressed using boolean substitutions instead of a Python expression:
+
+.. tabs::
+
+  .. group-tab:: XML
+
+    .. code-block:: xml
+
+      <executable cmd="ros2 param set /turtlesim background_r $(var new_background_r)"
+                  if="$(and $(equals $(var new_background_r) 200) $(var use_provided_red))"/>
+
+  .. group-tab:: YAML
+
+    .. code-block:: yaml
+
+      - executable:
+          cmd: ros2 param set /turtlesim background_r $(var new_background_r)
+          if: $(and $(equals $(var new_background_r) 200) $(var use_provided_red))
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+
+      from launch.conditions import IfCondition
+      from launch.substitutions import AndSubstitution, EqualsSubstitution, LaunchConfiguration
+
+      ExecuteProcess(
+          cmd=[[
+              FindExecutable(name='ros2'),
+              ' param set ',
+              '/turtlesim background_r ',
+              LaunchConfiguration('new_background_r'),
+          ]],
+          condition=IfCondition(
+              AndSubstitution(
+                  EqualsSubstitution(LaunchConfiguration('new_background_r'), '200'),
+                  LaunchConfiguration('use_provided_red'),
+              )
+          ),
+      )
+
 Documentation
 -------------
 

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -463,6 +463,10 @@ Boolean substitutions
 In addition to ``$(eval <python-expression>)``, a set of dedicated boolean substitutions is available for comparing values and combining the results.
 They can be used anywhere a substitution is allowed, including the ``if`` and ``unless`` attributes of any action.
 
+.. note::
+
+   Comparison is performed on the string representation of each argument.
+
 .. list-table::
    :header-rows: 1
    :widths: 25 30 45

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -455,6 +455,8 @@ Now you can pass the desired arguments to the launch file as follows:
 
         $ ros2 launch launch_tutorial example_substitutions_launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
+.. _BooleanSubstitutions:
+
 Boolean substitutions
 ---------------------
 

--- a/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Substitutions.rst
@@ -484,10 +484,10 @@ They can be used anywhere a substitution is allowed, including the ``if`` and ``
      - Logical OR of two boolean substitutions.
    * - ``$(any A B ...)``
      - ``AnySubstitution``
-     - Resolves to ``'true'`` if any argument is truthy.
+     - Resolves to ``'true'`` if any argument is true.
    * - ``$(all A B ...)``
      - ``AllSubstitution``
-     - Resolves to ``'true'`` only if every argument is truthy.
+     - Resolves to ``'true'`` only if every argument is true.
 
 The ``if`` predicate from the previous section can also be expressed using boolean substitutions instead of a Python expression:
 


### PR DESCRIPTION
## Description

I've finally come across the `equals` functionality and other features from https://github.com/ros2/launch/pull/649 and though it'd be good to have them represented on this documentation.

I wasn't sure if referencing the PR in the docs was a good idea so I didn't do that.

The changes were tested in vanilla Jazzy and Lyrical containers.

### Did you use Generative AI?

Claude Opus 4.7