### PR TITLE
docs: fix broken external links in tutorial and developer guide pages

### DIFF
--- a/source/Developer-Tools/Testing/Testing/Integration.rst
+++ b/source/Developer-Tools/Testing/Testing/Integration.rst
@@ -27,7 +27,7 @@ Background
 ----------
 
 Where unit tests focus on validating a very specific piece of functionality, integration tests focus on validating the interaction between pieces of code.
-In ROS 2 this is often accomplished by launching a system of one or several nodes, for example the `Gazebo simulator <https://gazebosim.org/home>`__ and the `Nav2 navigation <https://github.com/ros-planning/navigation2.git>`__ stack.
+In ROS 2 this is often accomplished by launching a system of one or several nodes, for example the `Gazebo simulator <https://gazebosim.org>`__ and the `Nav2 navigation <https://github.com/ros-planning/navigation2.git>`__ stack.
 As a result, these tests are more complex both to set up and to run.
 
 A key aspect of ROS 2 integration testing is that nodes that are part of different tests shouldn't communicate with each other, even when run in parallel.

--- a/source/Get-Started/About-ROS/About-ROS.rst
+++ b/source/Get-Started/About-ROS/About-ROS.rst
@@ -109,7 +109,7 @@ ROS works with other Open Robotics platforms to make development and deployment 
 * `Open-RMF`_ (Robotics Middleware Framework): Helps different robots work together and interact with building systems like lifts and doors.
 * `ros-controls`_: Enables real-time control of robots using ROS.
 
-.. _Gazebo: https://gazebosim.org/home
+.. _Gazebo: https://gazebosim.org
 .. _Open-RMF: https://www.open-rmf.org/
 .. _ros-controls: https://control.ros.org/rolling/index.html
 

--- a/source/ROS-Framework/client-libraries/About-Middleware-Implementations.rst
+++ b/source/ROS-Framework/client-libraries/About-Middleware-Implementations.rst
@@ -57,7 +57,7 @@ It also generates code for converting ROS message structures to and from DDS mes
 This generator is also responsible for creating a shared library for the message package it is being used in, which is specific to the messages in the message package and to the DDS vendor being used.
 
 As mentioned above, the ``rosidl_typesupport_introspection_<language>`` may be used instead of a vendor specific type support package if an RMW implementation supports runtime interpretation of messages.
-This ability to programmatically send and receive types over topics without generating code beforehand is achieved by supporting the `DDS X-Types Dynamic Data standard <https://www.omg.org/spec/DDS-XTypes/>`_.
+This ability to programmatically send and receive types over topics without generating code beforehand is achieved by supporting the `DDS X-Types Dynamic Data standard <https://www.omg.org/spec/DDS-XTypes/About-DDS-XTypes/>`_.
 As such, RMW implementations may provide support for the X-Types standard, and/or provide a package for type support generated at compile time specific to their DDS implementation.
 
 For examples of example of DDS RMW implementation repositories,

--- a/source/ROS-Framework/interfaces/topics/Working-with-topics/Quality-of-Service.rst
+++ b/source/ROS-Framework/interfaces/topics/Working-with-topics/Quality-of-Service.rst
@@ -23,7 +23,7 @@ We will then simulate a lossy network connection between them and show how diffe
 Prerequisites
 -------------
 This tutorial assumes you have a :doc:`working ROS 2 installation <../../../../Get-Started/Installation>` and OpenCV.
-See the `OpenCV documentation <http://docs.opencv.org/doc/tutorials/introduction/table_of_content_introduction/table_of_content_introduction.html#table-of-content-introduction>`__ for its installation instructions.
+See the `OpenCV documentation <https://docs.opencv.org/4.x/>`__ for its installation instructions.
 You will also need the ROS package ``image_tools``.
 
 .. tabs::
@@ -157,7 +157,7 @@ Add network traffic
 
    However, for macOS and Windows you can achieve a similar effect with the utilities "Network Link Conditioner" (part of the xcode tool suite) and `"Clumsy" <http://jagt.github.io/clumsy/index.html>`_, respectively, but they will not be covered in this tutorial.
 
