### PR TITLE
docs: add sw2robot to URDF exporters list

### DIFF
--- a/source/Capabilities/Simulation/URDF/Exporting-an-URDF-File.rst
+++ b/source/Capabilities/Simulation/URDF/Exporting-an-URDF-File.rst
@@ -35,6 +35,7 @@ However, we figured it would be helpful to produce a list of available URDF expo
  * `FusionSDF: Fusion 360 to SDF exporter <https://github.com/andreasBihlmaier/FusionSDF>`_
  * `OnShape URDF Exporter <https://github.com/Rhoban/onshape-to-robot>`_
  * `SolidWorks URDF Exporter <https://github.com/ros/solidworks_urdf_exporter>`_
+ * `sw2robot (SolidWorks mate-based exporter + cross-platform URDF editor) <https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2>`_
  * `ExportURDF Library (Fusion360, OnShape, Solidworks) <https://github.com/daviddorf2023/ExportURDF>`_
 
 **Other URDF Export and Conversion Tools**


### PR DESCRIPTION
## Description

Adds sw2robot to the CAD Exporters section of the URDF export page.

sw2robot infers the link tree and joint axes from a SolidWorks assembly's existing mates instead of requiring them to be laid out by hand, and ships a browser editor for correcting the result. Only the extract step needs Windows + SolidWorks; edit / build / export run on Windows, macOS and Linux from a single prebuilt binary. It also opens URDFs produced by other exporters, so it can be used as a follow-on editing step rather than a replacement.

Repo: https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2

<img width="480" height="274" alt="solidworks-to-robot" src="https://github.com/user-attachments/assets/6b2f1b91-a047-4d2f-b5e3-eda8206407e9" />


This follows the invitation at the bottom of the page ("If you have an URDF tool you like please consider adding it to the list above!") and the precedent of #6547, which added `fusion2URDF` to the same list.

### Did you use Generative AI?

Yes. Claude Opus 5 (via Claude Code) was used to locate the right page and to draft the entry and this description. The change itself is a single line, and I reviewed and verified it before submitting.

**Checks run locally** over the whole `source` tree (all pass):
