### PR TITLE
Fix link to nightly pre-release binaries

### DIFF
--- a/source/Developer-Tools/Testing/Testing.rst
+++ b/source/Developer-Tools/Testing/Testing.rst
@@ -113,7 +113,7 @@ These packaging jobs produce archives with pre-built binaries that can be downlo
 
 1. Make sure you have all dependencies installed according to the :doc:`latest development setup <../../Get-Started/Installation/Alternatives/Latest-Development-Setup>` for your platform.
 
-2. Go to https://ci.ros2.org/view/packaging/ and select a packaging job from the list corresponding to your platform.
+2. Go to https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies and select a packaging job from the list corresponding to your platform.
 
 3. Under the heading "Last Successful Artifacts" you should see a download link (e.g. for Windows, ``ros2-package-windows-AMD64.zip``).
 

--- a/source/Get-Started/Installation/Windows-Install-Binary.rst
+++ b/source/Get-Started/Installation/Windows-Install-Binary.rst
@@ -60,7 +60,7 @@ Install ROS 2
 -------------
 
 Binary releases of {DISTRO_TITLE_FULL} are not provided.
-Instead you may download nightly :ref:`prerelease binaries <https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies>`_.
+Instead you may download nightly `prerelease binaries <https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies>`_.
 
 * Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
 * Unpack the zip file somewhere on your system (we'll assume ``C:\dev\``).

--- a/source/Get-Started/Installation/Windows-Install-Binary.rst
+++ b/source/Get-Started/Installation/Windows-Install-Binary.rst
@@ -60,7 +60,7 @@ Install ROS 2
 -------------
 
 Binary releases of {DISTRO_TITLE_FULL} are not provided.
-Instead you may download nightly :ref:`prerelease binaries <Prerelease_binaries>`.
+Instead you may download nightly :ref:`prerelease binaries <https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies>`.
 
 * Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
 * Unpack the zip file somewhere on your system (we'll assume ``C:\dev\``).

--- a/source/Get-Started/Installation/Windows-Install-Binary.rst
+++ b/source/Get-Started/Installation/Windows-Install-Binary.rst
@@ -60,7 +60,7 @@ Install ROS 2
 -------------
 
 Binary releases of {DISTRO_TITLE_FULL} are not provided.
-Instead you may download nightly :ref:`prerelease binaries <https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies>`.
+Instead you may download nightly :ref:`prerelease binaries <https://github.com/ros2/ros2/releases/tag/release-rolling-nightlies>`_.
 
 * Download the latest package for Windows, e.g., ``ros2-package-windows-AMD64.zip``.
 * Unpack the zip file somewhere on your system (we'll assume ``C:\dev\``).


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Updated link for nightly pre-release binaries to direct GitHub URL.

I just refer to it directly as there are no extra instructions necessary to get this to work other than what is already in the current binary instructions (at least it should)

Fixes #7051 

### Did you use Generative AI?

No, but github did generate my commit message automatically (no idea with which model)

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
