### PR TITLE
Clarify ConstSharedPtr achieves zero-copy

### DIFF
--- a/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
+++ b/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
@@ -164,7 +164,7 @@ In this case, since they only come once per second, usually only the first messa
 Finally, you can see that "Published message..." and "Received message ..." lines with the same value also have the same address.
 This shows that the address of the message being received is the same as the one that was published and that it is not a copy.
 This is because we're publishing and subscribing with ``std::unique_ptr``\ s which allow ownership of a message to be moved around the system safely.
-You can also subscribe using a ``const std::shared_ptr<const T> &`` (``ConstSharedPtr``) callback, which shares immutable ownership of the message and achieves zero-copy even with multiple subscribers.
+You can also subscribe using a ``const std::shared_ptr<const T> &`` (``ConstSharedPtr``) callback, which shares immutable ownership of the message and achieves zero-copy even with multiple subscribers, so long as a ``std::unique_ptr`` was passed to the publisher.
 Subscribing with a plain ``const T &`` or a mutable ``std::shared_ptr<T>`` will not achieve zero-copy.
 
 The cyclic pipeline demo
@@ -381,9 +381,7 @@ And so one of the images being viewed is the original, with all the pointers the
 
 To avoid this copy in a one-to-many pipeline, subscribers can use ``ConstSharedPtr``
 (i.e. ``const std::shared_ptr<const T> &``) callbacks instead of ``UniquePtr``.
-The publisher retains a single immutable shared object and delivers it to all intra-process
-subscribers without copying, at the cost of no longer being able to mutate the message after
-publishing.
+The message is promoted from the published ``UniquePtr`` to a ``ConstSharedPtr``, which is delivered to all intra-process subscribers as a single immutable shared object, without copying.
 
 Pipeline with inter-process viewer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
+++ b/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
@@ -164,7 +164,8 @@ In this case, since they only come once per second, usually only the first messa
 Finally, you can see that "Published message..." and "Received message ..." lines with the same value also have the same address.
 This shows that the address of the message being received is the same as the one that was published and that it is not a copy.
 This is because we're publishing and subscribing with ``std::unique_ptr``\ s which allow ownership of a message to be moved around the system safely.
-You can also publish and subscribe with ``const &`` and ``std::shared_ptr``, but zero-copy will not occur in that case.
+You can also subscribe using a ``const std::shared_ptr<const T> &`` (``ConstSharedPtr``) callback, which shares immutable ownership of the message and achieves zero-copy even with multiple subscribers.
+Subscribing with a mutable ``std::shared_ptr<T>`` will not achieve zero-copy.
 
 The cyclic pipeline demo
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -377,6 +378,12 @@ But for the link between the ``watermark_node`` and the two image view nodes the
 It can be, however, delivered to one of them.
 Which one would get the original pointer is not defined, but instead is simply the last to be delivered.
 And so one of the images being viewed is the original, with all the pointers the same, and the other is a copy of the original image, made between the ``watermark_node`` and one of the ``image_view_node`` instances, which will have a different pointer for the third line of text.
+
+To avoid this copy in a one-to-many pipeline, subscribers can use ``ConstSharedPtr``
+(i.e. ``const std::shared_ptr<const T> &``) callbacks instead of ``UniquePtr``.
+The publisher retains a single immutable shared object and delivers it to all intra-process
+subscribers without copying, at the cost of no longer being able to mutate the message after
+publishing.
 
 Pipeline with inter-process viewer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
+++ b/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
@@ -379,8 +379,7 @@ It can be, however, delivered to one of them.
 Which one would get the original pointer is not defined, but instead is simply the last to be delivered.
 And so one of the images being viewed is the original, with all the pointers the same, and the other is a copy of the original image, made between the ``watermark_node`` and one of the ``image_view_node`` instances, which will have a different pointer for the third line of text.
 
-To avoid this copy in a one-to-many pipeline, subscribers can use ``ConstSharedPtr``
-(i.e. ``const std::shared_ptr<const T> &``) callbacks instead of ``UniquePtr``.
+To avoid this copy in a one-to-many pipeline, subscribers can use ``ConstSharedPtr`` (i.e. ``const std::shared_ptr<const T> &``) callbacks instead of ``UniquePtr``.
 The message is promoted from the published ``UniquePtr`` to a ``ConstSharedPtr``, which is delivered to all intra-process subscribers as a single immutable shared object, without copying.
 
 Pipeline with inter-process viewer

