### PR TITLE
fix: add instruction for RHEL

### DIFF
--- a/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
+++ b/source/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.rst
@@ -37,11 +37,17 @@ Install colcon
 
 .. tabs::
 
-  .. group-tab:: Linux
+  .. group-tab:: Ubuntu
 
     .. code-block:: console
 
         $ sudo apt install python3-colcon-common-extensions
+
+  .. group-tab:: RHEL
+
+    .. code-block:: console
+
+        $ sudo dnf install python3-colcon-common-extensions
 
   .. group-tab:: macOS
 

--- a/source/Tutorials/Intermediate/Rosdep.rst
+++ b/source/Tutorials/Intermediate/Rosdep.rst
@@ -157,9 +157,19 @@ If you are using ``rosdep`` with ROS, it is conveniently packaged along with the
 This is the recommended way to get ``rosdep``.
 You can install it with:
 
-.. code-block:: console
+.. tabs::
 
-    $ apt-get install python3-rosdep
+  .. group-tab:: Ubuntu
+
+    .. code-block:: console
+
+        $ sudo apt install python3-rosdep
+
+  .. group-tab:: RHEL
+
+    .. code-block:: console
+
+        $ sudo dnf install python3-rosdep
 
 .. note::
 

--- a/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
+++ b/source/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.rst
@@ -42,11 +42,17 @@ This tutorial expects you to have ``turtle_tf2_py`` package installed.
 
 .. tabs::
 
-  .. group-tab:: Linux
+  .. group-tab:: Ubuntu
 
     .. code-block:: console
 
         $ sudo apt install ros-{DISTRO}-turtle-tf2-py
+
+  .. group-tab:: RHEL
+
+    .. code-block:: console
+
+        $ sudo dnf install ros-{DISTRO}-turtle-tf2-py
 
   .. group-tab:: From Source
 


### PR DESCRIPTION
## Description

Hello, I would like to add instruction for RHEL on following pages

https://docs.ros.org/en/rolling/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.html
https://docs.ros.org/en/rolling/Tutorials/Intermediate/Rosdep.html
https://docs.ros.org/en/rolling/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.html

### Did you use Generative AI?

NO

### Additional Information

NO 
