### PR TITLE
Add Lyrical + Connext 7.7.0 to the version support table

### DIFF
--- a/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
+++ b/source/Installation/RMW-Implementations/DDS-Implementations/Working-with-RTI-Connext-DDS.rst
@@ -19,6 +19,7 @@ Install RTI Connext DDS
   ROS 2 Distribution  Installed using apt  To Build from Source
   ==================  ===================  ====================
   rolling             n/a                  ``7.7.0``
+  lyrical             ``7.7.0``            ``7.7.0``
   kilted              ``7.3.0``            ``7.3.0``
   jazzy               ``6.0.1``            ``6.0.1``
   humble              ``6.0.1``            ``6.0.1``


### PR DESCRIPTION
## Description

Add missing Lyrical + Connext 7.7.0 to the version support table.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
