### PR TITLE
Hide Releases page toctree

### DIFF
--- a/source/Releases.rst
+++ b/source/Releases.rst
@@ -25,7 +25,7 @@ Below is a list of current and historic ROS 2 distributions.
 Rows in the table marked in blue are the currently supported distributions.
 
 .. toctree::
-   :maxdepth: 3
+   :hidden:
 
    Releases/Release-Process
    Releases/Release-Lyrical-Luth


### PR DESCRIPTION
## Description

Otherwise, it generates a huge (3-deep) TOC above the distro table. I don't think we need this TOC here.

It used to be hidden before #7070, I think we should revert to how it was before.

**Before**

<img width="1325" height="2037" alt="Screenshot from 2026-09-06 14-22-34" src="https://github.com/user-attachments/assets/f294a5af-bae9-47b7-8c2e-5f9da8973a8e" />

**After**

<img width="1325" height="2037" alt="Screenshot from 2026-09-06 14-27-14" src="https://github.com/user-attachments/assets/422f21a5-34ad-4b94-98dc-19329a2f80b3" />

### Did you use Generative AI?

No

### Additional Information

Lyrical has this same change, but not the older distros, so only backport to `lyrical`.