### PR TITLE
Fix warning on deprecated ROS release notes. 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -95,13 +95,6 @@ extensions = [
 
 intersphinx_mapping = {
     'python':        ('https://docs.python.org/3', None),
-    'catkin_pkg':    ('http://docs.ros.org/en/independent/api/catkin_pkg/html', None),
-    'jenkins_tools': ('http://docs.ros.org/en/independent/api/jenkins_tools/html', None),
-    'rosdep':        ('http://docs.ros.org/en/independent/api/rosdep/html', None),
-    'rosdistro':     ('http://docs.ros.org/en/independent/api/rosdistro/html', None),
-    'rosinstall':    ('http://docs.ros.org/en/independent/api/rosinstall/html', None),
-    'rospkg':        ('http://docs.ros.org/en/independent/api/rospkg/html', None),
-    'vcstools':      ('http://docs.ros.org/en/independent/api/vcstools/html', None)
 }
 
 # sphinx-copybutton config

--- a/source/Releases/Release-Dashing-Diademata.rst
+++ b/source/Releases/Release-Dashing-Diademata.rst
@@ -934,4 +934,4 @@ A few milestones leading up to the release:
 
     Wed. May 29th
         Freeze rosdistro.
-        No PRs for Dashing on the `rosdistro` repo will be merged (reopens after the release announcement).
+        No PRs for Dashing on the rosdistro repo will be merged (reopens after the release announcement).

--- a/source/Releases/Release-Eloquent-Elusor.rst
+++ b/source/Releases/Release-Eloquent-Elusor.rst
@@ -387,4 +387,4 @@ A few milestones leading up to the release:
 
     Tue. Nov 19th
         Freeze rosdistro.
-        No PRs for Eloquent on the `rosdistro` repo will be merged (reopens after the release announcement).
+        No PRs for Eloquent on the rosdistro repo will be merged (reopens after the release announcement).

--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -601,7 +601,7 @@ A few milestones leading up to the release:
 
     Wed. June 3rd, 2020
         Freeze rosdistro.
-        No PRs for Foxy on the `rosdistro` repo will be merged (reopens after the release announcement).
+        No PRs for Foxy on the rosdistro repo will be merged (reopens after the release announcement).
 
 .. [1] The ``ros_core`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.
 .. [2] The ``desktop`` variant described in the `variants <https://github.com/ros2/variants>`_ repository.


### PR DESCRIPTION
## Description

@keithkirkwood-3di  at [3Di is reporting a new warning that is blocking them](https://github.com/ros2/ros2_documentation/pull/6892#issuecomment-4752351443). I don't have a good sense of the root cause of the warning but the offending line doesn't seem like it is necessary and the warning only appears on deprecated releases so I am pretty sure it can be safely removed. 

Fixes # (issue)

### Did you use Generative AI?

No.

### Additional Information

If this doesn't work feel free to close the PR. 