-We are going to use the Linux network traffic control utility, ``tc`` (`man page <http://linux.die.net/man/8/tc>`_) .
+We are going to use the Linux network traffic control utility, ``tc`` (`man page <https://man7.org/linux/man-pages/man8/tc.8.html>`_) .
 
 .. code-block:: console
 

--- a/source/The-ROS2-Project/Contributing/Developer-Guide.rst
+++ b/source/The-ROS2-Project/Contributing/Developer-Guide.rst
@@ -153,7 +153,7 @@ Change control process
 
   * You can pass ``-s`` / ``--signoff`` to the ``git commit`` invocation or write the expected message manually (e.g. ``Signed-off-by: Your Name Developer <your.name@example.com>``).
 
-  * DCO is *not* required for pull requests that only address whitespace removal, typo correction, and other `trivial changes <http://cr.openjdk.java.net/~jrose/draft/trivial-fixes.html>`_.
+  * DCO is *not* required for pull requests that only address whitespace removal, typo correction, and other `trivial changes <https://openjdk.org/bylaws#trivial-change>`_.
 
 * Always run CI jobs for all `tier 1 platforms <https://reps.openrobotics.org/rep-2000/#support-tiers>`_ for every pull request and include links to jobs in the pull request.
   (If you don't have access to the Jenkins jobs someone will trigger the jobs for you.)
@@ -294,7 +294,7 @@ When filing an issue please make sure to:
     Reasoning: This helps us narrow down the layer in the stack at which the issue might be.
 
 - Include a list of steps to reproduce the issue.
-- In case of a bug consider to provide a `short, self contained, correct (compilable), example <http://sscce.org/>`__.
+- In case of a bug consider to provide a `short, self contained, correct (compilable), example <https://stackoverflow.com/help/minimal-reproducible-example>`__.
   Issues are much more likely to be resolved if others can reproduce them easily.
 
 - Mention troubleshooting steps that have been tried already, including:


### PR DESCRIPTION
## Summary
Fixes a bounded subset of broken external links in active tutorial and developer guide pages.

Ref: #4209

## Scope of Changes
- `source/Developer-Tools/Testing/Testing/Integration.rst`: Update broken Gazebo website link (`https://gazebosim.org/home` -> `https://gazebosim.org`)
- `source/Get-Started/About-ROS/About-ROS.rst`: Update broken Gazebo website link (`https://gazebosim.org/home` -> `https://gazebosim.org`)
- `source/ROS-Framework/client-libraries/About-Middleware-Implementations.rst`: Update broken OMG spec URL (`https://www.omg.org/spec/DDS-XTypes/` -> `https://www.omg.org/spec/DDS-XTypes/About-DDS-XTypes/`)
- `source/The-ROS2-Project/Contributing/Developer-Guide.rst`: Update dead trivial-fixes link (`http://cr.openjdk.java.net/~jrose/draft/trivial-fixes.html` -> `https://openjdk.org/bylaws#trivial-change`)
- `source/The-ROS2-Project/Contributing/Developer-Guide.rst`: Update dead sscce link (`http://sscce.org/` -> `https://stackoverflow.com/help/minimal-reproducible-example`)
- `source/ROS-Framework/interfaces/topics/Working-with-topics/Quality-of-Service.rst`: Update broken OpenCV tutorial link (`http://docs.opencv.org/...` -> `https://docs.opencv.org/4.x/`) and die.net tc man page link (`http://linux.die.net/man/8/tc` -> `https://man7.org/linux/man-pages/man8/tc.8.html`)

## Exclusions
- Historical release notes and archived distributions (per #4209 issue guidelines)
- Dynamic anchor false-positives
- Links actively covered by other open PRs

## Local Validation Results
- `ros2doc/bin/python3 -m sphinx -b html -c . source build/html`: **PASSED** (0 build errors)
- `PATH=ros2doc/bin:$PATH PYTHONPATH=. ros2doc/bin/python ./sphinx-lint-with-ros source`: **PASSED** (0 problems found)
- `git ls-files '*.md' '*.rst' \| xargs ros2doc/bin/codespell --config codespell.cfg`: **PASSED** (0 spelling errors)