### PR TITLE
Clarify underlay and overlay description

### DIFF
--- a/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
+++ b/source/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.rst
@@ -22,8 +22,9 @@ Background
 
 ROS 2 relies on the notion of combining workspaces using the shell environment.
 "Workspace" is a ROS term for the location on your system where you're developing with ROS 2.
-The core ROS 2 workspace is called the underlay.
-Subsequent local workspaces are called overlays.
+In a typical ROS 2 setup, the core ROS 2 installation is the underlay.
+A local workspace sourced after that installation is an overlay because it is layered on top of the underlay.
+The same workspace can act as an underlay for another workspace that is sourced later.
 When developing with ROS 2, you will typically have several workspaces active concurrently.
 
 Combining workspaces makes developing against different versions of ROS 2, or against different sets of packages, easier.


### PR DESCRIPTION
## Summary

This PR clarifies the underlay and overlay explanation in the ROS 2 environment configuration tutorial.

The previous wording could imply that a workspace is always either an underlay or an overlay. This update clarifies that the relationship depends on sourcing order: a workspace sourced later overlays the workspaces sourced before it, and that same workspace can act as an underlay for another workspace sourced later.

## Changes

- Clarifies that the core ROS 2 installation is typically the underlay.
- Clarifies that a local workspace sourced after the installation is an overlay.
- Adds that the same workspace can act as an underlay for another workspace sourced later.

## Testing

I ran:

- `make html`
- `make lint`
- `make spellcheck`
- `git diff --check`

Relates #1487.

## AI assistance disclosure

I used Claude Code to help prepare the wording change, then manually reviewed the diff and test results before submitting.