### PR TITLE
Fix broken Linux command-line guide link

### DIFF
--- a/source/ROS-Framework/client-libraries/Working-with-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
+++ b/source/ROS-Framework/client-libraries/Working-with-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.rst
@@ -39,7 +39,11 @@ Prerequisites
 * `git installation <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`__
 * :doc:`turtlesim installation <../../../../Get-Started/Introducing-Turtlesim/Introducing-Turtlesim>`
 * Have :doc:`rosdep installed <../Rosdep>`
-* Understanding of basic terminal commands (`here's a guide for Linux <https://www2.cs.sfu.ca/~ggbaker/reference/unix/>`__)
+* Understanding of basic terminal commands
+
+  * `SFU guide for Linux/Unix <https://www2.cs.sfu.ca/~ggbaker/reference/unix/>`__
+  * `Ubuntu Linux command-line guide for beginners <https://ubuntu.com/desktop/docs/en/latest/tutorial/the-linux-command-line-for-beginners/>`__
+
 * Text editor of your choice
 
 Tasks


### PR DESCRIPTION
## Summary

This PR improves the Linux command-line prerequisite in the Creating a Workspace tutorial.

Based on maintainer feedback, the existing SFU Unix/Linux guide is retained and the Ubuntu beginner command-line guide is added as an alternative.

## Changes

- Keeps the existing SFU Unix/Linux command-line guide.
- Adds Ubuntu's Linux command-line beginner guide as an alternative.
- Presents both resources as choices under the terminal-command prerequisite.

## Testing

I ran:

- `make html`
- `make lint`
- `make spellcheck`
- `git diff --check`

The documentation build succeeded, lint reported no problems, spellcheck passed, and `git diff --check` returned no issues.

Part of #4209.

## AI assistance disclosure

I used Claude Code to help prepare the documentation change, then manually reviewed the diff and test results before submitting.