### PR TITLE
faster parallel build support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ ifeq ($(OS),Windows_NT)
     PYTHON := python
 endif
 BUILD      = $(PYTHON) -m sphinx
-OPTS       =-c . -W # Treat warnings as errors
+JOBS       ?= auto
+# Attached form (-j<JOBS>, no space) so sphinx-multiversion forwards it to sphinx-build
+# instead of mistaking the value for a positional argument.
+OPTS       =-c . -W -j$(JOBS) # Treat warnings as errors, build in parallel ($(JOBS) workers)
 LIVE_HOST  ?= 0.0.0.0
 LIVE_PORT  ?= 2022
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ To test building the multisite version deployed to the website use:
 
 **NB:** This will ignore local workspace changes and build from the branches.
 
+### Faster (parallel) builds
+
+Both `make html` and `make multiversion` build Sphinx in parallel by default,
+using one worker per CPU core (Sphinx's `-j auto`). This is handled inside
+Sphinx, so it works the same on Linux, macOS, and Windows — note that a plain
+`make -j` does **not** help, because each build is a single Sphinx invocation.
+
+To pin the number of workers instead of auto-detecting, set `JOBS`:
+
+```
+make html JOBS=8
+make multiversion JOBS=8
+```
+
+**NB:** For `make multiversion`, `JOBS` parallelizes the work *within* each
+branch's build; the branches themselves are still built one after another.
+
 ### Note for Windows (WSL) Users
 
 When building the documentation on windows using WSL, it is recommended to clone and work with this repository inside the Linux filesystem (for example, under `/home/<user>/`) rather than under `/mnt/c`.

--- a/source/The-ROS2-Project/Contributing/Documentation/Creating-or-updating-documentation.rst
+++ b/source/The-ROS2-Project/Contributing/Documentation/Creating-or-updating-documentation.rst
@@ -208,6 +208,18 @@ To build the site for just the current active branch:
 
 #. In your browser, open ``build/html/index.html`` to see the output.
 
+.. note::
+
+   The build runs Sphinx in parallel by default, using one worker per CPU core.
+   This is handled inside Sphinx (its ``-j auto`` option), so it behaves the same
+   on Linux, macOS, and Windows; a plain ``make -j`` does not help, because each
+   build is a single Sphinx invocation.
+   To pin the number of workers instead of auto-detecting, set ``JOBS``:
+
+   .. code-block:: console
+
+      $ make html JOBS=8
+
 6 Building the site for all branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -223,6 +235,7 @@ This has two drawbacks:
 
 * The multiversion plugin doesn't understand how to do incremental builds, so it always rebuilds everything.
   This can be slow.
+  Parallel builds still apply within each branch (``make multiversion JOBS=8``), but the branches themselves are built one after another.
 
 * The build process will always check out exactly the branches listed in the ``conf.py`` file.
   This means that local changes will not be shown.


### PR DESCRIPTION
## Description

building documentation in local env takes really long time because it does not process parallel taking advantage of platform resource.
now it builds (html and multiversion) in parallel with multiple CPU threads from the platform.

the following is just an example of before and after, based on WSL env that i use my laptop windows.

- before

```console
[tomoyafujita@LEPF69NNSE] time make html
Running Sphinx v8.2.3
loading translations [en]... done
...
The HTML pages are in build/html.

real    2m49.326s
user    2m19.910s
sys     0m0.801s

###
[tomoyafujita@LEPF69NNSE] time make multiversion
sphinx-multiversion -c . -W  "source" build/html
outputdir 'galactic' for refs/remotes/origin/galactic conflicts with other versions
...
The HTML pages are in ../../../home/tomoyafujita/github.com/ros2/ros2_documentation/build/html/lyrical.
python3 make_sitemapindex.py

real    13m39.083s
user    11m19.921s
sys     0m7.366s
```

- after

```console
[tomoyafujita@LEPF69NNSE] time make html
Running Sphinx v8.2.3
loading translations [en]... done
...
The HTML pages are in build/html.

real    0m42.459s
user    1m46.927s
sys     0m7.723s

###

[tomoyafujita@LEPF69NNSE] time make multiversion
sphinx-multiversion -c . -W -jauto  "source" build/html
outputdir 'galactic' for refs/remotes/origin/galactic conflicts with other versions
...
The HTML pages are in ../../../home/tomoyafujita/github.com/ros2/ros2_documentation/build/html/lyrical.
python3 make_sitemapindex.py

real    4m22.492s
user    14m15.248s
sys     1m11.643s
```

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Did you use Generative AI?

Yes, Claude Fable

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
