### PR TITLE
Fix main invocation in sphinx-lint-with-ros

### DIFF
--- a/sphinx-lint-with-ros
+++ b/sphinx-lint-with-ros
@@ -4,4 +4,5 @@ import plugins.ros_checkers
 import sys
 from sphinxlint.cli import main
 
-sys.exit(main(sys.argv))
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Description

We need to fire the actual function call for invoking `main()` after the imports are all done.

This resolves a RuntimeError on Python 3.14.

### Did you use Generative AI?

No

### Additional Information


https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods

```
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html
```