### PR TITLE
RViz XYOrbit view controller describe Z translation

### DIFF
--- a/source/Developer-Tools/Visualization/RViz/RViz-User-Guide/RViz-User-Guide.rst
+++ b/source/Developer-Tools/Visualization/RViz/RViz-User-Guide/RViz-User-Guide.rst
@@ -236,11 +236,17 @@ Controls:
 
 XYOrbit
 ^^^^^^^
-Same as the orbital camera, with the focus point restricted to the XY plane.
+Same as the orbital camera, except that translation operations occur along the XY plane and Z axis of the fixed frame instead of those of the camera frame.
 
 Controls:
 
-See orbital camera.
+* **Left mouse button**: Click and drag to rotate around the focal point.
+* **Left mouse button + Shift** or **Middle mouse button**: Click and drag to move the focal point in the fixed frame XY plane.
+* **Right mouse button**: Click and drag to zoom in/out of the focal point.
+  Dragging up zooms in, down zooms out.
+* **Right mouse button + Shift**: Click and drag to translate along the fixed frame Z axis.
+* **Scrollwheel**: Zoom in/out of the focal point.
+* **Scrollwheel + Shift**: Translate along the fixed frame Z axis.
 
 ThirdPersonFollower
 ^^^^^^^^^^^^^^^^^^^
@@ -250,7 +256,7 @@ This could be handy if you are doing 3D mapping of a hallway with corners for ex
 
 Controls:
 
-See orbital camera.
+See XYOrbit camera.
 
 
 Custom Views


### PR DESCRIPTION
Since `rviz_default_plugins` version 16.0.1 the XYOrbit view controller supports translation along the Z axis ([changelog](https://github.com/ros2/rviz/blob/rolling/rviz_default_plugins/CHANGELOG.rst#1601-2026-06-11) and [feature PR](https://github.com/ros2/rviz/pull/1721)). This change describes this new feature.

## Description
Describes each key combination and effect, this results in some overlap with the Orbit view controller but I think that to the reader it's clearer this way than only describing the differences. Also, ThirdPersonFollower inherits from XYOrbit and takes over its controls, therefore refer to that doc instead of that of the orbital camera.

### Did you use Generative AI?

No.

### Additional Information

These changes must **not** be backported because they describe a feature that got added only recently to Rviz2 rolling (first released as part of `rviz_view_controllers` 16.0.1) and didn't get backported.
