### PR TITLE
RViz guide fix heading

### DIFF
--- a/source/Developer-Tools/Visualization/RViz/RViz-User-Guide/RViz-User-Guide.rst
+++ b/source/Developer-Tools/Visualization/RViz/RViz-User-Guide/RViz-User-Guide.rst
@@ -234,9 +234,9 @@ Controls:
 * **Right mouse button**: Click and drag to zoom the image.
 * **Scrollwheel**: Zoom the image.
 
-Same as the orbital camera, with the focus point restricted to the XY plane.
 XYOrbit
 ^^^^^^^
+Same as the orbital camera, with the focus point restricted to the XY plane.
 
 Controls:
 


### PR DESCRIPTION
With https://github.com/ros2/ros2_documentation/pull/7067 I messed up the XYOrbit view controller heading in the RViz user guide. I'm sorry for this occurrence, I should have proofread my changes more thoroughly. This PR fixes the heading.

Current rolling docs:
<img width="914" height="488" alt="image" src="https://github.com/user-attachments/assets/27cf952e-2083-4e49-a00a-62f6fe53facf" />

With this PR:
<img width="914" height="537" alt="image" src="https://github.com/user-attachments/assets/9f890090-0f7d-4766-bf14-f9eb138724eb" />

