### PR TITLE
3di | TOC update - align main toc titles with About ROS article

### DIFF
--- a/source/Developer-Tools.rst
+++ b/source/Developer-Tools.rst
@@ -1,5 +1,5 @@
-Developer tools
-===============
+Tools
+=====
 
 
 Coming Soon
@@ -8,9 +8,9 @@ Coming Soon
    :maxdepth: 3
 
    Developer-Tools/About-introspection-and-analysis
+   Developer-Tools/About-Launch
    Developer-Tools/About-Debugging
    Developer-Tools/About-Build
    Developer-Tools/About-visualization
    Developer-Tools/About-package-documentation
-   Developer-Tools/About-Launch
    Developer-Tools/About-testing

--- a/source/Developer-Tools/About-Build.rst
+++ b/source/Developer-Tools/About-Build.rst
@@ -1,4 +1,4 @@
-Building
+Builds
 ========
 
 Coming Soon

--- a/source/Developer-Tools/About-Launch.rst
+++ b/source/Developer-Tools/About-Launch.rst
@@ -2,8 +2,8 @@
 
     Concepts/Basic/About-Launch
 
-Launch
-======
+Node management
+===============
 .. toctree::
    :maxdepth: 1
    :hidden:

--- a/source/Integrations-and-related.rst
+++ b/source/Integrations-and-related.rst
@@ -1,6 +1,6 @@
 
-Integrations and related projects
-=================================
+Integrations
+============
 
 Coming Soon
 

--- a/source/Integrations-and-related/Related-Projects.rst
+++ b/source/Integrations-and-related/Related-Projects.rst
@@ -3,7 +3,7 @@
     Related-Projects
 
 
-Related Projects
+Related projects
 ================
 
 Gazebo

--- a/source/Migration-and-Upgrades.rst
+++ b/source/Migration-and-Upgrades.rst
@@ -1,4 +1,4 @@
-Migration and Upgrades
+Migration and upgrades
 ======================
 
 Coming Soon

--- a/source/Migration-and-Upgrades/Using-Custom-Rosdistro.rst
+++ b/source/Migration-and-Upgrades/Using-Custom-Rosdistro.rst
@@ -2,7 +2,7 @@
 
     How-To-Guides/Using-Custom-Rosdistro
 
-Using Custom Rosdistro Version
+Using custom rosdistro version
 ==============================
 
 

--- a/source/ROS-Framework.rst
+++ b/source/ROS-Framework.rst
@@ -1,7 +1,7 @@
 
 
-ROS framework
-=============
+Framework
+=========
 
 Coming Soon
 

--- a/source/The-ROS2-Project.rst
+++ b/source/The-ROS2-Project.rst
@@ -1,5 +1,5 @@
-ROS Community
-=============
+Community
+=========
 
 Check out the resources below to learn more about the advancement of the ROS 2 project.
 

--- a/source/The-ROS2-Project/Adopters.rst
+++ b/source/The-ROS2-Project/Adopters.rst
@@ -2,7 +2,7 @@
 
   The-ROS2-Project/Adopters/Adopters
 
-ROS 2 Adopters
+ROS 2 adopters
 ==============
 
 This page showcases organizations and projects using ROS in any capacity.

--- a/source/The-ROS2-Project/Feature-Ideas.rst
+++ b/source/The-ROS2-Project/Feature-Ideas.rst
@@ -4,7 +4,7 @@
 
 .. _FeatureIdeas:
 
-Feature Ideas
+Feature ideas
 =============
 
 .. contents:: Table of Contents

--- a/source/The-ROS2-Project/Features.rst
+++ b/source/The-ROS2-Project/Features.rst
@@ -4,7 +4,7 @@
 
 .. _Features:
 
-Features Status
+Features status
 ===============
 
 The features listed below are available in the current ROS 2 release.

--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -4,7 +4,7 @@
 
 .. _Governance:
 
-Project Governance
+Project governance
 ==================
 
 .. contents:: Table of Contents

--- a/source/The-ROS2-Project/Platform-EOL-Policy.rst
+++ b/source/The-ROS2-Project/Platform-EOL-Policy.rst
@@ -1,6 +1,6 @@
 .. _PlatformEOLPolicy:
 
-Platform EOL Policy
+Platform EOL policy
 ===================
 
 .. contents:: Table of Contents

--- a/source/The-ROS2-Project/Platform-Support-Tiers.rst
+++ b/source/The-ROS2-Project/Platform-Support-Tiers.rst
@@ -1,4 +1,4 @@
-Platform Support Tiers
+Platform support tiers
 ======================
 
 Platforms are defined as a combination of the OS, the architecture, and the RMW implementation.

--- a/source/The-ROS2-Project/ROSCon-Content.rst
+++ b/source/The-ROS2-Project/ROSCon-Content.rst
@@ -4,7 +4,7 @@
 
 .. _ROSCon:
 
-ROSCon Talks
+ROSCon talks
 ============
 
 The following `ROSCon <https://roscon.ros.org>`__ talks have been given on ROS 2 and provide information about the workings of ROS 2 and various demos:

--- a/source/The-ROS2-Project/Release-Schedule.rst
+++ b/source/The-ROS2-Project/Release-Schedule.rst
@@ -1,4 +1,4 @@
-Release Schedule
+Release schedule
 ================
 
 Frequency

--- a/source/index.rst
+++ b/source/index.rst
@@ -12,11 +12,11 @@ ROS 2 Documentation
 
    Get-Started
    ROS-Framework
-   Capabilities
    Developer-Tools
-   Migration-and-Upgrades
-   Integrations-and-related
+   Capabilities
    The-ROS2-Project
+   Integrations-and-related
+   Migration-and-Upgrades
    Contact
    Glossary
    Citations

--- a/source/index.rst
+++ b/source/index.rst
@@ -14,9 +14,9 @@ ROS 2 Documentation
    ROS-Framework
    Developer-Tools
    Capabilities
-   The-ROS2-Project
    Integrations-and-related
    Migration-and-Upgrades
+   The-ROS2-Project
    Contact
    Glossary
    Citations


### PR DESCRIPTION
## Description

We've updated the titles of the articles in the TOC to be consistent with the way those articles are named in the “About ROS” article. For example. we've updated **Building** > **Builds** and **Launch** > **Node management**.  

We've also updated capitalisation to make article titles consistently use sentence case.

Related to: ros2/ros2_documentation/issues #6825

### Did you use Generative AI?

No

### Additional Information

Documentation updates from 3di Information Solutions, agreed with Geoff and Tully.

### Label

Please add **backport-lyrical**.