### PR TITLE
update instructions to match reality

### DIFF
--- a/source/Developer-Tools/Build/Releasing/Index-Your-Packages.rst
+++ b/source/Developer-Tools/Build/Releasing/Index-Your-Packages.rst
@@ -61,7 +61,8 @@ For example, the name of the ROS Rolling folder is ``rolling``.
 For each ROS distribution you want to release into:
 
 1. fill out the following template
-2. put the filled-out template into the ``distribution.yaml`` file in the corresponding ROS distribution's folder
+2. put the filled-out template into the ``distribution.yaml`` file in the corresponding ROS distribution's folder. 
+3. make sure the MY-REPO-NAME stands on the right place in the alphabetical ordering in the yaml file.
 
 .. code-block:: yaml
 

--- a/source/Developer-Tools/Build/Releasing/Index-Your-Packages.rst
+++ b/source/Developer-Tools/Build/Releasing/Index-Your-Packages.rst
@@ -61,8 +61,8 @@ For example, the name of the ROS Rolling folder is ``rolling``.
 For each ROS distribution you want to release into:
 
 1. fill out the following template
-2. put the filled-out template into the ``distribution.yaml`` file in the corresponding ROS distribution's folder. 
-3. make sure the MY-REPO-NAME stands on the right place in the alphabetical ordering in the yaml file.
+2. put the filled-out template into the ``distribution.yaml`` file in the corresponding ROS distribution's folder 
+3. make sure the MY-REPO-NAME stands on the right place in the alphabetical ordering in the yaml file
 
 .. code-block:: yaml
 

--- a/source/Developer-Tools/Build/Releasing/Index-Your-Packages.rst
+++ b/source/Developer-Tools/Build/Releasing/Index-Your-Packages.rst
@@ -61,7 +61,7 @@ For example, the name of the ROS Rolling folder is ``rolling``.
 For each ROS distribution you want to release into:
 
 1. fill out the following template
-2. put the filled-out template into the ``distribution.yaml`` file in the corresponding ROS distribution's folder 
+2. put the filled-out template into the ``distribution.yaml`` file in the corresponding ROS distribution's folder
 3. make sure the MY-REPO-NAME stands on the right place in the alphabetical ordering in the yaml file
 
 .. code-block:: yaml


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

So in the instructions ros adding the repository to a distribution, it does not warn that you need to do this in alphabetical order. The automated github review bot does mark this as being important: 
<img width="916" height="278" alt="image" src="https://github.com/user-attachments/assets/ace5e6f0-3b9b-489f-9331-3a41a8041944" />

See this PR for references: https://github.com/ros/rosdistro/pull/53467

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, specify the model (e.g., GitHub Copilot v3.2)
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
