### PR TITLE
Clarify ROS 2 contributing description

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -73,7 +73,7 @@ If you're interested in the advancement of the ROS 2 project:
 
 * :doc:`Contributing <The-ROS2-Project/Contributing>`
 
-  - Best practices and methodology for contributing to ROS 2, as well as instructions for migrating existing ROS 1 content to ROS 2
+  - Best practices and methodology for contributing code, documentation, and other improvements to ROS 2, as well as instructions for migrating existing ROS 1 documentation to ROS 2
 
 * :doc:`Distributions <Releases>`
 


### PR DESCRIPTION
## Summary

This PR clarifies the Contributing description on the ROS 2 documentation index page.

The previous wording used "content", which could sound like documentation-only contributions. This update clarifies that ROS 2 contributions include code, documentation, and other improvements.

## Changes

- Clarifies that ROS 2 contributions include code, documentation, and other improvements.
- Clarifies that ROS 1 migration refers to documentation.

## Testing

I ran:

- `make html`
- `make lint`
- `make spellcheck`
- `git diff --check`

Relates #1487.

## AI assistance disclosure

I used Claude Code to help prepare the small wording change, then manually reviewed the diff and test results before submitting.