### PR TITLE
Generate Open Graph metadata (backport #7004 to lyrical)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -89,6 +89,7 @@ extensions = [
     'sphinx_adopters',
     'sphinxcontrib.googleanalytics',
     'sphinxcontrib.mermaid',
+    'sphinxext.opengraph',
 ]
 
 # Intersphinx mapping
@@ -207,6 +208,13 @@ html_js_files = ['adopters.js']
 htmlhelp_basename = 'ros2_docsdoc'
 
 html_baseurl = 'https://docs.ros.org/en'
+
+# -- Options for Open Graph (sphinxext-opengraph) -------------------------
+
+# Default settings for fallback/local builds
+ogp_site_url = 'https://docs.ros.org/en/lyrical/'
+ogp_site_name = 'ROS 2 Documentation'
+ogp_image = '_static/lyrical-small.png'
 
 # The sitemap_url_scheme is used by the sitemap generator to figure out how
 # to generate links.  Essentially, the sitemap generator uses the following:
@@ -327,9 +335,11 @@ def smv_rewrite_configs(app, config):
     # to rewrite the various configuration items with the current version.
     if app.config.smv_current_version != '':
         app.config.html_baseurl = app.config.html_baseurl + '/' + app.config.smv_current_version
+        app.config.ogp_site_url = app.config.html_baseurl + '/'
         app.config.project = 'ROS 2 Documentation: ' + app.config.smv_current_version.title()
 
         app.config.html_logo = 'source/Releases/' + app.config.smv_current_version + '-small.png'
+        app.config.ogp_image = '_static/' + app.config.smv_current_version + '-small.png'
 
         # Override default values
         distro = app.config.smv_current_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 codespell
 doc8
 docutils
+matplotlib
 pip
 pytest
 sphinx
@@ -13,3 +14,4 @@ sphinx-tabs
 sphinx-tamer
 sphinxcontrib-googleanalytics
 sphinxcontrib-mermaid
+sphinxext-opengraph


### PR DESCRIPTION
Backport of #7004 to the lyrical branch. The default (fallback/local) ogp_site_url and ogp_image are adjusted from 'rolling' to 'lyrical'.

This metadata can be passed through Anubis to support site previews. Also adds the matplotlib dependency, quietly needed by sphinxext-opengraph.

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

Yes, Claude Fable

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
