### PR TITLE
[Tf2 Tutorials] Add note on using TransformListener with NodeInterfaces for Composable Nodes

### DIFF
--- a/source/ROS-Framework/client-libraries/Working-with-Client-Libraries/Tf2/Writing-A-Tf2-Listener-Cpp.rst
+++ b/source/ROS-Framework/client-libraries/Working-with-Client-Libraries/Tf2/Writing-A-Tf2-Listener-Cpp.rst
@@ -227,6 +227,19 @@ Once the listener is created, it starts receiving tf2 transformations over the w
     tf_listener_ =
       std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
+.. note::
+
+   The constructor above (``TransformListener(*tf_buffer_)``) is a simplified constructor that creates a separate internal node under the hood to manage the subscriptions.
+
+   If you are writing a **Composable Node** (component) or need the transform listener to honor node-specific options and topic remappings (such as namespace or topic remapping for ``/tf``), pass ``this`` (or your node's ``NodeInterfaces``) to the constructor instead:
+
+   .. code-block:: C++
+
+      tf_listener_ =
+        std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this);
+
+   This ensures the subscriptions are created on the existing node and inherit all parameter and topic configurations.
+
 Finally, we query the listener for a specific transformation.
 We call ``lookup_transform`` method with following arguments:
 


### PR DESCRIPTION
## Description

In the "Writing a listener (C++)" tf2 tutorial, the `TransformListener` is constructed using the simplified single-argument constructor:
```cpp
tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
```

Under the hood, this simplified constructor instantiates a separate internal standalone ROS 2 node rather than attaching subscriptions to the current node. Consequently:
- In **Composable Nodes** (components loaded into a container), topic remappings and namespace options passed to the component via `NodeOptions` are not forwarded to the internal node, causing `/tf` and `/tf_static` subscriptions to remain in the root namespace.
- Any node-level remappings (such as remapping `/tf` -> `/my_robot/tf`) configured on the parent node are ignored.

This PR adds an explicit `.. note::` block to the tutorial explaining that passing `this` (or the node's `NodeInterfaces`):
```cpp
tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this);
```
is recommended when writing composable nodes or when node options, namespaces, and topic remappings need to be respected.

Related: https://github.com/ros2/rclcpp/issues/3001

### Did you use Generative AI?

Yes. Gemini was used to analyze issue ros2/rclcpp#3001 and draft this documentation update.

### Additional Information

Target file: `source/ROS-Framework/client-libraries/Working-with-Client-Libraries/Tf2/Writing-A-Tf2-Listener-Cpp.rst`