--- a/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
+++ b/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
@@ -165,7 +165,8 @@ Finally, you can see that "Published message..." and "Received message ..." line
 This shows that the address of the message being received is the same as the one that was published and that it is not a copy.
 This is because we're publishing and subscribing with ``std::unique_ptr``\ s which allow ownership of a message to be moved around the system safely.
 You can also subscribe using a ``const std::shared_ptr<const T> &`` (``ConstSharedPtr``) callback, which shares immutable ownership of the message and achieves zero-copy even with multiple subscribers, so long as a ``std::unique_ptr`` was passed to the publisher.
-Subscribing with a plain ``const T &`` or a mutable ``std::shared_ptr<T>`` will not achieve zero-copy.
+A ``const T &`` callback behaves identically, as it is delivered from that same shared, immutable message; the only difference is that the reference is not valid once the callback returns, so such a subscriber cannot retain the message.
+A mutable ``std::shared_ptr<T>`` callback (which is deprecated) instead takes ownership of the message: it is zero-copy when it is the only subscriber, but forces a copy for all but one subscriber once there is more than one.
 
 The cyclic pipeline demo
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -379,7 +380,7 @@ It can be, however, delivered to one of them.
 Which one would get the original pointer is not defined, but instead is simply the last to be delivered.
 And so one of the images being viewed is the original, with all the pointers the same, and the other is a copy of the original image, made between the ``watermark_node`` and one of the ``image_view_node`` instances, which will have a different pointer for the third line of text.
 
-To avoid this copy in a one-to-many pipeline, subscribers can use ``ConstSharedPtr`` (i.e. ``const std::shared_ptr<const T> &``) callbacks instead of ``UniquePtr``.
+To avoid this copy in a one-to-many pipeline, subscribers can use a ``ConstSharedPtr`` (i.e. ``const std::shared_ptr<const T> &``) or a ``const T &`` callback instead of ``UniquePtr``.
 The message is promoted from the published ``UniquePtr`` to a ``ConstSharedPtr``, which is delivered to all intra-process subscribers as a single immutable shared object, without copying.
 
 Pipeline with inter-process viewer

--- a/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
+++ b/source/ROS-Framework/nodes/Working-with-nodes/intra-process/Intra-Process-Communication.rst
@@ -165,7 +165,7 @@ Finally, you can see that "Published message..." and "Received message ..." line
 This shows that the address of the message being received is the same as the one that was published and that it is not a copy.
 This is because we're publishing and subscribing with ``std::unique_ptr``\ s which allow ownership of a message to be moved around the system safely.
 You can also subscribe using a ``const std::shared_ptr<const T> &`` (``ConstSharedPtr``) callback, which shares immutable ownership of the message and achieves zero-copy even with multiple subscribers.
-Subscribing with a mutable ``std::shared_ptr<T>`` will not achieve zero-copy.
+Subscribing with a plain ``const T &`` or a mutable ``std::shared_ptr<T>`` will not achieve zero-copy.
 
 The cyclic pipeline demo
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
The existing note on subscriber callback types incorrectly implied that no `shared_ptr` variant could achieve zero-copy, grouping mutable `shared_ptr<T>` and `ConstSharedPtr` together.
This is misleading: `const std::shared_ptr<const T> &` (`ConstSharedPtr`) uses immutable shared ownership and delivers zero-copy to multiple intra-process subscribers simultaneously, making it the correct pattern for one-to-many composition.

Changes:
- Correct the `shared_ptr` sentence in the two-node pipeline section to distinguish `ConstSharedPtr` (zero-copy capable) from mutable `shared_ptr<T>` (not zero-copy)
- Add a follow-on paragraph to the two-image-viewer section explaining that `ConstSharedPtr` callbacks avoid the fan-out copy penalty that `UniquePtr` incurs in one-to-many graphs

A more detailed write up with tests and findings is available [here](https://mshields.name/blog/2026-08-12-zero-copy-intra-process-communications-with-ros-2/)

### Did you use Generative AI?
No

### Additional Information
The correction to the `shared_ptr` note is a factual fix as the previous wording could lead readers to incorrectly avoid `ConstSharedPtr` in one-to-many scenarios where it is the appropriate tool.